### PR TITLE
Fix banking_name data migration issue

### DIFF
--- a/db/data/20191008102825_copy_full_names_to_banking_names.rb
+++ b/db/data/20191008102825_copy_full_names_to_banking_names.rb
@@ -1,7 +1,7 @@
 class CopyFullNamesToBankingNames < ActiveRecord::Migration[5.2]
   def up
     Claim.where(banking_name: nil).each do |c|
-      c.update!(banking_name: c.full_name)
+      c.update_attribute(:banking_name, c.full_name)
     end
   end
 


### PR DESCRIPTION
Running this on production raised an error because some claims failed validation when `update!` was called. We resolve this by using `update_attribute` to skip validations.