### PR TITLE
Clarify requirements of rotating the certificates

### DIFF
--- a/docs/govuk-verify-rotating-keys-and-certificates.md
+++ b/docs/govuk-verify-rotating-keys-and-certificates.md
@@ -205,7 +205,7 @@ Make sure to securely delete the copies of the keys and certificates stored in
 
 ## Step 10. Clean up – remove your local IP address from the Azure key vault firewall
 
-The key vault firewall should aumatically get reset on a redeploy, but double
+The key vault firewall should automatically get reset on a redeploy, but double
 check to be sure:
 
 - Navigate to the key vault in the Azure Portal

--- a/docs/govuk-verify-rotating-keys-and-certificates.md
+++ b/docs/govuk-verify-rotating-keys-and-certificates.md
@@ -24,6 +24,9 @@ To perform this task, you will need:
 - The
   [Azure CLI installed](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 - The codebase cloned locally
+- If you're performing the rotation on production you will need either an
+  existing account with a GOV.UK Verify identity provider or the required
+  documents necessary for signing up to one
 
 Speak to the product manager if you need access to the GOV.UK Manage
 certificates service or the Azure portal.


### PR DESCRIPTION
It is necessary to be able to complete the GOV.UK Verify journey if
rotating the certificates on production to check the new keys and
certificates are working as expected.

It is mentioned futher down that a real account is needed but stating
the requirement up front may help decide who carries out and when the
rotation is done. Signing up to an identity provider isn't always
instant and may take several days.