### PR TITLE
Limit Geckoboard updates to the current academic year

### DIFF
--- a/app/jobs/geckoboard/update_undecided_claims_job.rb
+++ b/app/jobs/geckoboard/update_undecided_claims_job.rb
@@ -3,7 +3,12 @@ module Geckoboard
     self.cron_expression = "0 3 * * *"
 
     def perform
-      Claim::GeckoboardDataset.new(claims: Claim.awaiting_decision).save
+      claims_to_update = []
+      Policies.all.each do |policy|
+        policy_configuration = PolicyConfiguration.for(policy)
+        claims_to_update += Claim.by_policy(policy).by_academic_year(policy_configuration.current_academic_year).awaiting_decision
+      end
+      Claim::GeckoboardDataset.new(claims: claims_to_update).save
     end
   end
 end

--- a/lib/tasks/geckoboard.rake
+++ b/lib/tasks/geckoboard.rake
@@ -2,6 +2,11 @@ namespace :geckoboard do
   desc "Reset and recreate Geckoboard claims dataset"
   task reset: :environment do
     Claim::GeckoboardDataset.new.delete
-    Claim::GeckoboardDataset.new(claims: Claim.submitted).save
+    claims_to_update = []
+    Policies.all.each do |policy|
+      policy_configuration = PolicyConfiguration.for(policy)
+      claims_to_update += Claim.by_policy(policy).by_academic_year(policy_configuration.current_academic_year).submitted
+    end
+    Claim::GeckoboardDataset.new(claims: claims_to_update).save
   end
 end

--- a/spec/jobs/geckoboard/update_undecided_claims_job_spec.rb
+++ b/spec/jobs/geckoboard/update_undecided_claims_job_spec.rb
@@ -6,15 +6,19 @@ RSpec.describe Geckoboard::UpdateUndecidedClaimsJob do
       @dataset_post_stub = stub_geckoboard_dataset_update
     end
 
-    it "updates the Geckoboard claim dataset with all undecided claims" do
-      claims_awaiting_decision = create_list(:claim, 2, :submitted)
+    it "updates the Geckoboard claim dataset with all undecided claims for the current academic year" do
+      academic_year_2019 = AcademicYear.new("2019")
+      academic_year_2020 = AcademicYear.new("2020")
+      policy_configurations(:student_loans).update!(current_academic_year: "2020/2021")
+      create_list(:claim, 2, :submitted, policy: StudentLoans, academic_year: academic_year_2019)
+      claims_awaiting_decision_2020 = create_list(:claim, 2, :submitted, policy: StudentLoans, academic_year: academic_year_2020)
       create(:claim, :approved)
       create(:claim, :submittable)
 
       Geckoboard::UpdateUndecidedClaimsJob.new.perform
 
       expect(@dataset_post_stub.with { |request|
-        request_body_matches_geckoboard_data_for_claims?(request, claims_awaiting_decision)
+        request_body_matches_geckoboard_data_for_claims?(request, claims_awaiting_decision_2020)
       }).to have_been_requested
     end
   end


### PR DESCRIPTION
This changes the behaviour of the Geckoboard update job and reset task to only include claims from the current academic year (as configured).

Geckoboard will still need manually resetting each time the academic year is updated.
