### PR TITLE
Service operators can add a support ticket to a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Improve message shown when inconsistent payroll information is found
-- Admin users can add a support ticket to claims
+- Service operators can add a support ticket to claims
 
 ## [Release 068] - 2020-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Improve message shown when inconsistent payroll information is found
+- Admin users can add a support ticket to claims
 
 ## [Release 068] - 2020-03-31
 

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class NotesController < BaseAdminController
-    before_action :load_claim
     before_action :ensure_service_operator
+    before_action :load_claim
 
     def index
       @note = Note.new

--- a/app/controllers/admin/support_tickets_controller.rb
+++ b/app/controllers/admin/support_tickets_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class SupportTicketsController < BaseAdminController
+    before_action :ensure_service_operator
     before_action :load_claim
 
     def create

--- a/app/controllers/admin/support_tickets_controller.rb
+++ b/app/controllers/admin/support_tickets_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class SupportTicketsController < BaseAdminController
+    before_action :load_claim
+
+    def create
+      @support_ticket = @claim.build_support_ticket(support_ticket_params)
+      @support_ticket.save!
+      redirect_to admin_claim_notes_url(@claim)
+    end
+
+    private
+
+    def load_claim
+      @claim = Claim.find(params[:claim_id])
+    end
+
+    def support_ticket_params
+      params.require(:support_ticket).permit(:url).merge(created_by: admin_user)
+    end
+  end
+end

--- a/app/controllers/admin/support_tickets_controller.rb
+++ b/app/controllers/admin/support_tickets_controller.rb
@@ -4,8 +4,11 @@ module Admin
 
     def create
       @support_ticket = @claim.build_support_ticket(support_ticket_params)
-      @support_ticket.save!
-      redirect_to admin_claim_notes_url(@claim)
+      if @support_ticket.save
+        redirect_to admin_claim_notes_url(@claim)
+      else
+        render "admin/notes/index"
+      end
     end
 
     private

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -91,6 +91,7 @@ class Claim < ApplicationRecord
   has_many :tasks
   has_many :amendments
   has_many :notes
+  has_one :support_ticket
 
   belongs_to :eligibility, polymorphic: true, inverse_of: :claim, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -1,0 +1,6 @@
+class SupportTicket < ApplicationRecord
+  belongs_to :claim
+  belongs_to :created_by, class_name: "DfeSignIn::User"
+
+  validates :claim, :created_by, presence: true
+end

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -3,4 +3,5 @@ class SupportTicket < ApplicationRecord
   belongs_to :created_by, class_name: "DfeSignIn::User"
 
   validates :claim, :created_by, presence: true
+  validates :url, url: {message: "Enter a valid support ticket URL"}
 end

--- a/app/views/admin/claims/_tabs.html.erb
+++ b/app/views/admin/claims/_tabs.html.erb
@@ -4,7 +4,7 @@
   </li>
 
   <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "notes") %>" role="presentation">
-    <%= link_to_unless_current "Notes", admin_claim_notes_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "notes") } %>
+    <%= link_to_unless_current "Notes and support", admin_claim_notes_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "notes") } %>
     <%= "(#{claim.notes.count})" if claim.notes.any? %>
   </li>
 

--- a/app/views/admin/notes/index.html.erb
+++ b/app/views/admin/notes/index.html.erb
@@ -15,6 +15,7 @@
     <section class="govuk-tabs__panel" role="tabpanel" aria-labelledby="tab_tasks">
       <div class="govuk-grid-row">
        <div class="govuk-grid-column-two-thirds">
+          <%= render "admin/support_tickets/widget", claim: @claim, support_ticket: (@claim.support_ticket || SupportTicket.new) %>
 
           <h2 class="govuk-heading-m">Claim notes</h2>
 

--- a/app/views/admin/notes/index.html.erb
+++ b/app/views/admin/notes/index.html.erb
@@ -34,7 +34,7 @@
             <% end %>
           </div>
 
-          <%= render "form", claim: @claim, note: @note %>
+          <%= render "admin/notes/form", claim: @claim, note: @note || Note.new %>
         </div>
       </div>
     </section>

--- a/app/views/admin/support_tickets/_widget.html.erb
+++ b/app/views/admin/support_tickets/_widget.html.erb
@@ -1,0 +1,22 @@
+<% if support_ticket.persisted? %>
+
+  <h2 class="govuk-heading-m">Support ticket</h2>
+  <p class="govuk-body-m">
+    <%= link_to claim.support_ticket.url, claim.support_ticket.url, class: "govuk-link" %>
+  </p>
+
+<% else %>
+
+  <%= form_with model: [:admin, claim, support_ticket] do |form| %>
+    <%= form_group_tag support_ticket, :url do %>
+      <%= form.label :url, "Support ticket", class: "govuk-label govuk-label--m" %>
+      <span class="govuk-hint" id="ticket-hint">
+        Create a ticket on Zendesk and enter the URL here.
+      </span>
+      <%= form.text_field :url, class: "govuk-input govuk-input", autocomplete: "off", "aria-describedby" => "ticket-hint" %>
+    <% end %>
+
+    <%= form.submit "Save support ticket", class: "govuk-button" %>
+  <% end %>
+
+<% end %>

--- a/app/views/admin/support_tickets/_widget.html.erb
+++ b/app/views/admin/support_tickets/_widget.html.erb
@@ -9,6 +9,7 @@
 
   <%= form_with model: [:admin, claim, support_ticket] do |form| %>
     <%= form_group_tag support_ticket, :url do %>
+      <%= errors_tag support_ticket, :url %>
       <%= form.label :url, "Support ticket", class: "govuk-label govuk-label--m" %>
       <span class="govuk-hint" id="ticket-hint">
         Create a ticket on Zendesk and enter the URL here.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
       end
       resources :amendments, only: [:index, :new, :create]
       resources :notes, only: [:index, :create]
+      resources :support_tickets, only: [:create]
       get "search", on: :collection
     end
 

--- a/db/migrate/20200402093512_create_support_tickets.rb
+++ b/db/migrate/20200402093512_create_support_tickets.rb
@@ -1,0 +1,10 @@
+class CreateSupportTickets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :support_tickets, id: :uuid do |t|
+      t.string :url, null: false
+      t.references :claim, foreign_key: true, type: :uuid
+      t.references :created_by, type: :uuid, foreign_key: {to_table: :dfe_sign_in_users}
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_135833) do
+ActiveRecord::Schema.define(version: 2020_04_02_093512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -242,6 +242,16 @@ ActiveRecord::Schema.define(version: 2020_03_30_135833) do
     t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
 
+  create_table "support_tickets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "url", null: false
+    t.uuid "claim_id"
+    t.uuid "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["claim_id"], name: "index_support_tickets_on_claim_id"
+    t.index ["created_by_id"], name: "index_support_tickets_on_created_by_id"
+  end
+
   create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.uuid "claim_id"
@@ -270,6 +280,8 @@ ActiveRecord::Schema.define(version: 2020_03_30_135833) do
   add_foreign_key "schools", "local_authority_districts"
   add_foreign_key "student_loans_eligibilities", "schools", column: "claim_school_id"
   add_foreign_key "student_loans_eligibilities", "schools", column: "current_school_id"
+  add_foreign_key "support_tickets", "claims"
+  add_foreign_key "support_tickets", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "tasks", "claims"
   add_foreign_key "tasks", "dfe_sign_in_users", column: "created_by_id"
 end

--- a/spec/factories/support_tickets.rb
+++ b/spec/factories/support_tickets.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :support_ticket do
+    sequence(:url) { |n| "https://example.com/ticket/#{n}" }
+
+    association :claim, factory: [:claim, :submitted]
+    association :created_by, factory: :dfe_signin_user
+  end
+end

--- a/spec/features/admin_claim_notes_spec.rb
+++ b/spec/features/admin_claim_notes_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Admin claim notes" do
     visit admin_claims_path
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    click_on "Notes"
+    click_on "Notes and support"
 
     expect(page).to have_content(existing_note.body)
     expect(page).to have_content(existing_note.created_by.full_name)

--- a/spec/features/admin_claim_support_tickets_spec.rb
+++ b/spec/features/admin_claim_support_tickets_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Admin claim support tickets" do
+  before { @signed_in_user = sign_in_as_service_operator }
+
+  scenario "the service operator adds a support ticket to a claim" do
+    claim = create(:claim, :submitted)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+    click_on "Notes"
+
+    fill_in "Support ticket", with: "https://account-sub-domain.zendesk.com/agent/tickets/1638"
+    click_on "Save support ticket"
+
+    expect(claim.support_ticket).to be_present
+    expect(claim.support_ticket.url).to eq("https://account-sub-domain.zendesk.com/agent/tickets/1638")
+    expect(claim.support_ticket.created_by).to eq(@signed_in_user)
+
+    expect(page).to have_link(href: "https://account-sub-domain.zendesk.com/agent/tickets/1638")
+  end
+end

--- a/spec/features/admin_claim_support_tickets_spec.rb
+++ b/spec/features/admin_claim_support_tickets_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Admin claim support tickets" do
     visit admin_claims_path
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    click_on "Notes"
+    click_on "Notes and support"
 
     fill_in "Support ticket", with: "https://account-sub-domain.zendesk.com/agent/tickets/1638"
     click_on "Save support ticket"

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe SupportTicket, type: :model do
+  it "validates the url attribute is a valid HTTP URL" do
+    support_ticket = build(:support_ticket)
+
+    support_ticket.url = "http://example.com/a-page"
+    expect(support_ticket).to be_valid
+
+    support_ticket.url = "https://example.com/a-page"
+    expect(support_ticket).to be_valid
+
+    support_ticket.url = "not-a-url"
+    expect(support_ticket).not_to be_valid
+    expect(support_ticket.errors.messages[:url]).to eq(["Enter a valid support ticket URL"])
+  end
+end

--- a/spec/requests/admin_support_tickets_spec.rb
+++ b/spec/requests/admin_support_tickets_spec.rb
@@ -22,5 +22,16 @@ RSpec.describe "admin/support_tickets controller" do
       expect(claim.support_ticket).not_to be_present
       expect(response.body).to include("Enter a valid support ticket URL")
     end
+
+    it "refuses requests from users without the service operator role" do
+      non_service_operator_roles.each do |role|
+        sign_in_to_admin_with_role(role)
+
+        post admin_claim_support_tickets_path(claim), params: {support_ticket: {url: "https://some/ticket/url"}}
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include("Not authorised")
+      end
+    end
   end
 end

--- a/spec/requests/admin_support_tickets_spec.rb
+++ b/spec/requests/admin_support_tickets_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe "admin/support_tickets controller" do
       expect(claim.support_ticket.url).to eq("https://some/ticket/url")
       expect(claim.support_ticket.created_by).to eq(@signed_in_user)
     end
+
+    it "shows an error message when the URL is not valid" do
+      post admin_claim_support_tickets_path(claim), params: {support_ticket: {url: "not/a/real/ticket/url"}}
+
+      expect(claim.support_ticket).not_to be_present
+      expect(response.body).to include("Enter a valid support ticket URL")
+    end
   end
 end

--- a/spec/requests/admin_support_tickets_spec.rb
+++ b/spec/requests/admin_support_tickets_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "admin/support_tickets controller" do
+  let(:claim) { create(:claim, :submitted) }
+
+  describe "admin/support_tickets#create" do
+    before { @signed_in_user = sign_in_as_service_operator }
+
+    it "creates a SupportTicket against the Claim when the user is a service operator" do
+      post admin_claim_support_tickets_path(claim), params: {support_ticket: {url: "https://some/ticket/url"}}
+
+      expect(response).to redirect_to(admin_claim_notes_path(claim))
+
+      expect(claim.support_ticket).to be_present
+      expect(claim.support_ticket.url).to eq("https://some/ticket/url")
+      expect(claim.support_ticket.created_by).to eq(@signed_in_user)
+    end
+  end
+end


### PR DESCRIPTION
This allows a support operator to add a support ticket directly to a claim.

## The form for adding
<img width="1033" alt="Screenshot 2020-04-02 at 13 20 19" src="https://user-images.githubusercontent.com/3687/78248712-0f39cb00-74e5-11ea-83e8-dedfa8654a4d.png">

## The link when added
<img width="1043" alt="Screenshot 2020-04-02 at 13 22 47" src="https://user-images.githubusercontent.com/3687/78248716-106af800-74e5-11ea-9fcf-3b54358f3398.png">

A future PR will add the ability to edit the support ticket URL.
