### PR TITLE
story/ECP-480-474 ineligible school for ECP claim 

### DIFF
--- a/app/helpers/early_career_payments_helper.rb
+++ b/app/helpers/early_career_payments_helper.rb
@@ -1,0 +1,11 @@
+module EarlyCareerPaymentsHelper
+  def ineligible_heading(claim)
+    if claim.eligibility.ineligibility_reason == :subject_to_formal_performance_action
+      content_tag(:h1, I18n.t("early_career_payments.ineligible.poor_performance_heading"), class: "govuk-heading-xl")
+    elsif claim.eligibility.ineligibility_reason == :ineligible_current_school
+      content_tag(:h1, I18n.t("early_career_payments.ineligible.school_heading"), class: "govuk-heading-xl")
+    else
+      content_tag(:h1, I18n.t("early_career_payments.ineligible.heading"), class: "govuk-heading-xl")
+    end
+  end
+end

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -70,6 +70,7 @@ module EarlyCareerPayments
 
     def ineligible?
       ineligible_nqt_in_academic_year_after_itt? ||
+        ineligible_current_school? ||
         no_entire_term_contract? ||
         not_employed_directly? ||
         subject_to_formal_performance_action? ||
@@ -82,6 +83,7 @@ module EarlyCareerPayments
     def ineligibility_reason
       [
         :generic_ineligibility,
+        :ineligible_current_school,
         :subject_to_formal_performance_action,
         :itt_subject_none_of_the_above,
         :not_teaching_now_in_eligible_itt_subject
@@ -110,6 +112,10 @@ module EarlyCareerPayments
 
     def ineligible_nqt_in_academic_year_after_itt?
       nqt_in_academic_year_after_itt == false
+    end
+
+    def ineligible_current_school?
+      current_school.present? && !current_school.eligible_for_early_career_payments?
     end
 
     def ineligible_itt_academic_year?

--- a/app/models/early_career_payments/school_check_email_data_export_presenter.rb
+++ b/app/models/early_career_payments/school_check_email_data_export_presenter.rb
@@ -1,0 +1,13 @@
+module EarlyCareerPayments
+  class SchoolCheckEmailDataExportPresenter
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def subject
+      ""
+    end
+  end
+end

--- a/app/models/early_career_payments/school_eligibility.rb
+++ b/app/models/early_career_payments/school_eligibility.rb
@@ -1,0 +1,341 @@
+module EarlyCareerPayments
+  class SchoolEligibility
+    ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES = [
+      "E06000001", # Hartlepool
+      "E06000002", # Middlesbrough
+      "E06000003", # Redcar and Cleveland
+      "E06000004", # Stockton-on-Tees
+      "E06000005", # Darlington
+      "E06000006", # Halton
+      "E06000007", # Warrington
+      "E06000008", # Blackburn with Darwen
+      "E06000009", # Blackpool
+      "E06000010", # Kingston upon Hull, City of
+      "E06000011", # East Riding of Yorkshire
+      "E06000012", # North East Lincolnshire
+      "E06000013", # North Lincolnshire
+      "E06000014", # York
+      "E06000015", # Derby
+      "E06000016", # Leicester
+      "E06000017", # Rutland
+      "E06000018", # Nottingham
+      "E06000019", # Herefordshire, County of
+      "E06000020", # Telford and Wrekin
+      "E06000021", # Stoke-on-Trent
+      "E06000022", # Bath and North East Somerset
+      "E06000023", # Bristol, City of
+      "E06000024", # North Somerset
+      "E06000025", # South Gloucestershire
+      "E06000026", # Plymouth
+      "E06000027", # Torbay
+      "E06000030", # Swindon
+      "E06000031", # Peterborough
+      "E06000032", # Luton
+      "E06000033", # Southend-on-Sea
+      "E06000034", # Thurrock
+      "E06000035", # Medway
+      "E06000036", # Bracknell Forest
+      "E06000037", # West Berkshire
+      "E06000038", # Reading
+      "E06000039", # Slough
+      "E06000040", # Windsor and Maidenhead
+      "E06000041", # Wokingham
+      "E06000042", # Milton Keynes
+      "E06000043", # Brighton and Hove
+      "E06000044", # Portsmouth
+      "E06000045", # Southampton
+      "E06000046", # Isle of Wight
+      "E06000047", # County Durham
+      "E06000049", # Cheshire East
+      "E06000050", # Cheshire West and Chester
+      "E06000051", # Shropshire
+      "E06000052", # Cornwall
+      "E06000053", # Isles of Scilly
+      "E06000054", # Wiltshire
+      "E06000055", # Bedford
+      "E06000056", # Central Bedfordshire
+      "E06000057", # Northumberland
+      "E06000058", # Bournemouth, Christchurch and Poole
+      "E06000059", # Dorset
+      "E06000060", # Buckinghamshire
+      "E07000004", # Aylesbury Vale
+      "E07000005", # Chiltern
+      "E07000006", # South Bucks
+      "E07000007", # Wycombe
+      "E07000008", # Cambridge
+      "E07000009", # East Cambridgeshire
+      "E07000010", # Fenland
+      "E07000011", # Huntingdonshire
+      "E07000012", # South Cambridgeshire
+      "E07000026", # Allerdale
+      "E07000027", # Barrow-in-Furness
+      "E07000028", # Carlisle
+      "E07000029", # Copeland
+      "E07000030", # Eden
+      "E07000031", # South Lakeland
+      "E07000032", # Amber Valley
+      "E07000033", # Bolsover
+      "E07000034", # Chesterfield
+      "E07000035", # Derbyshire Dales
+      "E07000036", # Erewash
+      "E07000037", # High Peak
+      "E07000038", # North East Derbyshire
+      "E07000039", # South Derbyshire
+      "E07000040", # East Devon
+      "E07000041", # Exeter
+      "E07000042", # Mid Devon
+      "E07000043", # North Devon
+      "E07000044", # South Hams
+      "E07000045", # Teignbridge
+      "E07000046", # Torridge
+      "E07000047", # West Devon
+      "E07000061", # Eastbourne
+      "E07000062", # Hastings
+      "E07000063", # Lewes
+      "E07000064", # Rother
+      "E07000065", # Wealden
+      "E07000066", # Basildon
+      "E07000067", # Braintree
+      "E07000068", # Brentwood
+      "E07000069", # Castle Point
+      "E07000070", # Chelmsford
+      "E07000071", # Colchester
+      "E07000072", # Epping Forest
+      "E07000073", # Harlow
+      "E07000074", # Maldon
+      "E07000075", # Rochford
+      "E07000076", # Tendring
+      "E07000077", # Uttlesford
+      "E07000078", # Cheltenham
+      "E07000079", # Cotswold
+      "E07000080", # Forest of Dean
+      "E07000081", # Gloucester
+      "E07000082", # Stroud
+      "E07000083", # Tewkesbury
+      "E07000084", # Basingstoke and Deane
+      "E07000085", # East Hampshire
+      "E07000086", # Eastleigh
+      "E07000087", # Fareham
+      "E07000088", # Gosport
+      "E07000089", # Hart
+      "E07000090", # Havant
+      "E07000091", # New Forest
+      "E07000092", # Rushmoor
+      "E07000093", # Test Valley
+      "E07000094", # Winchester
+      "E07000095", # Broxbourne
+      "E07000096", # Dacorum
+      "E07000098", # Hertsmere
+      "E07000099", # North Hertfordshire
+      "E07000102", # Three Rivers
+      "E07000103", # Watford
+      "E07000105", # Ashford
+      "E07000106", # Canterbury
+      "E07000107", # Dartford
+      "E07000108", # Dover
+      "E07000109", # Gravesham
+      "E07000110", # Maidstone
+      "E07000111", # Sevenoaks
+      "E07000112", # Folkestone and Hythe
+      "E07000113", # Swale
+      "E07000114", # Thanet
+      "E07000115", # Tonbridge and Malling
+      "E07000116", # Tunbridge Wells
+      "E07000117", # Burnley
+      "E07000118", # Chorley
+      "E07000119", # Fylde
+      "E07000120", # Hyndburn
+      "E07000121", # Lancaster
+      "E07000122", # Pendle
+      "E07000123", # Preston
+      "E07000124", # Ribble Valley
+      "E07000125", # Rossendale
+      "E07000126", # South Ribble
+      "E07000127", # West Lancashire
+      "E07000128", # Wyre
+      "E07000129", # Blaby
+      "E07000130", # Charnwood
+      "E07000131", # Harborough
+      "E07000132", # Hinckley and Bosworth
+      "E07000133", # Melton
+      "E07000134", # North West Leicestershire
+      "E07000135", # Oadby and Wigston
+      "E07000136", # Boston
+      "E07000137", # East Lindsey
+      "E07000138", # Lincoln
+      "E07000139", # North Kesteven
+      "E07000140", # South Holland
+      "E07000141", # South Kesteven
+      "E07000142", # West Lindsey
+      "E07000143", # Breckland
+      "E07000144", # Broadland
+      "E07000145", # Great Yarmouth
+      "E07000146", # King's Lynn and West Norfolk
+      "E07000147", # North Norfolk
+      "E07000148", # Norwich
+      "E07000149", # South Norfolk
+      "E07000150", # Corby
+      "E07000151", # Daventry
+      "E07000152", # East Northamptonshire
+      "E07000153", # Kettering
+      "E07000154", # Northampton
+      "E07000155", # South Northamptonshire
+      "E07000156", # Wellingborough
+      "E07000163", # Craven
+      "E07000164", # Hambleton
+      "E07000165", # Harrogate
+      "E07000166", # Richmondshire
+      "E07000167", # Ryedale
+      "E07000168", # Scarborough
+      "E07000169", # Selby
+      "E07000170", # Ashfield
+      "E07000171", # Bassetlaw
+      "E07000172", # Broxtowe
+      "E07000173", # Gedling
+      "E07000174", # Mansfield
+      "E07000175", # Newark and Sherwood
+      "E07000176", # Rushcliffe
+      "E07000177", # Cherwell
+      "E07000178", # Oxford
+      "E07000179", # South Oxfordshire
+      "E07000180", # Vale of White Horse
+      "E07000181", # West Oxfordshire
+      "E07000187", # Mendip
+      "E07000188", # Sedgemoor
+      "E07000189", # South Somerset
+      "E07000192", # Cannock Chase
+      "E07000193", # East Staffordshire
+      "E07000194", # Lichfield
+      "E07000195", # Newcastle-under-Lyme
+      "E07000196", # South Staffordshire
+      "E07000197", # Stafford
+      "E07000198", # Staffordshire Moorlands
+      "E07000199", # Tamworth
+      "E07000200", # Babergh
+      "E07000202", # Ipswich
+      "E07000203", # Mid Suffolk
+      "E07000207", # Elmbridge
+      "E07000208", # Epsom and Ewell
+      "E07000209", # Guildford
+      "E07000210", # Mole Valley
+      "E07000211", # Reigate and Banstead
+      "E07000212", # Runnymede
+      "E07000213", # Spelthorne
+      "E07000214", # Surrey Heath
+      "E07000215", # Tandridge
+      "E07000216", # Waverley
+      "E07000217", # Woking
+      "E07000218", # North Warwickshire
+      "E07000219", # Nuneaton and Bedworth
+      "E07000220", # Rugby
+      "E07000221", # Stratford-on-Avon
+      "E07000222", # Warwick
+      "E07000223", # Adur
+      "E07000224", # Arun
+      "E07000225", # Chichester
+      "E07000226", # Crawley
+      "E07000227", # Horsham
+      "E07000228", # Mid Sussex
+      "E07000229", # Worthing
+      "E07000234", # Bromsgrove
+      "E07000235", # Malvern Hills
+      "E07000236", # Redditch
+      "E07000237", # Worcester
+      "E07000238", # Wychavon
+      "E07000239", # Wyre Forest
+      "E07000240", # St Albans
+      "E07000241", # Welwyn Hatfield
+      "E07000242", # East Hertfordshire
+      "E07000243", # Stevenage
+      "E07000244", # East Suffolk
+      "E07000245", # West Suffolk
+      "E07000246", # Somerset West and Taunton
+      "E08000001", # Bolton
+      "E08000002", # Bury
+      "E08000003", # Manchester
+      "E08000004", # Oldham
+      "E08000005", # Rochdale
+      "E08000006", # Salford
+      "E08000007", # Stockport
+      "E08000008", # Tameside
+      "E08000009", # Trafford
+      "E08000010", # Wigan
+      "E08000011", # Knowsley
+      "E08000012", # Liverpool
+      "E08000013", # St.Helens
+      "E08000014", # Sefton
+      "E08000015", # Wirral
+      "E08000016", # Barnsley
+      "E08000017", # Doncaster
+      "E08000018", # Rotherham
+      "E08000019", # Sheffield
+      "E08000021", # Newcastle upon Tyne
+      "E08000022", # North Tyneside
+      "E08000023", # South Tyneside
+      "E08000024", # Sunderland
+      "E08000025", # Birmingham
+      "E08000026", # Coventry
+      "E08000027", # Dudley
+      "E08000028", # Sandwell
+      "E08000029", # Solihull
+      "E08000030", # Walsall
+      "E08000031", # Wolverhampton
+      "E08000032", # Bradford
+      "E08000033", # Calderdale
+      "E08000034", # Kirklees
+      "E08000035", # Leeds
+      "E08000036", # Wakefield
+      "E09000037", # Gateshead
+      "E09000001", # City of London
+      "E09000002", # Barking and Dagenham
+      "E09000003", # Barnet
+      "E09000004", # Bexley
+      "E09000005", # Brent
+      "E09000006", # Bromley
+      "E09000007", # Camden
+      "E09000008", # Croydon
+      "E09000009", # Ealing
+      "E09000010", # Enfield
+      "E09000011", # Greenwich
+      "E09000012", # Hackney
+      "E09000013", # Hammersmith and Fulham
+      "E09000014", # Haringey
+      "E09000015", # Harrow
+      "E09000016", # Havering
+      "E09000017", # Hillingdon
+      "E09000018", # Hounslow
+      "E09000019", # Islington
+      "E09000020", # Kensington and Chelsea
+      "E09000021", # Kingston upon Thames
+      "E09000022", # Lambeth
+      "E09000023", # Lewisham
+      "E09000024", # Merton
+      "E09000025", # Newham
+      "E09000026", # Redbridge
+      "E09000027", # Richmond upon Thames
+      "E09000028", # Southwark
+      "E09000029", # Sutton
+      "E09000030", # Tower Hamlets
+      "E09000031", # Waltham Forest
+      "E09000032", # Wandsworth
+      "E09000033" # Westminster
+    ].freeze
+
+    def initialize(school)
+      @school = school
+    end
+
+    def eligible_current_school?
+      @school.open? &&
+        eligible_local_authority_district? &&
+        (@school.state_funded? || @school.secure_unit?) &&
+        @school.secondary_or_equivalent?
+    end
+
+    private
+
+    def eligible_local_authority_district?
+      ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
+    end
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -135,6 +135,10 @@ class School < ApplicationRecord
     MathsAndPhysics::SchoolEligibility.new(self).eligible_current_school?
   end
 
+  def eligible_for_early_career_payments?
+    EarlyCareerPayments::SchoolEligibility.new(self).eligible_current_school?
+  end
+
   def state_funded?
     (STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school") ||
       secure_unit? ||

--- a/app/views/early_career_payments/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/early_career_payments/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -1,0 +1,54 @@
+<p class="govuk-body">
+  This is because either:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <p class="govuk-body">
+      It is not a state-funded secondary school in England and is therefore not eligible. 
+      For more information, check the 
+      <%= link_to "eligibility page", EarlyCareerPayments.eligibility_page_url, class: "govuk-link" %>.
+    </p>
+  </li>
+  <li>
+    <p class="govuk-body">
+      We could not find a school matching those details in the system.
+    </p>
+  </li>
+    <li>
+    <p class="govuk-body">
+      The school you selected is listed as closed.
+    </p>
+  </li>
+</ul>
+
+<h3 class="govuk-heading-m">
+  What can you do next
+</h3>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <p class="govuk-body">
+      Check the spelling, including any apostrophes or full stops used in the school’s name.
+    </p>
+  </li>
+  <li>
+    <p class="govuk-body">
+      Check to make sure the school you selected is not listed as closed.
+    </p>
+  </li>
+  <li>
+    <p class="govuk-body">
+      Check to make sure you selected the correct school. 
+      If your school shares a name with others in the country, 
+      make sure you select the one with the correct postcode.
+    </p>
+  </li>
+</ul>
+
+<%= link_to "Try again", claim_path(current_policy_routing_name, "current-school"), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
+
+<p class="govuk-body">
+  If you need help with your claim, contact
+  <a class="govuk-link" href="mailto:#">earlycareerpayments@education.gov.uk</a>
+</p>

--- a/app/views/early_career_payments/claims/ineligible.html.erb
+++ b/app/views/early_career_payments/claims/ineligible.html.erb
@@ -2,9 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= I18n.t("early_career_payments.ineligible.heading") %> <%= current_claim.eligibility.ineligibility_reason == :subject_to_formal_performance_action ? "for an early-careers payment" : nil %>
-    </h1>
+    <%= ineligible_heading(current_claim) %>
 
     <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
 

--- a/app/views/early_career_payments/claims/personal_details.html.erb
+++ b/app/views/early_career_payments/claims/personal_details.html.erb
@@ -6,7 +6,7 @@
 
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-padding-bottom-6">
           <h1 class="govuk-fieldset__heading">
               <%= t("early_career_payments.personal_details") %>
           </h1>
@@ -14,7 +14,7 @@
 
         <div class="govuk-!-padding-bottom-6">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">
+            <h1 class="govuk-fieldset__heading govuk-!-padding-bottom-3">
               <%= t("questions.name") %>
             </h1>
           </legend>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,9 @@ en:
     support_email_address: "earlycareerteacherpayments@digital.education.gov.uk"
     landing_page: "Apply for an early-career payment"
     ineligible:
+      poor_performance_heading: "You are not eligible for an early-careers payment"
       heading: "You are not eligible"
+      school_heading: "This school is not eligible"
       reason:
         itt_subject: "Early-career payments are only available for teachers who did their ITT in:"
         not_teaching_subject: "You can only get this payment if you are still teaching maths/chemistry/physics/modern languages."

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -21,5 +21,11 @@ FactoryBot.define do
       school_type_group { School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.sample }
       phase { School::SECONDARY_PHASES.sample }
     end
+
+    trait :early_career_payments_eligible do
+      local_authority_district { LocalAuthorityDistrict.find(ActiveRecord::FixtureSet.identify(:barnsley, :uuid)) }
+      school_type_group { School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.sample }
+      phase { School::SECONDARY_PHASES.sample }
+    end
   end
 end

--- a/spec/features/ineligible_early_career_payments_claims_spec.rb
+++ b/spec/features/ineligible_early_career_payments_claims_spec.rb
@@ -20,6 +20,16 @@ RSpec.feature "Ineligible Teacher Early Career Payments claims" do
     expect(page).to have_text("Based on the answers you have provided you are not eligible #{I18n.t("early_career_payments.claim_description")}")
   end
 
+  scenario "When the school selected is ineligible" do
+    start_early_career_payments_claim
+
+    # [PAGE 02/03] - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school schools(:bradford_grammar_school)
+
+    expect(page).to have_text("This school is not eligible")
+  end
+
   scenario "When subject to formal performance action" do
     start_early_career_payments_claim
 
@@ -303,6 +313,5 @@ RSpec.feature "Ineligible Teacher Early Career Payments claims" do
   end
 
   # Additional sad paths
-  # TODO [PAGE 17] - This school is not eligible (sad path)
   # TODO [PAGE 19] - You will be eligible for an early career payment in 2022
 end

--- a/spec/helpers/early_career_payments_helper_spec.rb
+++ b/spec/helpers/early_career_payments_helper_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe EarlyCareerPaymentsHelper do
+  let(:claim) { build(:claim, policy: policy, eligibility: eligibility) }
+  let(:eligibility) { build(:early_career_payments_eligibility) }
+
+  describe "#ineligible_heading" do
+    context "A generic ineligible ECP claim" do
+      let(:policy) { EarlyCareerPayments }
+
+      it "generates the generic heading for an ineligible claim" do
+        expect(helper.ineligible_heading(claim)).to include I18n.t("early_career_payments.ineligible.heading")
+      end
+    end
+
+    context "An ineligible ECP claim based on poor performance" do
+      let(:policy) { EarlyCareerPayments }
+      let(:eligibility) { build(:early_career_payments_eligibility, subject_to_formal_performance_action: true) }
+
+      it "generates the correct heading for an ineligible claim based on poor performance" do
+        expect(helper.ineligible_heading(claim)).to include I18n.t("early_career_payments.ineligible.poor_performance_heading")
+      end
+    end
+
+    context "An ineligible ECP claim based on an ineligible school" do
+      let(:policy) { EarlyCareerPayments }
+      let(:eligibility) { build(:early_career_payments_eligibility, current_school: School.find(ActiveRecord::FixtureSet.identify(:bradford_grammar_school, :uuid))) }
+
+      it "generates the correct heading for an ineligible claim based on an ineligible school" do
+        expect(helper.ineligible_heading(claim)).to include I18n.t("early_career_payments.ineligible.school_heading")
+      end
+    end
+  end
+end

--- a/spec/models/early_career_payments/school_eligibility_spec.rb
+++ b/spec/models/early_career_payments/school_eligibility_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe EarlyCareerPayments::SchoolEligibility do
+  describe "#eligible_current_school?" do
+    context "with a secondary school" do
+      let(:secondary_school) {
+        School.new(
+          school_type_group: :la_maintained,
+          phase: :secondary,
+          close_date: nil,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary school in an eligible local authority district" do
+        expect(EarlyCareerPayments::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        secondary_school.assign_attributes(close_date: Date.new)
+        expect(EarlyCareerPayments::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        secondary_school.assign_attributes(school_type_group: :independent_schools)
+        expect(EarlyCareerPayments::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
+      end
+    end
+
+    context "with an explicitly eligible school in an ineligible local authority district" do
+      let(:explicitly_eligible_school) {
+        School.new(
+          school_type_group: :la_maintained,
+          phase: :secondary,
+          close_date: nil,
+          urn: 136791,
+          local_authority_district: local_authority_districts(:camden)
+        )
+      }
+
+      it "returns true if the school is otherwise eligible" do
+        expect(EarlyCareerPayments::SchoolEligibility.new(explicitly_eligible_school).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        explicitly_eligible_school.assign_attributes(close_date: Date.new)
+        expect(EarlyCareerPayments::SchoolEligibility.new(explicitly_eligible_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        explicitly_eligible_school.assign_attributes(school_type_group: :independent_schools)
+        expect(EarlyCareerPayments::SchoolEligibility.new(explicitly_eligible_school).eligible_current_school?).to eql false
+      end
+    end
+
+    context "with a special school" do
+      let(:special_school) {
+        School.new(
+          close_date: nil,
+          school_type: :community_special_school,
+          school_type_group: :special_schools,
+          statutory_high_age: 16,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent special school in an eligible local authority district" do
+        expect(EarlyCareerPayments::SchoolEligibility.new(special_school).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        special_school.assign_attributes(close_date: Date.new)
+        expect(EarlyCareerPayments::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        special_school.assign_attributes(school_type_group: :independent_schools)
+        expect(EarlyCareerPayments::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        special_school.assign_attributes(statutory_high_age: 11)
+        expect(EarlyCareerPayments::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+    end
+
+    context "with alternative provision school" do
+      let(:alternative_provision_school) {
+        School.new(
+          close_date: nil,
+          school_type_group: :la_maintained,
+          school_type: :pupil_referral_unit,
+          statutory_high_age: 19,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent alternative provision school in an eligible local authority district" do
+        expect(EarlyCareerPayments::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns false when closed" do
+        alternative_provision_school.assign_attributes(close_date: Date.new)
+        expect(EarlyCareerPayments::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        alternative_provision_school.assign_attributes(statutory_high_age: 11)
+        expect(EarlyCareerPayments::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
+      end
+
+      it "returns true with a secure unit" do
+        alternative_provision_school.assign_attributes(school_type_group: :other, school_type: :secure_unit)
+        expect(EarlyCareerPayments::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+    end
+
+    context "with a City Technology College (CTC)" do
+      let(:city_technology_college) {
+        School.new(
+          close_date: nil,
+          school_type: :city_technology_college,
+          school_type_group: :independent_schools,
+          statutory_high_age: 16,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent CTC in an eligible local authority district" do
+        expect(EarlyCareerPayments::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        city_technology_college.assign_attributes(close_date: Date.new)
+        expect(EarlyCareerPayments::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        city_technology_college.assign_attributes(statutory_high_age: 11)
+        expect(EarlyCareerPayments::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eq false
+      end
+    end
+  end
+
+  context "when it is not a secondary school" do
+    it "returns false" do
+      primary_school = School.new(
+        phase: :primary,
+        school_type_group: :la_maintained,
+        local_authority_district: local_authority_districts(:barnsley)
+      )
+      expect(EarlyCareerPayments::SchoolEligibility.new(primary_school).eligible_current_school?).to eql false
+    end
+  end
+end


### PR DESCRIPTION
- New district area codes for ECP claims covering all secondary schools within England
- Ineligible page wired up
- Tests built around new criteria for eligible and ineligible schools with the ECP schools
- Extra - Personal details padding fixed 
