### PR TITLE
Make the new task view primary

### DIFF
--- a/app/controllers/admin/amendments_controller.rb
+++ b/app/controllers/admin/amendments_controller.rb
@@ -11,7 +11,7 @@ class Admin::AmendmentsController < Admin::BaseAdminController
     @amendment = Amendment.amend_claim(@claim, claim_params, amendment_params)
 
     if @amendment.persisted?
-      redirect_to admin_claim_url(@claim)
+      redirect_to admin_claim_tasks_url(@claim), notice: "Claim has been amended successfully"
     else
       render "new"
     end

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -29,7 +29,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
     if @claims.none?
       flash.now[:notice] = "Cannot find a claim for query \"#{params[:query]}\""
     elsif @claims.one?
-      redirect_to(admin_claim_url(@claims.first))
+      redirect_to(admin_claim_tasks_url(@claims.first))
     end
   end
 

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -54,9 +54,7 @@
 
     <% if @decision.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
-    <% else %>
-      <%= render "admin/decisions/decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
-  <% end %>
+    <% end %>
   </div>
 
   <% if @claim.amendments.any? %>

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -55,7 +55,11 @@ RSpec.feature "Admin amends a claim" do
     expect(claim.bank_account_number).to eq("18929492")
     expect(claim.building_society_roll_number).to eq("JF 838281")
 
-    expect(current_url).to eq(admin_claim_url(claim))
+    expect(current_url).to eq(admin_claim_tasks_url(claim))
+
+    expect(page).to have_content("Claim has been amended successfully")
+
+    click_on "View full claim"
 
     expect(page).to have_content("Teacher reference number\nchanged from 1234567 to 7654321")
     expect(page).to have_content("Date of birth\nchanged from #{I18n.l(date_of_birth, format: :day_month_year)} to #{I18n.l(new_date_of_birth, format: :day_month_year)}")
@@ -123,6 +127,8 @@ RSpec.feature "Admin amends a claim" do
       expect(amendment.created_by).to eq(service_operator)
 
       expect(claim.eligibility.student_loan_repayment_amount).to eq(300)
+
+      click_on "View full claim"
 
       expect(page).to have_content("Student loan repayment amount\nchanged from £550.00 to £300.00")
 

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -88,37 +88,4 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(page).to have_content("You must select ‘Yes’ or ‘No’")
     expect(claim.tasks.find_by(name: "qualifications")).to be_nil
   end
-
-  scenario "service operator checks and approves a Maths & Physics claim where the claimant did not complete GOV.UK Verify" do
-    claim = create(:claim, :unverified, policy: MathsAndPhysics)
-
-    visit admin_claims_path
-    find("a[href='#{admin_claim_tasks_path(claim)}']").click
-
-    expect(page).to have_content("1. Qualifications")
-    expect(page).to have_content("2. Employment")
-    expect(page).to have_content("3. Identity confirmation")
-    expect(page).to have_content("4. Decision")
-
-    click_on I18n.t("admin.tasks.identity_confirmation")
-
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.identity_confirmation", name: claim.full_name))
-    expect(page).to have_content(claim.eligibility.current_school.name)
-    expect(page).to have_content(claim.eligibility.current_school.phone_number)
-
-    choose "Yes"
-    click_on "Save and continue"
-
-    expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
-
-    expect(page).to have_content("Claim decision")
-
-    choose "Approve"
-    fill_in "Decision notes", with: "All checks passed!"
-    click_on "Confirm decision"
-
-    expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.latest_decision).to be_approved
-    expect(claim.latest_decision.created_by).to eq(user)
-  end
 end

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -92,36 +92,4 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     expect(page).to have_content("Claim decision")
   end
-
-  scenario "service operator checks and approves a Student Loans claim where the claimant did not complete GOV.UK Verify" do
-    claim = create(
-      :claim,
-      :unverified,
-      policy: StudentLoans,
-      student_loan_plan: StudentLoan::PLAN_2,
-      eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: "1987.65")
-    )
-
-    visit admin_claims_path
-    find("a[href='#{admin_claim_tasks_path(claim)}']").click
-
-    expect(page).to have_content("1. Qualifications")
-    expect(page).to have_content("2. Employment")
-    expect(page).to have_content("3. Student loan amount")
-    expect(page).to have_content("4. Identity confirmation")
-    expect(page).to have_content("5. Decision")
-
-    click_on I18n.t("admin.tasks.identity_confirmation")
-
-    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.identity_confirmation", name: claim.full_name))
-    expect(page).to have_content(claim.eligibility.current_school.name)
-    expect(page).to have_content(claim.eligibility.current_school.phone_number)
-
-    choose "Yes"
-    click_on "Save and continue"
-
-    expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
-
-    expect(page).to have_content("Claim decision")
-  end
 end

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -25,7 +25,8 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
 
     click_on "View claims"
     find("a[href='#{admin_claim_tasks_path(second_inconsistent_claim)}']").click
-    click_on "View full claim"
+
+    click_on "Approve or reject this claim"
 
     expect(page).to have_field("Approve", disabled: true)
     expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")
@@ -37,6 +38,9 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
     click_on "Amend claim"
 
     expect(second_inconsistent_claim.reload).to be_approvable
+
+    click_on "View tasks"
+    click_on "Approve or reject this claim"
 
     choose "Approve"
     fill_in "Decision notes", with: "Everything matches"

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -39,7 +39,6 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
 
     expect(second_inconsistent_claim.reload).to be_approvable
 
-    click_on "View tasks"
     click_on "Approve or reject this claim"
 
     choose "Approve"

--- a/spec/features/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin_claim_without_verified_identity_spec.rb
@@ -7,21 +7,30 @@ RSpec.feature "Admin checking a claim without a verified identity" do
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
   end
 
-  scenario "the service operator is told the identity hasn't been confirmed and can approve the claim" do
-    claim_without_identity_confirmation = create(:claim, :unverified)
+  scenario "the service operator can do a manual identity check and approve the claim" do
+    unverified_claim = create(:claim, :unverified)
 
     click_on "View claims"
-    find("a[href='#{admin_claim_tasks_path(claim_without_identity_confirmation)}']").click
-    click_on "View full claim"
+    find("a[href='#{admin_claim_tasks_path(unverified_claim)}']").click
 
-    expect(page).to have_content("The claimant did not complete GOV.UK Verify")
-    expect(page).to have_content(claim_without_identity_confirmation.school.phone_number)
+    expect(page).to have_content("4. Identity confirmation")
+
+    click_on I18n.t("admin.tasks.identity_confirmation")
+
+    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.identity_confirmation", name: unverified_claim.full_name))
+    expect(page).to have_content(unverified_claim.eligibility.current_school.name)
+    expect(page).to have_content(unverified_claim.eligibility.current_school.phone_number)
+
+    choose "Yes"
+    click_on "Save and continue"
+
+    expect(unverified_claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
 
     choose "Approve"
     fill_in "Decision notes", with: "Identity confirmed via phone call"
     click_on "Confirm decision"
 
-    expect(claim_without_identity_confirmation.latest_decision.created_by).to eq(user)
-    expect(claim_without_identity_confirmation.latest_decision.notes).to eq("Identity confirmed via phone call")
+    expect(unverified_claim.latest_decision.created_by).to eq(user)
+    expect(unverified_claim.latest_decision.notes).to eq("Identity confirmed via phone call")
   end
 end

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Admin claim amendments" do
                                                              notes: "Claimant made a typo"})
         }.to change { claim.reload.amendments.size }.by(1)
 
-        expect(response).to redirect_to(admin_claim_url(claim))
+        expect(response).to redirect_to(admin_claim_tasks_url(claim))
 
         amendment = claim.amendments.last
         expect(amendment.claim_changes).to eq({
@@ -38,7 +38,7 @@ RSpec.describe "Admin claim amendments" do
       it "saves the normalised value in the amendment when updating bank sort code" do
         post admin_claim_amendments_url(claim, amendment: {claim: {bank_sort_code: "11 12 13"}, notes: "Claimant made a typo"})
 
-        expect(response).to redirect_to(admin_claim_url(claim))
+        expect(response).to redirect_to(admin_claim_tasks_url(claim))
 
         expect(claim.reload.amendments.last.claim_changes).to eq({"bank_sort_code" => ["010203", "111213"]})
         expect(claim.bank_sort_code).to eq("111213")
@@ -50,7 +50,7 @@ RSpec.describe "Admin claim amendments" do
         post admin_claim_amendments_url(claim, amendment: {claim: {bank_sort_code: "111213", building_society_roll_number: ""},
                                                            notes: "Claimant made a typo"})
 
-        expect(response).to redirect_to(admin_claim_url(claim))
+        expect(response).to redirect_to(admin_claim_tasks_url(claim))
 
         expect(claim.reload.amendments.last.claim_changes).to eq({"bank_sort_code" => ["010203", "111213"]})
       end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Admin claims", type: :request do
     it "redirects to a claim when one exists" do
       get search_admin_claims_path(query: claim1.reference)
 
-      expect(response).to redirect_to(admin_claim_path(claim1))
+      expect(response).to redirect_to(admin_claim_tasks_path(claim1))
     end
 
     it "shows a list of matching claims if there are more than one" do


### PR DESCRIPTION
We have now switched both policies to using the new "task"-based UI as the primary interface for viewing and checking claims, but there are still a few things that either only exist on the old "full view", or bits of interaction that assume the old "full view" is the main screen for viewing a claim.

- Remove the "decision" form from the "full claim" view. There should only be one place where a user decides the outcome of a claim.
- Searching for a claim should take the user to the "tasks" view, not the "full claim" view.
- Amending a claim should take the user back to the "tasks" view, not the "full claim" view.
