### PR TITLE
Increase Verify timeout to 120 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Changes made to content pages ready for academic year 2020-21
+- Increase Verify timeout from 90 minutes to 120 minutes
 
 ## [Release 080] - 2020-06-25
 

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -1,6 +1,6 @@
 module Verify
   class AuthenticationsController < BasePublicController
-    CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 90
+    CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 120
 
     include PartOfClaimJourney
 

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -103,11 +103,11 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
     end
   end
 
-  scenario "Users who take longer than 90 minutes to complete Verify are told that their session has timed out", js: true do
+  scenario "Users who take longer than 120 minutes to complete Verify are told that their session has timed out", js: true do
     stub_vsp_translate_response_request
     click_on "Continue"
 
-    travel 95.minutes do
+    travel 125.minutes do
       click_on "Perform identity check"
       expect(page).to have_text("Your session has ended due to inactivity")
     end


### PR DESCRIPTION
As advised by Verify, the maximum amount of time people can spend in the
Verify flow has been increased from 90 minutes to 120 minutes. This
increases our application timeout to match, making sure people who spend
longer in Verify will not return to an expired session.