### PR TITLE
Service operators can add notes to claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
-- Admin users can add notes to claims
+- Service operators can add notes to claims
 
 ## [Release 067] - 2020-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Admin users can add notes to claims
+
 ## [Release 067] - 2020-03-30
 
 - Exclude claims from previous academic years on matching claims screen

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class NotesController < BaseAdminController
     before_action :load_claim
+    before_action :ensure_service_operator
 
     def index
       @note = Note.new

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -9,8 +9,11 @@ module Admin
 
     def create
       @note = Note.new(note_params)
-      @note.save!
-      redirect_to admin_claim_notes_url(@claim)
+      if @note.save
+        redirect_to admin_claim_notes_url(@claim)
+      else
+        render :index
+      end
     end
 
     private

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -1,0 +1,25 @@
+module Admin
+  class NotesController < BaseAdminController
+    before_action :load_claim
+
+    def index
+      @note = Note.new
+    end
+
+    def create
+      @note = Note.new(note_params)
+      @note.save!
+      redirect_to admin_claim_notes_url(@claim)
+    end
+
+    private
+
+    def load_claim
+      @claim = Claim.find(params[:claim_id])
+    end
+
+    def note_params
+      params.require(:note).permit(:body).merge(claim: @claim, created_by: admin_user)
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -90,6 +90,7 @@ class Claim < ApplicationRecord
   has_many :decisions
   has_many :tasks
   has_many :amendments
+  has_many :notes
 
   belongs_to :eligibility, polymorphic: true, inverse_of: :claim, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,6 @@
+class Note < ApplicationRecord
+  belongs_to :claim
+  belongs_to :created_by, class_name: "DfeSignIn::User"
+
+  validates :body, :created_by, presence: true
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,5 +2,6 @@ class Note < ApplicationRecord
   belongs_to :claim
   belongs_to :created_by, class_name: "DfeSignIn::User"
 
-  validates :body, :created_by, presence: true
+  validates :created_by, presence: true
+  validates :body, presence: {message: "Enter a note"}
 end

--- a/app/views/admin/claims/_tabs.html.erb
+++ b/app/views/admin/claims/_tabs.html.erb
@@ -2,6 +2,12 @@
   <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "tasks") %>" role="presentation">
     <%= link_to_unless_current "Tasks", admin_claim_tasks_path(claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "tasks") } %>
   </li>
+
+  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "notes") %>" role="presentation">
+    <%= link_to_unless_current "Notes", admin_claim_notes_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "notes") } %>
+    <%= "(#{claim.notes.count})" if claim.notes.any? %>
+  </li>
+
   <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "amendments") %>" role="presentation">
     <%= link_to_unless_current "Claim amendments", admin_claim_amendments_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "amendments") } %>
     <%= "(#{claim.amendments.count})" if claim.amendments.any? %>

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: note, url: admin_claim_notes_path(claim) do |form| %>
+  <%= form_group_tag note, :body do %>
+    <%= form.label :body, "Add note", class: "govuk-label govuk-label--m" %>
+    <span class="govuk-hint" id="notes-hint">
+      Write a brief update. Do not include any personal data about the claimant.
+    </span>
+    <%= form.text_area :body, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
+  <% end %>
+
+  <%= form.submit "Add note", class: "govuk-button" %>
+<% end %>

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -1,6 +1,7 @@
 <%= form_with model: note, url: admin_claim_notes_path(claim) do |form| %>
   <%= form_group_tag note, :body do %>
     <%= form.label :body, "Add note", class: "govuk-label govuk-label--m" %>
+    <%= errors_tag note, :body %>
     <span class="govuk-hint" id="notes-hint">
       Write a brief update. Do not include any personal data about the claimant.
     </span>

--- a/app/views/admin/notes/index.html.erb
+++ b/app/views/admin/notes/index.html.erb
@@ -22,9 +22,7 @@
             <% @claim.notes.order(created_at: :desc).each do |note| %>
               <div class="hmcts-timeline__item">
                 <section>
-                  <p class="govuk-body">
-                    <%= note.body %>
-                  </p>
+                  <%= simple_format note.body, class: "govuk-body" %>
                 </section>
 
                 <p class="hmcts-timeline__description">

--- a/app/views/admin/notes/index.html.erb
+++ b/app/views/admin/notes/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} notes") } %>
+
+<%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
+
+<div class="govuk-grid-row">
+  <%= render "admin/tasks/claim_summary", claim: @claim, heading: @claim.reference %>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-tabs" data-module="govuk-tabs">
+    <h2 class="govuk-tabs__title">Contents</h2>
+
+    <%= render "admin/claims/tabs", claim: @claim %>
+
+    <section class="govuk-tabs__panel" role="tabpanel" aria-labelledby="tab_tasks">
+      <div class="govuk-grid-row">
+       <div class="govuk-grid-column-two-thirds">
+
+          <h2 class="govuk-heading-m">Claim notes</h2>
+
+          <div class="hmcts-timeline">
+            <% @claim.notes.order(created_at: :desc).each do |note| %>
+              <div class="hmcts-timeline__item">
+                <section>
+                  <p class="govuk-body">
+                    <%= note.body %>
+                  </p>
+                </section>
+
+                <p class="hmcts-timeline__description">
+                  by <%= user_details(note.created_by, include_line_break: false) %>
+                  on <%= l(note.created_at) %>
+                </p>
+              </div>
+            <% end %>
+          </div>
+
+          <%= render "form", claim: @claim, note: @note %>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
         resources :undos, only: [:create, :new], controller: "decisions_undo"
       end
       resources :amendments, only: [:index, :new, :create]
+      resources :notes, only: [:index, :create]
       get "search", on: :collection
     end
 

--- a/db/migrate/20200330135833_create_notes.rb
+++ b/db/migrate/20200330135833_create_notes.rb
@@ -1,0 +1,12 @@
+class CreateNotes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notes, id: :uuid do |t|
+      t.string :body
+      t.references :claim, foreign_key: true, type: :uuid
+      t.references :created_by, type: :uuid, foreign_key: {to_table: :dfe_sign_in_users}
+      t.timestamps
+
+      t.index [:claim_id, :created_at], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_16_100421) do
+ActiveRecord::Schema.define(version: 2020_03_30_135833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -142,6 +142,17 @@ ActiveRecord::Schema.define(version: 2020_03_16_100421) do
     t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 
+  create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "body"
+    t.uuid "claim_id"
+    t.uuid "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["claim_id", "created_at"], name: "index_notes_on_claim_id_and_created_at", unique: true
+    t.index ["claim_id"], name: "index_notes_on_claim_id"
+    t.index ["created_by_id"], name: "index_notes_on_created_by_id"
+  end
+
   create_table "payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "payroll_run_id"
     t.decimal "award_amount", precision: 7, scale: 2
@@ -250,6 +261,8 @@ ActiveRecord::Schema.define(version: 2020_03_16_100421) do
   add_foreign_key "claims", "payments"
   add_foreign_key "decisions", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"
+  add_foreign_key "notes", "claims"
+  add_foreign_key "notes", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "payments", "payroll_runs"
   add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "confirmation_report_uploaded_by_id"
   add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "created_by_id"

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :note do
+    sequence(:body) { |n| "Note about the claim #{n}" }
+
+    association :claim, factory: [:claim, :submitted]
+    association :created_by, factory: :dfe_signin_user
+  end
+end

--- a/spec/features/admin_claim_notes_spec.rb
+++ b/spec/features/admin_claim_notes_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Admin claim notes" do
+  before { @signed_in_user = sign_in_as_service_operator }
+
+  scenario "the service operator adds notes to a claim" do
+    claim = create(:claim, :submitted)
+    existing_note = create(:note, body: "Some note about claim", claim: claim)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+    click_on "Notes"
+
+    expect(page).to have_content(existing_note.body)
+    expect(page).to have_content(existing_note.created_by.full_name)
+
+    fill_in "Add note", with: "No data for this teacher in TPS, needs a manual employment check"
+    expect { click_on "Add note" }.to change { claim.notes.count }.by(1)
+
+    note = claim.notes.last
+    expect(note.body).to have_content("No data for this teacher in TPS, needs a manual employment check")
+    expect(note.created_by).to eq(@signed_in_user)
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+end

--- a/spec/requests/admin_notes_spec.rb
+++ b/spec/requests/admin_notes_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe "admin/notes controller" do
       expect(note.created_by).to eq(@signed_in_user)
     end
 
+    it "shows an error message when the note is missing" do
+      post admin_claim_notes_path(claim), params: {note: {body: ""}}
+
+      expect(claim.notes.count).to eq(0)
+
+      expect(response.body).to include("Enter a note")
+    end
+
     it "refuses requests from users without the service operator role" do
       non_service_operator_roles.each do |role|
         sign_in_to_admin_with_role(role)

--- a/spec/requests/admin_notes_spec.rb
+++ b/spec/requests/admin_notes_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "admin/notes controller" do
+  let(:claim) { create(:claim, :submitted) }
+
+  describe "admin/notes#index" do
+    before { @signed_in_user = sign_in_as_service_operator }
+
+    it "list the notes on a claim" do
+      note = create(:note, claim: claim, body: "Need to verify the student loan amount")
+      user = note.created_by
+
+      get admin_claim_notes_path(claim)
+
+      expect(response.body).to include("Claim notes")
+      expect(response.body).to include("Need to verify the student loan amount")
+      expect(response.body).to include("by #{user.full_name}")
+    end
+  end
+
+  describe "admin/notes#create" do
+    before { @signed_in_user = sign_in_as_service_operator }
+
+    it "creates a note against the claim by the signed-in user" do
+      post admin_claim_notes_path(claim), params: {note: {body: "Some note"}}
+
+      expect(response).to redirect_to(admin_claim_notes_path(claim))
+
+      expect(claim.notes.count).to eq 1
+
+      note = claim.notes.last
+      expect(note.body).to eq("Some note")
+      expect(note.created_by).to eq(@signed_in_user)
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -22,6 +22,13 @@ module RequestHelpers
     }.fetch(policy)
   end
 
+  def non_service_operator_roles
+    [
+      DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE,
+      DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE
+    ]
+  end
+
   # Signs in as a user with the service operator role. Returns the signed-in User record.
   def sign_in_as_service_operator
     user = create(:dfe_signin_user)


### PR DESCRIPTION
This adds a simple notes feature that allows service operators to add notes against claims:

<img width="1058" alt="Screenshot 2020-03-30 at 17 08 31" src="https://user-images.githubusercontent.com/3687/77935337-3441fa00-72a9-11ea-8a6b-b689399ecfc6.png">
