### PR TITLE
Fix GOV.UK Verify removal [ECP-593]

### DIFF
--- a/app/models/automated_checks/update_admin_claim_tasks_with_dqt.rb
+++ b/app/models/automated_checks/update_admin_claim_tasks_with_dqt.rb
@@ -39,7 +39,7 @@ module AutomatedChecks
     end
 
     def perform_identity_confirmation
-      if claim.identity_verified? && awaiting_task?("identity_confirmation") && identity_matches?
+      if awaiting_task?("identity_confirmation") && identity_matches?
         claim.tasks.create!(task_attributes("identity_confirmation"))
         @completed_tasks += 1
       end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -15,8 +15,6 @@ FactoryBot.define do
     end
 
     trait :submittable do
-      verified
-
       first_name { "Jo" }
       surname { "Bloggs" }
       address_line_1 { "1 Test Road" }

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -1,54 +1,109 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a Maths & Physics claim" do
-  let!(:claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
+  context "without GOV.UK Verify" do
+    let!(:claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
 
-  before { @signed_in_user = sign_in_as_service_operator }
+    before { @signed_in_user = sign_in_as_service_operator }
 
-  scenario "service operator checks and approves a Maths & Physics claim" do
-    visit admin_claims_path
-    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+    scenario "service operator checks and approves a Maths & Physics claim" do
+      visit admin_claims_path
+      find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    expect(page).to have_content("1. Identity confirmation")
-    expect(page).to have_content("2. Qualifications")
-    expect(page).to have_content("3. Employment")
-    expect(page).to have_content("4. Decision")
+      expect(page).to have_content("1. Identity confirmation")
+      expect(page).to have_content("2. Qualifications")
+      expect(page).to have_content("3. Employment")
+      expect(page).to have_content("4. Decision")
 
-    click_on I18n.t("admin.tasks.identity_confirmation")
+      click_on I18n.t("admin.tasks.identity_confirmation")
 
-    expect(page).to have_content("Do our records for this teacher match the above name and date of birth from this claim?")
+      expect(page).to have_content("Did #{claim.full_name} submit the claim?")
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.qualifications"))
-    expect(page).to have_content("Award year")
-    expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+      expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.qualifications"))
+      expect(page).to have_content("Award year")
+      expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.employment"))
-    expect(page).to have_content("Current school")
-    expect(page).to have_link(claim.eligibility.current_school.name)
+      expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.employment"))
+      expect(page).to have_content("Current school")
+      expect(page).to have_link(claim.eligibility.current_school.name)
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
 
-    expect(page).to have_content("Claim decision")
+      expect(page).to have_content("Claim decision")
 
-    choose "Approve"
-    fill_in "Decision notes", with: "All checks passed!"
-    click_on "Confirm decision"
+      choose "Approve"
+      fill_in "Decision notes", with: "All checks passed!"
+      click_on "Confirm decision"
 
-    expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.latest_decision).to be_approved
-    expect(claim.latest_decision.created_by).to eq(@signed_in_user)
+      expect(page).to have_content("Claim has been approved successfully")
+      expect(claim.latest_decision).to be_approved
+      expect(claim.latest_decision.created_by).to eq(@signed_in_user)
+    end
+  end
+
+  context "with GOV.UK Verify" do
+    let!(:claim) { create(:claim, :verified, :submitted, policy: MathsAndPhysics) }
+
+    before { @signed_in_user = sign_in_as_service_operator }
+
+    scenario "service operator checks and approves a Maths & Physics claim" do
+      visit admin_claims_path
+      find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+      expect(page).to have_content("1. Identity confirmation")
+      expect(page).to have_content("2. Qualifications")
+      expect(page).to have_content("3. Employment")
+      expect(page).to have_content("4. Decision")
+
+      click_on I18n.t("admin.tasks.identity_confirmation")
+
+      expect(page).to have_content("Do our records for this teacher match the above name and date of birth from this claim?")
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+
+      expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.qualifications"))
+      expect(page).to have_content("Award year")
+      expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+
+      expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.employment"))
+      expect(page).to have_content("Current school")
+      expect(page).to have_link(claim.eligibility.current_school.name)
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
+
+      expect(page).to have_content("Claim decision")
+
+      choose "Approve"
+      fill_in "Decision notes", with: "All checks passed!"
+      click_on "Confirm decision"
+
+      expect(page).to have_content("Claim has been approved successfully")
+      expect(claim.latest_decision).to be_approved
+      expect(claim.latest_decision.created_by).to eq(@signed_in_user)
+    end
   end
 end

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -1,72 +1,146 @@
 require "rails_helper"
 
 RSpec.feature "Admin checking a Student Loans claim" do
-  let!(:claim) {
-    create(
-      :claim,
-      :submitted,
-      policy: StudentLoans,
-      student_loan_plan: StudentLoan::PLAN_2,
-      eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: "1987.65")
-    )
-  }
+  context "without GOV.UK Verify" do
+    let!(:claim) {
+      create(
+        :claim,
+        :submitted,
+        policy: StudentLoans,
+        student_loan_plan: StudentLoan::PLAN_2,
+        eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: "1987.65")
+      )
+    }
 
-  before { @signed_in_user = sign_in_as_service_operator }
+    before { @signed_in_user = sign_in_as_service_operator }
 
-  scenario "service operator checks and approves a Student Loans claim" do
-    visit admin_claims_path
-    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+    scenario "service operator checks and approves a Student Loans claim" do
+      visit admin_claims_path
+      find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    expect(page).to have_content("1. Identity confirmation")
-    expect(page).to have_content("2. Qualifications")
-    expect(page).to have_content("3. Employment")
-    expect(page).to have_content("4. Student loan amount")
-    expect(page).to have_content("5. Decision")
+      expect(page).to have_content("1. Identity confirmation")
+      expect(page).to have_content("2. Qualifications")
+      expect(page).to have_content("3. Employment")
+      expect(page).to have_content("4. Student loan amount")
+      expect(page).to have_content("5. Decision")
 
-    click_on I18n.t("admin.tasks.identity_confirmation")
+      click_on I18n.t("admin.tasks.identity_confirmation")
 
-    expect(page).to have_content("Do our records for this teacher match the above name and date of birth from this claim?")
+      expect(page).to have_content("Did #{claim.full_name} submit the claim?")
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications"))
-    expect(page).to have_content("Award year")
-    expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+      expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications"))
+      expect(page).to have_content("Award year")
+      expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.employment"))
-    expect(page).to have_content("Current school")
-    expect(page).to have_link(claim.eligibility.current_school.name)
+      expect(page).to have_content(I18n.t("student_loans.admin.task_questions.employment"))
+      expect(page).to have_content("Current school")
+      expect(page).to have_link(claim.eligibility.current_school.name)
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.student_loan_amount"))
-    expect(page).to have_content("£1,987.65")
-    expect(page).to have_content("Plan 2")
+      expect(page).to have_content(I18n.t("student_loans.admin.task_questions.student_loan_amount"))
+      expect(page).to have_content("£1,987.65")
+      expect(page).to have_content("Plan 2")
 
-    choose "Yes"
-    click_on "Save and continue"
+      choose "Yes"
+      click_on "Save and continue"
 
-    expect(claim.tasks.find_by!(name: "student_loan_amount").passed?).to eq(true)
+      expect(claim.tasks.find_by!(name: "student_loan_amount").passed?).to eq(true)
 
-    expect(page).to have_content("Claim decision")
+      expect(page).to have_content("Claim decision")
 
-    choose "Approve"
-    fill_in "Decision notes", with: "All checks passed!"
-    click_on "Confirm decision"
+      choose "Approve"
+      fill_in "Decision notes", with: "All checks passed!"
+      click_on "Confirm decision"
 
-    expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.latest_decision).to be_approved
-    expect(claim.latest_decision.created_by).to eq(@signed_in_user)
+      expect(page).to have_content("Claim has been approved successfully")
+      expect(claim.latest_decision).to be_approved
+      expect(claim.latest_decision.created_by).to eq(@signed_in_user)
+    end
+  end
+
+  context "with GOV.UK Verify" do
+    let!(:claim) {
+      create(
+        :claim,
+        :verified,
+        :submitted,
+        policy: StudentLoans,
+        student_loan_plan: StudentLoan::PLAN_2,
+        eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: "1987.65")
+      )
+    }
+
+    before { @signed_in_user = sign_in_as_service_operator }
+
+    scenario "service operator checks and approves a Student Loans claim" do
+      visit admin_claims_path
+      find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+      expect(page).to have_content("1. Identity confirmation")
+      expect(page).to have_content("2. Qualifications")
+      expect(page).to have_content("3. Employment")
+      expect(page).to have_content("4. Student loan amount")
+      expect(page).to have_content("5. Decision")
+
+      click_on I18n.t("admin.tasks.identity_confirmation")
+
+      expect(page).to have_content("Do our records for this teacher match the above name and date of birth from this claim?")
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+
+      expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications"))
+      expect(page).to have_content("Award year")
+      expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+
+      expect(page).to have_content(I18n.t("student_loans.admin.task_questions.employment"))
+      expect(page).to have_content("Current school")
+      expect(page).to have_link(claim.eligibility.current_school.name)
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
+
+      expect(page).to have_content(I18n.t("student_loans.admin.task_questions.student_loan_amount"))
+      expect(page).to have_content("£1,987.65")
+      expect(page).to have_content("Plan 2")
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(claim.tasks.find_by!(name: "student_loan_amount").passed?).to eq(true)
+
+      expect(page).to have_content("Claim decision")
+
+      choose "Approve"
+      fill_in "Decision notes", with: "All checks passed!"
+      click_on "Confirm decision"
+
+      expect(page).to have_content("Claim has been approved successfully")
+      expect(claim.latest_decision).to be_approved
+      expect(claim.latest_decision.created_by).to eq(@signed_in_user)
+    end
   end
 end

--- a/spec/fixtures/files/example_dqt_report.csv
+++ b/spec/fixtures/files/example_dqt_report.csv
@@ -7,5 +7,4 @@ dfeta text1,dfeta text2,dfeta trn,fullname,birthdate,dfeta ninumber,dfeta qtsdat
 6758493,CD123456,6758493,Terry Ineligible,21/4/1979,QQ123456C,12/3/2000,Politics,,,L200,,,Mathematics,,,G100,,
 5554433,EF123456,5554433,Already decided,15/5/1985,QQ123456C,9/1/2019,Chemistry,,,F100,,,Chemistry,,,F100,,
 6060606,GH123456,6060606,Already automated,4/10/1980,QQ123456C,10/5/2018,Spanish Studies,,,R400,,,Other Modern Language,,,R900,,
-9996060,DP5NEGWP,6060606,Not verified Bob,2/05/1979,QQ123456C,10/5/2018,Spanish Studies,,,R400,,,Other Modern Language,,,R900,,
 9876543,ZY987654,9876543,Dwayne Hecos,8/1/1991,QQ123456C,20/5/2017,Pure mathematics,,,100405,,,Numerical analysis,,,101027,,

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -12,14 +12,13 @@ RSpec.describe AutomatedChecks::DqtReportConsumer do
   let!(:claim_with_decision) { claim_from_example_dqt_report(:claim_with_decision) }
   let!(:claim_with_qualification_task) { claim_from_example_dqt_report(:claim_with_qualification_task) }
   let!(:existing_qualification_task) { claim_with_qualification_task.tasks.find_by!(name: "qualifications") }
-  let!(:unverified_claim_with_matching_identity_data) { claim_from_example_dqt_report(:unverified_claim_with_matching_identity_data) }
 
   describe "#ingest" do
     before { dqt_report_consumer.ingest }
 
     it "sets attributes that report the number of tasks automatically completed and the number of claims checked" do
-      expect(dqt_report_consumer.completed_tasks).to eq(5)
-      expect(dqt_report_consumer.total_claims_checked).to eq(7)
+      expect(dqt_report_consumer.completed_tasks).to eq(4)
+      expect(dqt_report_consumer.total_claims_checked).to eq(6)
     end
 
     it "creates a qualification task for claims that are eligible" do
@@ -44,13 +43,6 @@ RSpec.describe AutomatedChecks::DqtReportConsumer do
       expect(new_id_confirmation_task.passed).to eq(true)
       expect(new_id_confirmation_task.manual).to eq(false)
       expect(new_id_confirmation_task.created_by).to eq(admin_user)
-    end
-
-    it "doesn‘t create an identity_confirmation task for claims that are unverified" do
-      qualification_task = unverified_claim_with_matching_identity_data.tasks.find_by!(name: "qualifications")
-      expect(qualification_task.passed).to eq(true)
-
-      expect(unverified_claim_with_matching_identity_data.tasks.find_by(name: "identity_confirmation")).to be_nil
     end
 
     it "doesn't create an identity_confirmation task if either the surname or DOB does not match" do

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -65,12 +65,6 @@ module FixtureHelpers
         reference: "GH123456",
         date_of_birth: Date.new(1980, 10, 4),
         tasks: [build(:task, name: "qualifications")])
-    when :unverified_claim_with_matching_identity_data
-      create(:claim, :unverified,
-        teacher_reference_number: "9996060",
-        reference: "DP5NEGWP",
-        surname: "Bob",
-        date_of_birth: Date.new(1979, 5, 2))
     end
   end
 


### PR DESCRIPTION
- Remove verified trait from submittable claim factory
- Fix automated checks update admin claim tasks with DQT
- Fix automated checks DQT report consumer spec
- Fix admin checks claim specs

Bugs are fixed but UX needs some work, especially admin tasks identity confirmation:

- The question for outstanding claims that went through Verify don't mention it
- The question for claims that haven't gone through Verify say they haven't which is technically true but, apart from the above, we're not actually using Verify anymore.