### PR TITLE
Add an additional claim rejection reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add an additional rejection reason to the claim rejection email (Zendesk
+  #13584)
+
 ## [Release 087] - 2020-11-02
 
 - Update the DQT automation to include HECOS codes as well as JACS codes

--- a/app/views/claim_mailer/rejection_reasons/_maths_and_physics.text.erb
+++ b/app/views/claim_mailer/rejection_reasons/_maths_and_physics.text.erb
@@ -1,3 +1,4 @@
+* we have been trying to contact you regarding your claim but we have not heard from you and therefore cannot resolve your claim
 * you are not employed to teach maths or physics at an eligible state-funded secondary school
 * you did not complete your initial teacher training in maths or physics and you do not have a degree in maths or physics
 * you completed your initial teacher training in or before the academic year <%= @ineligible_qts_year.to_s(:long) %>

--- a/app/views/claim_mailer/rejection_reasons/_student_loans.text.erb
+++ b/app/views/claim_mailer/rejection_reasons/_student_loans.text.erb
@@ -1,3 +1,4 @@
+* we have been trying to contact you regarding your claim but we have not heard from you and therefore cannot resolve your claim
 * you completed your initial teacher training in or before the academic year <%= @ineligible_qts_year.to_s(:long) %>
 * you did not teach at an eligible school between <%= StudentLoans.current_financial_year %>
 * you are not currently employed to teach at a state-funded secondary school


### PR DESCRIPTION
Zendesk: https://dxw.zendesk.com/agent/tickets/13584

Add an additional rejection reason to the rejection email which is seent out to
both Maths & Physics and Student Loans claims. The reason reads:

`- We have been trying to contact you regarding your claim but we have not heard from you and therefore cannot resolve your claim.`

<!-- Do you need to update CHANGELOG.md? -->
