### PR TITLE
Remove banking_name when scrubbing personal data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Remove banking_name when scrubbing personal data from a claim
+
 ## [Release 077] - 2020-06-18
 
 - When removing personal data from claims, don’t treat a claim as rejected if

--- a/app/models/claim/personal_data_scrubber.rb
+++ b/app/models/claim/personal_data_scrubber.rb
@@ -20,7 +20,8 @@ class Claim
       :national_insurance_number,
       :bank_sort_code,
       :bank_account_number,
-      :building_society_roll_number
+      :building_society_roll_number,
+      :banking_name
     ]
 
     TIME_BEFORE_CLAIM_CONSIDERED_OLD = 2.months

--- a/db/data/20200622125327_scrub_banking_name_from_scrubbed_claims.rb
+++ b/db/data/20200622125327_scrub_banking_name_from_scrubbed_claims.rb
@@ -1,0 +1,4 @@
+# Run me with `rails runner db/data/20200622125327_scrub_banking_name_from_scrubbed_claims.rb`
+
+Claim.where("personal_data_removed_at IS NOT NULL AND banking_name IS NOT NULL")
+  .update_all(banking_name: nil)

--- a/spec/models/claim/personal_data_scrubber_spec.rb
+++ b/spec/models/claim/personal_data_scrubber_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Claim::PersonalDataScrubber, type: :model do
       expect(cleaned_claim.bank_sort_code).to be_nil
       expect(cleaned_claim.bank_account_number).to be_nil
       expect(cleaned_claim.building_society_roll_number).to be_nil
+      expect(cleaned_claim.banking_name).to be_nil
       expect(cleaned_claim.personal_data_removed_at).to eq(Time.zone.now)
     end
   end
@@ -83,6 +84,7 @@ RSpec.describe Claim::PersonalDataScrubber, type: :model do
       expect(cleaned_claim.bank_sort_code).to be_nil
       expect(cleaned_claim.bank_account_number).to be_nil
       expect(cleaned_claim.building_society_roll_number).to be_nil
+      expect(cleaned_claim.banking_name).to be_nil
       expect(cleaned_claim.personal_data_removed_at).to eq(Time.zone.now)
     end
   end


### PR DESCRIPTION
It seems like we missed this one when we were choosing which fields to
scrub.

Our data retention policy [1] says that the only personal data we keep
are TRN and email address.

We already remove first_name, last_name, and all bank account numbers.
So I see no reason why we should be keeping banking_name.

This includes a data migration to fix the already-scrubbed claims.

[1] https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1086193761/Data+handling+and+retention
