### PR TITLE
Fix incorrect summing with claims by policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix incorrect summing for claims by policy
+
 ## [Release 085] - 2020-10-07
 
 - Update payment email copy

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -21,7 +21,7 @@ class PayrollRun < ApplicationRecord
   end
 
   def total_claim_amount_for_policy(policy)
-    claims.by_policy(policy).sum(:award_amount)
+    claims.by_policy(policy).sum(&:award_amount)
   end
 
   def self.create_with_claims!(claims, attrs = {})

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -75,11 +75,15 @@ RSpec.describe PayrollRun, type: :model do
       payment_4 = build(:payment, claims: [
         build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1000))
       ])
+      payment_5 = build(:payment, claims: [
+        build(:claim, :approved, teacher_reference_number: "1234567", bank_sort_code: "123456", bank_account_number: "12345678", eligibility: build(:maths_and_physics_eligibility, :eligible)),
+        build(:claim, :approved, teacher_reference_number: "1234567", bank_sort_code: "123456", bank_account_number: "12345678", eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1000))
+      ])
 
-      payroll_run = PayrollRun.create!(created_by: user, payments: [payment_1, payment_2, payment_3, payment_4])
+      payroll_run = PayrollRun.create!(created_by: user, payments: [payment_1, payment_2, payment_3, payment_4, payment_5])
 
-      expect(payroll_run.total_claim_amount_for_policy(StudentLoans)).to eq(2500)
-      expect(payroll_run.total_claim_amount_for_policy(MathsAndPhysics)).to eq(4000)
+      expect(payroll_run.total_claim_amount_for_policy(StudentLoans)).to eq(3500)
+      expect(payroll_run.total_claim_amount_for_policy(MathsAndPhysics)).to eq(6000)
     end
   end
 


### PR DESCRIPTION
The `total_claim_amount_for_policy` calculation is currently summing the claim's payment award amount, not the acutal claim's award amount. This works when payments are only for one policy (i.e. the claim's award amount and the payment's award amount are equal). However, if a claimant has claimed for multiple policies, both policies are double counted, resulting in incorrect breakdowns via policy.

I've tweaked the code to sum at the code level using https://apidock.com/rails/Enumerable/sum, rather than https://apidock.com/rails/ActiveRecord/Calculations/sum. This does mean that all the rows have to be loaded into memory to do the calculation, but I think this is a reasonable trade-off, given that this page is only loaded once or twice per claim window.

<!-- Do you need to update CHANGELOG.md? -->
