### PR TITLE
DQT Report consumer performs automated identity confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- DQT report upload now performs automated identity confirmation checks
+
 ## [Release 071] - 2020-04-03
 
 - The identity confirmation task is now present on all submitted claims

--- a/app/controllers/admin/qualification_report_uploads_controller.rb
+++ b/app/controllers/admin/qualification_report_uploads_controller.rb
@@ -9,11 +9,12 @@ module Admin
 
     def create
       @dqt_report_consumer = AutomatedChecks::DQTReportConsumer.new(params[:file], admin_user)
-      result = @dqt_report_consumer.ingest
-      if result
-        redirect_to admin_claims_path, notice: "DQT report uploaded successfully. Automatically created checks for #{pluralize(@dqt_report_consumer.completed_tasks, "claim")} out of #{pluralize(@dqt_report_consumer.total_records, "record")}."
-      else
+
+      if @dqt_report_consumer.errors.any?
         render :new
+      else
+        @dqt_report_consumer.ingest
+        redirect_to admin_claims_path, notice: "DQT report uploaded successfully. Automatically created checks for #{pluralize(@dqt_report_consumer.completed_tasks, "claim")} out of #{pluralize(@dqt_report_consumer.total_records, "record")}."
       end
     rescue ActiveRecord::RecordInvalid
       redirect_to new_admin_qualification_report_upload_path, alert: "There was a problem, please try again"

--- a/app/controllers/admin/qualification_report_uploads_controller.rb
+++ b/app/controllers/admin/qualification_report_uploads_controller.rb
@@ -14,7 +14,7 @@ module Admin
         render :new
       else
         @dqt_report_consumer.ingest
-        redirect_to admin_claims_path, notice: "DQT report uploaded successfully. Automatically created checks for #{pluralize(@dqt_report_consumer.completed_tasks, "claim")} out of #{pluralize(@dqt_report_consumer.total_records, "record")}."
+        redirect_to admin_claims_path, notice: "DQT report uploaded successfully. Automatically completed #{pluralize(@dqt_report_consumer.completed_tasks, "task")} from #{pluralize(@dqt_report_consumer.total_records, "DQT record")}."
       end
     rescue ActiveRecord::RecordInvalid
       redirect_to new_admin_qualification_report_upload_path, alert: "There was a problem, please try again"

--- a/app/controllers/admin/qualification_report_uploads_controller.rb
+++ b/app/controllers/admin/qualification_report_uploads_controller.rb
@@ -14,7 +14,7 @@ module Admin
         render :new
       else
         @dqt_report_consumer.ingest
-        redirect_to admin_claims_path, notice: "DQT report uploaded successfully. Automatically completed #{pluralize(@dqt_report_consumer.completed_tasks, "task")} from #{pluralize(@dqt_report_consumer.total_records, "DQT record")}."
+        redirect_to admin_claims_path, notice: "DQT report uploaded successfully. Automatically completed #{pluralize(@dqt_report_consumer.completed_tasks, "task")} for #{pluralize(@dqt_report_consumer.total_claims_checked, "checked claim")}."
       end
     rescue ActiveRecord::RecordInvalid
       redirect_to new_admin_qualification_report_upload_path, alert: "There was a problem, please try again"

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -27,14 +27,9 @@ module AutomatedChecks
         dqt_records.each do |record|
           claim = claim_for_record(record)
 
-          if claim && awaiting_task?(claim, "qualifications") && claim.policy::DQTRecord.new(record).eligible?
-            claim.tasks.create!(task_attributes("qualifications"))
-            @completed_tasks += 1
-          end
-
-          if claim && awaiting_task?(claim, "identity_confirmation") && identity_matches?(claim, record)
-            claim.tasks.create!(task_attributes("identity_confirmation"))
-            @completed_tasks += 1
+          if claim
+            perform_qualification_check(claim, record)
+            perform_identity_confirmation(claim, record)
           end
         end
       end
@@ -49,6 +44,20 @@ module AutomatedChecks
     end
 
     private
+
+    def perform_qualification_check(claim, record)
+      if awaiting_task?(claim, "qualifications") && claim.policy::DQTRecord.new(record).eligible?
+        claim.tasks.create!(task_attributes("qualifications"))
+        @completed_tasks += 1
+      end
+    end
+
+    def perform_identity_confirmation(claim, record)
+      if awaiting_task?(claim, "identity_confirmation") && identity_matches?(claim, record)
+        claim.tasks.create!(task_attributes("identity_confirmation"))
+        @completed_tasks += 1
+      end
+    end
 
     def claims
       @claims ||= Claim.awaiting_decision.includes(:tasks)

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -19,8 +19,8 @@ module AutomatedChecks
       ActiveRecord::Base.transaction do
         dqt_records.each do |record|
           claim = claim_for_record(record)
-          next if record.fetch(:qts_date).blank? || claim.nil?
-          if claim.policy::DQTRecord.new(record).eligible?
+
+          if claim && claim.policy::DQTRecord.new(record).eligible?
             claim.tasks.create!(task_attributes)
             @completed_tasks += 1
           end

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -20,8 +20,8 @@ module AutomatedChecks
 
       ActiveRecord::Base.transaction do
         claims = Claim.awaiting_task("qualifications")
-        records = DQTReportCsvToRecords.new(csv.rows).transform
-        records.each do |record|
+
+        dqt_records.each do |record|
           claim = claims.detect { |c| c.reference == record.fetch(:claim_reference) }
           next if record.fetch(:qts_date).blank? || claim.nil?
           if claim.policy::DQTRecord.new(record).eligible?
@@ -29,7 +29,7 @@ module AutomatedChecks
             @completed_tasks += 1
           end
         end
-        @total_records = records.count
+        @total_records = dqt_records.count
       end
     end
 
@@ -38,6 +38,10 @@ module AutomatedChecks
     end
 
     private
+
+    def dqt_records
+      @dqt_records ||= DQTReportCsvToRecords.new(@csv.rows).transform
+    end
 
     def task_attributes
       {

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -53,7 +53,7 @@ module AutomatedChecks
     end
 
     def perform_identity_confirmation(claim, record)
-      if awaiting_task?(claim, "identity_confirmation") && identity_matches?(claim, record)
+      if claim.identity_verified? && awaiting_task?(claim, "identity_confirmation") && identity_matches?(claim, record)
         claim.tasks.create!(task_attributes("identity_confirmation"))
         @completed_tasks += 1
       end

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -7,7 +7,7 @@ module AutomatedChecks
   # The records will be used to determine if a claimant's qualifications
   # make them eligible for a specific policy.
   class DQTReportConsumer
-    attr_reader :csv, :completed_tasks, :total_records
+    attr_reader :csv, :completed_tasks
 
     def initialize(file, admin_user)
       @csv = DQTReportCsv.new(file)
@@ -25,12 +25,15 @@ module AutomatedChecks
             @completed_tasks += 1
           end
         end
-        @total_records = dqt_records.count
       end
     end
 
     def errors
       csv.errors
+    end
+
+    def total_claims_checked
+      claims.size
     end
 
     private

--- a/app/models/automated_checks/dqt_report_consumer.rb
+++ b/app/models/automated_checks/dqt_report_consumer.rb
@@ -16,8 +16,6 @@ module AutomatedChecks
     end
 
     def ingest
-      return if errors.any?
-
       ActiveRecord::Base.transaction do
         dqt_records.each do |record|
           claim = claim_for_record(record)

--- a/app/models/maths_and_physics/dqt_record.rb
+++ b/app/models/maths_and_physics/dqt_record.rb
@@ -49,7 +49,7 @@ module MathsAndPhysics
     private
 
     def eligible_qts_date?
-      AcademicYear.for(qts_award_date) >= MathsAndPhysics.first_eligible_qts_award_year
+      qts_award_date.present? && AcademicYear.for(qts_award_date) >= MathsAndPhysics.first_eligible_qts_award_year
     end
 
     def eligible_qualification_subject?

--- a/app/models/student_loans/dqt_record.rb
+++ b/app/models/student_loans/dqt_record.rb
@@ -27,7 +27,7 @@ module StudentLoans
     private
 
     def eligible_qts_date?
-      AcademicYear.for(qts_award_date) >= StudentLoans.first_eligible_qts_award_year
+      qts_award_date.present? && AcademicYear.for(qts_award_date) >= StudentLoans.first_eligible_qts_award_year
     end
   end
 end

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -18,11 +18,15 @@ RSpec.feature "Admins automated qualification check" do
 
     click_on "Upload"
 
-    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 1 task for 4 checked claims."
+    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 2 tasks for 4 checked claims."
+
     expect(claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+    expect(claim_with_eligible_dqt_record.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+
     expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_decision.tasks.find_by(name: "qualifications")).to be_nil
+
     expect(claim_with_qualification_task.tasks.find_by(name: "qualifications")).to eq(existing_qualification_task)
   end
 end

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Admins automated qualification check" do
 
     click_on "Upload"
 
-    expect(page).to have_content "DQT report uploaded successfully. Automatically created checks for 1 claim out of 7 records."
+    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 1 task from 7 DQT records."
     expect(claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications").passed?).to eq(true)
     expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature "Admins automated qualification check" do
 
   scenario "Service operators can upload and run automated DQT checks" do
     claim_with_eligible_dqt_record = claim_from_example_dqt_report(:eligible_claim_with_matching_data)
+    eligible_claim_with_non_matching_birthdate = claim_from_example_dqt_report(:eligible_claim_with_non_matching_birthdate)
+    eligible_claim_with_non_matching_surname = claim_from_example_dqt_report(:eligible_claim_with_non_matching_surname)
     claim_without_dqt_record = claim_from_example_dqt_report(:claim_without_dqt_record)
     claim_with_ineligible_dqt_record = claim_from_example_dqt_report(:claim_with_ineligible_dqt_record)
     claim_with_decision = claim_from_example_dqt_report(:claim_with_decision)
@@ -18,10 +20,16 @@ RSpec.feature "Admins automated qualification check" do
 
     click_on "Upload"
 
-    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 2 tasks for 4 checked claims."
+    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 4 tasks for 6 checked claims."
 
     expect(claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications").passed?).to eq(true)
     expect(claim_with_eligible_dqt_record.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+
+    expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "qualifications").passed?).to eq(true)
+    expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "identity_confirmation")).to be_nil
+
+    expect(eligible_claim_with_non_matching_surname.tasks.find_by(name: "qualifications").passed?).to eq(true)
+    expect(eligible_claim_with_non_matching_surname.tasks.find_by(name: "identity_confirmation")).to be_nil
 
     expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil

--- a/spec/features/admin_automated_qualification_check_spec.rb
+++ b/spec/features/admin_automated_qualification_check_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Admins automated qualification check" do
 
     click_on "Upload"
 
-    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 1 task from 7 DQT records."
+    expect(page).to have_content "DQT report uploaded successfully. Automatically completed 1 task for 4 checked claims."
     expect(claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications").passed?).to eq(true)
     expect(claim_without_dqt_record.tasks.find_by(name: "qualifications")).to be_nil
     expect(claim_with_ineligible_dqt_record.tasks.find_by(name: "qualifications")).to be_nil

--- a/spec/fixtures/files/example_dqt_report.csv
+++ b/spec/fixtures/files/example_dqt_report.csv
@@ -7,3 +7,4 @@ dfeta text1,dfeta text2,dfeta trn,fullname,birthdate,dfeta ninumber,dfeta qtsdat
 6758493,CD123456,6758493,Terry Ineligible,21/4/1979,QQ123456C,12/3/2000,Politics,,,L200,,,Mathematics,,,G100,,
 5554433,EF123456,5554433,Already decided,15/5/1985,QQ123456C,9/1/2019,Chemistry,,,F100,,,Chemistry,,,F100,,
 6060606,GH123456,6060606,Already automated,4/10/1980,QQ123456C,10/5/2018,Spanish Studies,,,R400,,,Other Modern Language,,,R900,,
+9996060,DP5NEGWP,6060606,Not verified Bob,2/05/1979,QQ123456C,10/5/2018,Spanish Studies,,,R400,,,Other Modern Language,,,R900,,

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -34,33 +34,31 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
 
       expect(claim_with_qualification_task.tasks.find_by(name: "qualifications")).to eql(existing_qualification_task)
     end
+  end
 
-    context "when a malformed CSV is uploaded" do
-      let(:file) do
-        tempfile = Tempfile.new
-        tempfile.write("Malformed CSV\"")
-        tempfile.rewind
-        tempfile
-      end
-
-      it "doesn’t do anything and sets an error" do
-        expect(dqt_report_consumer.ingest).to be_falsey
-        expect(dqt_report_consumer.errors).to eql(["The selected file must be a CSV"])
-      end
+  context "when given a malformed CSV file" do
+    let(:file) do
+      tempfile = Tempfile.new
+      tempfile.write("Malformed CSV\"")
+      tempfile.rewind
+      tempfile
     end
 
-    context "when the CSV doesn’t have all the expected headers" do
-      let(:file) do
-        tempfile = Tempfile.new
-        tempfile.write("dfeta text1,dfeta text2,dfeta trn,dfeta qtsdate,fullname,birthdate\n")
-        tempfile.rewind
-        tempfile
-      end
+    it "reports an appropriate error mesage" do
+      expect(dqt_report_consumer.errors).to eql(["The selected file must be a CSV"])
+    end
+  end
 
-      it "doesn’t do anything and sets an error" do
-        expect(dqt_report_consumer.ingest).to be_falsey
-        expect(dqt_report_consumer.errors).to eql(["The selected file is missing some expected columns: dfeta ninumber, HESubject1Value, HESubject2Value, HESubject3Value, ITTSub1Value, ITTSub2Value, ITTSub3Value"])
-      end
+  context "when given a CSV without the expected headers" do
+    let(:file) do
+      tempfile = Tempfile.new
+      tempfile.write("dfeta text1,dfeta text2,dfeta trn,dfeta qtsdate,fullname,birthdate\n")
+      tempfile.rewind
+      tempfile
+    end
+
+    it "reports the misssing columns in the error message" do
+      expect(dqt_report_consumer.errors).to eql(["The selected file is missing some expected columns: dfeta ninumber, HESubject1Value, HESubject2Value, HESubject3Value, ITTSub1Value, ITTSub2Value, ITTSub3Value"])
     end
   end
 end

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   describe "#ingest" do
     before { dqt_report_consumer.ingest }
 
-    it "sets attributes that report the number of tasks automatically completed and the number of DQT records checked" do
+    it "sets attributes that report the number of tasks automatically completed and the number of claims checked" do
       expect(dqt_report_consumer.completed_tasks).to eq(1)
-      expect(dqt_report_consumer.total_records).to eq(7)
+      expect(dqt_report_consumer.total_claims_checked).to eq(4)
     end
 
     it "creates a qualification task for claims that are eligible" do

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -12,13 +12,14 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   let!(:claim_with_decision) { claim_from_example_dqt_report(:claim_with_decision) }
   let!(:claim_with_qualification_task) { claim_from_example_dqt_report(:claim_with_qualification_task) }
   let!(:existing_qualification_task) { claim_with_qualification_task.tasks.find_by!(name: "qualifications") }
+  let!(:unverified_claim_with_matching_identity_data) { claim_from_example_dqt_report(:unverified_claim_with_matching_identity_data) }
 
   describe "#ingest" do
     before { dqt_report_consumer.ingest }
 
     it "sets attributes that report the number of tasks automatically completed and the number of claims checked" do
-      expect(dqt_report_consumer.completed_tasks).to eq(4)
-      expect(dqt_report_consumer.total_claims_checked).to eq(6)
+      expect(dqt_report_consumer.completed_tasks).to eq(5)
+      expect(dqt_report_consumer.total_claims_checked).to eq(7)
     end
 
     it "creates a qualification task for claims that are eligible" do
@@ -43,6 +44,13 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
       expect(new_id_confirmation_task.passed).to eq(true)
       expect(new_id_confirmation_task.manual).to eq(false)
       expect(new_id_confirmation_task.created_by).to eq(admin_user)
+    end
+
+    it "doesn‘t create an identity_confirmation task for claims that are unverified" do
+      qualification_task = unverified_claim_with_matching_identity_data.tasks.find_by!(name: "qualifications")
+      expect(qualification_task.passed).to eq(true)
+
+      expect(unverified_claim_with_matching_identity_data.tasks.find_by(name: "identity_confirmation")).to be_nil
     end
 
     it "doesn't create an identity_confirmation task if either the surname or DOB does not match" do

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   let(:file) { example_dqt_report_csv }
   let(:admin_user) { build(:dfe_signin_user) }
   let!(:claim_with_eligible_dqt_record) { claim_from_example_dqt_report(:eligible_claim_with_matching_data) }
+  let!(:eligible_claim_with_non_matching_birthdate) { claim_from_example_dqt_report(:eligible_claim_with_non_matching_birthdate) }
+  let!(:eligible_claim_with_non_matching_surname) { claim_from_example_dqt_report(:eligible_claim_with_non_matching_surname) }
   let!(:claim_without_dqt_record) { claim_from_example_dqt_report(:claim_without_dqt_record) }
   let!(:claim_with_ineligible_dqt_record) { claim_from_example_dqt_report(:claim_with_ineligible_dqt_record) }
   let!(:claim_with_decision) { claim_from_example_dqt_report(:claim_with_decision) }
@@ -15,12 +17,22 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
     before { dqt_report_consumer.ingest }
 
     it "sets attributes that report the number of tasks automatically completed and the number of claims checked" do
-      expect(dqt_report_consumer.completed_tasks).to eq(2)
-      expect(dqt_report_consumer.total_claims_checked).to eq(4)
+      expect(dqt_report_consumer.completed_tasks).to eq(4)
+      expect(dqt_report_consumer.total_claims_checked).to eq(6)
     end
 
     it "creates a qualification task for claims that are eligible" do
       new_qualication_task = claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications")
+      expect(new_qualication_task.passed).to eq(true)
+      expect(new_qualication_task.manual).to eq(false)
+      expect(new_qualication_task.created_by).to eq(admin_user)
+
+      new_qualication_task = eligible_claim_with_non_matching_birthdate.tasks.find_by!(name: "qualifications")
+      expect(new_qualication_task.passed).to eq(true)
+      expect(new_qualication_task.manual).to eq(false)
+      expect(new_qualication_task.created_by).to eq(admin_user)
+
+      new_qualication_task = eligible_claim_with_non_matching_surname.tasks.find_by!(name: "qualifications")
       expect(new_qualication_task.passed).to eq(true)
       expect(new_qualication_task.manual).to eq(false)
       expect(new_qualication_task.created_by).to eq(admin_user)
@@ -31,6 +43,11 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
       expect(new_id_confirmation_task.passed).to eq(true)
       expect(new_id_confirmation_task.manual).to eq(false)
       expect(new_id_confirmation_task.created_by).to eq(admin_user)
+    end
+
+    it "doesn't create an identity_confirmation task if either the surname or DOB does not match" do
+      expect(eligible_claim_with_non_matching_birthdate.tasks.find_by(name: "identity_confirmation")).to be_nil
+      expect(eligible_claim_with_non_matching_surname.tasks.find_by(name: "identity_confirmation")).to be_nil
     end
 
     it "doesn’t create a qualification task when the claim already has a decision" do

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
     before { dqt_report_consumer.ingest }
 
     it "sets attributes that report the number of tasks automatically completed and the number of claims checked" do
-      expect(dqt_report_consumer.completed_tasks).to eq(1)
+      expect(dqt_report_consumer.completed_tasks).to eq(2)
       expect(dqt_report_consumer.total_claims_checked).to eq(4)
     end
 
@@ -24,6 +24,13 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
       expect(new_qualication_task.passed).to eq(true)
       expect(new_qualication_task.manual).to eq(false)
       expect(new_qualication_task.created_by).to eq(admin_user)
+    end
+
+    it "creates an identity_confirmation task for claims where the surname and DOB in the record matches the claim" do
+      new_id_confirmation_task = claim_with_eligible_dqt_record.tasks.find_by!(name: "identity_confirmation")
+      expect(new_id_confirmation_task.passed).to eq(true)
+      expect(new_id_confirmation_task.manual).to eq(false)
+      expect(new_id_confirmation_task.created_by).to eq(admin_user)
     end
 
     it "doesn’t create a qualification task when the claim already has a decision" do

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -14,10 +14,13 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   describe "#ingest" do
     before { dqt_report_consumer.ingest }
 
-    it "creates a qualification task for claims that are eligible" do
-      new_qualication_task = claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications")
+    it "sets attributes that report the number of tasks automatically completed and the number of DQT records checked" do
       expect(dqt_report_consumer.completed_tasks).to eq(1)
       expect(dqt_report_consumer.total_records).to eq(7)
+    end
+
+    it "creates a qualification task for claims that are eligible" do
+      new_qualication_task = claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications")
       expect(new_qualication_task.passed).to eq(true)
       expect(new_qualication_task.manual).to eq(false)
       expect(new_qualication_task.created_by).to eq(admin_user)

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
   let!(:existing_qualification_task) { claim_with_qualification_task.tasks.find_by!(name: "qualifications") }
 
   describe "#ingest" do
-    it "creates a qualification task for claims that are eligible" do
-      dqt_report_consumer.ingest
+    before { dqt_report_consumer.ingest }
 
+    it "creates a qualification task for claims that are eligible" do
       new_qualication_task = claim_with_eligible_dqt_record.tasks.find_by!(name: "qualifications")
       expect(dqt_report_consumer.completed_tasks).to eq(1)
       expect(dqt_report_consumer.total_records).to eq(7)
@@ -24,14 +24,10 @@ RSpec.describe AutomatedChecks::DQTReportConsumer do
     end
 
     it "doesn’t create a qualification task when the claim already has a decision" do
-      dqt_report_consumer.ingest
-
       expect(claim_with_decision.tasks.find_by(name: "qualifications")).to be_nil
     end
 
     it "doesn’t create a qualification task when the claim already has one" do
-      dqt_report_consumer.ingest
-
       expect(claim_with_qualification_task.tasks.find_by(name: "qualifications")).to eql(existing_qualification_task)
     end
   end

--- a/spec/models/maths_and_physics/dqt_record_spec.rb
+++ b/spec/models/maths_and_physics/dqt_record_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe MathsAndPhysics::DQTRecord do
           expect(MathsAndPhysics::DQTRecord.new(attributes.merge({qts_date: Date.parse("8/3/2000")})).eligible?). to eql false
         end
       end
+
+      it "returns false when given a record with a blank qts_date" do
+        expect(MathsAndPhysics::DQTRecord.new({qts_date: "", itt_subject_jac_codes: [jac_code], degree_jac_codes: []}).eligible?). to eql false
+      end
     end
 
     EXAMPLE_NON_ELIGIBLE_JAC_CODES.each do |jac_code|

--- a/spec/models/student_loans/dqt_record_spec.rb
+++ b/spec/models/student_loans/dqt_record_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe StudentLoans::DQTRecord do
       expect(StudentLoans::DQTRecord.new({qts_date: Date.parse("1/10/2014")}).eligible?). to eql true
     end
 
-    it "returns false if the given date is not an eligible year" do
+    it "returns false if the given QTS award date is not an eligible year" do
       expect(StudentLoans::DQTRecord.new({qts_date: Date.parse("8/3/2000")}).eligible?). to eql false
+    end
+
+    it "returns false if the given QTS award date is blank" do
+      expect(StudentLoans::DQTRecord.new({qts_date: ""}).eligible?). to eql false
     end
   end
 end

--- a/spec/requests/admin_qualification_report_upload_spec.rb
+++ b/spec/requests/admin_qualification_report_upload_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Admin qualification report upload" do
         qualification_task = claim.tasks.find_by(name: "qualifications")
         expect(qualification_task.created_by).to eql(@signed_in_user)
 
-        expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically created checks for 1 claim out of 1 record.")
+        expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically completed 1 task from 1 DQT record.")
         expect(response).to redirect_to(admin_claims_path)
       end
     end

--- a/spec/requests/admin_qualification_report_upload_spec.rb
+++ b/spec/requests/admin_qualification_report_upload_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe "Admin qualification report upload" do
       end
     end
 
-    context "when there's an error creating the tasks" do
+    context "when there's an ActiveRecord::RecordInvalid error raised during the file ingest" do
       it "displays an error and prompts the user to try again" do
-        allow_any_instance_of(Claim).to receive_message_chain("tasks.create!").and_raise(ActiveRecord::RecordInvalid)
+        expect_any_instance_of(AutomatedChecks::DQTReportConsumer).to receive("ingest").and_raise(ActiveRecord::RecordInvalid)
 
         expect {
           post admin_qualification_report_uploads_path, params: {file: file}

--- a/spec/requests/admin_qualification_report_upload_spec.rb
+++ b/spec/requests/admin_qualification_report_upload_spec.rb
@@ -28,15 +28,18 @@ RSpec.describe "Admin qualification report upload" do
     end
 
     context "when the data in CSV matches the data in the claim" do
-      it "creates qualification task for the claim" do
+      it "creates qualification and identity_confirmation tasks for the claim" do
         expect {
           post admin_qualification_report_uploads_path, params: {file: file}
-        }.to change { claim.tasks.count }.by(1)
+        }.to change { claim.tasks.count }.by(2)
 
         qualification_task = claim.tasks.find_by(name: "qualifications")
         expect(qualification_task.created_by).to eql(@signed_in_user)
 
-        expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically completed 1 task for 1 checked claim.")
+        id_confirmation_task = claim.tasks.find_by(name: "identity_confirmation")
+        expect(id_confirmation_task.created_by).to eql(@signed_in_user)
+
+        expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically completed 2 tasks for 1 checked claim.")
         expect(response).to redirect_to(admin_claims_path)
       end
     end

--- a/spec/requests/admin_qualification_report_upload_spec.rb
+++ b/spec/requests/admin_qualification_report_upload_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Admin qualification report upload" do
         qualification_task = claim.tasks.find_by(name: "qualifications")
         expect(qualification_task.created_by).to eql(@signed_in_user)
 
-        expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically completed 1 task from 1 DQT record.")
+        expect(flash[:notice]).to eql("DQT report uploaded successfully. Automatically completed 1 task for 1 checked claim.")
         expect(response).to redirect_to(admin_claims_path)
       end
     end

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -9,7 +9,7 @@ module FixtureHelpers
   def claim_from_example_dqt_report(trait)
     case trait
     when :eligible_claim_with_matching_data
-      # Eligible claim with matching data in DQT
+      # Eligible claim with matching name and DOB in DQT
       create(:claim, :submitted,
         surname: "ELIGIBLE",
         teacher_reference_number: "1234567",

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -57,6 +57,12 @@ module FixtureHelpers
         reference: "GH123456",
         date_of_birth: Date.new(1980, 10, 4),
         tasks: [build(:task, name: "qualifications")])
+    when :unverified_claim_with_matching_identity_data
+      create(:claim, :unverified,
+        teacher_reference_number: "9996060",
+        reference: "DP5NEGWP",
+        surname: "Bob",
+        date_of_birth: Date.new(1979, 5, 2))
     end
   end
 


### PR DESCRIPTION
This updates the DQT report upload so that it will automatically mark identity confirmation tasks as a PASS if the date of birth and surname held in the claimant's DQT record matches the details we received from GOV.UK Verify. It will not automatically confirm identity for claims without GOV.UK Verify identity information, these will need to be manually confirmed.