### PR TITLE
User interface for undoing a decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - Exclude claims from previous academic years on matching claims screen
 - Fix a bug with automated DQT checks where the report has multiple rows for the
   same claim
+- Allow a claim's decision to be amended by a service operator
 
 ## [Release 066] - 2020-03-25
 

--- a/app/controllers/admin/decisions_undo_controller.rb
+++ b/app/controllers/admin/decisions_undo_controller.rb
@@ -1,0 +1,37 @@
+class Admin::DecisionsUndoController < Admin::BaseAdminController
+  before_action :load_claim
+  before_action :load_decision
+
+  before_action :ensure_service_operator
+
+  def new
+    @amendment = Amendment.new
+  end
+
+  def create
+    @amendment = Amendment.undo_decision(@decision, amendment_params)
+
+    if @amendment.persisted?
+      redirect_to admin_claim_path(@claim)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def load_claim
+    @claim = Claim.find(params[:claim_id])
+  end
+
+  def load_decision
+    @decision = @claim.decisions.find(params[:decision_id])
+  end
+
+  def amendment_params
+    {
+      notes: params[:amendment][:notes],
+      created_by: admin_user
+    }
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -291,7 +291,7 @@ class Claim < ApplicationRecord
   end
 
   def amendable?
-    submitted? && !decision_made? && !payrolled? && !personal_data_removed?
+    submitted? && !payrolled? && !personal_data_removed?
   end
 
   def decision_undoable?

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -150,6 +150,20 @@
         </div>
       <% end %>
     <% end %>
+
+    <% if @claim.latest_decision %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <p class="govuk-body">Claim decision</p>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body">
+            <strong><%= @claim.latest_decision.result.capitalize %></strong>
+            (<%= link_to "Undo decision", new_admin_claim_decision_undo_path(@claim, @claim.latest_decision), class: "govuk-link" %>)
+          </p>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
   <div class="govuk-grid-row">

--- a/app/views/admin/decisions_undo/new.html.erb
+++ b/app/views/admin/decisions_undo/new.html.erb
@@ -1,0 +1,40 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      Undo claim decision for claim <%= @claim.reference %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= render("shared/error_summary", instance: @amendment) if @amendment.errors.any? %>
+
+    <p class="govuk-body">
+      Claim <%= @claim.reference %> is currently <%= @claim.latest_decision.result %>. If you undo this
+      decision, the claim will be marked as undecided. You'll need to approve or reject this claim later.
+    </p>
+  </div>
+</div>
+
+<%= form_with url: admin_claim_decision_undos_path(@claim, @decision), scope: :amendment, model: @amendment do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-form-group">
+        <%= f.label :notes, "Change notes", class: "govuk-label" %>
+        <span class="govuk-hint">
+          Please write a brief note to explain why you're undoing this decision.
+        </span>
+        <%= f.text_area :notes, class: "govuk-textarea", rows: 5 %>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= f.submit t("admin.undo_decision.#{@claim.latest_decision.result}"), class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= link_to "Cancel", admin_claim_url(@claim), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,9 @@ en:
       identity_confirmation: "Confirm the claimant made the claim"
       payroll_gender: "Add a payroll gender for HMRC"
       student_loan_amount: "Check student loan amount"
+    undo_decision:
+      approved: "Undo approval"
+      rejected: "Undo rejection"
   answers:
     qts_award_years:
       before_cut_off_date: "In or before the academic year %{year}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,9 @@ Rails.application.routes.draw do
     resources :claims, only: [:index, :show] do
       resources :tasks, only: [:index, :show, :create], param: :name, constraints: {name: %r{#{ClaimCheckingTasks::TASK_NAMES.join("|")}}}
       resources :payroll_gender_tasks, only: [:create], param: :name, name: "payroll_gender"
-      resources :decisions, only: [:create, :new]
+      resources :decisions, only: [:create, :new] do
+        resources :undos, only: [:create, :new], controller: "decisions_undo"
+      end
       resources :amendments, only: [:new, :create]
       get "search", on: :collection
     end

--- a/spec/features/admin_amend_decision_spec.rb
+++ b/spec/features/admin_amend_decision_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "Undoing a claim's decision" do
+  let(:claim) { create(:claim, :rejected) }
+  let(:service_operator) { create(:dfe_signin_user, given_name: "Jo", family_name: "Bloggs") }
+
+  scenario "Service operator can undo a claim's decision" do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+
+    visit admin_claim_url(claim)
+
+    click_on "Amend claim"
+    click_on "Undo decision"
+
+    fill_in "Change notes", with: "Here are some notes"
+
+    expect { click_on "Undo rejection" }.to change { claim.reload.amendments.size }.by(1)
+
+    expect(claim.decisions.last.undone?).to eq(true)
+
+    amendment = claim.amendments.last
+
+    expect(amendment.claim).to eq(claim)
+    expect(amendment.notes).to eq("Here are some notes")
+    expect(amendment.claim_changes).to eq({decision: ["rejected", "undecided"]})
+
+    expect(page).to have_content("Decision\nchanged from rejected to undecided")
+    expect(page).to have_content("Change notes\nHere are some notes")
+  end
+end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe Amendment, type: :model do
   end
 
   it "is invalid if its claim is not amendable" do
-    amendment = build(:amendment, claim: create(:claim, :rejected))
+    claim = create(:claim, :approved)
+    create(:payment, claims: [claim])
+
+    amendment = build(:amendment, claim: claim)
     expect(amendment).not_to be_valid
 
     amendment.claim = build(:claim, :approved)

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -788,20 +788,20 @@ RSpec.describe Claim, type: :model do
       expect(claim.amendable?).to eq(true)
     end
 
-    it "returns false for an approved claim" do
+    it "returns true for an approved claim" do
       claim = create(:claim, :approved)
-      expect(claim.amendable?).to eq(false)
+      expect(claim.amendable?).to eq(true)
+    end
+
+    it "returns true for a rejected claim" do
+      claim = create(:claim, :rejected)
+      expect(claim.amendable?).to eq(true)
     end
 
     it "returns false for a payrolled claim" do
       claim = build(:claim, :approved)
       create(:payment, claims: [claim])
 
-      expect(claim.amendable?).to eq(false)
-    end
-
-    it "returns false for a rejected claim" do
-      claim = create(:claim, :rejected)
       expect(claim.amendable?).to eq(false)
     end
 

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -92,7 +92,8 @@ RSpec.describe "Admin claim amendments" do
       end
 
       context "when the claim is not amendable" do
-        let(:claim) { create(:claim, :rejected) }
+        let(:payment) { create(:payment, :with_figures) }
+        let(:claim) { create(:claim, :approved, payment: payment) }
 
         it "shows an error" do
           post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: claim.teacher_reference_number},

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe "Admin claims", type: :request do
         end
 
         context "when the claim is not amendable" do
-          let(:claim) { create(:claim, :rejected) }
+          let(:payment) { create(:payment, :with_figures) }
+          let(:claim) { create(:claim, :approved, payment: payment) }
 
           it "does not display a link to amend the claim" do
             get admin_claim_path(claim)

--- a/spec/requests/admin_undo_decisions_spec.rb
+++ b/spec/requests/admin_undo_decisions_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Undoing decisions", type: :request do
+  context "when signed in as a service operator" do
+    let(:service_operator) { create(:dfe_signin_user) }
+
+    before do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+    end
+
+    describe "#create" do
+      let(:claim) { create(:claim, :approved) }
+      let(:decision) { claim.latest_decision }
+
+      it "sets a decision to undone and creates an amendment record" do
+        post admin_claim_decision_undos_path(claim_id: claim.id, decision_id: decision.id), params: {
+          amendment: {
+            notes: "Here are some notes"
+          }
+        }
+
+        expect(response).to redirect_to(admin_claim_path(claim))
+
+        expect(decision.reload.undone?).to eq(true)
+        expect(claim.amendments.count).to eq(1)
+
+        amendment = claim.amendments.first
+
+        expect(amendment.claim).to eq(claim)
+        expect(amendment.notes).to eq("Here are some notes")
+        expect(amendment.claim_changes).to eq({decision: ["approved", "undecided"]})
+      end
+
+      it "does not save the decision or admendment if the claim has been subsequently paid" do
+        create(:payment, claims: [claim])
+
+        post admin_claim_decision_undos_path(claim_id: claim.id, decision_id: decision.id), params: {
+          amendment: {
+            notes: "Here are some notes"
+          }
+        }
+
+        expect(response.body).to include("This claim cannot have its decision undone")
+
+        expect(decision.reload.undone?).to eq(false)
+        expect(claim.amendments.count).to eq(0)
+      end
+
+      it "does not save the decision or amendment if the amendment is invalid" do
+        post admin_claim_decision_undos_path(claim_id: claim.id, decision_id: decision.id), params: {
+          amendment: {
+            notes: ""
+          }
+        }
+
+        expect(response.body).to include("Enter a message to explain why you are making this amendment")
+
+        expect(decision.reload.undone?).to eq(false)
+        expect(claim.amendments.count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This builds on #972 to add a UI to allow a decision to be undone. It works in a similar way to how other amendments are made, by adding creating an Amendment record with notes and details on what changes have been made.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/77648176-9fb16200-6f5f-11ea-93a6-f524e4f0b9ee.png)

![image](https://user-images.githubusercontent.com/109774/77648195-a7710680-6f5f-11ea-85f3-e532305f5a7a.png)

![image](https://user-images.githubusercontent.com/109774/77642615-daae9800-6f55-11ea-83ac-f845adeb9a95.png)

