### PR TITLE
[story/ECP-873] - change duration of OTP from 60 to 900 seconds

### DIFF
--- a/app/helpers/early_career_payments_helper.rb
+++ b/app/helpers/early_career_payments_helper.rb
@@ -8,4 +8,8 @@ module EarlyCareerPaymentsHelper
       content_tag(:h1, I18n.t("early_career_payments.ineligible.heading"), class: "govuk-heading-xl")
     end
   end
+
+  def one_time_password_validity_duration
+    pluralize(OneTimePassword::OTP_PASSWORD_INTERVAL / 60, "minute")
+  end
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -1,5 +1,6 @@
 class ClaimMailer < ApplicationMailer
   helper :application
+  helper :early_career_payments
 
   def submitted(claim)
     set_common_instance_variables(claim)

--- a/app/views/claim_mailer/ecp_email_verification.text.erb
+++ b/app/views/claim_mailer/ecp_email_verification.text.erb
@@ -4,6 +4,6 @@ This is your 6-character one time password:
 
 <%= @one_time_password %>
 
-It is valid for 15 minutes. We recommend you copy and paste this into the text field on the email verification screen in the service.
+It is valid for <%= one_time_password_validity_duration %>. We recommend you copy and paste this into the text field on the email verification screen in the service.
 
 If you have any issues with the password, email us at: earlycareerteacherpayments@digital.education.gov.uk with your unique reference and your query.

--- a/app/views/early_career_payments/claims/_one_time_password.html.erb
+++ b/app/views/early_career_payments/claims/_one_time_password.html.erb
@@ -13,7 +13,7 @@
         <div id="one-time-password-hint" class="govuk-hint">
           We have sent an email to <b><strong><%= current_claim.email_address %></strong></b> with a 6 character password. We recommend you copy and paste the password from the email.
           <br><br>
-          You will have <%= OneTimePassword::OTP_PASSWORD_INTERVAL %> seconds from receiving the email before the password will expire.
+          You will have <%= one_time_password_validity_duration %> from receiving the email before the password will expire.
         </div>
 
         <%= errors_tag current_claim, :one_time_password %>

--- a/lib/one_time_password.rb
+++ b/lib/one_time_password.rb
@@ -4,7 +4,7 @@ module OneTimePassword
   extend ActiveSupport::Concern
 
   OTP_SECRET = ROTP::Base32.random.freeze
-  OTP_PASSWORD_INTERVAL = 60
+  OTP_PASSWORD_INTERVAL = 900
   ONE_TIME_PASSWORD_LENGTH = 6
 
   private

--- a/spec/helpers/early_career_payments_helper_spec.rb
+++ b/spec/helpers/early_career_payments_helper_spec.rb
@@ -31,4 +31,20 @@ describe EarlyCareerPaymentsHelper do
       end
     end
   end
+
+  describe "#one_time_password_validity_duration" do
+    context "with 'OTP_PASSWORD_INTERVAL' constant set" do
+      it "reports '1 minute' when 60 (seconds)" do
+        stub_const("OneTimePassword::OTP_PASSWORD_INTERVAL", 60)
+
+        expect(helper.one_time_password_validity_duration).to eq("1 minute")
+      end
+
+      it "reports '1 minute' when 60 (seconds)" do
+        stub_const("OneTimePassword::OTP_PASSWORD_INTERVAL", 900)
+
+        expect(helper.one_time_password_validity_duration).to eq("15 minutes")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is borne out of work from our UCD colleagues who have determined 15 minutes is an appropriate duration.

**_Evidence_**
#### Email claimant will receive
N.B. This is from the logs, but the wording is correct
![ECP-873-change-one-time-password-to-15-minutes-evidence-of-email-sent-to-claimant](https://user-images.githubusercontent.com/37293320/119715109-8a81dd00-be5b-11eb-8583-13fc28b6b3b6.png)


#### OTP challenge screen
![ECP-873-change-OTP-to-15-minutes-personal-details-journey](https://user-images.githubusercontent.com/37293320/119714484-d6805200-be5a-11eb-840e-cab8b29e0c3c.png)


