### PR TITLE
Disable alerts on development

### DIFF
--- a/azure/resource_groups/alerts/parameters/development.template.json
+++ b/azure/resource_groups/alerts/parameters/development.template.json
@@ -15,6 +15,9 @@
     },
     "secretsResourceGroupId": {
       "value": "${secretsResourceGroupId}"
+    },
+    "enableAlerts": {
+      "value": false
     }
   }
 }


### PR DESCRIPTION
There's noone actively working on the project, the alerts for
development are mostly ignored and generate noise.

This can easily be reversed when people start sprinting on the project
again.

The production alerts will continue to notify us but they may need some
tweaking as they are also generating a lot of noise.

<!-- Do you need to update CHANGELOG.md? -->
