### PR TITLE
Fix incorrect display of claims in payroll run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - Update the DQT automation to include HECOS codes as well as JACS codes
 - Update email copy for claim submitted and claim approved
+- Fix incorrect display of claims in payroll run
 
 ## [Release 086] - 2020-10-08
 

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -108,28 +108,27 @@
     </thead>
     <tbody class="govuk-table__body">
       <% @payroll_run.payments.each do |payment| %>
-        <% first_claim = payment.claims.first %>
-        <% number_of_claims = payment.claims.count %>
-        <tr class="govuk-table__row">
-          <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= payment.id %></th>
-          <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
-          <td class="govuk-table__cell"><%= first_claim.reference %></td>
-          <td class="govuk-table__cell"><%= first_claim.policy.short_name %></td>
-          <td class="govuk-table__cell"><%= number_to_currency(first_claim.award_amount) %></td>
-          <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= number_to_currency(payment.award_amount) %></td>
-          <% unless @payroll_run.confirmation_report_uploaded? %>
-            <td class="govuk-table__cell" rowspan="<%= number_of_claims %>">
-              <%= link_to remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id), class: "govuk-link" do %>
-                Remove <span class="govuk-visually-hidden">payment row</span>
-              <% end %>
-            </td>
-          <% end %>
-        </tr>
-        <% payment.claims.drop(1).each do |claim| %>
+        <% payment.claims.each_with_index do |claim, index| %>
+          <% number_of_claims = payment.claims.length %>
+
           <tr class="govuk-table__row">
+            <% if index == 0 %>
+              <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= payment.id %></th>
+              <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
+            <% end %>
             <td class="govuk-table__cell"><%= claim.reference %></td>
             <td class="govuk-table__cell"><%= claim.policy.short_name %></td>
             <td class="govuk-table__cell"><%= number_to_currency(claim.award_amount) %></td>
+            <% if index == 0 %>
+              <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= number_to_currency(payment.award_amount) %></td>
+              <% unless @payroll_run.confirmation_report_uploaded? %>
+                <td class="govuk-table__cell" rowspan="<%= number_of_claims %>">
+                  <%= link_to remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id), class: "govuk-link" do %>
+                    Remove <span class="govuk-visually-hidden">payment row</span>
+                  <% end %>
+                </td>
+              <% end %>
+            <% end %>
           </tr>
         <% end %>
       <% end %>


### PR DESCRIPTION
We were using two different ways to gather the list of claims to be
displayed for a payment. Each of these imposes a different ordering on
the claims in the SQL that it generates:

1. payment.claims.first: this does ORDER BY claims.created_at
2. payment.claims: this does no ORDER BY and hence returns Postgres's
   default order, which is undefined [1].

This means that when the Postgres default order doesn’t match the
created_at order, these two sources of data won’t agree and hence we
might see duplicate and missing claims against a payment.

This commit changes it so that we only use one source of data -
payment.claims.

I haven’t added a regression test here because I’m not sure how I’d set
up example data where the Postgres order doesn’t match the created_at
order, given that the Postgres order is unpredictable.

[1] https://www.postgresql.org/docs/current/queries-order.html

Zendesk: https://dxw.zendesk.com/agent/tickets/12942
