### PR TITLE
Improve development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ Architecture decision records can be found in the
      “When using this certificate:” dropdown to `Always Trust` in the Trust
      section.
 2. Run `bundle install` and `yarn install` to install the dependencies
-3. Run `bundle exec rails db:setup` to set up the database development
-4. Run `bundle exec foreman start` to launch the app on https://localhost:3000/
-5. Visit one of the following urls in your browser to access the relevant
+3. Fetch the `DFE_SIGN_IN_API_SECRET` development secret from the
+   [Azure key vault](docs/secrets.md) and store it in `.env` at the root of the
+   repository.
+4. Run `bundle exec rails db:setup` to set up the database development
+5. Run `bundle exec foreman start` to launch the app on https://localhost:3000/
+6. Visit one of the following urls in your browser to access the relevant
    policy:
 
 - **Student Loans:** https://localhost:3000/student-loans/claim

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -24,7 +24,8 @@ Then, follow these steps to complete your onboarding:
 1. Log in to your DfE email.
 2. If Google asks you to set up two-factor authentication, see
    [this advice](#how-to-set-up-two-factor-auth-for-your-digitaleducationgovuk-google-account).
-3. Follow the link in the Azure invitation email and create an account.
+3. Follow the link in the Azure invitation email and create an account. Your
+   password should be no longer than 16 characters.
 4. Click on
    [this link](https://portal.azure.com/?Microsoft_Azure_PIMCommon=true#blade/Microsoft_AAD_IAM/GroupDetailsMenuBlade/Owners/groupId/6642920a-1aab-49bb-9a20-365131195349)
    – we’ll use this to confirm you’re using the correct directory in Azure.


### PR DESCRIPTION
 - Add note about Azure's maximum password length
 - Added step for fetching DFE_SIGN_IN_API_SECRET from the key vault in
   order to run the `db:setup` rake task
