### PR TITLE
Seperate policies in payment with a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Update payment email copy
+- Seperate policies in payment with a space
 
 ## [Release 084] - 2020-09-30
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -37,7 +37,7 @@ class Payment < ApplicationRecord
   delegate :scheduled_payment_date, to: :payroll_run
 
   def policies_in_payment
-    claims.map { |claim| claim.policy.to_s }.uniq.sort.join(",")
+    claims.map { |claim| claim.policy.to_s }.uniq.sort.join(" ")
   end
 
   private

--- a/spec/models/payment_confirmation_csv_spec.rb
+++ b/spec/models/payment_confirmation_csv_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PaymentConfirmationCsv do
     let(:csv) do
       <<~CSV
         Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies
-        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325,"MathsAndPhysics,StudentLoans"
+        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325,"MathsAndPhysics StudentLoans"
       CSV
     end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Payment do
         create(:claim, :approved, personal_details.merge(policy: MathsAndPhysics))
       ])
 
-      expect(payment.policies_in_payment).to eq("MathsAndPhysics,StudentLoans")
+      expect(payment.policies_in_payment).to eq("MathsAndPhysics StudentLoans")
     end
   end
 end


### PR DESCRIPTION
Cantium's CSV parser doesn't like commas in columns, so we're splitting the policies with a space instead
