### PR TITLE
Add column to payroll report which lists the policies involved in any payment

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -36,6 +36,10 @@ class Payment < ApplicationRecord
   delegate(*(PERSONAL_DETAILS_ATTRIBUTES_PERMITTING_DISCREPANCIES + PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES), to: :claim_for_personal_details)
   delegate :scheduled_payment_date, to: :payroll_run
 
+  def policies_in_payment
+    claims.map { |claim| claim.policy.to_s }.uniq.sort.join(",")
+  end
+
   private
 
   def personal_details_must_be_consistent

--- a/app/models/payment_confirmation_csv.rb
+++ b/app/models/payment_confirmation_csv.rb
@@ -11,7 +11,8 @@ class PaymentConfirmationCsv
     "Employers NI",
     "Student Loans",
     "Tax",
-    "Net Pay"
+    "Net Pay",
+    "Claim Policies"
   ].freeze
 
   def initialize(file)

--- a/app/models/payroll/payments_csv.rb
+++ b/app/models/payroll/payments_csv.rb
@@ -33,7 +33,8 @@ module Payroll
       bank_account_number: "ACCOUNT_NUMBER",
       roll_number: "ROLL_NUMBER",
       scheme_amount: "SCHEME_AMOUNT",
-      payment_id: "PAYMENT_ID"
+      payment_id: "PAYMENT_ID",
+      policies_in_payment: "CLAIM_POLICIES"
     }.freeze
 
     def initialize(payroll_run)

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -123,9 +123,9 @@ RSpec.feature "Payroll" do
     expect(page).to have_content("Upload Payment Confirmation Report")
 
     csv = <<~CSV
-      Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-      DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
-      DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
+      Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+      DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,StudentLoans
+      DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,StudentLoans
     CSV
 
     file = Tempfile.new

--- a/spec/models/payment_confirmation_csv_spec.rb
+++ b/spec/models/payment_confirmation_csv_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe PaymentConfirmationCsv do
   context "The CSV is valid and has all the correct data" do
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325,"MathsAndPhysics,StudentLoans"
       CSV
     end
 
@@ -41,8 +41,8 @@ RSpec.describe PaymentConfirmationCsv do
   context "The CSV does not have the expected headers" do
     let(:csv) do
       <<~CSV
-        Payroll Ref,Gross Val,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325
+        Payroll Ref,Gross Val,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325,StudentLoans
       CSV
     end
 
@@ -69,8 +69,8 @@ RSpec.describe PaymentConfirmationCsv do
     let(:byte_order_mark) { "\xEF\xBB\xBF" }
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325,StudentLoans
       CSV
     end
 

--- a/spec/models/payment_confirmation_spec.rb
+++ b/spec/models/payment_confirmation_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe PaymentConfirmation do
   let(:payroll_run) { create(:payroll_run, claims_counts: {[MathsAndPhysics, StudentLoans] => 1, StudentLoans => 1}) }
   let(:csv) do
     <<~CSV
-      Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-      DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
-      DFE00002,"1,211.15",#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
+      Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+      DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,StudentLoans
+      DFE00002,"1,211.15",#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,"MathsAndPhysics,StudentLoans"
     CSV
   end
   let(:file) do
@@ -94,8 +94,8 @@ RSpec.describe PaymentConfirmation do
     let(:payroll_run) { create(:payroll_run, claims_counts: {StudentLoans => 1}) }
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,,6,325
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,,6,325,StudentLoans
       CSV
     end
 
@@ -120,10 +120,10 @@ RSpec.describe PaymentConfirmation do
     let(:extra_claim) { create(:claim) }
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
-        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
-        DFE00003,904.15,#{extra_claim.reference},77.84,89.51,40,162.8,534
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,StudentLoans
+        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,StudentLoans
+        DFE00003,904.15,#{extra_claim.reference},77.84,89.51,40,162.8,534,StudentLoans
       CSV
     end
 
@@ -139,8 +139,8 @@ RSpec.describe PaymentConfirmation do
   context "The CSV has a claim missing from the run" do
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,MathsAndPhysics
       CSV
     end
 
@@ -158,10 +158,10 @@ RSpec.describe PaymentConfirmation do
   context "The CSV has a duplicate claim" do
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
-        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
-        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,StudentLoans
+        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,StudentLoans
+        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,StudentLoans
       CSV
     end
 
@@ -181,9 +181,9 @@ RSpec.describe PaymentConfirmation do
   context "The CSV has a blank value for a required field" do
     let(:csv) do
       <<~CSV
-        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-        DFE00001,,#{payroll_run.payments[0].id},,38.98,0,89.6,325
-        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+        DFE00001,,#{payroll_run.payments[0].id},,38.98,0,89.6,325,StudentLoans
+        DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,StudentLoans
       CSV
     end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -168,4 +168,44 @@ RSpec.describe Payment do
       expect(payment.payroll_gender).to eq("female")
     end
   end
+
+  describe "policies in payment" do
+    let(:personal_details) do
+      {
+        national_insurance_number: generate(:national_insurance_number),
+        teacher_reference_number: generate(:teacher_reference_number),
+        email_address: generate(:email_address),
+        bank_sort_code: "112233",
+        bank_account_number: "95928482",
+        address_line_1: "64 West Lane",
+        student_loan_plan: StudentLoan::PLAN_1
+      }
+    end
+
+    it "returns the correct string for a payment with one claim" do
+      payment = create(:payment, claims: [
+        create(:claim, :approved, personal_details.merge(policy: StudentLoans))
+      ])
+
+      expect(payment.policies_in_payment).to eq("StudentLoans")
+    end
+
+    it "returns the correct string for a payment with multiple claims under one policy" do
+      payment = create(:payment, claims: [
+        create(:claim, :approved, personal_details.merge(policy: StudentLoans)),
+        create(:claim, :approved, personal_details.merge(policy: StudentLoans))
+      ])
+
+      expect(payment.policies_in_payment).to eq("StudentLoans")
+    end
+
+    it "returns the correct string for a payment with multiple claims under different policies" do
+      payment = create(:payment, claims: [
+        create(:claim, :approved, personal_details.merge(policy: StudentLoans)),
+        create(:claim, :approved, personal_details.merge(policy: MathsAndPhysics))
+      ])
+
+      expect(payment.policies_in_payment).to eq("MathsAndPhysics,StudentLoans")
+    end
+  end
 end

--- a/spec/models/payroll/payment_csv_row_spec.rb
+++ b/spec/models/payroll/payment_csv_row_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe Payroll::PaymentCsvRow do
           claim.bank_account_number,
           claim.building_society_roll_number,
           payment_award_amount.to_s,
-          payment.id
+          payment.id,
+          payment.policies_in_payment
         ])
       end
     end

--- a/spec/models/payroll/payments_csv_spec.rb
+++ b/spec/models/payroll/payments_csv_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Payroll::PaymentsCsv do
         ROLL_NUMBER
         SCHEME_AMOUNT
         PAYMENT_ID
+        CLAIM_POLICIES
       ].join(",")
 
       expect(file_lines[0]).to eq(expected_header_row)

--- a/spec/requests/admin_payment_confirmation_report_upload_spec.rb
+++ b/spec/requests/admin_payment_confirmation_report_upload_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
         let(:payroll_run) { create(:payroll_run, claims_counts: {StudentLoans => 2}) }
         let(:csv) do
           <<~CSV
-            Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-            DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
-            DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534
+            Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+            DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,StudentLoans
+            DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,534,StudentLoans
           CSV
         end
 
@@ -51,8 +51,8 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
         let(:payroll_run) { create(:payroll_run, claims_counts: {StudentLoans => 2}) }
         let(:csv) do
           <<~CSV
-            Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
-            DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325
+            Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
+            DFE00001,487.48,#{payroll_run.payments[0].id},33.9,38.98,0,89.6,325,StudentLoans
             DFE00002,904.15,#{payroll_run.payments[1].id},77.84,89.51,40,162.8,
           CSV
         end


### PR DESCRIPTION
This adds a new column to the payroll report, which lists the policies involved in that payment as an alphabetically-sorted comma-delimited string.

**Do not merge** until we have confirmed what the response column will be in the confirmation report.