### PR TITLE
Other task view changes

### DIFF
--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -6,23 +6,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
 
-    <% if @claim.payroll_gender_missing? && !@claim.decision_made? %>
-      <div class="govuk-body-l govuk-flash__notice">
-        <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
-      </div>
-    <% end %>
-
     <% if @claim.personal_data_removed? %>
       <div class="govuk-body-l govuk-flash__notice">
         This claim had personal data removed on <%= l(@claim.personal_data_removed_at.to_date) %>.
-      </div>
-    <% end %>
-
-    <% if @matching_claims.any? %>
-      <div class="govuk-body-l govuk-flash__warning">
-        <a href="#claims-with-matches">
-          <%= t("admin.duplicate_attributes_message", count: @matching_claims.count, policy: @claim.policy.short_name) %>
-        </a>
       </div>
     <% end %>
 

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -26,7 +26,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= claim.full_name %>
+        <%= claim.personal_data_removed? ? personal_data_removed_text : claim.full_name %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -35,7 +35,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= l(claim.date_of_birth, format: :day_month_year) %>
+        <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year) %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -57,7 +57,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= claim.national_insurance_number %>
+        <%= claim.personal_data_removed? ? personal_data_removed_text : claim.national_insurance_number %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">

--- a/spec/features/admin_claim_without_personal_data_spec.rb
+++ b/spec/features/admin_claim_without_personal_data_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Admin checking a claim with personal data removed" do
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
   end
 
-  scenario "the service operator sees that the personal data has been removed" do
+  scenario "the service operator sees that personal data has been removed from the full claim view" do
     claim_with_personal_data_removed = create(:claim, :rejected, :personal_data_removed)
 
     visit admin_claim_path(claim_with_personal_data_removed)
@@ -16,5 +16,17 @@ RSpec.feature "Admin checking a claim with personal data removed" do
     expect(page).to have_content("Date of birth Removed")
     expect(page).to have_content("National Insurance number Removed")
     expect(page).to have_content("Address Removed")
+  end
+
+  scenario "the service operator sees that personal data has been removed from the view on tasks page" do
+    claim_with_personal_data_removed = create(:claim, :rejected, :personal_data_removed)
+
+    visit admin_claim_path(claim_with_personal_data_removed)
+
+    click_on "View tasks"
+
+    expect(page).to have_content("Full name Removed")
+    expect(page).to have_content("Date of birth Removed")
+    expect(page).to have_content("NI number Removed")
   end
 end

--- a/spec/features/admin_duplicate_claims_spec.rb
+++ b/spec/features/admin_duplicate_claims_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature "Service operator can see potential duplicate claims" do
     find("a[href='#{admin_claim_tasks_path(claim_to_approve)}']").click
     click_on "View full claim"
 
-    expect(page).to have_content("Details in this claim match another Student Loans claim")
     expect(page).to have_content("Student Loans claim with matching details")
 
     expect(page).to have_content("#{claim_with_matching_teacher_reference_number.reference}\nTeacher reference number")


### PR DESCRIPTION
Relates to PR https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/994 
Make the new "task list" view of a claim the primary screen for working with claims.

Claims with personal data removed now indicate those fields with "Removed" as we do on the "Full claim view" within the task view page.

<img width="1300" alt="Screenshot 2020-03-30 at 14 34 26" src="https://user-images.githubusercontent.com/59832893/77932869-04452780-72a6-11ea-8462-59565e9f1b17.png">

Warning banners for matching claims and missing payroll gender have now been removed from the "Full claim view"

**Before:**
<img width="1147" alt="Screenshot 2020-03-30 at 16 09 15" src="https://user-images.githubusercontent.com/59832893/77933093-55edb200-72a6-11ea-9608-7399c81680f8.png">

**After:**
<img width="1147" alt="Screenshot 2020-03-30 at 16 49 11" src="https://user-images.githubusercontent.com/59832893/77933242-7d447f00-72a6-11ea-9cc6-765296b08510.png">