### PR TITLE
Make the new SAML encryption key primary and remove old

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -189,16 +189,11 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsProdVspSamlEncryption1KeyBase64"
+        "secretName": "TeacherPaymentsProdVspSamlEncryption2KeyBase64"
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "TeacherPaymentsProdVspSamlEncryption2KeyBase64"
-      }
+      "value": ""
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"


### PR DESCRIPTION
We're now successfully using the new certificates so we can remove the old key and make the new key the primary one.
