### PR TITLE
Break down display of payment information by claim in payroll admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Break down number of claims and claim amount in payroll runs by policy
+
 ## [Release 081] - 2020-09-01
 
 - Changes made to content pages ready for academic year 2020-21

--- a/app/helpers/admin/payment_helper.rb
+++ b/app/helpers/admin/payment_helper.rb
@@ -1,8 +1,0 @@
-module Admin
-  module PaymentHelper
-    def claim_references(payment)
-      references = payment.claims.pluck(:reference)
-      references.join("<br/>").html_safe
-    end
-  end
-end

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -16,6 +16,14 @@ class PayrollRun < ApplicationRecord
     payments.sum(:award_amount)
   end
 
+  def number_of_claims_for_policy(policy)
+    claims.by_policy(policy).count
+  end
+
+  def total_claim_amount_for_policy(policy)
+    claims.by_policy(policy).sum(:award_amount)
+  end
+
   def self.create_with_claims!(claims, attrs = {})
     ActiveRecord::Base.transaction do
       PayrollRun.create!(attrs).tap do |payroll_run|

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -56,6 +56,27 @@
       <% end %>
     </dl>
   </div>
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">Summary of claim amounts by service</h2>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Service</th>
+          <th scope="col" class="govuk-table__header">Number of claims</th>
+          <th scope="col" class="govuk-table__header">Total claimed amount</th>
+        </tr>
+        <% Policies.all.each do |policy| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= policy.short_name %></th>
+            <td class="govuk-table__cell"><%= @payroll_run.number_of_claims_for_policy(policy) %></td>
+            <td class="govuk-table__cell"><%= number_to_currency(@payroll_run.total_claim_amount_for_policy(policy)) %></td>
+          </tr>
+        <% end %>
+      </thead>
+      <tbody class="govuk-table__body">
+      </tbody>
+    </table>
+  </div>
   <% unless @payroll_run.download_triggered? %>
     <div class="govuk-grid-column-full">
       <div class="govuk-form-group">

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -75,7 +75,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Payment ID</th>
-        <th scope="col" class="govuk-table__header">Claim Reference(s)</th>
+        <th scope="col" class="govuk-table__header">Claim Reference</th>
         <th scope="col" class="govuk-table__header">Payee Name</th>
         <% unless @payroll_run.confirmation_report_uploaded? %>
           <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
@@ -84,18 +84,25 @@
     </thead>
     <tbody class="govuk-table__body">
       <% @payroll_run.payments.each do |payment| %>
+        <% first_claim = payment.claims.first %>
+        <% number_of_claims = payment.claims.count %>
         <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header"><%= payment.id %></th>
-          <td class="govuk-table__cell"><%= claim_references(payment) %></td>
-          <td class="govuk-table__cell"><%= payment.banking_name %></td>
+          <th scope="row" rowspan="<%= payment.claims.count %>" class="govuk-table__header"><%= payment.id %></th>
+          <td class="govuk-table__cell"><%= payment.claims.first.reference %></td>
+          <td class="govuk-table__cell" rowspan="<%= payment.claims.count %>"><%= payment.banking_name %></td>
           <% unless @payroll_run.confirmation_report_uploaded? %>
-            <td class="govuk-table__cell">
+            <td class="govuk-table__cell" rowspan="<%= number_of_claims %>">
               <%= link_to remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id), class: "govuk-link" do %>
                 Remove <span class="govuk-visually-hidden">payment row</span>
               <% end %>
             </td>
           <% end %>
         </tr>
+        <% payment.claims.drop(1).each do |claim| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= claim.reference %></td>
+          </tr>
+        <% end %>
       <% end %>
     </tbody>
     </table>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -75,8 +75,11 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Payment ID</th>
-        <th scope="col" class="govuk-table__header">Claim Reference</th>
         <th scope="col" class="govuk-table__header">Payee Name</th>
+        <th scope="col" class="govuk-table__header">Claim Reference</th>
+        <th scope="col" class="govuk-table__header">Service</th>
+        <th scope="col" class="govuk-table__header">Claim Amount</th>
+        <th scope="col" class="govuk-table__header">Payment Amount</th>
         <% unless @payroll_run.confirmation_report_uploaded? %>
           <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
         <% end %>
@@ -87,9 +90,12 @@
         <% first_claim = payment.claims.first %>
         <% number_of_claims = payment.claims.count %>
         <tr class="govuk-table__row">
-          <th scope="row" rowspan="<%= payment.claims.count %>" class="govuk-table__header"><%= payment.id %></th>
-          <td class="govuk-table__cell"><%= payment.claims.first.reference %></td>
-          <td class="govuk-table__cell" rowspan="<%= payment.claims.count %>"><%= payment.banking_name %></td>
+          <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= payment.id %></th>
+          <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
+          <td class="govuk-table__cell"><%= first_claim.reference %></td>
+          <td class="govuk-table__cell"><%= first_claim.policy.short_name %></td>
+          <td class="govuk-table__cell"><%= number_to_currency(first_claim.award_amount) %></td>
+          <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= number_to_currency(payment.award_amount) %></td>
           <% unless @payroll_run.confirmation_report_uploaded? %>
             <td class="govuk-table__cell" rowspan="<%= number_of_claims %>">
               <%= link_to remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id), class: "govuk-link" do %>
@@ -101,6 +107,8 @@
         <% payment.claims.drop(1).each do |claim| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= claim.reference %></td>
+            <td class="govuk-table__cell"><%= claim.policy.short_name %></td>
+            <td class="govuk-table__cell"><%= number_to_currency(claim.award_amount) %></td>
           </tr>
         <% end %>
       <% end %>

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -42,6 +42,47 @@ RSpec.describe PayrollRun, type: :model do
     end
   end
 
+  describe "#number_of_claims_for_policy" do
+    it "returns the correct number of claims under each policy" do
+      payment_1 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1500))
+      ])
+      payment_2 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:maths_and_physics_eligibility, :eligible))
+      ])
+      payment_3 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:maths_and_physics_eligibility, :eligible))
+      ])
+
+      payroll_run = PayrollRun.create!(created_by: user, payments: [payment_1, payment_2, payment_3])
+
+      expect(payroll_run.number_of_claims_for_policy(StudentLoans)).to eq(1)
+      expect(payroll_run.number_of_claims_for_policy(MathsAndPhysics)).to eq(2)
+    end
+  end
+
+  describe "#total_claim_amount_for_policy" do
+    it "returns the correct total amount claimed under each policy" do
+      payment_1 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1500))
+      ])
+      payment_2 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:maths_and_physics_eligibility, :eligible))
+      ])
+      payment_3 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:maths_and_physics_eligibility, :eligible))
+      ])
+      payment_4 = build(:payment, claims: [
+        build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1000))
+      ])
+
+      payroll_run = PayrollRun.create!(created_by: user, payments: [payment_1, payment_2, payment_3, payment_4])
+
+      expect(payroll_run.total_claim_amount_for_policy(StudentLoans)).to eq(2500)
+      expect(payroll_run.total_claim_amount_for_policy(MathsAndPhysics)).to eq(4000)
+    end
+  end
+
   describe ".create_with_claims!" do
     let(:claims) { Policies.all.map { |policy| create(:claim, :approved, policy: policy) } }
     subject!(:payroll_run) { PayrollRun.create_with_claims!(claims, created_by: user) }


### PR DESCRIPTION
When viewing a Payroll Run in admin:

- Add a breakdown of the number of claims and total claim amount under each policy
- Add the total amount of each payment to the list of payments
- In the list of payments, where a payment includes multiple claims, include one row for each claim
- Add the policy of each claim to the list of payments
- Add the amount of each claim to the list of payments

![localhost_3000_admin_payroll_runs_0627bb26-5f04-4ed6-9225-ff7baa5174f0](https://user-images.githubusercontent.com/619082/91874288-ef642a00-ec71-11ea-9d3b-f03cd80653a0.png)
