### PR TITLE
Remove negative contraction from validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Move shipping logs to logstash to Filebeat
+- Remove a negative contraction in some text, to follow GOV.UK style guide
 
 ## [Release 072] - 2020-04-03
 

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -131,7 +131,7 @@ module StudentLoans
     end
 
     def one_subject_must_be_selected
-      errors.add(:subjects_taught, "Select if you taught Biology, Chemistry, Physics, Computing, Languages or you didn’t teach any of these subjects") if subjects_taught.empty?
+      errors.add(:subjects_taught, "Select if you taught Biology, Chemistry, Physics, Computing, Languages or you did not teach any of these subjects") if subjects_taught.empty?
     end
 
     def ineligible_current_school?


### PR DESCRIPTION
It’s inconsistent with the question wording and also the GOV.UK style
guide recommends avoiding negative contractions.
