### PR TITLE
Update vsp keys and certs on development

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -192,7 +192,7 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsDevVspSamlSigning6KeyBase64"
+        "secretName": "TeacherPaymentsDevVspSamlSigning7KeyBase64"
       }
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -200,7 +200,7 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
+        "secretName": "TeacherPaymentsDevVspSamlEncryption7KeyBase64"
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {


### PR DESCRIPTION
We're now self-signing certificates for the GOV.UK Verify VSP. This updates development to use the newly created key and certificate that we generated for testing purposes.