### PR TITLE
[task/ECP-410] - bump mimemagic from 0.3.6 to 0.3.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
This is related to the existing versions of the gem below 0.3.7 having been removed from rubygems due to change of licensing to GPL-2.


Here is the issue referenced in this weeks rubyweekly - https://github.com/rails/rails/issues/41750
https://rubyweekly.com/link/105250/web
https://rubyweekly.com/issues/545 top article