### PR TITLE
Reduce sensitivity of high response time alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Reduce sensitivity of high response time alert
+
 ## [Release 089] - 2021-03-05
 
 - Infrastructure changes

--- a/azure/templates/app_alerts.json
+++ b/azure/templates/app_alerts.json
@@ -49,8 +49,8 @@
         "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average response times for ', variables('appServiceName'), ' are greater than 2 seconds.')]",
         "severity": 1,
-        "evaluationFrequency": "PT1M",
-        "windowSize": "PT5M",
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
         "targetResourceType": "Microsoft.Web/sites",
         "targetResourceRegion": "[resourceGroup().location]",
         "criteria": {


### PR DESCRIPTION
The high response time alert is triggering a lot. Looking at the history
it seems to get back to normal after ~5 minutes. The impact on the user
would be minimal so I don't think it's worth investigating the
underlying cause just yet.

We previously reduced the sensitivity of the high CPU usage alert (in
f1e949da55a5c9b5e7c56d763801ce4d30b6d68b). I've opted to use the same
thresholds as that change.
