### PR TITLE
Ignore undone rejections when anonymizing claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- When removing personal data from claims, don’t treat a claim as rejected if
+  the rejection has been undone
+
 ## [Release 076] - 2020-06-16
 
 - Security updates

--- a/app/models/claim/personal_data_scrubber.rb
+++ b/app/models/claim/personal_data_scrubber.rb
@@ -48,7 +48,7 @@ class Claim
         .joins(:decisions)
         .where(personal_data_removed_at: nil)
         .where(
-          "(decisions.result = :rejected AND decisions.created_at < :minimum_time) OR scheduled_payment_date < :minimum_time",
+          "(decisions.undone = false AND decisions.result = :rejected AND decisions.created_at < :minimum_time) OR scheduled_payment_date < :minimum_time",
           minimum_time: TIME_BEFORE_CLAIM_CONSIDERED_OLD.ago,
           rejected: Decision.results.fetch(:rejected)
         )

--- a/spec/models/claim/personal_data_scrubber_spec.rb
+++ b/spec/models/claim/personal_data_scrubber_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Claim::PersonalDataScrubber, type: :model do
     expect { Claim::PersonalDataScrubber.new.scrub_completed_claims }.not_to change { claim.reload.attributes }
   end
 
+  it "does not delete details from a claim with a rejection which is old but undone" do
+    claim = create(:claim, :submitted)
+    create(:decision, :rejected, :undone, claim: claim, created_at: over_two_months_ago)
+
+    expect { Claim::PersonalDataScrubber.new.scrub_completed_claims }.not_to change { claim.reload.attributes }
+  end
+
   it "deletes expected details from an old rejected claim, setting a personal_data_removed_at timestamp" do
     freeze_time do
       claim = create(:claim, :submitted)


### PR DESCRIPTION
A claim with an undone rejection should not be considered as rejected
and hence this rejection should not contribute to its eligibility to be
anonymized.

We recently accidentally scrubbed the personal data from some claims
which had been rejected and then subsequently approved, and only noticed
this when the payroll CSV file generation blew up because the payroll
gender was missing. We had to restore these claims' personal data from a
database backup.

https://dxw.zendesk.com/agent/tickets/11941
