### PR TITLE
[feature/ECP-194] - remove 'obtain security approval' section

### DIFF
--- a/docs/dfe-sign-in.md
+++ b/docs/dfe-sign-in.md
@@ -23,20 +23,6 @@ Follow these steps to get access to the pre-production environment:
 2. Click the “create a DfE Sign-in account” link and create an account (probably
    best to use your DfE email address).
 
-### Obtain Security Approval
-
-Security approval is required.This is obtained via the self-service portal.
-
-1. [Raise a ticket in Service Portal](https://dfe.service-now.com/serviceportal)
-   _**N.B.**_ If you are not on a `DfE device` a request for external access can
-   be raised by a manager or colleague with a `DfE device` via Requests >
-   Accounts and Access > Service Portal - External BOYD Access to the
-   Self-Service portal ONLY (You will need to provide a DfE email address)
-   > The wording for the request is "please can you invite
-   > first_name.last_name@digital.education.gov.uk to the Group Access Policy
-   > that restricts access to the Claim additional payments for teaching
-   > service, and add them to this service with the Service Operator role."
-
 ### Obtain DSI (DfE Sign In) Approval
 
 DSI change team approval is required. This is obtained via the service desk and


### PR DESCRIPTION
On discussion for the ticket there was mention that the section on 'Obtain Security Approval' was redundant. This was raised by Kristi Beak and discussed with @mattonfoot.

This PR actions the outcome of that discussion.

[ECP-194](https://dfedigital.atlassian.net/browse/ECP-194)
