### PR TITLE
Display the correct financial year in employment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Break down number of claims and claim amount in payroll runs by policy
+- Display the correct financial year for employment as part of the employment
+  task.
 
 ## [Release 081] - 2020-09-01
 

--- a/app/models/student_loans/admin_tasks_presenter.rb
+++ b/app/models/student_loans/admin_tasks_presenter.rb
@@ -19,7 +19,7 @@ module StudentLoans
 
     def employment
       [
-        ["6 April 2018 to 5 April 2019", display_school(eligibility.claim_school)],
+        [financial_year_for_academic_year(claim.academic_year), display_school(eligibility.claim_school)],
         [translate("admin.current_school"), display_school(eligibility.current_school)]
       ]
     end
@@ -42,6 +42,13 @@ module StudentLoans
 
     def eligibility
       claim.eligibility
+    end
+
+    def financial_year_for_academic_year(academic_year)
+      end_year = academic_year.start_year
+      start_year = end_year - 1
+
+      "6 April #{start_year} to 5 April #{end_year}"
     end
   end
 end

--- a/spec/models/student_loans/admin_tasks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_tasks_presenter_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
         [I18n.t("admin.current_school"), presenter.display_school(eligibility.current_school)]
       ]
     end
+    it "correctly returns the expected string for financial year" do
+      claim_2025 = build(:claim,
+        academic_year: "2025/2026",
+        student_loan_plan: StudentLoan::PLAN_1,
+        eligibility: build(
+          :student_loans_eligibility,
+          qts_award_year: "on_or_after_cut_off_date",
+          claim_school: school,
+          current_school: school
+        ))
+      presenter_2025 = described_class.new(claim_2025)
+      expect(presenter_2025.employment[0][0]).to eq "6 April 2024 to 5 April 2025"
+    end
   end
 
   describe "#student_loan_amount" do


### PR DESCRIPTION
Previously, this check would always display the 2018-19 financial year. It now generates the string based on the academic year of the claim.
