### PR TITLE
Update payment email copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update payment email copy
+
 ## [Release 084] - 2020-09-30
 
 - Update data report request to retrieve email address and date of birth

--- a/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
+++ b/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
@@ -54,6 +54,8 @@ The Gross amount is comprised of the payment you receive, and the Income Tax and
 
 You may also see ‘Teaching payments DfE retention scheme’ listed as the secondary employer that made this payment.
 
+^ This email should be treated as a payslip, and as such kept for your own records in line with HMRC recommendations (22 months after the financial year the payment relates to). The payment breakdown details will not appear on your P60, and cannot be reissued.
+
 # Contact us
 
 <% @payment.claims.each do |claim| %>

--- a/app/views/payment_mailer/confirmation_for_single_claim.text.erb
+++ b/app/views/payment_mailer/confirmation_for_single_claim.text.erb
@@ -42,6 +42,8 @@ The Gross amount is comprised of the payment you receive, and the Income Tax and
 
 You may also see ‘Teaching payments DfE retention scheme’ listed as the secondary employer that made this payment.
 
+^ This email should be treated as a payslip, and as such kept for your own records in line with HMRC recommendations (22 months after the financial year the payment relates to). The payment breakdown details will not appear on your P60, and cannot be reissued.
+
 # Contact us
 
 Email <%= support_email_address(@policy.routing_name) %> giving your reference: <%= @reference %>, if you have any questions.

--- a/spec/mailers/previews/payment_mailer_preview.rb
+++ b/spec/mailers/previews/payment_mailer_preview.rb
@@ -1,10 +1,10 @@
 class PaymentMailerPreview < ActionMailer::Preview
   def confirmation_for_single_claim
-    PaymentMailer.confirmation(payment(claims_count: "= 1"), DateTime.now.to_time.to_i)
+    PaymentMailer.confirmation(payment(claims_count: "= 1"))
   end
 
   def confirmation_for_multiple_claims
-    PaymentMailer.confirmation(payment(claims_count: "> 1"), DateTime.now.to_time.to_i)
+    PaymentMailer.confirmation(payment(claims_count: "> 1"))
   end
 
   private


### PR DESCRIPTION
This adds some additional context to make sure users are clear that the email should be treated as a payslip

# Screenshots

![Screenshot_2020-10-07 Page title(1)](https://user-images.githubusercontent.com/109774/95322790-f562b180-0894-11eb-8a92-da31037ece83.png)
![Screenshot_2020-10-07 Page title](https://user-images.githubusercontent.com/109774/95322797-f8f63880-0894-11eb-9f4b-d03efb513d16.png)
