### PR TITLE
Update name of certificate to match version in Azure

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -9,7 +9,7 @@
       "value": ["development.additional-teaching-payment.education.gov.uk"]
     },
     "appServiceCertificateSecretNames": {
-      "value": ["sslCertificate-wildcard-additional-teaching-payment-education-gov-uk"]
+      "value": ["development-additional-teaching-payment-education-gov-uk"]
     },
     "appServiceHostNameToCertificateSecretNameIndexMap": {
       "value": {


### PR DESCRIPTION
At the latest certificate renewal, a new certificate name was created. This commit changes the deployed configuration to use that certificate name, so it does not revert to the old (expired) certificate each deploy.