### PR TITLE
1387 make sure we set the service team up to deal with payroll discrepancies if they occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Improve message shown when inconsistent payroll information is found
+
 ## [Release 068] - 2020-03-31
 
 - Service operators can add notes to claims

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -3,7 +3,12 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
-      <%= t('admin.claims_preventing_payment_message', count: claims_preventing_payment.count, claim_references: claims_preventing_payment.map(&:reference).to_sentence) %>
+      <p class="govuk-!-margin-top-0">
+        <%= t('admin.claims_preventing_payment_message', count: claims_preventing_payment.count, claim_references: claims_preventing_payment.map(&:reference).to_sentence) %>
+      </p>
+      <p>
+        <%= t('admin.claims_preventing_payment_message.action')%>
+      </p>
     </strong>
   </div>
 <% end %>

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -4,10 +4,14 @@
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
       <p class="govuk-!-margin-top-0">
-        <%= t('admin.claims_preventing_payment_message', count: claims_preventing_payment.count, claim_references: claims_preventing_payment.map(&:reference).to_sentence) %>
+        This claim cannot currently be approved because we’re already paying
+        <%= claims_preventing_payment.one? ? "another claim" : "other claims" %>
+        (<%= claims_preventing_payment.map(&:reference).to_sentence %>)
+        to this claimant in this payroll month using different payment details.
       </p>
       <p>
-        <%= t('admin.claims_preventing_payment_message.action')%>
+        Please check the guidance in the operations playbook and speak to a
+        Grade 7 before making a decision on this claim.
       </p>
     </strong>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,12 +76,20 @@ en:
       notes: "Notes"
       created_by: "Created by"
     claims_preventing_payment_message:
-      one: This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
-      other: This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
+      one:
+        This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this
+        claimant in this payroll month using different payment details.
+      other:
+        This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this
+        claimant in this payroll month using different payment details.
+      action:
+        Please check the guidance in the operations playbook and speak to a Grade 7 before making a decision on this
+        claim.
     duplicate_attributes_message:
       one: Details in this claim match another %{policy} claim
       other: Details in this claim match other %{policy} claims
-    unknown_payroll_gender_preventing_approval_message: This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
+    unknown_payroll_gender_preventing_approval_message:
+      This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
     tasks:
       qualifications: "Check qualification information"
       employment: "Check employment information"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,16 +75,6 @@ en:
       result: "Result"
       notes: "Notes"
       created_by: "Created by"
-    claims_preventing_payment_message:
-      one:
-        This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this
-        claimant in this payroll month using different payment details.
-      other:
-        This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this
-        claimant in this payroll month using different payment details.
-      action:
-        Please check the guidance in the operations playbook and speak to a Grade 7 before making a decision on this
-        claim.
     duplicate_attributes_message:
       one: Details in this claim match another %{policy} claim
       other: Details in this claim match other %{policy} claims

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
     click_on "Approve or reject this claim"
 
     expect(page).to have_field("Approve", disabled: true)
-    expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")
+    expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details.")
+    expect(page).to have_content("Please check the guidance in the operations playbook and speak to a Grade 7 before making a decision on this claim.")
 
     click_on "Amend claim"
     fill_in "Bank sort code", with: approved_claim.bank_sort_code

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -26,8 +26,7 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
     click_on "Approve or reject this claim"
 
     expect(page).to have_field("Approve", disabled: true)
-    expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details.")
-    expect(page).to have_content("Please check the guidance in the operations playbook and speak to a Grade 7 before making a decision on this claim.")
+    expect(page).to have_content("This claim cannot currently be approved")
 
     click_on "Amend claim"
     fill_in "Bank sort code", with: approved_claim.bank_sort_code


### PR DESCRIPTION
This is the code side tweaks to help support the offline process service operators will follow to resolve payroll discrepancies. We now split up the text to it is a bit less heavy and it is now divided into chunks explaining the problem and what they can do to resolve it.

![image](https://user-images.githubusercontent.com/13239597/78110891-ae7e9580-73f3-11ea-878d-0eb40013c7df.png)
