### PR TITLE
Run the automated DQT checks in a transaction

### DIFF
--- a/app/controllers/admin/qualification_report_uploads_controller.rb
+++ b/app/controllers/admin/qualification_report_uploads_controller.rb
@@ -15,6 +15,8 @@ module Admin
       else
         render :new
       end
+    rescue ActiveRecord::RecordInvalid
+      redirect_to new_admin_qualification_report_upload_path, alert: "There was a problem, please try again"
     end
   end
 end


### PR DESCRIPTION
There's a potential race condition where a user could manually complete
a qualification task at the same time (after `Claim.awaiting_task`) and
cause an exception to occur. By wrapping the process in a transaction
we can make the script fail gracefully.
