### PR TITLE
Wire-up the EarlyCareerPayments landing page so that it starts the claimants ECP journey - [feature/ECP-539]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog]
 - Reduce sensitivity of high response time alert
 - Build new Early Career Payments Policy
 - Build new Early Career Payments Journey with following page additions
+  - Add Landing Page - 'Apply for an early-career payment'
   - Eligibility Journey
     - Add 'Did you do your NQT the academic year after your ITT?'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
-- Remove GOVUK Verify IAS components and from claimant journeys
+- Remove GOVUK Verify IAS components
+- Remove GOVUK Verify from claimant journeys
 - Documentation updates - DFE Signin process
 - Reduce sensitivity of high response time alert
+- Build new Early Career Payments Policy
+- Build new Early Career Payments Journey with following page additions
+  - Eligibility Journey
+    - Add 'Did you do your NQT the academic year after your ITT?'
 
 ## [Release 089] - 2021-03-05
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -13,4 +13,7 @@ class StaticPagesController < BasePublicController
 
   def terms_conditions
   end
+
+  def landing_page
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -193,6 +193,8 @@ class Claim < ApplicationRecord
   end
 
   def submittable?
+    return true if policy == EarlyCareerPayments && !submitted?
+
     valid?(:submit) && !submitted?
   end
 

--- a/app/models/early_career_payments.rb
+++ b/app/models/early_career_payments.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Module namespace specific to the policy for claiming early career payments.
+#
+# Early-career payments are available to teachers starting their initial teacher training (ITT)
+# in the 2018 to 2019, 2019 to 2020 or 2020 to 2021 academic year.
+# This is in addition to receiving a bursary or scholarship during ITT.
+module EarlyCareerPayments
+  extend self
+
+  POLICY_START_YEAR = AcademicYear.new(2021).freeze
+
+  def start_page_url
+    if Rails.env.production?
+      "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools"
+    else
+      "/#{routing_name}/claim"
+    end
+  end
+
+  def eligibility_page_url
+    "https://www.gov.uk/publications/TO-BE-REPLACED-by-response-to-ECP-518"
+  end
+
+  def routing_name
+    "early-career-payments"
+  end
+
+  def locale_key
+    routing_name.underscore
+  end
+
+  def notify_reply_to_id
+    "3f85a1f7-9400-4b48-9a31-eaa643d6b977"
+  end
+
+  def feedback_url
+    "https://docs.google.com/forms/TO-BE-REPLACED-by-response-to-ECP-509/viewform"
+  end
+
+  def short_name
+    I18n.t("early_career_payments.policy_short_name")
+  end
+
+  def first_eligible_qts_award_year(claim_year = nil)
+    POLICY_START_YEAR
+  end
+
+  def last_ineligible_qts_award_year
+    first_eligible_qts_award_year - 1
+  end
+end

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -1,0 +1,32 @@
+module EarlyCareerPayments
+  class Eligibility < ApplicationRecord
+    EDITABLE_ATTRIBUTES = [
+      :nqt_in_academic_year_after_itt
+    ].freeze
+    AMENDABLE_ATTRIBUTES = [].freeze
+
+    self.table_name = "early_career_payments_eligibilities"
+
+    has_one :claim, as: :eligibility, inverse_of: :eligibility
+
+    validates :nqt_in_academic_year_after_itt, on: [:"nqt-in-academic-year-after-itt", :submit], inclusion: {in: [true, false], message: "Select yes if you did your NQT in the academic year after your ITT"}
+
+    def policy
+      EarlyCareerPayments
+    end
+
+    def ineligible?
+      ineligible_nqt_in_academic_year_after_itt?
+    end
+
+    def award_amount
+      BigDecimal("2000.00")
+    end
+
+    private
+
+    def ineligible_nqt_in_academic_year_after_itt?
+      nqt_in_academic_year_after_itt == false
+    end
+  end
+end

--- a/app/models/early_career_payments/eligibility_answers_presenter.rb
+++ b/app/models/early_career_payments/eligibility_answers_presenter.rb
@@ -1,0 +1,36 @@
+module EarlyCareerPayments
+  class EligibilityAnswersPresenter
+    include ActionView::Helpers::TranslationHelper
+
+    attr_reader :eligibility
+
+    def initialize(eligibility)
+      @eligibility = eligibility
+    end
+
+    # Formats the eligibility as a list of questions and answers, each
+    # accompanied by a slug for changing the answer. Suitable for playback to
+    # the claimant for them to review on the check-your-answers page.
+    #
+    # Returns an array. Each element of this an array is an array of three
+    # elements:
+    # [0]: question text;
+    # [1]: answer text;
+    # [2]: slug for changing the answer.
+    def answers
+      [].tap do |a|
+        a << nqt_in_academic_year_after_itt
+      end
+    end
+
+    private
+
+    def nqt_in_academic_year_after_itt
+      [
+        translate("early_career_payments.questions.nqt_in_academic_year_after_itt"),
+        (eligibility.nqt_in_academic_year_after_itt? ? "Yes" : "No"),
+        "nqt-in-academic-year-after-itt"
+      ]
+    end
+  end
+end

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -1,0 +1,30 @@
+module EarlyCareerPayments
+  # Determines the slugs that make up the claim process for a Early Career Payments
+  # claim. Based on the existing answers on the claim, the sequence of slugs
+  # will change. For example, if the claimant has said they are
+  # FIXME change when exclusions are known
+  # will not be part of the sequence.
+  #
+  # Note that the sequence is recalculated on each call to `slugs` so that it
+  # accounts for any changes that may have been made to the claim and always
+  # reflects the sequence based on the claim's current state.
+  class SlugSequence
+    SLUGS = [
+      "nqt-in-academic-year-after-itt",
+      "check-your-answers",
+      "ineligible"
+    ].freeze
+
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def slugs
+      SLUGS.dup.tap do |sequence|
+        sequence.delete("ineligible") unless claim.eligibility.ineligible?
+      end
+    end
+  end
+end

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -2,7 +2,8 @@
 module Policies
   POLICIES = [
     StudentLoans,
-    MathsAndPhysics
+    MathsAndPhysics,
+    EarlyCareerPayments
   ].freeze
 
   AMENDABLE_ELIGIBILITY_ATTRIBUTES = POLICIES.map { |policy| policy::Eligibility::AMENDABLE_ATTRIBUTES }.flatten.freeze

--- a/app/views/claim_mailer/rejection_reasons/_early_career_payments.text.erb
+++ b/app/views/claim_mailer/rejection_reasons/_early_career_payments.text.erb
@@ -1,0 +1,2 @@
+* we have been trying to contact you regarding your claim but we have not heard from you and therefore cannot resolve your claim
+* you completed your initial teacher training in or before the academic year <%= @ineligible_qts_year.to_s(:long) %>

--- a/app/views/early_career_payments/claims/nqt_in_academic_year_after_itt.html.erb
+++ b/app/views/early_career_payments/claims/nqt_in_academic_year_after_itt.html.erb
@@ -1,0 +1,51 @@
+<% content_for(:page_title, page_title(t("early_career_payments.questions.nqt_in_academic_year_after_itt"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.nqt_in_academic_year_after_itt": "claim_eligibility_attributes_nqt_in_academic_year_after_itt_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form  do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :nqt_in_academic_year_after_itt %>
+
+          <fieldset class="govuk-fieldset" aria-describedby="nqt_in_academic_year_after_itt-hint" role="group">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("early_career_payments.questions.nqt_in_academic_year_after_itt") %>
+              </h1>
+            </legend>
+
+            <span class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
+              You are still eligible to claim if you usually teach another
+              subject but sometimes teach maths or physics.
+            </span>
+
+            <%= errors_tag current_claim.eligibility, :nqt_in_academic_year_after_itt %>
+
+            <div class="govuk-radios govuk-radios--inline">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:nqt_in_academic_year_after_itt, true, class: "govuk-radios__input") %>
+                <%= fields.label :nqt_in_academic_year_after_itt_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:nqt_in_academic_year_after_itt, false, class: "govuk-radios__input") %>
+                <%= fields.label :nqt_in_academic_year_after_itt_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/shared/_svg_for_govuk_button_start_icon.html.erb
+++ b/app/views/shared/_svg_for_govuk_button_start_icon.html.erb
@@ -1,0 +1,3 @@
+<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+  <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+</svg>

--- a/app/views/static_pages/landing_page.html.erb
+++ b/app/views/static_pages/landing_page.html.erb
@@ -26,11 +26,10 @@
       <a class="govuk-link" href="/">eligibility page.</a>
     </p>
 
-    <a href="/" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">Start Now
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-      </svg>
-    </a>
+    <%= link_to new_claim_url(EarlyCareerPayments.routing_name), role: :button, draggable: false, class: "govuk-button govuk-button--start", data: { module: "govuk-button"} do %>
+      Start Now
+      <%= render partial: "shared/svg_for_govuk_button_start_icon" %>
+    <% end %>
 
     <h2 class="govuk-heading-l">Future claims</h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,3 +202,10 @@ en:
         employment: "Does the claimant’s previous and current schools match the above information from their claim?"
         student_loan_amount: "Does the claimant’s student loan amount and plan type match the information we hold about their loan?"
         matching_details: "Is this claim still valid despite having matching details with other claims?"
+  early_career_payments:
+    policy_name: "Claim a early career payment"
+    policy_short_name: "Early Career Payments"
+    claim_description: "for an early career payment"
+    support_email_address: "earlycareerteacherpayments@digital.education.gov.uk"
+    questions:
+      nqt_in_academic_year_after_itt: "Did you do your NQT the academic year after your ITT?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,5 +207,6 @@ en:
     policy_short_name: "Early Career Payments"
     claim_description: "for an early career payment"
     support_email_address: "earlycareerteacherpayments@digital.education.gov.uk"
+    landing_page: "Apply for an early-career payment"
     questions:
       nqt_in_academic_year_after_itt: "Did you do your NQT the academic year after your ITT?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,10 @@ Rails.application.routes.draw do
     %w[privacy_notice terms_conditions contact_us cookies accessibility_statement].each do |page_name|
       get page_name.dasherize, to: "static_pages##{page_name}", as: page_name
     end
+
+    scope path: "/", constraints: {policy: Policies.all.detect { |policy| policy.routing_name == "early-career-payments" }.routing_name} do
+      get "landing-page", to: "static_pages#landing_page", as: :landing_page
+    end
   end
 
   constraints lambda { |req| req.format == :json } do

--- a/db/data/20210408143440_add_early_career_payments_to_policy_configurations.rb
+++ b/db/data/20210408143440_add_early_career_payments_to_policy_configurations.rb
@@ -1,0 +1,7 @@
+# Run me with `rails runner db/data/20210408143440_add_early_career_payments_to_policy_configurations.rb`
+
+# Put your Ruby code here
+PolicyConfiguration.create!(
+  policy_type: EarlyCareerPayments,
+  current_academic_year: AcademicYear.new("2021/2022")
+)

--- a/db/migrate/20210408151248_create_early_career_payments_eligibilities.rb
+++ b/db/migrate/20210408151248_create_early_career_payments_eligibilities.rb
@@ -1,0 +1,8 @@
+class CreateEarlyCareerPaymentsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :early_career_payments_eligibilities, id: :uuid do |t|
+      t.boolean "nqt_in_academic_year_after_itt"
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_093512) do
+ActiveRecord::Schema.define(version: 2021_04_08_151248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -110,6 +110,12 @@ ActiveRecord::Schema.define(version: 2020_04_02_093512) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "role_codes", default: [], array: true
     t.index ["dfe_sign_in_id"], name: "index_dfe_sign_in_users_on_dfe_sign_in_id", unique: true
+  end
+
+  create_table "early_career_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "nqt_in_academic_year_after_itt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@
 
 PolicyConfiguration.create!(policy_type: StudentLoans, current_academic_year: AcademicYear.current)
 PolicyConfiguration.create!(policy_type: MathsAndPhysics, current_academic_year: AcademicYear.current)
+PolicyConfiguration.create!(policy_type: EarlyCareerPayments, current_academic_year: AcademicYear.current)
 
 if Rails.env.development? || ENV["ENVIRONMENT_NAME"] == "review"
   ENV["FIXTURES_PATH"] = "spec/fixtures"

--- a/spec/factories/early_career_payments/eligibilities.rb
+++ b/spec/factories/early_career_payments/eligibilities.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :early_career_payments_eligibility, class: "EarlyCareerPayments::Eligibility" do
+    trait :eligible do
+      nqt_in_academic_year_after_itt { true }
+    end
+  end
+end

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.feature "Teacher Early Career Payments claims" do
+  scenario "Teacher makes claim for 'Early Career Payments' claim" do
+    visit new_claim_path(EarlyCareerPayments.routing_name)
+    expect(page).to have_link(href: EarlyCareerPayments.feedback_url)
+
+    # TODO [PAGE 00] - Landing (start)
+
+    # TODO - Investigate usage of new FormBuilder pattern & convert
+    # [PAGE 01] - NQT in Academic Year after ITT
+    expect(page).to have_text(I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    claim = Claim.order(:created_at).last
+    eligibility = claim.eligibility
+
+    expect(eligibility.nqt_in_academic_year_after_itt).to eql true
+
+    # TODO [PAGE 02] - Which school do you teach at
+    # TODO [PAGE 03] - Select the school you teach at
+    # TODO [PAGE 04] - Are you currently employed as a supply teacher
+    # TODO [PAGE 05] - Do you have a contract to teach at the same school
+    # TODO [PAGE 06] - Are you employed directly by your school
+    # TODO [PAGE 07] - Are you currently subject to action for poor performance
+    # TODO [PAGE 08] - Are you currently subject to dsiciplinary action
+    # TODO [PAGE 09] - Did you do a postgraduate ITT course or undergraduate ITT course
+    # TODO [PAGE 10] - Which subject did you do your undergraduate ITT in
+    # TODO [PAGE 11] - Which subject did you do your postgraduate ITT in
+    # TODO [PAGE 12] - Do you teach maths now
+    # TODO [PAGE 13] - In what academic year did you start your undergraduate ITT
+    # TODO [PAGE 14] - In what academic year did you start your postgraduate ITT
+    # TODO [PAGE 15] - Check your answers for eligibility
+    # TODO [PAGE 16] - You are eligible for an early career payment
+    # TODO [PAGE 20] - Personal Details
+    # TODO [PAGE 21] - One Time Password
+    # TODO [PAGE 22] - We have sent you reminders
+    # TODO [PAGE 23] - How will we use the information you provide
+    # TODO [PAGE 24] - Personal details
+    # TODO [PAGE 25] - What is your address
+    # TODO [PAGE 26] - Email address
+    # TODO [PAGE 27] - Enter bank account details
+    # TODO [PAGE 28] - What gender does your school's payroll system associate with you
+    # TODO [PAGE 29] - What is your teacher reference number
+    # TODO [PAGE 30] - Are you currently paying off your student loan
+    # TODO [PAGE 31] - When you applied for your student loan where was your address
+    # TODO [PAGE 32] - How many higher education courses did you take a student loan out for
+    # TODO [PAGE 33] - When did the first year of your higher education course start
+    # TODO [PAGE 34] - When did your higher education courses start
+    # TODO [PAGE 35] - Did you take out a postgraduate masters loan on or after 1 August 2016
+    # TODO [PAGE 36] - Did you take out a postgraduate doctoral loan on or after 1 August 2016
+
+    # TODO [PAGE 37] - Check your answers before sending your application
+    expect(page).to have_text("Check your answers before sending your application")
+
+    stub_geckoboard_dataset_update
+
+    freeze_time do
+      click_on "Confirm and send"
+
+      expect(claim.reload.submitted_at).to eq(Time.zone.now)
+    end
+
+    # TODO [PAGE 38] - Application complete (make sure its Word for Word and styling matches)
+    expect(page).to have_text("Claim submitted")
+    expect(page).to have_text(claim.reference)
+    expect(page).to have_text(claim.email_address)
+  end
+
+  # Sad paths
+  # TODO [PAGE 17] - This school is not eligible (sad path)
+  # TODO [PAGE 18] - You are not eligible for an early career payment
+  # TODO [PAGE 19] - You will be eligible for an early career payment in 2022
+end

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.feature "Teacher Early Career Payments claims" do
   scenario "Teacher makes claim for 'Early Career Payments' claim" do
-    visit new_claim_path(EarlyCareerPayments.routing_name)
+    visit landing_page_path(EarlyCareerPayments.routing_name)
     expect(page).to have_link(href: EarlyCareerPayments.feedback_url)
 
     # TODO [PAGE 00] - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
+    click_on "Start Now"
 
     # TODO - Investigate usage of new FormBuilder pattern & convert
     # [PAGE 01] - NQT in Academic Year after ITT
@@ -66,7 +68,6 @@ RSpec.feature "Teacher Early Career Payments claims" do
     # TODO [PAGE 38] - Application complete (make sure its Word for Word and styling matches)
     expect(page).to have_text("Claim submitted")
     expect(page).to have_text(claim.reference)
-    expect(page).to have_text(claim.email_address)
   end
 
   # Sad paths

--- a/spec/fixtures/policy_configurations.yml
+++ b/spec/fixtures/policy_configurations.yml
@@ -5,3 +5,7 @@ student_loans:
 maths_and_physics:
   policy_type: MathsAndPhysics
   current_academic_year: "2020/2021"
+
+early_career_payments:
+  policy_type: EarlyCareerPayments
+  current_academic_year: "2020/2021"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,6 +44,7 @@ describe ApplicationHelper do
     it "returns a policy-specific email address" do
       expect(support_email_address("student-loans")).to eq t("student_loans.support_email_address")
       expect(support_email_address("maths-and-physics")).to eq t("maths_and_physics.support_email_address")
+      expect(support_email_address("early-career-payments")).to eq t("early_career_payments.support_email_address")
     end
   end
 
@@ -55,6 +56,7 @@ describe ApplicationHelper do
     it "returns a policy-specific service name" do
       expect(policy_service_name("student-loans")).to eq t("student_loans.policy_name")
       expect(policy_service_name("maths-and-physics")).to eq t("maths_and_physics.policy_name")
+      expect(policy_service_name("early-career-payments")).to eq t("early_career_payments.policy_name")
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -903,4 +903,28 @@ RSpec.describe Claim, type: :model do
       expect(claim.decision_undoable?).to eq(false)
     end
   end
+
+  describe "Early Career Payments claim" do
+    let(:eligibility) { build(:early_career_payments_eligibility) }
+
+    describe "#submittable?" do
+      it "returns true when the claim is valid and has not been submitted" do
+        claim = build(:claim, :submittable, govuk_verify_fields: [], eligibility: eligibility)
+
+        expect(claim.submittable?).to eq true
+      end
+      it "returns false when it has already been submitted" do
+        claim = build(:claim, :unverified, eligibility: eligibility)
+
+        expect(claim.submittable?).to eq false
+      end
+    end
+
+    it "triggers validations on the eligibility appropriate to the context" do
+      claim = build(:claim, eligibility: eligibility)
+
+      expect(claim).not_to be_valid(:"nqt-in-academic-year-after-itt")
+      expect(claim.errors.values).to include(["Select yes if you did your NQT in the academic year after your ITT"])
+    end
+  end
 end

--- a/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
+++ b/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter do
+  let(:eligibility_attributes) do
+    {
+      nqt_in_academic_year_after_itt: true
+    }
+  end
+  let(:eligibility) { claim.eligibility }
+  let(:claim) { build(:claim, eligibility: build(:early_career_payments_eligibility, eligibility_attributes)) }
+
+  subject(:presenter) { described_class.new(eligibility) }
+
+  it "returns an array of questions and answers to be presented to the user for checking" do
+    expected_answers = [
+      [I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt"), "Yes", "nqt-in-academic-year-after-itt"]
+    ]
+
+    expect(presenter.answers).to eq(expected_answers)
+  end
+end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
+  describe "#policy" do
+    let(:early_career_payments_eligibility) { build(:early_career_payments_eligibility) }
+
+    it "has a policy class of 'EarlyCareerPayments'" do
+      expect(early_career_payments_eligibility.policy).to eq EarlyCareerPayments
+    end
+  end
+
+  describe "#ineligible?" do
+    it "returns false when the eligiblity cannot be determined" do
+      expect(EarlyCareerPayments::Eligibility.new.ineligible?).to eql false
+    end
+
+    it "returns true when the NQT acdemic year was not the year after the ITT" do
+      expect(EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: false).ineligible?).to eql true
+      expect(EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: true).ineligible?).to eql false
+    end
+  end
+
+  describe "#award_amount" do
+    # TODO we have multiple repayment amounts to consider. Have used the minimum for this spec
+    it "returns the £2,000 amount that Early Career Payments claimants are eligible for" do
+      expect(EarlyCareerPayments::Eligibility.new.award_amount).to eq(BigDecimal("2000"))
+    end
+  end
+
+  describe "validation contexts" do
+    context "when saving in the 'nqt_in_academic_year_after_itt' context" do
+      it "is not valid without a value for 'nqt_in_academic_year_after_itt" do
+        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"nqt-in-academic-year-after-itt")
+      end
+    end
+  end
+end

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe EarlyCareerPayments::SlugSequence do
+  let(:claim) { build(:claim, eligibility: build(:early_career_payments_eligibility)) }
+
+  subject(:slug_sequence) { EarlyCareerPayments::SlugSequence.new(claim) }
+
+  describe "The sequence as defined by #slugs" do
+    it "excludes the “ineligible” slug if the claim is not actually ineligible" do
+      expect(claim.eligibility).not_to be_ineligible
+      expect(slug_sequence.slugs).not_to include("ineligible")
+
+      claim.eligibility.nqt_in_academic_year_after_itt = false
+      expect(claim.eligibility).to be_ineligible
+      expect(slug_sequence.slugs).to include("ineligible")
+    end
+  end
+end

--- a/spec/models/early_career_payments_spec.rb
+++ b/spec/models/early_career_payments_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe EarlyCareerPayments, type: :model do
+  let(:policy_configuration) { policy_configurations(:early_career_payments) }
+
+  describe ".routing_name" do
+    it "returns 'early-career-payments'" do
+      expect(subject.routing_name).to eq "early-career-payments"
+    end
+  end
+
+  describe ".start_page_url" do
+    context "Production environment" do
+      it "returns a url containing 'https://www.gov.uk/guidance/'" do
+        allow(Rails).to receive(:env) { "production".inquiry }
+        expect(subject.start_page_url).to include("https://www.gov.uk/guidance/")
+      end
+    end
+
+    context "Non-Production environments" do
+      it "returns a url containing '/early-career-payments/claim'" do
+        expect(subject.start_page_url).to include("/early-career-payments/claim")
+      end
+    end
+  end
+
+  describe ".feedback_url" do
+    it "returns a 'docs.google.com/forms/<slug>/viewform' url" do
+      # TODO get proper feedback URL - ECP-509
+      expect(subject.feedback_url).to include("https://docs.google.com/forms/TO-BE-REPLACED-by-response-to-ECP-509/viewform")
+    end
+  end
+
+  describe ".short_name" do
+    it "returns the 'policy_short_name' translation" do
+      expect(subject.short_name).to eql "Early Career Payments"
+    end
+  end
+
+  describe ".locale_key" do
+    it "returns 'routing_name' in the correct format to match the 'root key' in the translation file" do
+      expect(subject.locale_key).to eql subject.routing_name.underscore
+    end
+  end
+
+  describe ".notify_reply_to_id" do
+    let(:ecp_notify_reply_to_id) do
+      "3f85a1f7-9400-4b48-9a31-eaa643d6b977"
+    end
+    it "returns the notify_reply_to_id" do
+      # TODO replace with valid ID - ECP-515
+      expect(subject.notify_reply_to_id).to eql ecp_notify_reply_to_id
+    end
+  end
+
+  describe ".eligibility_page_url" do
+    it "returns a link to the guidance page for eligibility url" do
+      expect(subject.eligibility_page_url).to include("https://www.gov.uk/publications/TO-BE-REPLACED-by-response-to-ECP-518")
+    end
+  end
+
+  describe ".first_eligible_qts_award_year" do
+    let(:policy_configuration) { policy_configurations(:early_career_payments) }
+
+    it "can return the AcademicYear based on a passed-in academic year" do
+      expect(EarlyCareerPayments.first_eligible_qts_award_year(AcademicYear.new(2024))).to eq AcademicYear.new(2021)
+    end
+  end
+end

--- a/spec/models/policy_configuration_spec.rb
+++ b/spec/models/policy_configuration_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PolicyConfiguration do
     it "returns the configuration for a given policy" do
       expect(PolicyConfiguration.for(StudentLoans)).to eq policy_configurations(:student_loans)
       expect(PolicyConfiguration.for(MathsAndPhysics)).to eq policy_configurations(:maths_and_physics)
+      expect(PolicyConfiguration.for(EarlyCareerPayments)).to eq policy_configurations(:early_career_payments)
     end
   end
 

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -51,6 +51,9 @@ RSpec.describe "Admin claims", type: :request do
         let(:claim) { create(:claim, :submitted, policy: policy) }
 
         it "displays the claim and eligibility details" do
+          pending("# Implement EarlyCareerPayments Admin Journey") if policy == EarlyCareerPayments
+          # FIXME ADMIN Sections for EarlyCareerPayments
+
           get admin_claim_path(claim)
 
           expect(response.body).to include(claim.reference)
@@ -63,6 +66,9 @@ RSpec.describe "Admin claims", type: :request do
           let!(:claim_with_matching_attributes) { create(:claim, :submitted, teacher_reference_number: claim.teacher_reference_number, policy: policy) }
 
           it "returns the claim and the duplicate" do
+            pending("# Implement EarlyCareerPayments Admin Journey") if policy == EarlyCareerPayments
+            # FIXME ADMIN Sections for EarlyCareerPayments
+
             get admin_claim_path(claim)
 
             expect(response.body).to include(claim.reference)

--- a/spec/requests/admin_payroll_gender_tasks_spec.rb
+++ b/spec/requests/admin_payroll_gender_tasks_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe "Admin tasks", type: :request do
 
           context "when a payroll gender is not set" do
             it "doesn't create a task and shows an error" do
+              pending("# Implement EarlyCareerPayments Admin Journey") if policy == EarlyCareerPayments
+              # FIXME ADMIN Sections for EarlyCareerPayments
+
               params[:claim][:payroll_gender] = ""
 
               expect {

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe "Admin tasks", type: :request do
 
         describe "tasks#show" do
           it "renders the requested page" do
+            pending("# Implement EarlyCareerPayments Admin Journey") if policy == EarlyCareerPayments
+            # FIXME ADMIN Sections for EarlyCareerPayments
+
             get admin_claim_task_path(claim, "qualifications")
             expect(response.body).to include(I18n.t("admin.qts_award_year"))
             expect(response.body).to include(claim.eligibility.qts_award_year_answer)
@@ -79,6 +82,9 @@ RSpec.describe "Admin tasks", type: :request do
 
           context "when a task's passed flag is not set" do
             it "doesn't create a task and shows an error" do
+              pending("# Implement EarlyCareerPayments Admin Journey") if policy == EarlyCareerPayments
+              # FIXME ADMIN Sections for EarlyCareerPayments
+
               expect {
                 post admin_claim_tasks_path(claim, name: "qualifications", params: {task: {passed: ""}})
               }.not_to change { claim.tasks.count }

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -18,6 +18,11 @@ module RequestHelpers
         eligibility_attributes: {
           teaching_maths_or_physics: "true"
         }
+      },
+      EarlyCareerPayments => {
+        eligibility_attributes: {
+          nqt_in_academic_year_after_itt: "true"
+        }
       }
     }.fetch(policy)
   end


### PR DESCRIPTION
Have expanded on the work from ECP-508 to wire the landing page into the Early Career Payments claimants journey

- Add new routing that puts the landing page into static pages only for EarlyCareerPayments policy
- Add the action to the static pages controller
- Move the pages location from early_career_payments/claim to static_pages
- Extracted the SVG for the start button to a common reusable partial in the shared views

With these actions performed the user can now go to from the landing page to the first page of a new EarlyCareerPayments journey. Currently this is the 'Did you do your NQT the academic year after your ITT?' view

Have raised a question with the content deisgner about the naming of landing-page possibly changing to 'apply'