### PR TITLE
Handle common errors in confirmation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add contextual information when incorrect data is in a confirmation report
+- Remove thousand seperators from numeric columns in confirmation reports
+
 ## [Release 078] - 2020-06-22
 
 - Remove banking_name when scrubbing personal data from a claim

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -93,7 +93,7 @@ class PaymentConfirmation
     if payment.save(context: :upload)
       updated_payment_ids.add(payment.id)
     else
-      errors.append("The claim at line #{@line_number} has invalid data")
+      errors.append("The claim at line #{@line_number} has invalid data - #{payment.errors.full_messages.to_sentence}")
     end
   end
 end

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -82,18 +82,22 @@ class PaymentConfirmation
     end
 
     payment.payroll_reference = row["Payroll Reference"]
-    payment.gross_value = row["Gross Value"]
-    payment.national_insurance = row["NI"]
-    payment.employers_national_insurance = row["Employers NI"]
-    payment.student_loan_repayment = row["Student Loans"]
-    payment.tax = row["Tax"]
-    payment.net_pay = row["Net Pay"]
-    payment.gross_pay = row["Gross Value"].to_d - row["Employers NI"].to_d
+    payment.gross_value = cast_as_numeric(row["Gross Value"])
+    payment.national_insurance = cast_as_numeric(row["NI"])
+    payment.employers_national_insurance = cast_as_numeric(row["Employers NI"])
+    payment.student_loan_repayment = cast_as_numeric(row["Student Loans"])
+    payment.tax = cast_as_numeric(row["Tax"])
+    payment.net_pay = cast_as_numeric(row["Net Pay"])
+    payment.gross_pay = cast_as_numeric(row["Gross Value"]).to_d - cast_as_numeric(row["Employers NI"]).to_d
 
     if payment.save(context: :upload)
       updated_payment_ids.add(payment.id)
     else
       errors.append("The claim at line #{@line_number} has invalid data - #{payment.errors.full_messages.to_sentence}")
     end
+  end
+
+  def cast_as_numeric(number)
+    number&.gsub(",", "")
   end
 end

--- a/spec/models/payment_confirmation_spec.rb
+++ b/spec/models/payment_confirmation_spec.rb
@@ -182,14 +182,14 @@ RSpec.describe PaymentConfirmation do
     let(:csv) do
       <<~CSV
         Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
+        DFE00001,,#{payroll_run.payments[0].id},,38.98,0,89.6,325
         DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
       CSV
     end
 
     it "fails and populates its errors, and does not update the payments" do
       expect(payment_confirmation.ingest).to be_falsey
-      expect(payment_confirmation.errors).to eq(["The claim at line 2 has invalid data"])
+      expect(payment_confirmation.errors).to eq(["The claim at line 2 has invalid data - Gross value can't be blank and National insurance can't be blank"])
 
       expect(payroll_run.payments[0].reload.payroll_reference).to eq(nil)
       expect(payroll_run.payments[1].reload.payroll_reference).to eq(nil)

--- a/spec/models/payment_confirmation_spec.rb
+++ b/spec/models/payment_confirmation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PaymentConfirmation do
     <<~CSV
       Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
       DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
-      DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
+      DFE00002,"1,211.15",#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
     CSV
   end
   let(:file) do
@@ -36,13 +36,13 @@ RSpec.describe PaymentConfirmation do
       expect(first_payment.gross_pay).to eq("448.5".to_d)
 
       expect(second_payment.payroll_reference).to eq("DFE00002")
-      expect(second_payment.gross_value).to eq("904.15".to_d)
+      expect(second_payment.gross_value).to eq("1211.15".to_d)
       expect(second_payment.national_insurance).to eq("77.84".to_d)
       expect(second_payment.employers_national_insurance).to eq("89.51".to_d)
       expect(second_payment.student_loan_repayment).to eq("40".to_d)
       expect(second_payment.tax).to eq("162.8".to_d)
       expect(second_payment.net_pay).to eq("534".to_d)
-      expect(second_payment.gross_pay).to eq("814.64".to_d)
+      expect(second_payment.gross_pay).to eq("1121.64".to_d)
     end
 
     it "populates the payroll run's confirmation_report_uploaded_by and sets a payment date of the upcoming Friday" do


### PR DESCRIPTION
This adds contextual information for confirmation reports with incorrect data (to make diagnosis easier), as well as attempting to get around the issue when Excel adds thousand seperators to numeric columns when saving / editing a CSV.