### PR TITLE
Set role="button" for links masquerading as such

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make "Continue" links appear as buttons to screen readers
 - Fix missing assets for error pages
 - Fix for allowing IPv6 addresses to visit the admin area
 

--- a/app/views/claims/eligibility_confirmed.html.erb
+++ b/app/views/claims/eligibility_confirmed.html.erb
@@ -6,6 +6,6 @@
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
     <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April 2018 and 5 April 2019.</p>
 
-    <%= link_to "Continue", claim_path("information-provided"), class: "govuk-button" %>
+    <%= link_to "Continue", claim_path("information-provided"), class: "govuk-button", role: "button" %>
   </div>
 </div>

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -26,7 +26,7 @@
       We will send you details about these payments once we have processed your claim.
     </p>
 
-    <%= link_to "Continue", new_verify_authentications_path, class: "govuk-button" %>
+    <%= link_to "Continue", new_verify_authentications_path, class: "govuk-button", role: "button" %>
 
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">


### PR DESCRIPTION
Setting the ARIA button role will make these links that are styled as buttons appear as button controls to screen readers.
