### PR TITLE
Transform DQT report rows to unique records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Exclude claims from previous academic years on matching claims screen
+- Fix a bug with automated DQT checks where the report has multiple rows for the
+  same claim
 
 ## [Release 066] - 2020-03-25
 

--- a/app/models/automated_checks/dqt_report_csv_to_records.rb
+++ b/app/models/automated_checks/dqt_report_csv_to_records.rb
@@ -1,0 +1,34 @@
+module AutomatedChecks
+  class DQTReportCsvToRecords
+    CLAIM_REFERENCE_COLUMN = "dfeta text2".freeze
+
+    def initialize(csv_rows)
+      @csv_rows = csv_rows
+    end
+
+    def transform
+      @csv_rows.group_by { |row| row.fetch(CLAIM_REFERENCE_COLUMN) }.map do |rows|
+        grouped_rows = rows[1]
+        {
+          claim_reference: grouped_rows.first.fetch(CLAIM_REFERENCE_COLUMN),
+          qts_date: parse_date(grouped_rows.first.fetch("dfeta qtsdate")),
+          date_of_birth: parse_date(grouped_rows.first.fetch("birthdate")),
+          degree_jac_codes: collate_fields_from_rows(%w[HESubject1Value HESubject2Value HESubject3Value], grouped_rows),
+          itt_subject_jac_codes: collate_fields_from_rows(%w[ITTSub1Value ITTSub2Value ITTSub3Value], grouped_rows)
+        }
+      end
+    end
+
+    private
+
+    def collate_fields_from_rows(fields, rows)
+      rows.map { |c| c.to_h.slice(*fields).values }.flatten.compact.uniq
+    end
+
+    def parse_date(date)
+      Date.parse(date)
+    rescue
+      nil
+    end
+  end
+end

--- a/app/models/maths_and_physics/dqt_record.rb
+++ b/app/models/maths_and_physics/dqt_record.rb
@@ -30,18 +30,16 @@ module MathsAndPhysics
       "F3" # Physics
     ].freeze
 
-    # The row from a DQTReportCsv as a hash. Expected to contain the keys:
-    # "dfeta qtsdate" -     A string representation of the date the teacher
-    #                       achieved qualified teacher status.
-    #                       Format: %-d/%-m/%Y
-    # "ITTSub(n)Value" -    A string value containing the teacher's ITT subject
-    #                       specialism JAC code.
-    # "HESubject(n)Value" - A string value containing the teacher's
-    #                       undergraduate or postgraduate degree JAC code
-    def initialize(data)
-      @qts_award_date = Date.parse(data.fetch("dfeta qtsdate"))
-      @itt_subject_codes = data.slice("ITTSub1Value", "ITTSub2Value", "ITTSub3Value").compact.values
-      @degree_codes = data.slice("HESubject1Value", "HESubject2Value", "HESubject3Value").compact.values
+    # The record transformed from a DQTReportCsv. Expected to contain the keys:
+    # :qts_date              - The date the teacher achieved qualified teacher
+    #                          status.
+    #                          Format: %d/%m/%Y
+    # :itt_subject_jac_codes - An array of the claimants ITT subject JAC codes.
+    # :degree_jac_codes      - An array of the claimants degree JAC codes.
+    def initialize(record)
+      @qts_award_date = record.fetch(:qts_date)
+      @itt_subject_codes = record.fetch(:itt_subject_jac_codes)
+      @degree_codes = record.fetch(:degree_jac_codes)
     end
 
     def eligible?

--- a/app/models/student_loans/dqt_record.rb
+++ b/app/models/student_loans/dqt_record.rb
@@ -13,12 +13,11 @@ module StudentLoans
   class DQTRecord
     attr_reader :qts_award_date
 
-    # The row from a DQTReportCsv as a hash. Expected to contain the keys:
-    # data["dfeta qtsdate"] - A string representation of the date the teacher
-    #                         achieved qualified teacher status.
-    #                         Format: %-d/%-m/%Y
-    def initialize(data)
-      @qts_award_date = Date.parse(data.fetch("dfeta qtsdate"))
+    # The record transformed from a DQTReportCsv. Expected to contain the keys:
+    # :qts_date - The date the teacher achieved qualified teacher status.
+    #             Format: %d/%m/%Y
+    def initialize(record)
+      @qts_award_date = record.fetch(:qts_date)
     end
 
     def eligible?

--- a/spec/fixtures/files/example_dqt_report.csv
+++ b/spec/fixtures/files/example_dqt_report.csv
@@ -1,5 +1,6 @@
 dfeta text1,dfeta text2,dfeta trn,fullname,birthdate,dfeta ninumber,dfeta qtsdate,dfeta he hesubject1idname,dfeta he hesubject2idname,dfeta he hesubject3idname,HESubject1Value,HESubject2Value,HESubject3Value,dfeta subject1idname,dfeta subject2idname,dfeta subject3idname,ITTSub1Value,ITTSub2Value,ITTSub3Value
 1234567,AB123456,1234567,Fred Eligible,23/8/1990,QQ123456C,23/8/2017,Politics,,,L200,,,Politics,,,L200,,
+1234567,AB123456,1234567,Fred Eligible,23/8/1990,QQ123456C,23/8/2017,Law By Area,,,M100,,,Politics,,,L200,,
 8901231,RR123456,8901231,Jo Eligible,11/2/1970,QQ123456C,20/6/2017,Psychology,,,C800,,,Psychology,,,C800,,
 3456789,XX123456,3456789,,,,,,,,,,,,,,,,
 6758493,CD123456,6758493,Terry Ineligible,21/4/1979,QQ123456C,12/3/2000,Politics,,,L200,,,Mathematics,,,G100,,

--- a/spec/models/automated_checks/dqt_report_csv_to_records_spec.rb
+++ b/spec/models/automated_checks/dqt_report_csv_to_records_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
+  subject(:dqt_report_csv_to_records) { described_class.new(rows) }
+  let(:rows) do
+    [
+      {
+        "dfeta text2" => "AB123456",
+        "dfeta qtsdate" => "24/10/2017",
+        "birthdate" => "10/09/1980",
+        "HESubject1Value" => "G100",
+        "HESubject2Value" => "F100",
+        "HESubject3Value" => nil,
+        "ITTSub1Value" => "E100",
+        "ITTSub2Value" => nil,
+        "ITTSub3Value" => nil
+      },
+      {
+        "dfeta text2" => "AB123456",
+        "dfeta qtsdate" => "24/10/2017",
+        "birthdate" => "10/09/1980",
+        "HESubject1Value" => "R100",
+        "HESubject2Value" => nil,
+        "HESubject3Value" => nil,
+        "ITTSub1Value" => "E100",
+        "ITTSub2Value" => nil,
+        "ITTSub3Value" => nil
+      },
+      {
+        "dfeta text2" => "XX999999",
+        "dfeta qtsdate" => "17/06/2016",
+        "birthdate" => "05/03/1993",
+        "HESubject1Value" => "X100",
+        "HESubject2Value" => nil,
+        "HESubject3Value" => nil,
+        "ITTSub1Value" => "X100",
+        "ITTSub2Value" => nil,
+        "ITTSub3Value" => nil
+      }
+    ]
+  end
+
+  describe "#transform" do
+    it "transforms multiple rows with the same reference to unique records" do
+      expected_records = [
+        {
+          claim_reference: "AB123456",
+          qts_date: Date.new(2017, 10, 24),
+          date_of_birth: Date.new(1980, 9, 10),
+          degree_jac_codes: ["G100", "F100", "R100"],
+          itt_subject_jac_codes: ["E100"]
+        },
+        {
+          claim_reference: "XX999999",
+          qts_date: Date.new(2016, 6, 17),
+          date_of_birth: Date.new(1993, 3, 5),
+          degree_jac_codes: ["X100"],
+          itt_subject_jac_codes: ["X100"]
+        }
+      ]
+      expect(dqt_report_csv_to_records.transform).to eql(expected_records)
+    end
+  end
+
+  context "when there is no qualification data in the record" do
+    let(:rows) do
+      [
+        {
+          "dfeta text2" => "RE123456",
+          "dfeta qtsdate" => nil,
+          "birthdate" => "24/03/1988",
+          "HESubject1Value" => nil,
+          "HESubject2Value" => nil,
+          "HESubject3Value" => nil,
+          "ITTSub1Value" => nil,
+          "ITTSub2Value" => nil,
+          "ITTSub3Value" => nil
+        }
+      ]
+    end
+
+    it "handles nil values" do
+      expected_records = [
+        {
+          claim_reference: "RE123456",
+          qts_date: nil,
+          date_of_birth: Date.new(1988, 3, 24),
+          degree_jac_codes: [],
+          itt_subject_jac_codes: []
+        }
+      ]
+      expect(dqt_report_csv_to_records.transform).to eql(expected_records)
+    end
+  end
+end

--- a/spec/models/maths_and_physics/dqt_record_spec.rb
+++ b/spec/models/maths_and_physics/dqt_record_spec.rb
@@ -9,44 +9,44 @@ RSpec.describe MathsAndPhysics::DQTRecord do
   describe "#eligible?" do
     EXAMPLE_ELIGIBLE_JAC_CODES.each do |jac_code|
       context "when the given ITT subject (#{jac_code}) is eligible" do
-        let(:attributes) { {"ITTSub1Value" => jac_code} }
+        let(:attributes) { {itt_subject_jac_codes: [jac_code], degree_jac_codes: []} }
 
         it "returns true if the given QTS award date is after the first eligible academic year" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "19/3/2017"})).eligible?). to eql true
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("19/3/2017")})).eligible?). to eql true
         end
 
         it "returns true if the given QTS award date is in the first eligible academic year" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "1/10/2015"})).eligible?). to eql true
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("1/10/2015")})).eligible?). to eql true
         end
 
         it "returns false if the given date is not an eligible year" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "8/3/2000"})).eligible?). to eql false
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("8/3/2000")})).eligible?). to eql false
         end
       end
 
       context "when the given degree (#{jac_code}) is eligible" do
-        let(:attributes) { {"HESubject1Value" => jac_code} }
+        let(:attributes) { {degree_jac_codes: [jac_code], itt_subject_jac_codes: []} }
 
         it "returns true if the given QTS award date is after the first eligible academic year" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "19/3/2017"})).eligible?). to eql true
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("19/3/2017")})).eligible?). to eql true
         end
 
         it "returns true if the given QTS award date is in the first eligible academic year" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "1/10/2015"})).eligible?). to eql true
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("1/10/2015")})).eligible?). to eql true
         end
 
         it "returns false if the given date is not an eligible year" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "8/3/2000"})).eligible?). to eql false
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("8/3/2000")})).eligible?). to eql false
         end
       end
     end
 
     EXAMPLE_NON_ELIGIBLE_JAC_CODES.each do |jac_code|
       context "when the given ITT subject or degree (#{jac_code}) isn't eligible" do
-        let(:attributes) { {"ITTSub1Value" => jac_code, "HESubject1Value" => jac_code} }
+        let(:attributes) { {itt_subject_jac_codes: [jac_code], degree_jac_codes: [jac_code]} }
 
         it "always returns false" do
-          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({"dfeta qtsdate" => "19/3/2017"})).eligible?). to eql false
+          expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("19/3/2017")})).eligible?). to eql false
         end
       end
     end

--- a/spec/models/student_loans/dqt_record_spec.rb
+++ b/spec/models/student_loans/dqt_record_spec.rb
@@ -3,15 +3,15 @@ require "rails_helper"
 RSpec.describe StudentLoans::DQTRecord do
   describe "#eligble?" do
     it "returns true if the given QTS award date is after the first eligible academic year" do
-      expect(StudentLoans::DQTRecord.new({"dfeta qtsdate" => "19/3/2017"}).eligible?). to eql true
+      expect(StudentLoans::DQTRecord.new({qts_date: Date.parse("19/3/2017")}).eligible?). to eql true
     end
 
     it "returns true if the given QTS award date is in the first eligible academic year" do
-      expect(StudentLoans::DQTRecord.new({"dfeta qtsdate" => "1/10/2014"}).eligible?). to eql true
+      expect(StudentLoans::DQTRecord.new({qts_date: Date.parse("1/10/2014")}).eligible?). to eql true
     end
 
     it "returns false if the given date is not an eligible year" do
-      expect(StudentLoans::DQTRecord.new({"dfeta qtsdate" => "8/3/2000"}).eligible?). to eql false
+      expect(StudentLoans::DQTRecord.new({qts_date: Date.parse("8/3/2000")}).eligible?). to eql false
     end
   end
 end


### PR DESCRIPTION
When we built the automated DQT checks we were working on the assumption
that there would be a single row for each record. It turns out there
can be multiple rows for each claimant.

We need to munge these rows down to unique records so we can iterate
through them and safely create checks for each claim.

The claim reference, date of birth and QTS award year are all consistent
between grouped rows so we can use the first row's value. For the ITT
subject and degree JAC codes we need to collate and combine these values
from the multiple grouped rows.

As this new class is responsible for transforming the data in to a shape
we expect I used the opportunity to move the logic to do with
parsing the dates and transforming columns to arrays.
