### PR TITLE
Revert "[task/ECP-319] - remove references to GOVUK Verify from Azure scripts"

### DIFF
--- a/azure/resource_groups/alerts/template.json
+++ b/azure/resource_groups/alerts/template.json
@@ -34,6 +34,12 @@
     "workerContainerInstanceId": {
       "type": "string"
     },
+    "vspAppServiceId": {
+      "type": "string"
+    },
+    "vspAppServicePlanId": {
+      "type": "string"
+    },
     "databaseServerId": {
       "type": "string"
     },
@@ -48,6 +54,7 @@
     "appAlertsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app')]",
     "healthAlertsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-health')]",
     "databaseAlertsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database')]",
+    "vspAlertsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-vsp')]",
 
     "alertActionGroupName": "[concat(parameters('resourceNamePrefix'), '-ag')]",
 
@@ -153,6 +160,36 @@
           },
           "databaseServerId": {
             "value": "[parameters('databaseServerId')]"
+          },
+          "enableAlerts": {
+            "value": "[parameters('enableAlerts')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('vspAlertsDeploymentName')]",
+      "dependsOn": ["[resourceId('Microsoft.Insights/actionGroups', variables('alertActionGroupName'))]"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'app_alerts.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "alertNamePrefix": {
+            "value": "[variables('alertNamePrefix')]"
+          },
+          "actionGroupId": {
+            "value": "[resourceId('Microsoft.Insights/actionGroups', variables('alertActionGroupName'))]"
+          },
+          "appServiceId": {
+            "value": "[parameters('vspAppServiceId')]"
+          },
+          "appServicePlanId": {
+            "value": "[parameters('vspAppServicePlanId')]"
           },
           "enableAlerts": {
             "value": "[parameters('enableAlerts')]"

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -31,6 +31,24 @@
     "appServicePlanSkuCapacity": {
       "value": 2
     },
+    "vspAppServiceDockerImage": {
+      "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
+    },
+    "vspAppServicePlanSkuTier": {
+      "value": "PremiumV2"
+    },
+    "vspAppServicePlanSkuSize": {
+      "value": "P1v2"
+    },
+    "vspAppServicePlanSkuFamily": {
+      "value": "Pv2"
+    },
+    "vspAppServicePlanSkuCapacity": {
+      "value": 2
+    },
+    "verifyHubPossibleOutboundIpAddresses": {
+      "value": ["35.176.130.173", "18.130.112.6", "3.8.225.78"]
+    },
     "databaseName": {
       "value": "development"
     },
@@ -165,6 +183,34 @@
     },
     "WORKER_COUNT": {
       "value": 2
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "value": "INTEGRATION"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsDevVspSamlSigning8KeyBase64"
+      }
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsDevVspSamlEncryption8KeyBase64"
+      }
+    },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "value": ""
+    },
+    "VSP.EUROPEAN_IDENTITY_ENABLED": {
+      "value": "true"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "value": "https://development.additional-teaching-payment.education.gov.uk"
     }
   }
 }

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -27,6 +27,12 @@
         "www.claim-additional-teaching-payment.service.gov.uk": 1
       }
     },
+    "vspAppServiceDockerImage": {
+      "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
+    },
+    "verifyHubPossibleOutboundIpAddresses": {
+      "value": ["18.130.47.107", "18.130.64.77", "35.176.149.113"]
+    },
     "databaseName": {
       "value": "production"
     },
@@ -166,6 +172,34 @@
     },
     "WORKER_COUNT": {
       "value": 2
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "value": "PRODUCTION"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsProdVspSamlSigning2KeyBase64"
+      }
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsProdVspSamlEncryption2KeyBase64"
+      }
+    },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "value": ""
+    },
+    "VSP.EUROPEAN_IDENTITY_ENABLED": {
+      "value": "true"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "value": "https://additional-teaching-payment.education.gov.uk"
     }
   }
 }

--- a/azure/resource_groups/app/parameters/test.template.json
+++ b/azure/resource_groups/app/parameters/test.template.json
@@ -34,6 +34,24 @@
     "appServicePlanSkuCapacity": {
       "value": 1
     },
+    "vspAppServiceDockerImage": {
+      "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
+    },
+    "vspAppServicePlanSkuTier": {
+      "value": "PremiumV2"
+    },
+    "vspAppServicePlanSkuSize": {
+      "value": "P1v2"
+    },
+    "vspAppServicePlanSkuFamily": {
+      "value": "Pv2"
+    },
+    "vspAppServicePlanSkuCapacity": {
+      "value": 1
+    },
+    "verifyHubPossibleOutboundIpAddresses": {
+      "value": ["35.176.130.173", "18.130.112.6", "3.8.225.78"]
+    },
     "databaseName": {
       "value": "test"
     },
@@ -166,6 +184,34 @@
     },
     "WORKER_COUNT": {
       "value": 1
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "value": "INTEGRATION"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsDevVspSamlSigning6KeyBase64"
+      }
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
+      }
+    },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "value": ""
+    },
+    "VSP.EUROPEAN_IDENTITY_ENABLED": {
+      "value": "true"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "value": "https://development.additional-teaching-payment.education.gov.uk"
     }
   }
 }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -63,6 +63,28 @@
       "type": "int",
       "defaultValue": 2
     },
+    "vspAppServiceDockerImage": {
+      "type": "string"
+    },
+    "vspAppServicePlanSkuTier": {
+      "type": "string",
+      "defaultValue": "PremiumV2"
+    },
+    "vspAppServicePlanSkuSize": {
+      "type": "string",
+      "defaultValue": "P2v2"
+    },
+    "vspAppServicePlanSkuFamily": {
+      "type": "string",
+      "defaultValue": "Pv2"
+    },
+    "vspAppServicePlanSkuCapacity": {
+      "type": "int",
+      "defaultValue": 2
+    },
+    "verifyHubPossibleOutboundIpAddresses": {
+      "type": "array"
+    },
     "workerSubnetId": {
       "type": "string"
     },
@@ -140,6 +162,24 @@
     },
     "WORKER_COUNT": {
       "type": "int"
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "type": "string"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "type": "securestring"
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "type": "securestring"
+    },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "type": "securestring"
+    },
+    "VSP.EUROPEAN_IDENTITY_ENABLED": {
+      "type": "string"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "type": "string"
     }
   },
   "variables": {
@@ -187,6 +227,8 @@
     "appServiceWebTestDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-web-test')]",
     "databaseServerFirewallRulesDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server-firewall-rules')]",
     "databaseDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database')]",
+    "vspDeploymentName": "[concat(parameters('resourceNamePrefix'), '-vsp')]",
+    "vspAppServiceWebTestDeploymentName": "[concat(parameters('resourceNamePrefix'), '-vsp-app-service-web-test')]",
 
     "databaseServerName": "[concat(parameters('resourceNamePrefix'), '-db')]",
 
@@ -199,6 +241,12 @@
     "appServiceWebTestName": "[concat(variables('appServiceName'), '-webtest')]",
 
     "canonicalHostname": "[if(parameters('useAppServiceHostNames'), first(parameters('appServiceHostNames')), concat(variables('appServiceName'), '.azurewebsites.net'))]",
+
+    "vspAppServicePlanName": "[concat(parameters('resourceNamePrefix'), '-vsp-asp')]",
+    "vspAppServiceName": "[concat(parameters('resourceNamePrefix'), '-vsp-as')]",
+    "vspAppServiceRuntimeStack": "[concat('DOCKER|', parameters('vspAppServiceDockerImage'))]",
+
+    "vspAppServiceWebTestName": "[concat(variables('vspAppServiceName'), '-webtest')]",
 
     "workerContainerName": "[concat(parameters('resourceNamePrefix'), '-worker-container')]",
     "workerContainerInstanceName": "[concat(parameters('resourceNamePrefix'), '-worker-aci')]",
@@ -262,7 +310,8 @@
       "name": "[variables('availabilityTestsDeploymentName')]",
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', variables('applicationInsightsDeploymentName'))]",
-        "[resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))]"
+        "[resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))]",
+        "[resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -280,6 +329,11 @@
                 "nameSuffix": "[variables('appServiceWebTestName')]",
                 "url": "[concat('https://', reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.appServiceCanonicalHostName.value, '/healthcheck')]",
                 "guid": "[guid(variables('appServiceWebTestName'))]"
+              },
+              {
+                "nameSuffix": "[variables('vspAppServiceWebTestName')]",
+                "url": "[concat('https://', reference(resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))).outputs.appServiceHostName.value, '/admin/healthcheck')]",
+                "guid": "[guid(variables('vspAppServiceName'))]"
               }
             ]
           },
@@ -471,6 +525,10 @@
               {
                 "name": "WORKER_COUNT",
                 "value": "[parameters('WORKER_COUNT')]"
+              },
+              {
+                "name": "GOVUK_VERIFY_VSP_HOST",
+                "value": "[concat('https://', variables('vspAppServiceName'), '.azurewebsites.net')]"
               }
             ]
           }
@@ -506,6 +564,79 @@
           }
         }
       }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('vspDeploymentName')]",
+      "dependsOn": ["[resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))]"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'vsp.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "gitCommitHash": {
+            "value": "[parameters('gitCommitHash')]"
+          },
+          "appServicePlanName": {
+            "value": "[variables('vspAppServicePlanName')]"
+          },
+          "appServicePlanSkuTier": {
+            "value": "[parameters('vspAppServicePlanSkuTier')]"
+          },
+          "appServicePlanSkuSize": {
+            "value": "[parameters('vspAppServicePlanSkuSize')]"
+          },
+          "appServicePlanSkuFamily": {
+            "value": "[parameters('vspAppServicePlanSkuFamily')]"
+          },
+          "appServicePlanSkuCapacity": {
+            "value": "[parameters('vspAppServicePlanSkuCapacity')]"
+          },
+          "appServiceName": {
+            "value": "[variables('vspAppServiceName')]"
+          },
+          "appServiceRuntimeStack": {
+            "value": "[variables('vspAppServiceRuntimeStack')]"
+          },
+          "appServiceAlwaysOn": {
+            "value": "[parameters('appServiceAlwaysOn')]"
+          },
+          "appServiceAllowedIpAddresses": {
+            "value": "[union(reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.appServicePossibleOutboundIpAddresses.value, parameters('verifyHubPossibleOutboundIpAddresses'), variables('azureAvailabilityTestIpAddresses'))]"
+          },
+          "appServiceEnvironmentVariables": {
+            "value": [
+              {
+                "name": "VERIFY_ENVIRONMENT",
+                "value": "[parameters('VSP.VERIFY_ENVIRONMENT')]"
+              },
+              {
+                "name": "SERVICE_ENTITY_IDS",
+                "value": "[concat('[', '''', parameters('VSP.VERIFY_ENTITY_ID'), '''', ']')]"
+              },
+              {
+                "name": "SAML_SIGNING_KEY",
+                "value": "[parameters('VSP.SAML_SIGNING_KEY')]"
+              },
+              {
+                "name": "SAML_PRIMARY_ENCRYPTION_KEY",
+                "value": "[parameters('VSP.SAML_PRIMARY_ENCRYPTION_KEY')]"
+              },
+              {
+                "name": "SAML_SECONDARY_ENCRYPTION_KEY",
+                "value": "[parameters('VSP.SAML_SECONDARY_ENCRYPTION_KEY')]"
+              },
+              {
+                "name": "EUROPEAN_IDENTITY_ENABLED",
+                "value": "[parameters('VSP.EUROPEAN_IDENTITY_ENABLED')]"
+              }
+            ]
+          }
+        }
+      }
     }
   ],
   "outputs": {
@@ -528,6 +659,14 @@
     "workerContainerInstanceId": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.workerContainerInstanceId.value]"
+    },
+    "vspAppServicePlanId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))).outputs.appServicePlanId.value]"
+    },
+    "vspAppServiceId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))).outputs.appServiceId.value]"
     }
   }
 }

--- a/azure/templates/vsp.json
+++ b/azure/templates/vsp.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "gitCommitHash": {
+      "type": "string"
+    },
+    "appServicePlanName": {
+      "type": "string"
+    },
+    "appServicePlanSkuTier": {
+      "type": "string"
+    },
+    "appServicePlanSkuSize": {
+      "type": "string"
+    },
+    "appServicePlanSkuFamily": {
+      "type": "string"
+    },
+    "appServicePlanSkuCapacity": {
+      "type": "int"
+    },
+    "appServiceName": {
+      "type": "string"
+    },
+    "appServiceRuntimeStack": {
+      "type": "string"
+    },
+    "appServiceAlwaysOn": {
+      "type": "bool"
+    },
+    "appServiceAllowedIpAddresses": {
+      "type": "array"
+    },
+    "appServiceEnvironmentVariables": {
+      "type": "array",
+      "defaultValue": []
+    },
+    "enableLogs": {
+      "type": "bool",
+      "defaultValue": true
+    }
+  },
+  "variables": {
+    "platformBuildingBlocksDeploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/7a4748a0cf366193d31434bd7796d483bd281385/templates/",
+    "deploymentUrlBase": "[concat('https://raw.githubusercontent.com/DFE-Digital/dfe-teachers-payment-service/', parameters('gitCommitHash'), '/azure/templates/')]",
+
+    "appServiceLogsDeploymentName": "[concat(deployment().name, '-app-service-logs')]",
+    "appServicePlanDeploymentName": "[concat(deployment().name, '-app-service-plan')]",
+
+    "appServiceAllowedIpAddressCount": "[length(parameters('appServiceAllowedIpAddresses'))]",
+
+    "appServiceStagingSlotName": "[concat(parameters('appServiceName'), '/staging')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('appServicePlanDeploymentName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'app_service_plan.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServicePlanName": {
+            "value": "[parameters('appServicePlanName')]"
+          },
+          "appServicePlanSkuTier": {
+            "value": "[parameters('appServicePlanSkuTier')]"
+          },
+          "appServicePlanSkuSize": {
+            "value": "[parameters('appServicePlanSkuSize')]"
+          },
+          "appServicePlanSkuFamily": {
+            "value": "[parameters('appServicePlanSkuFamily')]"
+          },
+          "appServicePlanSkuCapacity": {
+            "value": "[parameters('appServicePlanSkuCapacity')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2018-11-01",
+      "name": "[parameters('appServiceName')]",
+      "kind": "app,linux,container",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]"],
+      "properties": {
+        "httpsOnly": true,
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+        "siteConfig": {
+          "alwaysOn": "[parameters('appServiceAlwaysOn')]",
+          "appSettings": "[parameters('appServiceEnvironmentVariables')]",
+          "copy": [
+            {
+              "name": "ipSecurityRestrictions",
+              "count": "[add(variables('appServiceAllowedIpAddressCount'), 1)]",
+              "input": {
+                "ipAddress": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), if(contains(parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')], '/'), parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')], concat(parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')], '/32')), '0.0.0.0/1')]",
+                "action": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), 'Allow', 'Deny')]",
+                "priority": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), 65000, 2147483647)]",
+                "name": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), concat('Allow ', parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')]), 'Deny all')]"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/slots",
+      "apiVersion": "2018-11-01",
+      "name": "[variables('appServiceStagingSlotName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+        "httpsOnly": true,
+        "siteConfig": {
+          "alwaysOn": false,
+          "linuxFxVersion": "[parameters('appServiceRuntimeStack')]",
+          "appSettings": "[parameters('appServiceEnvironmentVariables')]",
+          "copy": [
+            {
+              "name": "ipSecurityRestrictions",
+              "count": "[add(variables('appServiceAllowedIpAddressCount'), 1)]",
+              "input": {
+                "ipAddress": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), if(contains(parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')], '/'), parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')], concat(parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')], '/32')), '0.0.0.0/1')]",
+                "action": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), 'Allow', 'Deny')]",
+                "priority": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), 65000, 2147483647)]",
+                "name": "[if(less(copyIndex('ipSecurityRestrictions'), variables('appServiceAllowedIpAddressCount')), concat('Allow ', parameters('appServiceAllowedIpAddresses')[copyIndex('ipSecurityRestrictions')]), 'Deny all')]"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "condition": "[parameters('enableLogs')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('appServiceLogsDeploymentName')]",
+      "dependsOn": ["[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('platformBuildingBlocksDeploymentUrlBase'), 'app-service-logs.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServiceName": {
+            "value": "[parameters('appServiceName')]"
+          },
+          "httpLoggingEnabled": {
+            "value": true
+          },
+          "requestTracingEnabled": {
+            "value": true
+          },
+          "detailedErrorLoggingEnabled": {
+            "value": true
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "appServicePlanId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+    },
+    "appServiceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
+    },
+    "appServiceHostName": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Web/sites', parameters('appServiceName'))).defaultHostName]"
+    }
+  }
+}


### PR DESCRIPTION
Reverts DFE-Digital/claim-additional-payments-for-teaching#1274

This is being reverted because on investigation into why Releases are failing on Azure Development (and would be too on Production) are caused by the incorrect sequencing of resource deletion.
It turns out that the last Microsoft component to be deleted is the `AppServicePlan` so that needs to be decoupled from this removal.

As per this article from Microsoft - https://docs.microsoft.com/en-us/answers/questions/169500/unable-to-delete-virtual-network-and-a-resource-gr.html

Also reverting as about to go into Private Beta. Prior to this we want to be have the code deployed in Azure development for our Business colleagues to perform exploratory testing against.

Approach discussed and investigation by @WorkSutton and @and-lucas-kelly 