### PR TITLE
DfE Sign-in specs refactoring

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def sign_out
       session.destroy
-      redirect_to admin_root_path, notice: "You've been signed out"
+      redirect_to admin_sign_in_path, notice: "You've been signed out"
     end
 
     def callback

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -12,11 +12,10 @@ RSpec.feature "Admin amends a claim" do
       building_society_roll_number: "RN 123456")
   end
   let(:date_of_birth) { 25.years.ago.to_date }
-  let(:service_operator) { create(:dfe_signin_user, given_name: "Jo", family_name: "Bloggs") }
+
+  before { @signed_in_user = sign_in_as_service_operator }
 
   scenario "Service operator amends a claim" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
-
     visit admin_claim_url(claim)
 
     click_on "Amend claim"
@@ -46,7 +45,7 @@ RSpec.feature "Admin amends a claim" do
       "building_society_roll_number" => ["RN 123456", "JF 838281"]
     })
     expect(amendment.notes).to eq("This claimant got some of their details wrong and then contacted us")
-    expect(amendment.created_by).to eq(service_operator)
+    expect(amendment.created_by).to eq(@signed_in_user)
 
     expect(claim.reload.teacher_reference_number).to eq("7654321")
     expect(claim.date_of_birth).to eq(new_date_of_birth)
@@ -69,12 +68,10 @@ RSpec.feature "Admin amends a claim" do
     expect(page).to have_content("Building society roll number\nchanged from RN 123456 to JF 838281")
 
     expect(page).to have_content("This claimant got some of their details wrong and then contacted us")
-    expect(page).to have_content("by Jo Bloggs on #{I18n.l(Time.current)}")
+    expect(page).to have_content("by #{@signed_in_user.full_name} on #{I18n.l(Time.current)}")
   end
 
   scenario "Service operator cancels amending a claim" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
-
     visit admin_claim_url(claim)
 
     click_on "Amend claim"
@@ -94,8 +91,6 @@ RSpec.feature "Admin amends a claim" do
       "bank_account_number" => nil
     })
 
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
-
     visit admin_claim_amendments_url(claim)
 
     expect(page).to have_content("Teacher reference number\nchanged from 7654321 to 1234567")
@@ -109,8 +104,6 @@ RSpec.feature "Admin amends a claim" do
     end
 
     scenario "Service operator amends the student loan repayment amount" do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
-
       visit admin_claim_url(claim)
 
       click_on "Amend claim"
@@ -124,7 +117,7 @@ RSpec.feature "Admin amends a claim" do
         "student_loan_repayment_amount" => [550, 300]
       })
       expect(amendment.notes).to eq("The claimant calculated the incorrect student loan repayment amount")
-      expect(amendment.created_by).to eq(service_operator)
+      expect(amendment.created_by).to eq(@signed_in_user)
 
       expect(claim.eligibility.student_loan_repayment_amount).to eq(300)
 
@@ -133,7 +126,7 @@ RSpec.feature "Admin amends a claim" do
       expect(page).to have_content("Student loan repayment amount\nchanged from £550.00 to £300.00")
 
       expect(page).to have_content("The claimant calculated the incorrect student loan repayment amount")
-      expect(page).to have_content("by Jo Bloggs on #{I18n.l(Time.current)}")
+      expect(page).to have_content("by #{@signed_in_user.full_name} on #{I18n.l(Time.current)}")
     end
   end
 end

--- a/spec/features/admin_amend_decision_spec.rb
+++ b/spec/features/admin_amend_decision_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 RSpec.feature "Undoing a claim's decision" do
   let(:claim) { create(:claim, :rejected) }
-  let(:service_operator) { create(:dfe_signin_user, given_name: "Jo", family_name: "Bloggs") }
 
   scenario "Service operator can undo a claim's decision" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+    signed_in_user = sign_in_as_service_operator
 
     visit admin_claim_url(claim)
 
@@ -28,5 +27,6 @@ RSpec.feature "Undoing a claim's decision" do
 
     expect(page).to have_content("Decision\nchanged from rejected to undecided")
     expect(page).to have_content("Change notes\nHere are some notes")
+    expect(page).to have_content("by #{signed_in_user.full_name}")
   end
 end

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admins automated qualification check" do
-  let(:user) { create(:dfe_signin_user) }
-
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { sign_in_as_service_operator }
 
   scenario "Service operators can upload and run automated DQT checks" do
     eligible_claim_with_matching_data = claim_from_example_dqt_report(:eligible_claim_with_matching_data)

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -1,13 +1,9 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a Maths & Physics claim" do
-  let(:user) { create(:dfe_signin_user) }
-
   let!(:claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
 
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { @signed_in_user = sign_in_as_service_operator }
 
   scenario "service operator checks and approves a Maths & Physics claim" do
     visit admin_claims_path
@@ -45,7 +41,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
 
     expect(page).to have_content("Claim has been approved successfully")
     expect(claim.latest_decision).to be_approved
-    expect(claim.latest_decision.created_by).to eq(user)
+    expect(claim.latest_decision.created_by).to eq(@signed_in_user)
   end
 
   scenario "service operator can check a claim with matching details" do

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a Student Loans claim" do
-  let(:user) { create(:dfe_signin_user) }
-
   let!(:claim) {
     create(
       :claim,
@@ -13,9 +11,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
     )
   }
 
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { @signed_in_user = sign_in_as_service_operator }
 
   scenario "service operator checks and approves a Student Loans claim" do
     visit admin_claims_path
@@ -63,7 +59,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     expect(page).to have_content("Claim has been approved successfully")
     expect(claim.latest_decision).to be_approved
-    expect(claim.latest_decision.created_by).to eq(user)
+    expect(claim.latest_decision.created_by).to eq(@signed_in_user)
   end
 
   scenario "service operator can check a claim with matching details" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -109,40 +109,6 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content("Created by")
       expect(page).to have_content(user.full_name)
     end
-
-    context "when the service operator completes the last checking task" do
-      context "and the claimant has another approved claim in the same payroll window, with inconsistent personal details" do
-        let(:personal_details) do
-          {
-            national_insurance_number: generate(:national_insurance_number),
-            teacher_reference_number: generate(:teacher_reference_number),
-            date_of_birth: 30.years.ago.to_date,
-            student_loan_plan: StudentLoan::PLAN_1,
-            email_address: "email@example.com",
-            bank_sort_code: "112233",
-            bank_account_number: "95928482",
-            building_society_roll_number: nil
-          }
-        end
-        let!(:approved_claim) { create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823")) }
-        let!(:claim) { create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752")) }
-
-        scenario "User is informed that the claim cannot be approved" do
-          perform_last_task(claim)
-
-          expect(page).to have_field("Approve", disabled: true)
-          expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")
-        end
-      end
-
-      def perform_last_task(claim)
-        applicable_task_names = ClaimCheckingTasks.new(claim).applicable_task_names
-        visit admin_claim_task_path(claim, name: applicable_task_names.last)
-
-        choose "Yes"
-        click_on "Save and continue"
-      end
-    end
   end
 
   context "User is logged in as a payroll operator or a support user" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -1,12 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Admin checks a claim" do
-  let(:user) { create(:dfe_signin_user) }
-
   context "User is logged in as a service operator" do
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-    end
+    before { @signed_in_user = sign_in_as_service_operator }
 
     scenario "User can approve a claim" do
       freeze_time do
@@ -26,7 +22,7 @@ RSpec.feature "Admin checks a claim" do
         fill_in "Decision notes", with: "Everything matches"
         perform_enqueued_jobs { click_on "Confirm decision" }
 
-        expect(claim_to_approve.latest_decision.created_by).to eq(user)
+        expect(claim_to_approve.latest_decision.created_by).to eq(@signed_in_user)
         expect(claim_to_approve.latest_decision.notes).to eq("Everything matches")
 
         expect(page).to have_content("Claim has been approved successfully")
@@ -59,7 +55,7 @@ RSpec.feature "Admin checks a claim" do
       fill_in "Decision notes", with: "TRN doesn't exist"
       perform_enqueued_jobs { click_on "Confirm decision" }
 
-      expect(claim_to_reject.latest_decision.created_by).to eq(user)
+      expect(claim_to_reject.latest_decision.created_by).to eq(@signed_in_user)
       expect(claim_to_reject.latest_decision.notes).to eq("TRN doesn't exist")
 
       expect(page).to have_content("Claim has been rejected successfully")
@@ -107,7 +103,7 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content("Approved")
       expect(page).to have_content(claim_with_decision.latest_decision.notes)
       expect(page).to have_content("Created by")
-      expect(page).to have_content(user.full_name)
+      expect(page).to have_content(@signed_in_user.full_name)
     end
   end
 

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a claim with inconsistent payroll information" do
-  let(:user) { create(:dfe_signin_user) }
   let(:personal_details) do
     {
       national_insurance_number: generate(:national_insurance_number),
@@ -15,9 +14,7 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
     }
   end
 
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { sign_in_as_service_operator }
 
   scenario "cannot approve a second claim from an individual whilst the payroll information on the claims is inconsistent" do
     approved_claim = create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823"))

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a claim missing a payroll gender" do
-  let(:user) { create(:dfe_signin_user) }
-
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { @signed_in_user = sign_in_as_service_operator }
 
   scenario "service operator can add a payroll gender as part of the checking process" do
     claim = create(:claim, :submitted, policy: StudentLoans, payroll_gender: :dont_know)
@@ -41,6 +37,6 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
 
     expect(page).to have_content("Claim has been approved successfully")
     expect(claim.latest_decision).to be_approved
-    expect(claim.latest_decision.created_by).to eq(user)
+    expect(claim.latest_decision.created_by).to eq(@signed_in_user)
   end
 end

--- a/spec/features/admin_claim_without_personal_data_spec.rb
+++ b/spec/features/admin_claim_without_personal_data_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a claim with personal data removed" do
-  let(:user) { create(:dfe_signin_user) }
-
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { sign_in_as_service_operator }
 
   scenario "the service operator sees that the personal data has been removed" do
     claim_with_personal_data_removed = create(:claim, :rejected, :personal_data_removed)

--- a/spec/features/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin_claim_without_verified_identity_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a claim without a verified identity" do
-  let(:user) { create(:dfe_signin_user) }
-
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { @signed_in_user = sign_in_as_service_operator }
 
   scenario "the service operator can do a manual identity check and approve the claim" do
     unverified_claim = create(:claim, :unverified)
@@ -30,7 +26,7 @@ RSpec.feature "Admin checking a claim without a verified identity" do
     fill_in "Decision notes", with: "Identity confirmed via phone call"
     click_on "Confirm decision"
 
-    expect(unverified_claim.latest_decision.created_by).to eq(user)
+    expect(unverified_claim.latest_decision.created_by).to eq(@signed_in_user)
     expect(unverified_claim.latest_decision.notes).to eq("Identity confirmed via phone call")
   end
 end

--- a/spec/features/admin_claims_filtering_spec.rb
+++ b/spec/features/admin_claims_filtering_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admin claim filtering" do
-  let(:user) { create(:dfe_signin_user) }
-
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-  end
+  before { sign_in_as_service_operator }
 
   scenario "the service operator can filter claims by policy" do
     maths_and_physics_claims = create_list(:claim, 3, :submitted, policy: MathsAndPhysics)

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Service configuration" do
     js_status = javascript_enabled ? "enabled" : "disabled"
 
     scenario "Service operator closes a service for submissions, with JavaScript #{js_status}", js: javascript_enabled do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      sign_in_as_service_operator
 
       click_on "Manage services"
 
@@ -40,7 +40,7 @@ RSpec.feature "Service configuration" do
   scenario "Service operator opens a service for submissions" do
     policy_configuration.update(open_for_submissions: false)
 
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     click_on "Manage services"
 
@@ -67,7 +67,7 @@ RSpec.feature "Service configuration" do
 
   scenario "Service operator changes the academic year a service is accepting payments for" do
     travel_to Date.new(2023) do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      sign_in_as_service_operator
 
       click_on "Manage services"
 

--- a/spec/features/admin_data_report_request_spec.rb
+++ b/spec/features/admin_data_report_request_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Data report request" do
   scenario "Service operator can download an external data report request file" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     claims = create_list(:claim, 3, :submitted)
 

--- a/spec/features/admin_duplicate_claims_spec.rb
+++ b/spec/features/admin_duplicate_claims_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Service operator can see potential duplicate claims" do
   before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
   end
 
   scenario "they are shown other claims with matching details" do

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Payroll" do
-  let(:user) { create(:dfe_signin_user) }
   let!(:dataset_post_stub) { stub_geckoboard_dataset_update("claims.test") }
 
-  scenario "Service operator creates a payroll run" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  before { @signed_in_user = sign_in_as_service_operator }
 
+  scenario "Service operator creates a payroll run" do
     click_on "Payroll"
 
     create(:claim, :approved, policy: MathsAndPhysics)
@@ -25,7 +24,7 @@ RSpec.feature "Payroll" do
     payroll_run = PayrollRun.order(:created_at).last
 
     expect(page).to have_content("Approved claims 3")
-    expect(page).to have_content("Created by #{user.full_name}")
+    expect(page).to have_content("Created by #{@signed_in_user.full_name}")
     expect(page).to have_content("Total award amount £4,000")
     expect(page).to have_content("Payroll run created")
     expect(page).to have_field("payroll_run_download_link", with: new_admin_payroll_run_download_url(payroll_run))
@@ -34,7 +33,6 @@ RSpec.feature "Payroll" do
   context "when a payroll run already exists for the month" do
     scenario "Service operator cannot create a new payroll run" do
       create(:payroll_run, claims_counts: {StudentLoans => 2}, created_at: 5.minutes.ago)
-      sign_in_as_service_operator
 
       visit admin_payroll_runs_path
 
@@ -43,8 +41,6 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Any claims approved in the meantime are not included" do
-    sign_in_as_service_operator
-
     click_on "Payroll"
 
     expected_claims = create_list(:claim, 3, :approved)
@@ -63,8 +59,6 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can view a list of previous payroll runs" do
-    sign_in_as_service_operator
-
     first_payroll_run = create(:payroll_run, created_at: Time.zone.now - 1.month)
     last_payroll_run = create(:payroll_run, created_at: Time.zone.now)
 
@@ -80,8 +74,6 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can view a payroll run" do
-    sign_in_as_service_operator
-
     payroll_run = create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1})
 
     click_on "Payroll"
@@ -100,7 +92,6 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can remove a payment from a payroll run" do
-    sign_in_as_service_operator
     payroll_run = create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1})
     payment_to_delete = payroll_run.payments.first
     claim_reference = payment_to_delete.claims.first.reference
@@ -123,8 +114,6 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can upload a Payment Confirmation Report against a payroll run" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-
     payroll_run = create(:payroll_run, claims_counts: {StudentLoans => 2})
 
     click_on "Payroll"
@@ -150,7 +139,7 @@ RSpec.feature "Payroll" do
 
     expect(page.find("table")).to have_content("Uploaded")
 
-    expect(payroll_run.reload.confirmation_report_uploaded_by).to eq(user)
+    expect(payroll_run.reload.confirmation_report_uploaded_by).to eq(@signed_in_user)
     expect(payroll_run.payments[0].reload.gross_value).to eq("487.48".to_d)
 
     expect(ActionMailer::Base.deliveries.count).to eq(2)

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Payroll" do
   context "when a payroll run already exists for the month" do
     scenario "Service operator cannot create a new payroll run" do
       create(:payroll_run, claims_counts: {StudentLoans => 2}, created_at: 5.minutes.ago)
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      sign_in_as_service_operator
 
       visit admin_payroll_runs_path
 
@@ -43,7 +43,7 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Any claims approved in the meantime are not included" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     click_on "Payroll"
 
@@ -63,7 +63,7 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can view a list of previous payroll runs" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     first_payroll_run = create(:payroll_run, created_at: Time.zone.now - 1.month)
     last_payroll_run = create(:payroll_run, created_at: Time.zone.now)
@@ -80,7 +80,7 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can view a payroll run" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     payroll_run = create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1})
 
@@ -100,7 +100,7 @@ RSpec.feature "Payroll" do
   end
 
   scenario "Service operator can remove a payment from a payroll run" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
     payroll_run = create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1})
     payment_to_delete = payroll_run.payments.first
     claim_reference = payment_to_delete.claims.first.reference

--- a/spec/features/admin_search_spec.rb
+++ b/spec/features/admin_search_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admin search" do
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-  end
+  before { sign_in_as_service_operator }
 
   let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
   let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }

--- a/spec/features/admin_sessions_spec.rb
+++ b/spec/features/admin_sessions_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.feature "Admin session management" do
   scenario "A user is redirected to the admin root path after sign in" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     expect(page).to have_link("Sign out")
     expect(current_path).to eql(admin_root_path)
   end
 
   scenario "A signed in user can sign out" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     click_on "Sign out"
     expect(page).to have_content("You've been signed out")
@@ -21,7 +21,7 @@ RSpec.feature "Admin session management" do
 
     expect(current_path).to eql(admin_sign_in_path)
 
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
 
     expect(current_path).to eql(admin_claims_path)
   end

--- a/spec/features/admin_stats_spec.rb
+++ b/spec/features/admin_stats_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Admin stats" do
     @unfinished_claims = create_list(:claim, 1, :submittable)
     @claims_approaching_deadline = create_list(:claim, 2, :submitted, submitted_at: (Claim::DECISION_DEADLINE - 1.week).ago)
     @claims_passed_deadline = create_list(:claim, 1, :submitted, submitted_at: (Claim::DECISION_DEADLINE + 1.week).ago)
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
     visit admin_root_path
   end
 

--- a/spec/features/admin_timeout_spec.rb
+++ b/spec/features/admin_timeout_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Admin user session timeout", js: true do
     allow_any_instance_of(Admin::BaseAdminController).to receive(:admin_timeout_in_minutes) { two_seconds_in_minutes }
     allow_any_instance_of(Admin::BaseAdminController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
 
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_as_service_operator
   end
 
   scenario "Dialog warns user their session will timeout" do

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe "Admin claim amendments" do
   let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567", bank_sort_code: "010203", date_of_birth: 25.years.ago.to_date) }
 
   context "when signed in as a service operator" do
-    let(:service_operator) { create(:dfe_signin_user) }
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
-    end
+    before { @signed_in_user = sign_in_as_service_operator }
 
     describe "admin/amendments#index" do
       let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567") }
@@ -40,7 +37,7 @@ RSpec.describe "Admin claim amendments" do
         })
         expect(amendment.claim_changes).to be_a(Hash)
         expect(amendment.notes).to eq("Claimant made a typo")
-        expect(amendment.created_by).to eq(service_operator)
+        expect(amendment.created_by).to eq(@signed_in_user)
 
         expect(claim.teacher_reference_number).to eq("7654321")
         expect(claim.bank_sort_code).to eq("111213")

--- a/spec/requests/admin_authentication_spec.rb
+++ b/spec/requests/admin_authentication_spec.rb
@@ -1,128 +1,103 @@
 require "rails_helper"
 
 RSpec.describe "Admin authentication", type: :request do
-  describe "admin#index request" do
-    context "when the user is not authenticated" do
-      it "redirects to the sign in page and doesn’t set a session" do
-        get admin_root_path
+  describe "admin requests when not authenticated" do
+    it "redirects to the sign in page without setting a session" do
+      get admin_root_path
 
-        expect(response).to redirect_to(admin_sign_in_path)
-        expect(session[:user_id]).to be_nil
+      expect(response).to redirect_to(admin_sign_in_path)
+      expect(session[:user_id]).to be_nil
+    end
+  end
+
+  describe "admin/auth#callback" do
+    context "when the user is signing in for the first time" do
+      let(:dfe_sign_in_user_id) { SecureRandom.uuid }
+
+      it "creates a DfeSignIn::User record for the user and redirects to the admin root, setting the session ID" do
+        expect {
+          stub_dfe_sign_in_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_user_id)
+          post admin_dfe_sign_in_path
+          expect(response).to redirect_to(admin_auth_callback_path)
+          follow_redirect!
+        }.to change { DfeSignIn::User.count }.by(1)
+
+        new_user = DfeSignIn::User.last
+
+        expect(response).to redirect_to(admin_root_path)
+        expect(session[:user_id]).to eq(new_user.id)
+
+        expect(new_user.dfe_sign_in_id).to eq(dfe_sign_in_user_id)
+        expect(new_user.role_codes).to eq([DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
       end
     end
 
-    context "when the user is authenticated" do
-      let(:dfe_sign_in_id) { "userid-345" }
+    context "when the user already has a DfeSignIn::User record" do
+      let!(:user) { create(:dfe_signin_user, role_codes: []) }
 
-      let!(:user) { create(:dfe_signin_user, dfe_sign_in_id: dfe_sign_in_id) }
-
-      context "when the user is a service operator" do
-        before do
-          sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
-        end
-
-        it "renders the admin page, sets a session and applies the appropriate role to the user" do
-          get admin_root_path
-
-          expect(response).to be_successful
-          expect(response.body).to include("Sign out")
-
-          expect(user.reload.role_codes).to eq([DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
-
-          expect(session[:user_id]).to eq(user.id)
-        end
-
-        context "and they sign out" do
-          it "unsets the session" do
-            delete admin_sign_out_path
-
-            expect(session[:user_id]).to be_nil
-          end
-        end
-      end
-
-      context "when the user is a support user" do
-        before do
-          sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
-        end
-
-        it "renders the admin page, sets a session and applies the appropriate role to the user" do
-          get admin_root_path
-
-          expect(response).to be_successful
-          expect(response.body).to include("Sign out")
-
-          expect(user.reload.role_codes).to eq([DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE])
-
-          expect(session[:user_id]).to eq(user.id)
-        end
-      end
-
-      context "when the user is a payroll operator" do
-        before do
-          sign_in_to_admin_with_role(DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
-        end
-
-        it "renders the page, sets a session and applies the appropriate role to the user" do
-          payroll_run = create(:payroll_run)
-
-          get new_admin_payroll_run_download_path(payroll_run)
-
-          expect(response).to be_successful
-
-          expect(user.reload.role_codes).to eq([DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
-
-          expect(session[:user_id]).to eq(user.id)
-        end
-      end
-
-      context "when the user is not authorised to access the service" do
-        before do
-          sign_in_to_admin_with_role("not-the-role-code-we-expect")
-        end
-
-        it "shows a not authorised page and doesn’t set a session" do
-          expect(session[:user_id]).to be_nil
-
-          expect(response.code).to eq("401")
-          expect(response.body).to include("Not authorised")
-        end
-      end
-    end
-
-    context "when the user fails authentication" do
-      before do
-        OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
-      end
-
-      it "shows a not authorised page and doesn’t set a session" do
+      it "updates the existing DfeSignIn::User record and redirects to the admin root, setting the session ID" do
+        stub_dfe_sign_in_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
         post admin_dfe_sign_in_path
+        expect(response).to redirect_to(admin_auth_callback_path)
+        follow_redirect!
+
+        expect(response).to redirect_to(admin_root_path)
+        expect(session[:user_id]).to eq(user.id)
+        expect(user.reload.role_codes).to eq([DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
+      end
+    end
+
+    context "when the user requests an authenticated page without having signed in" do
+      let(:initial_request_path) { admin_payroll_runs_path }
+
+      before { get initial_request_path }
+
+      it "redirects the user to their originally requested page after they sign in" do
+        stub_dfe_sign_in_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+        post admin_dfe_sign_in_path
+        expect(response).to redirect_to(admin_auth_callback_path)
+        follow_redirect!
+
+        expect(response).to redirect_to(initial_request_path)
+      end
+    end
+
+    context "when the user does not have an authorised role" do
+      it "returns an Unauthorised response and doesn’t set a session" do
+        stub_dfe_sign_in_with_role("not-the-role-code-we-expect")
+        post admin_dfe_sign_in_path
+        expect(response).to redirect_to(admin_auth_callback_path)
         follow_redirect!
 
         expect(session[:user_id]).to be_nil
 
-        expect(response.body).to redirect_to(
+        expect(response.code).to eq("401")
+        expect(response.body).to include("Not authorised")
+      end
+    end
+
+    context "when the callback from DfE Sign-in is for invalid credentials" do
+      it "redirects to the auth failure page and doesn’t set a session" do
+        OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
+        post admin_dfe_sign_in_path
+        expect(response).to redirect_to(admin_auth_callback_path)
+        follow_redirect!
+
+        expect(session[:user_id]).to be_nil
+
+        expect(response).to redirect_to(
           admin_auth_failure_path(message: :invalid_credentials, strategy: :dfe)
         )
       end
     end
+  end
 
-    context "when a local DfeSignIn::User record matching the DfE Sign-in ID does not exist" do
-      let(:dfe_sign_in_id) { "userid-345" }
+  describe "admin/auth#sign_out" do
+    it "clears the session and redirects the user to the sign-in page" do
+      delete admin_sign_out_path
 
-      it "creates a DfeSignIn::User record and sets the record ID in the session" do
-        expect {
-          sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
-        }.to change {
-          DfeSignIn::User.count
-        }.by(1)
-
-        user = DfeSignIn::User.last
-        expect(user.dfe_sign_in_id).to eq(dfe_sign_in_id)
-        expect(user.role_codes).to eq([DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
-
-        expect(session[:user_id]).to eq(user.id)
-      end
+      expect(session[:user_id]).to be_nil
+      expect(response).to redirect_to(admin_sign_in_path)
     end
   end
 end

--- a/spec/requests/admin_authentication_spec.rb
+++ b/spec/requests/admin_authentication_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Admin", type: :request do
+RSpec.describe "Admin authentication", type: :request do
   describe "admin#index request" do
     context "when the user is not authenticated" do
       it "redirects to the sign in page and doesn’t set a session" do

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin claims", type: :request do
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-  end
+  before { sign_in_as_service_operator }
 
   describe "claims#index" do
     let!(:claims) { create_list(:claim, 3, :submitted) }

--- a/spec/requests/admin_configure_services_spec.rb
+++ b/spec/requests/admin_configure_services_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe "Service configuration" do
   let(:policy_configuration) { policy_configurations(:student_loans) }
 
   context "when signed in as a service operator" do
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-    end
+    before { sign_in_as_service_operator }
 
     describe "admin_policy_configurations#update" do
       it "sets the configuration's availability message and status" do

--- a/spec/requests/admin_decisions_spec.rb
+++ b/spec/requests/admin_decisions_spec.rb
@@ -2,11 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Admin decisions", type: :request do
   context "when signed in as a service operator" do
-    let(:user) { create(:dfe_signin_user) }
     let(:claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
 
     before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+      @signed_in_user = sign_in_as_service_operator
       @dataset_post_stub = stub_geckoboard_dataset_update
     end
 
@@ -69,7 +68,7 @@ RSpec.describe "Admin decisions", type: :request do
 
         expect(response.body).to include("Claim has been approved successfully")
 
-        expect(claim.latest_decision.created_by).to eq(user)
+        expect(claim.latest_decision.created_by).to eq(@signed_in_user)
         expect(claim.latest_decision.result).to eq("approved")
       end
 
@@ -80,7 +79,7 @@ RSpec.describe "Admin decisions", type: :request do
 
         expect(response.body).to include("Claim has been rejected successfully")
 
-        expect(claim.latest_decision.created_by).to eq(user)
+        expect(claim.latest_decision.created_by).to eq(@signed_in_user)
         expect(claim.latest_decision.result).to eq("rejected")
       end
 

--- a/spec/requests/admin_payment_confirmation_report_upload_spec.rb
+++ b/spec/requests/admin_payment_confirmation_report_upload_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
   let!(:dataset_post_stub) { stub_geckoboard_dataset_update("claims.test") }
 
   context "when signed in as a service operator" do
-    let(:admin) { create(:dfe_signin_user) }
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
-    end
+    before { @signed_in_user = sign_in_as_service_operator }
 
     describe "payment_confirmation_report_uploads#new" do
       it "returns an OK response" do
@@ -42,7 +39,7 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
           expect(payroll_run.payments[0].reload.payroll_reference).to eq("DFE00001")
           expect(payroll_run.payments[1].reload.payroll_reference).to eq("DFE00002")
 
-          expect(payroll_run.reload.confirmation_report_uploaded_by).to eq(admin)
+          expect(payroll_run.reload.confirmation_report_uploaded_by).to eq(@signed_in_user)
 
           expect(ActionMailer::Base.deliveries.count).to eq(2)
 

--- a/spec/requests/admin_payroll_gender_tasks_spec.rb
+++ b/spec/requests/admin_payroll_gender_tasks_spec.rb
@@ -4,11 +4,7 @@ RSpec.describe "Admin tasks", type: :request do
   let(:claim) { create(:claim, :submitted) }
 
   context "when signed in as a service operator" do
-    let(:user) { create(:dfe_signin_user) }
-
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-    end
+    before { @signed_in_user = sign_in_as_service_operator }
 
     Policies.all.each do |policy|
       context "with a #{policy} claim" do
@@ -33,7 +29,7 @@ RSpec.describe "Admin tasks", type: :request do
             expect(claim.reload.payroll_gender).to eq("male")
             expect(claim.tasks.last.name).to eql("payroll_gender")
             expect(claim.tasks.last.passed?).to eql(true)
-            expect(claim.tasks.last.created_by).to eql(user)
+            expect(claim.tasks.last.created_by).to eql(@signed_in_user)
             expect(response).to redirect_to(new_admin_claim_decision_path(claim))
           end
 

--- a/spec/requests/admin_payroll_run_payments_spec.rb
+++ b/spec/requests/admin_payroll_run_payments_spec.rb
@@ -1,14 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Admin payroll run payments" do
-  let(:admin) { create(:dfe_signin_user) }
-
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
-  end
-
   let(:payroll_run) { create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1}) }
   let(:payment) { payroll_run.payments.first }
+
+  before { @signed_in_user = sign_in_as_service_operator }
 
   describe "remove" do
     it "shows a confirmation screen" do
@@ -41,7 +37,7 @@ RSpec.describe "Admin payroll run payments" do
     end
 
     it "cannot delete a payment from an already confirmed payroll run" do
-      payroll_run.confirmation_report_uploaded_by = admin
+      payroll_run.confirmation_report_uploaded_by = @signed_in_user
       payroll_run.save!
 
       expect {

--- a/spec/requests/admin_qualification_report_upload_spec.rb
+++ b/spec/requests/admin_qualification_report_upload_spec.rb
@@ -1,10 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin qualification report upload" do
-  let(:admin) { create(:dfe_signin_user) }
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
-  end
+  before { @signed_in_user = sign_in_as_service_operator }
 
   describe "qualification_report_upload#new" do
     it "shows the upload form" do
@@ -37,7 +34,7 @@ RSpec.describe "Admin qualification report upload" do
         }.to change { claim.tasks.count }.by(1)
 
         qualification_task = claim.tasks.find_by(name: "qualifications")
-        expect(qualification_task.created_by).to eql(admin)
+        expect(qualification_task.created_by).to eql(@signed_in_user)
 
         expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically created checks for 1 claim out of 1 record.")
         expect(response).to redirect_to(admin_claims_path)

--- a/spec/requests/admin_sessions_spec.rb
+++ b/spec/requests/admin_sessions_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Admin Sessions", type: :request do
   describe "#refresh" do
-    it "updates the last_seen_at session timestamp and responds with OK" do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "_user_id", "_org_id")
+    before { sign_in_as_service_operator }
 
+    it "updates the last_seen_at session timestamp and responds with OK" do
       travel(1.minute) do
         get admin_refresh_session_path
 
@@ -14,8 +14,6 @@ RSpec.describe "Admin Sessions", type: :request do
     end
 
     it "does not extend an expired admin session" do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "_user_id", "_org_id")
-
       travel(2.hours) do
         get admin_refresh_session_path
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe "Admin", type: :request do
 
     context "when the user is authenticated" do
       let(:dfe_sign_in_id) { "userid-345" }
-      let(:organisation_id) { "organisationid-6789" }
 
       let!(:user) { create(:dfe_signin_user, dfe_sign_in_id: dfe_sign_in_id) }
 
       context "when the user is a service operator" do
         before do
-          sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id, organisation_id)
+          sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
         end
 
         it "renders the admin page, sets a session and applies the appropriate role to the user" do
@@ -44,7 +43,7 @@ RSpec.describe "Admin", type: :request do
 
       context "when the user is a support user" do
         before do
-          sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id, organisation_id)
+          sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
         end
 
         it "renders the admin page, sets a session and applies the appropriate role to the user" do
@@ -61,7 +60,7 @@ RSpec.describe "Admin", type: :request do
 
       context "when the user is a payroll operator" do
         before do
-          sign_in_to_admin_with_role(DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id, organisation_id)
+          sign_in_to_admin_with_role(DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
         end
 
         it "renders the page, sets a session and applies the appropriate role to the user" do
@@ -110,11 +109,10 @@ RSpec.describe "Admin", type: :request do
 
     context "when a local DfeSignIn::User record matching the DfE Sign-in ID does not exist" do
       let(:dfe_sign_in_id) { "userid-345" }
-      let(:organisation_id) { "organisationid-6789" }
 
       it "creates a DfeSignIn::User record and sets the record ID in the session" do
         expect {
-          sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id, organisation_id)
+          sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
         }.to change {
           DfeSignIn::User.count
         }.by(1)

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -4,11 +4,7 @@ RSpec.describe "Admin tasks", type: :request do
   let(:claim) { create(:claim, :submitted) }
 
   context "when signed in as a service operator" do
-    let(:user) { create(:dfe_signin_user) }
-
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-    end
+    before { @signed_in_user = sign_in_as_service_operator }
 
     describe "tasks#index" do
       it "shows a list of tasks for a claim" do
@@ -55,7 +51,7 @@ RSpec.describe "Admin tasks", type: :request do
 
             expect(claim.tasks.last.name).to eql("qualifications")
             expect(claim.tasks.last.passed?).to eql(true)
-            expect(claim.tasks.last.created_by).to eql(user)
+            expect(claim.tasks.last.created_by).to eql(@signed_in_user)
             expect(response).to redirect_to(admin_claim_task_path(claim, name: "employment"))
           end
 
@@ -76,7 +72,7 @@ RSpec.describe "Admin tasks", type: :request do
 
               expect(claim.tasks.reload.last.name).to eql(last_task)
               expect(claim.tasks.last.passed?).to eql(true)
-              expect(claim.tasks.last.created_by).to eql(user)
+              expect(claim.tasks.last.created_by).to eql(@signed_in_user)
               expect(response).to redirect_to(new_admin_claim_decision_path(claim))
             end
           end

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -2,19 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin session timing out", type: :request do
   let(:timeout_length_in_minutes) { AdminSessionTimeout::ADMIN_TIMEOUT_LENGTH_IN_MINUTES }
-  let(:dfe_sign_in_id) { "userid-345" }
-
-  let!(:user) { create(:dfe_signin_user, dfe_sign_in_id: dfe_sign_in_id) }
 
   let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }
   let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
 
-  before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
-  end
+  before { @signed_in_user = sign_in_as_service_operator }
 
   it "clears the session and redirects to the login page when no actions have been performed during the timeout period" do
-    expect(session[:user_id]).to eq(user.id)
+    expect(session[:user_id]).to eq(@signed_in_user.id)
 
     travel after_expiry do
       get admin_claims_path

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Admin session timing out", type: :request do
   let(:timeout_length_in_minutes) { AdminSessionTimeout::ADMIN_TIMEOUT_LENGTH_IN_MINUTES }
   let(:dfe_sign_in_id) { "userid-345" }
-  let(:organisation_id) { "organisationid-6789" }
 
   let!(:user) { create(:dfe_signin_user, dfe_sign_in_id: dfe_sign_in_id) }
 
@@ -11,7 +10,7 @@ RSpec.describe "Admin session timing out", type: :request do
   let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
 
   before do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id, organisation_id)
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id)
   end
 
   it "clears the session and redirects to the login page when no actions have been performed during the timeout period" do

--- a/spec/requests/admin_undo_decisions_spec.rb
+++ b/spec/requests/admin_undo_decisions_spec.rb
@@ -2,11 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Undoing decisions", type: :request do
   context "when signed in as a service operator" do
-    let(:service_operator) { create(:dfe_signin_user) }
-
-    before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
-    end
+    before { @signed_in_user = sign_in_as_service_operator }
 
     describe "#create" do
       let(:claim) { create(:claim, :approved) }
@@ -29,6 +25,7 @@ RSpec.describe "Undoing decisions", type: :request do
         expect(amendment.claim).to eq(claim)
         expect(amendment.notes).to eq("Here are some notes")
         expect(amendment.claim_changes).to eq({decision: ["approved", "undecided"]})
+        expect(amendment.created_by).to eq(@signed_in_user)
       end
 
       it "does not save the decision or admendment if the claim has been subsequently paid" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -100,11 +100,11 @@ module FeatureHelpers
     click_on "Continue"
   end
 
-  # Signs in as a user with the service operator role.
+  # Signs in as a user with the service operator role. Returns the signed-in User record.
   def sign_in_as_service_operator
-    create(:dfe_signin_user).tap do |user|
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.id)
-    end
+    user = create(:dfe_signin_user)
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+    user
   end
 
   def sign_in_to_admin_with_role(role_code, user_id = "123")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -100,8 +100,15 @@ module FeatureHelpers
     click_on "Continue"
   end
 
-  def sign_in_to_admin_with_role(*args)
-    stub_dfe_sign_in_with_role(*args)
+  # Signs in as a user with the service operator role.
+  def sign_in_as_service_operator
+    create(:dfe_signin_user).tap do |user|
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.id)
+    end
+  end
+
+  def sign_in_to_admin_with_role(role_code, user_id = "123")
+    stub_dfe_sign_in_with_role(role_code, user_id)
     visit admin_sign_in_path
     click_on "Sign in"
   end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -22,6 +22,13 @@ module RequestHelpers
     }.fetch(policy)
   end
 
+  # Signs in as a user with the service operator role. Returns the signed-in User record.
+  def sign_in_as_service_operator
+    user = create(:dfe_signin_user)
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+    user
+  end
+
   def sign_in_to_admin_with_role(*args)
     stub_dfe_sign_in_with_role(*args)
     post admin_dfe_sign_in_path


### PR DESCRIPTION
Whilst working on the work to add the amendments tab I noticed that there was scope to DRY up some of the helpers we use to simulate DfE Sign-in, and also that our request spec coverage around sign-in needed some consolidation. This PR does both, with a very minor change to the sign-out behaviour to redirect the user to the sign-in page, rather than to the admin root, which then redirects to sign-in.