### PR TITLE
Display decision result on the task view page for a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog]
 
 - Improve message shown when inconsistent payroll information is found
 - Service operators can add a support ticket to claims
+- Display the claim's decision within the heading on the task view page
 
 ## [Release 068] - 2020-03-31
 

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -95,6 +95,14 @@ module Admin
       content_tag("strong", status, class: tag_classes)
     end
 
+    def claim_summary_heading(claim)
+      if claim.decision_made?
+        claim.reference + " – " + claim.latest_decision.result.capitalize
+      else
+        claim.reference
+      end
+    end
+
     private
 
     def matching_attributes_for(claim)

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -1,7 +1,9 @@
 <div class="govuk-grid-column-full">
   <span class="govuk-caption-xl"><%= claim.policy.short_name %> (<%= claim.academic_year %>)</span>
   <h1 class="govuk-heading-xl govuk-heading--navigation">
-    <%= heading %>
+    <span id="claim-heading">
+      <%= claim_summary_heading(claim) %>
+    </span>
     <span class="govuk-body-m">
       <%= link_to "View full claim", admin_claim_path(claim), class: "govuk-link" %>
       <%= link_to "Amend claim", new_admin_claim_amendment_url(claim), class: "govuk-link" if claim.amendable? %>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -3,7 +3,7 @@
 <%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">
-  <%= render "claim_summary", claim: @claim, heading: @claim.reference %>
+  <%= render "claim_summary", claim: @claim %>
 </div>
 
 <div class="govuk-grid-row">

--- a/spec/features/admin_views_completed_claim_spec.rb
+++ b/spec/features/admin_views_completed_claim_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Admin can view completed claims" do
+  before { @signed_in_user = sign_in_as_service_operator }
+
+  scenario "Viewing a claim that has a decision made " do
+    claim_with_decision = create(:claim, :approved)
+
+    visit admin_claim_tasks_path(claim_with_decision)
+
+    within("span#claim-heading") do
+      expect(page).to have_content("Approved")
+    end
+  end
+
+  scenario "Viewing a claim that does not have decision made" do
+    claim_without_decision = create(:claim, :submitted)
+
+    visit admin_claim_tasks_path(claim_without_decision)
+
+    within("span#claim-heading") do
+      expect(page).to have_content(claim_without_decision.reference)
+    end
+  end
+end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -229,4 +229,22 @@ describe Admin::ClaimsHelper do
       expect(task_status_tag).to match("govuk-tag app-task-list__task-completed govuk-tag--inactive")
     end
   end
+
+  describe "#claim_summary_heading" do
+    context "when the claim has a decision" do
+      it "returns the reference field and the decision result" do
+        claim = create(:claim, :approved, reference: "1")
+        result = helper.claim_summary_heading(claim)
+        expect(result).to eql("1 – Approved")
+      end
+    end
+
+    context "when the claim does not have a decision" do
+      it "returns the reference field" do
+        claim = create(:claim, reference: "1")
+        result = helper.claim_summary_heading(claim)
+        expect(result).to eql("1")
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a decision is made on a claim, the claim's task view will now show the result within the header.
For claims which haven't had a decision made, the task view page will just display the claim reference (as shown in the before screenshot)

**Before:**
![Screenshot 2020-04-03 at 17 43 29](https://user-images.githubusercontent.com/59832893/78384777-b9435100-75d2-11ea-9ea8-0d71aa2a69d5.png)

**After:**
![Screenshot 2020-04-03 at 17 42 53](https://user-images.githubusercontent.com/59832893/78384799-bfd1c880-75d2-11ea-9464-a689f4711b08.png)

This ticket has taken longer than expected to complete, so I have broken it up into separate Pull Requests as I believe that this can be merged alone. 
The next parts to this ticket are:
- to show the payroll status
- to show the claim amount
- to remove other information that will be scrubbed