### PR TITLE
Add new SAML signing key for production VSP

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -181,7 +181,7 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsProdVspSamlSigning1KeyBase64"
+        "secretName": "TeacherPaymentsProdVspSamlSigning2KeyBase64"
       }
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {


### PR DESCRIPTION
GOV.​UK Verify has deployed the new signing certificate for our Verify Service Provider in production. The key exists in the key vault.