### PR TITLE
Add secondary SAML encryption key for VSP

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -193,7 +193,12 @@
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsProdVspSamlEncryption2KeyBase64"
+      }
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"


### PR DESCRIPTION
In preparation for rotating the certifications we need to configure the
VSP to accept the new SAML encryption key while still using the old
one. The rotation will happen in a separate change.