### PR TITLE
Ensure the surname in DQT matches the one in the claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog]
   same claim
 - Allow a claim's decision to be amended by a service operator
 - Move claim amendments to a seperate tab
+- Automated DQT checks verify that the surname in DQT matches the one in the
+  claim
 
 ## [Release 066] - 2020-03-25
 

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -49,7 +49,8 @@ module AutomatedChecks
     end
 
     def record_matches_claim?(record, claim)
-      record.fetch(:date_of_birth) == claim.date_of_birth
+      record.fetch(:date_of_birth) == claim.date_of_birth &&
+        record.fetch(:surname) == claim.surname
     end
   end
 end

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -50,7 +50,7 @@ module AutomatedChecks
 
     def record_matches_claim?(record, claim)
       record.fetch(:date_of_birth) == claim.date_of_birth &&
-        record.fetch(:surname) == claim.surname
+        record.fetch(:surname)&.casecmp?(claim.surname)
     end
   end
 end

--- a/app/models/automated_checks/dqt_report_csv_to_records.rb
+++ b/app/models/automated_checks/dqt_report_csv_to_records.rb
@@ -12,6 +12,7 @@ module AutomatedChecks
         {
           claim_reference: grouped_rows.first.fetch(CLAIM_REFERENCE_COLUMN),
           qts_date: parse_date(grouped_rows.first.fetch("dfeta qtsdate")),
+          surname: extract_surname(grouped_rows.first.fetch("fullname")),
           date_of_birth: parse_date(grouped_rows.first.fetch("birthdate")),
           degree_jac_codes: collate_fields_from_rows(%w[HESubject1Value HESubject2Value HESubject3Value], grouped_rows),
           itt_subject_jac_codes: collate_fields_from_rows(%w[ITTSub1Value ITTSub2Value ITTSub3Value], grouped_rows)
@@ -29,6 +30,10 @@ module AutomatedChecks
       Date.parse(date)
     rescue
       nil
+    end
+
+    def extract_surname(fullname)
+      (fullname || "").split(" ").last
     end
   end
 end

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Admins automated qualification check" do
 
   scenario "Service operators can upload and run automated DQT checks" do
     eligible_claim_with_matching_data = claim_from_example_dqt_report(:eligible_claim_with_matching_data)
-    eligible_claim_with_non_matching_data = claim_from_example_dqt_report(:eligible_claim_with_non_matching_data)
+    eligible_claim_with_non_matching_birthdate = claim_from_example_dqt_report(:eligible_claim_with_non_matching_birthdate)
     claim_without_dqt_record = claim_from_example_dqt_report(:claim_without_dqt_record)
     claim_with_ineligible_dqt_record = claim_from_example_dqt_report(:claim_with_ineligible_dqt_record)
     claim_with_decision = claim_from_example_dqt_report(:claim_with_decision)
@@ -25,7 +25,7 @@ RSpec.feature "Admins automated qualification check" do
 
     expect(page).to have_content "DQT report uploaded successfully. Automatically created checks for 1 claim out of 6 records."
     expect(eligible_claim_with_matching_data.tasks.find_by!(name: "qualifications").passed?).to eq(true)
-    expect(eligible_claim_with_non_matching_data.tasks.find_by(name: "qualifications")).to be_nil
+    expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_decision.tasks.find_by(name: "qualifications")).to be_nil

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Admins automated qualification check" do
   scenario "Service operators can upload and run automated DQT checks" do
     eligible_claim_with_matching_data = claim_from_example_dqt_report(:eligible_claim_with_matching_data)
     eligible_claim_with_non_matching_birthdate = claim_from_example_dqt_report(:eligible_claim_with_non_matching_birthdate)
+    eligible_claim_with_non_matching_surname = claim_from_example_dqt_report(:eligible_claim_with_non_matching_surname)
     claim_without_dqt_record = claim_from_example_dqt_report(:claim_without_dqt_record)
     claim_with_ineligible_dqt_record = claim_from_example_dqt_report(:claim_with_ineligible_dqt_record)
     claim_with_decision = claim_from_example_dqt_report(:claim_with_decision)
@@ -23,9 +24,10 @@ RSpec.feature "Admins automated qualification check" do
 
     click_on "Upload"
 
-    expect(page).to have_content "DQT report uploaded successfully. Automatically created checks for 1 claim out of 6 records."
+    expect(page).to have_content "DQT report uploaded successfully. Automatically created checks for 1 claim out of 7 records."
     expect(eligible_claim_with_matching_data.tasks.find_by!(name: "qualifications").passed?).to eq(true)
     expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "qualifications")).to be_nil
+    expect(eligible_claim_with_non_matching_surname.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_decision.tasks.find_by(name: "qualifications")).to be_nil

--- a/spec/fixtures/files/example_dqt_report.csv
+++ b/spec/fixtures/files/example_dqt_report.csv
@@ -2,6 +2,7 @@ dfeta text1,dfeta text2,dfeta trn,fullname,birthdate,dfeta ninumber,dfeta qtsdat
 1234567,AB123456,1234567,Fred Eligible,23/8/1990,QQ123456C,23/8/2017,Politics,,,L200,,,Politics,,,L200,,
 1234567,AB123456,1234567,Fred Eligible,23/8/1990,QQ123456C,23/8/2017,Law By Area,,,M100,,,Politics,,,L200,,
 8901231,RR123456,8901231,Jo Eligible,11/2/1970,QQ123456C,20/6/2017,Psychology,,,C800,,,Psychology,,,C800,,
+8981212,DD123456,8981212,Sarah Different,10/4/1980,QQ123456C,20/6/2017,Business Studies,,,N100,,,Mathematics,,,G100,,
 3456789,XX123456,3456789,,,,,,,,,,,,,,,,
 6758493,CD123456,6758493,Terry Ineligible,21/4/1979,QQ123456C,12/3/2000,Politics,,,L200,,,Mathematics,,,G100,,
 5554433,EF123456,5554433,Already decided,15/5/1985,QQ123456C,9/1/2019,Chemistry,,,F100,,,Chemistry,,,F100,,

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   let(:file) { example_dqt_report_csv }
   let(:admin_user) { build(:dfe_signin_user) }
   let!(:eligible_claim_with_matching_data) { claim_from_example_dqt_report(:eligible_claim_with_matching_data) }
-  let!(:eligible_claim_with_non_matching_data) { claim_from_example_dqt_report(:eligible_claim_with_non_matching_data) }
+  let!(:eligible_claim_with_non_matching_birthdate) { claim_from_example_dqt_report(:eligible_claim_with_non_matching_birthdate) }
   let!(:claim_without_dqt_record) { claim_from_example_dqt_report(:claim_without_dqt_record) }
   let!(:claim_with_ineligible_dqt_record) { claim_from_example_dqt_report(:claim_with_ineligible_dqt_record) }
   let!(:claim_with_decision) { claim_from_example_dqt_report(:claim_with_decision) }
@@ -27,7 +27,7 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
     it "doesn’t create a qualification task where the data doesn't match" do
       dqt_report_consumer.ingest
 
-      expect(eligible_claim_with_non_matching_data.tasks.find_by(name: "qualifications")).to be_nil
+      expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "qualifications")).to be_nil
       expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
       expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     end

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   let(:admin_user) { build(:dfe_signin_user) }
   let!(:eligible_claim_with_matching_data) { claim_from_example_dqt_report(:eligible_claim_with_matching_data) }
   let!(:eligible_claim_with_non_matching_birthdate) { claim_from_example_dqt_report(:eligible_claim_with_non_matching_birthdate) }
+  let!(:eligible_claim_with_non_matching_surname) { claim_from_example_dqt_report(:eligible_claim_with_non_matching_surname) }
   let!(:claim_without_dqt_record) { claim_from_example_dqt_report(:claim_without_dqt_record) }
   let!(:claim_with_ineligible_dqt_record) { claim_from_example_dqt_report(:claim_with_ineligible_dqt_record) }
   let!(:claim_with_decision) { claim_from_example_dqt_report(:claim_with_decision) }
@@ -18,7 +19,7 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
 
       new_qualication_task = eligible_claim_with_matching_data.tasks.find_by!(name: "qualifications")
       expect(dqt_report_consumer.completed_tasks).to eq(1)
-      expect(dqt_report_consumer.total_records).to eq(6)
+      expect(dqt_report_consumer.total_records).to eq(7)
       expect(new_qualication_task.passed).to eq(true)
       expect(new_qualication_task.manual).to eq(false)
       expect(new_qualication_task.created_by).to eq(admin_user)
@@ -28,6 +29,7 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
       dqt_report_consumer.ingest
 
       expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "qualifications")).to be_nil
+      expect(eligible_claim_with_non_matching_surname.tasks.find_by(name: "qualifications")).to be_nil
       expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
       expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     end

--- a/spec/models/automated_checks/dqt_report_csv_to_records_spec.rb
+++ b/spec/models/automated_checks/dqt_report_csv_to_records_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
       {
         "dfeta text2" => "AB123456",
         "dfeta qtsdate" => "24/10/2017",
+        "fullname" => "Jonathan Bishop",
         "birthdate" => "10/09/1980",
         "HESubject1Value" => "G100",
         "HESubject2Value" => "F100",
@@ -18,6 +19,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
       {
         "dfeta text2" => "AB123456",
         "dfeta qtsdate" => "24/10/2017",
+        "fullname" => "Jonathan Bishop",
         "birthdate" => "10/09/1980",
         "HESubject1Value" => "R100",
         "HESubject2Value" => nil,
@@ -29,6 +31,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
       {
         "dfeta text2" => "XX999999",
         "dfeta qtsdate" => "17/06/2016",
+        "fullname" => "Phillip David Collins",
         "birthdate" => "05/03/1993",
         "HESubject1Value" => "X100",
         "HESubject2Value" => nil,
@@ -46,6 +49,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
         {
           claim_reference: "AB123456",
           qts_date: Date.new(2017, 10, 24),
+          surname: "Bishop",
           date_of_birth: Date.new(1980, 9, 10),
           degree_jac_codes: ["G100", "F100", "R100"],
           itt_subject_jac_codes: ["E100"]
@@ -53,6 +57,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
         {
           claim_reference: "XX999999",
           qts_date: Date.new(2016, 6, 17),
+          surname: "Collins",
           date_of_birth: Date.new(1993, 3, 5),
           degree_jac_codes: ["X100"],
           itt_subject_jac_codes: ["X100"]
@@ -68,6 +73,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
         {
           "dfeta text2" => "RE123456",
           "dfeta qtsdate" => nil,
+          "fullname" => nil,
           "birthdate" => "24/03/1988",
           "HESubject1Value" => nil,
           "HESubject2Value" => nil,
@@ -84,6 +90,7 @@ RSpec.describe AutomatedChecks::DQTReportCsvToRecords do
         {
           claim_reference: "RE123456",
           qts_date: nil,
+          surname: nil,
           date_of_birth: Date.new(1988, 3, 24),
           degree_jac_codes: [],
           itt_subject_jac_codes: []

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -15,7 +15,7 @@ module FixtureHelpers
         reference: "AB123456",
         date_of_birth: Date.new(1990, 8, 23))
 
-    when :eligible_claim_with_non_matching_data
+    when :eligible_claim_with_non_matching_birthdate
       # Eligible claim and eligible DQT data but different date of birth
       create(:claim, :submitted,
         teacher_reference_number: "8901231",

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -11,6 +11,7 @@ module FixtureHelpers
     when :eligible_claim_with_matching_data
       # Eligible claim with matching data in DQT
       create(:claim, :submitted,
+        surname: "Eligible",
         teacher_reference_number: "1234567",
         reference: "AB123456",
         date_of_birth: Date.new(1990, 8, 23))
@@ -18,9 +19,18 @@ module FixtureHelpers
     when :eligible_claim_with_non_matching_birthdate
       # Eligible claim and eligible DQT data but different date of birth
       create(:claim, :submitted,
+        surname: "Eligible",
         teacher_reference_number: "8901231",
         reference: "RR123456",
         date_of_birth: Date.new(1899, 1, 1))
+
+    when :eligible_claim_with_non_matching_surname
+      # Eligible claim and eligible DQT data but different surname
+      create(:claim, :submitted,
+        surname: "Eligible",
+        teacher_reference_number: "8981212",
+        reference: "DD123456",
+        date_of_birth: Date.new(1980, 4, 10))
 
     when :claim_without_dqt_record
       # Submitted claim that has no DQT associated with it

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -11,7 +11,7 @@ module FixtureHelpers
     when :eligible_claim_with_matching_data
       # Eligible claim with matching data in DQT
       create(:claim, :submitted,
-        surname: "Eligible",
+        surname: "ELIGIBLE",
         teacher_reference_number: "1234567",
         reference: "AB123456",
         date_of_birth: Date.new(1990, 8, 23))


### PR DESCRIPTION
Currently claims checkers do an extra informal identity verification
on the record in DQT to make sure it matches the claimant. They check
the name and National Insurance number (NiNo). The NiNo doesn't always
exist in DQT so instead we can add the extra verification step as a
match against the surname.

We recognise that names are subject to change and can legitimately not
match, but these claims will still be checked just manually by a person
instead of automatically.

Surnames that come back from GOV.UK Verify can be all upper case. To
allow for this we need to make the comparison case insensitive.