### PR TITLE
[bug/ECP-643] - fix broken logic flows for 'Student Loans' sections of ECP journey

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -21,8 +21,8 @@ module ClaimsHelper
       a << [translate("questions.student_loan_country"), claim.student_loan_country.titleize, "student-loan-country"] if claim.student_loan_country.present?
       a << [translate("questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
       a << [translate("questions.student_loan_start_date.#{claim.student_loan_courses}"), t("answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
-      a << [translate("early_career_payments.questions.postgraduate_masters_loan"), (claim.eligibility.postgraduate_masters_loan ? "Yes" : "No"), "masters-loan"] if claim.has_ecp_policy?
-      a << [translate("early_career_payments.questions.postgraduate_doctoral_loan"), (claim.eligibility.postgraduate_doctoral_loan ? "Yes" : "No"), "doctoral-loan"] if claim.has_ecp_policy?
+      a << [translate("early_career_payments.questions.postgraduate_masters_loan"), (claim.eligibility.postgraduate_masters_loan ? "Yes" : "No"), "masters-loan"] if claim.has_ecp_policy? && claim.has_student_loan?
+      a << [translate("early_career_payments.questions.postgraduate_doctoral_loan"), (claim.eligibility.postgraduate_doctoral_loan ? "Yes" : "No"), "doctoral-loan"] if claim.has_ecp_policy? && claim.has_student_loan?
     end
   end
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -137,7 +137,7 @@ class Claim < ApplicationRecord
   validates :student_loan_country, on: [:"student-loan-country"], presence: {message: "Select the country you lived in when you applied for your student loan"}
   validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select the number of student loans you have taken out"}
   validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: ->(object, data) { I18n.t("validation_errors.student_loan_start_date.#{object.student_loan_courses}") }}
-  validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}, unless: :has_ecp_policy?
+  validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
   validates :student_loan_plan, on: [:amendment], inclusion: {in: [Claim::NO_STUDENT_LOAN], message: "You can’t amend the student loan plan type because the claimant said they are no longer paying off their student loan"}, if: :no_student_loan?
 
   validates :email_address, on: [:"email-address", :submit], presence: {message: "Enter an email address"}
@@ -149,7 +149,7 @@ class Claim < ApplicationRecord
   validates :bank_sort_code, on: [:"bank-details", :submit], presence: {message: "Enter a sort code"}
   validates :bank_account_number, on: [:"bank-details", :submit], presence: {message: "Enter an account number"}
 
-  validates :payroll_gender, on: [:"payroll-gender-task", :submit], presence: {message: "You must select a gender that will be passed to HMRC"}, unless: :has_ecp_policy?
+  validates :payroll_gender, on: [:"payroll-gender-task", :submit], presence: {message: "You must select a gender that will be passed to HMRC"}
 
   validate :bank_account_number_must_be_eight_digits
   validate :bank_sort_code_must_be_six_digits

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -18,7 +18,8 @@ module EarlyCareerPayments
     ATTRIBUTE_DEPENDENCIES = {
       "employed_as_supply_teacher" => ["has_entire_term_contract", "employed_directly"],
       "pgitt_or_ugitt_course" => ["eligible_itt_subject", "teaching_subject_now"],
-      "eligible_itt_subject" => ["teaching_subject_now"]
+      "eligible_itt_subject" => ["teaching_subject_now"],
+      "has_student_loan" => ["postgraduate_masters_loan", "postgraduate_doctoral_loan"]
     }.freeze
 
     self.table_name = "early_career_payments_eligibilities"
@@ -95,7 +96,7 @@ module EarlyCareerPayments
     def reset_dependent_answers
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
-          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name) || claim.changed.include?(attribute_name)
         end
       end
     end

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -56,6 +56,36 @@ module EarlyCareerPayments
         sequence.delete("employed-directly") unless claim.eligibility.employed_as_supply_teacher?
         sequence.delete("eligibility_confirmed") unless claim.eligibility.eligible?
         sequence.delete("ineligible") unless claim.eligibility.ineligible?
+        remove_student_loan_slugs(sequence) if claim.has_student_loan == false
+        remove_student_loan_country_slugs(sequence)
+      end
+    end
+
+    private
+
+    def remove_student_loan_slugs(sequence, slugs = nil)
+      slugs ||= %w[
+        student-loan-country
+        student-loan-how-many-courses
+        student-loan-start-date
+        masters-loan
+        doctoral-loan
+      ]
+
+      slugs.each { |slug| sequence.delete(slug) }
+    end
+
+    def remove_student_loan_country_slugs(sequence)
+      slugs = %w[
+        student-loan-how-many-courses
+        student-loan-start-date
+      ]
+
+      if [
+        StudentLoan::NORTHERN_IRELAND,
+        StudentLoan::SCOTLAND
+      ].include?(claim.student_loan_country)
+        remove_student_loan_slugs(sequence, slugs)
       end
     end
   end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -109,5 +109,13 @@ FactoryBot.define do
       has_student_loan { true }
       student_loan_country { StudentLoan::SCOTLAND }
     end
+
+    trait :with_no_student_loan do
+      has_student_loan { false }
+      student_loan_country { nil }
+      student_loan_courses { nil }
+      student_loan_start_date { nil }
+      student_loan_plan { nil }
+    end
   end
 end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -212,6 +212,19 @@ describe ClaimsHelper do
           expect(helper.student_loan_answers(claim)).to eq expected_answers
         end
       end
+
+      context "when claimant answered 'No' to 'Paying off Student Loan'" do
+        let(:eligibility) { build(:early_career_payments_eligibility, postgraduate_masters_loan: nil, postgraduate_doctoral_loan: nil) }
+        let(:trait) { :with_no_student_loan }
+
+        it "returns an arry with a single question and answer" do
+          expected_answers = [
+            [t("questions.has_student_loan"), "No", "student-loan"]
+          ]
+
+          expect(helper.student_loan_answers(claim)).to eq expected_answers
+        end
+      end
     end
   end
 end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -144,8 +144,9 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
   end
 
   describe "#reset_dependent_answers" do
+    let!(:claim) { build_stubbed(:claim, :with_student_loan, eligibility: eligibility) }
     let(:eligibility) do
-      create(
+      build_stubbed(
         :early_career_payments_eligibility,
         :eligible,
         employed_as_supply_teacher: true,
@@ -205,6 +206,24 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
       expect { eligibility.reset_dependent_answers }
         .to change { eligibility.employed_directly }
         .from(false).to(nil)
+    end
+
+    it "resets 'postgraduate_masters_loan' when the value of 'claim.has_student_loan' changes from true to false" do
+      expect { eligibility.reset_dependent_answers }.not_to change { eligibility.attributes }
+
+      claim.has_student_loan = false
+      expect { eligibility.reset_dependent_answers }
+        .to change { eligibility.postgraduate_masters_loan }
+        .from(true).to(nil)
+    end
+
+    it "resets 'postgraduate_doctoral_loan' when the value of 'claim.has_student_loan' changes from true to false" do
+      expect { eligibility.reset_dependent_answers }.not_to change { eligibility.attributes }
+
+      claim.has_student_loan = false
+      expect { eligibility.reset_dependent_answers }
+        .to change { eligibility.postgraduate_doctoral_loan }
+        .from(true).to(nil)
     end
   end
 

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -41,5 +41,74 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
         expect(slug_sequence.slugs).to include("eligibility_confirmed")
       end
     end
+
+    context "when the answer to 'paying off student loan' is 'No'" do
+      it "excludes 'student-loan-country', 'student-loan-how-many-courses', 'student-loan-start-date', 'masters-loan' and 'doctoral-loan'" do
+        claim.has_student_loan = false
+
+        expected_slugs = %w[
+          nqt-in-academic-year-after-itt
+          supply-teacher
+          formal-performance-action
+          disciplinary-action
+          postgraduate-itt-or-undergraduate-itt-course
+          eligible-itt-subject
+          teaching-subject-now
+          itt_year
+          check-your-answers-part-one
+          how_we_will_use_information_provided
+          personal-details
+          address
+          email-address
+          bank-details
+          gender
+          teacher-reference-number
+          student-loan
+          check-your-answers
+        ]
+
+        expect(slug_sequence.slugs).to eq expected_slugs
+      end
+    end
+
+    context "when the answer to 'student loan - home address ' is 'Scotland' OR 'Northen Ireland'" do
+      let(:expected_slugs) do
+        %w[
+          nqt-in-academic-year-after-itt
+          supply-teacher
+          formal-performance-action
+          disciplinary-action
+          postgraduate-itt-or-undergraduate-itt-course
+          eligible-itt-subject
+          teaching-subject-now
+          itt_year
+          check-your-answers-part-one
+          how_we_will_use_information_provided
+          personal-details
+          address
+          email-address
+          bank-details
+          gender
+          teacher-reference-number
+          student-loan
+          student-loan-country
+          masters-loan
+          doctoral-loan
+          check-your-answers
+        ]
+      end
+
+      it "excludes 'student-loan-how-many-courses', 'student-loan-start-date' - Northern Ireland" do
+        claim.student_loan_country = StudentLoan::NORTHERN_IRELAND
+
+        expect(slug_sequence.slugs).to eq expected_slugs
+      end
+
+      it "excludes 'student-loan-how-many-courses', 'student-loan-start-date' - Scotland" do
+        claim.student_loan_country = StudentLoan::SCOTLAND
+
+        expect(slug_sequence.slugs).to eq expected_slugs
+      end
+    end
   end
 end


### PR DESCRIPTION
- Don't show any student loans screens if the claimant answered 'No' to 'has_student_loan'