### PR TITLE
Remove some extra detail from claim submitted email

### DIFF
--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -8,7 +8,7 @@ This email will confirm the amount you'll receive and include a breakdown of you
 
 The payment breakdown will show the following contributions:
 
-* Student loan repayment, which is deducted from your payment if applicable
+* student loan repayment, which is deducted from your payment if applicable
 * Income Tax and Employee National Insurance
 
 For more information about these contributions, read the eligibility and payment guidance at <%= @policy.eligibility_page_url %>.

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -6,15 +6,7 @@ Your unique reference is <%= @claim.reference %>. You will need this if you cont
 
 # What happens next
 
-<%- if @claim.identity_verified? -%>
 We'll check the details you provided in your application and we'll tell you within <%= claim_decision_deadline_in_weeks %> if your claim was successful.
-<%- else -%>
-We’ll check the details you provided in your claim and then contact you to confirm your identity over the phone.
-
-We’ll send you an email from <%= support_email_address(@policy.routing_name) %> to arrange a convenient time for us to call you on your school's landline. Please add <%= support_email_address(@policy.routing_name) %> to your address book to make sure you receive this email.
-
-You'll find out if your claim was successful within <%= claim_decision_deadline_in_weeks %> and you'll receive email updates as your application progresses.
-<%- end -%>
 
 From the point your claim is approved it can take a further 6 weeks to make a payment into your account.
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -39,15 +39,6 @@ RSpec.describe ClaimMailer, type: :mailer do
         it "mentions that claim has been received in the subject and body" do
           expect(mail.subject).to include("been received")
           expect(mail.body.encoded).to include("We've received your claim")
-          expect(mail.body.encoded).not_to include("confirm your identity")
-        end
-
-        it "adjusts the content for claims that need manual identity confirmation" do
-          claim.update!(govuk_verify_fields: [])
-
-          expect(mail.subject).to include("been received")
-          expect(mail.body.encoded).to include("We've received your claim")
-          expect(mail.body.encoded).to include("confirm your identity")
         end
       end
 


### PR DESCRIPTION
The client requested that we remove the additional information about
phoning the claimant to verify their identity. The email is now the same
regardless of whether the claimant’s identity is already verified or
not. This is because they have had to “change (their) processes”.

This tweaks the original change made in e5a4543.

(No change to the `CHANGELOG` since it's already covered in the "Unreleased" section there.)