### PR TITLE
Restrict sources for JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make content-security-policy more restrictive
 - Use a fieldset for the gender question to improve accessibility
 - Make "Continue" links appear as buttons to screen readers
 - Fix missing assets for error pages

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,8 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src :self, :https, :data
   policy.img_src :self, :https, :data
   policy.object_src :none
-  policy.script_src :self, "https://*.google-analytics.com", "https://www.googletagmanager.com"
+  policy.script_src :self
+  policy.connect_src :self, "https://www.google-analytics.com"
   policy.style_src :self
 
   # Specify URI for violation reports


### PR DESCRIPTION
We moved to self-hosting the Google Analytics code so we should no
longer include their hosts in our allowed sources for JavaScript. We do
still need the browser to connect to Google Analytics though, otherwise
tracking calls won't be made.