### PR TITLE
Forbid amending student loan plan when no loan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- A service operator isn’t allowed to amend student loan plan when the claimant
+  has already paid off their student loan
+
 ## [Release 074] - 2020-04-07
 
 - Display payroll status of claim within task view

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -138,6 +138,7 @@ class Claim < ApplicationRecord
   validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select the number of student loans you have taken out"}
   validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: ->(object, data) { I18n.t("validation_errors.student_loan_start_date.#{object.student_loan_courses}") }}
   validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
+  validates :student_loan_plan, on: [:amendment], inclusion: {in: [Claim::NO_STUDENT_LOAN], message: "You can’t amend the student loan plan type because the claimant said they are no longer paying off their student loan"}, if: :no_student_loan?
 
   validates :email_address, on: [:"email-address", :submit], presence: {message: "Enter an email address"}
   validates :email_address, format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email in the format name@example.com"},

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -118,6 +118,17 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  context "when amending a claim with no student loan" do
+    it "cannot have its student loan plan type amended to anything other than NO_STUDENT_LOAN" do
+      claim = build(:claim, :submittable, has_student_loan: false, student_loan_plan: Claim::NO_STUDENT_LOAN)
+
+      expect(claim).to be_valid(:amendment)
+
+      claim.student_loan_plan = StudentLoan::PLAN_1
+      expect(claim).not_to be_valid(:amendment)
+    end
+  end
+
   it "is not submittable without a value for the student_loan_plan present" do
     expect(build(:claim, :submittable, student_loan_plan: nil)).not_to be_valid(:submit)
     expect(build(:claim, :submittable, student_loan_plan: Claim::NO_STUDENT_LOAN)).to be_valid(:submit)

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe "Admin claim amendments" do
         expect(response.body).to include("Enter an account number")
       end
 
+      it "displays a validation error and does not update the claim or create an amendment when trying to change the student loan plan when the claimant is no longer paying off their student loan" do
+        claim.update!(has_student_loan: false, student_loan_plan: Claim::NO_STUDENT_LOAN)
+
+        expect {
+          post admin_claim_amendments_url(claim, amendment: {claim: {student_loan_plan: "plan_2"},
+                                                             notes: "Contacted claimant to find out plan type"})
+        }.not_to change { [claim.reload.student_loan_plan, claim.amendments.size] }
+
+        expect(response).to have_http_status(:ok)
+
+        expect(response.body).to include("You can’t amend the student loan plan type")
+      end
+
       it "displays an error message and does not create an amendment when none of the claim’s values are changed" do
         expect {
           post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: claim.teacher_reference_number},


### PR DESCRIPTION
In our current claim journey we only collect the claimant’s student loan
plan type if they tell us they’re still paying off their student loan.
This is because when we designed the claim journey, the only reason we
needed to know the plan type was so payroll could calculate the correct
student loan contributions to be deducted from the claim amount.

We recently had a case where a service operator amended a claim where
the claimant was no longer paying off their student loan, to set the
loan plan type to Plan 2.

Their reason for doing so was sensible – we also need to know the plan
type to be able to check the claim amount for TSLR claims. However, once
this claim was sent to Cantium, they saw the claim as having “no student
loan” and also having a plan type, which from their point of view
doesn’t make sense and which caused an error in their payroll system.

This problem would benefit from some service design thought – to find a
way to collect plan type even when the claimant has paid off their loan.
But until then, I just want to prevent the system from getting into this
state, so I’m adding a validation that prevents a service operator from
adding a plan type when the loan is already paid off. If a service
operator needs to collect this information – for checking the claim
amount – they should add a note to the claim.

I’ve suggested to the product owner that they add a card to their
backlog to explore this problem once they have development / service
design capacity.
