### PR TITLE
[bug/ECP-903] - fix issue when 'No' is selected for Student Loans question and claim could failing valid?(:submit)

### DIFF
--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -59,8 +59,8 @@ module EarlyCareerPayments
     validates :eligible_itt_subject, on: [:"eligible-itt-subject", :submit], presence: {message: "Select if you completed your initial teacher training in Chemistry, Foreign Languages, Mathematics, Physics or None of these subjects"}
     validates :teaching_subject_now, on: [:"teaching-subject-now", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently teaching in your ITT subject now"}
     validates :itt_academic_year, on: [:"itt-year", :submit], presence: {message: "Select if you started your initial teacher training in 2018 - 2019, 2019 - 2020, 2020 - 2021 or None of these academic years"}
-    validates :postgraduate_masters_loan, on: [:"masters-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a Postgraduate Master Loan taken out on or after 1st August 2016"}
-    validates :postgraduate_doctoral_loan, on: [:"doctoral-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a Postgraduate Doctoral Loan taken out on or after 1st August 2018"}
+    validates :postgraduate_masters_loan, on: [:"masters-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a Postgraduate Master Loan taken out on or after 1st August 2016"}, unless: :no_student_loan?
+    validates :postgraduate_doctoral_loan, on: [:"doctoral-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a Postgraduate Doctoral Loan taken out on or after 1st August 2018"}, unless: :no_student_loan?
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
@@ -140,6 +140,10 @@ module EarlyCareerPayments
         not_employed_directly? ||
         subject_to_disciplinary_action? ||
         ineligible_itt_academic_year?
+    end
+
+    def no_student_loan?
+      claim.no_student_loan?
     end
   end
 end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -309,19 +309,75 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
       end
     end
 
-    context "when saving in the 'postgraduate_masters_loan' context" do
-      it "is not valid without a value for 'postgraduate_masters_loan'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"masters-loan")
-        expect(EarlyCareerPayments::Eligibility.new(postgraduate_masters_loan: true)).to be_valid(:"masters-loan")
-        expect(EarlyCareerPayments::Eligibility.new(postgraduate_masters_loan: false)).to be_valid(:"masters-loan")
+    describe "when saving in the 'postgraduate_masters_loan' context" do
+      let!(:claim) { build_stubbed(:claim, :with_student_loan, eligibility: eligibility) }
+      let(:eligibility) do
+        build_stubbed(
+          :early_career_payments_eligibility,
+          :eligible,
+          employed_as_supply_teacher: true,
+          has_entire_term_contract: false,
+          employed_directly: false,
+          pgitt_or_ugitt_course: :undergraduate,
+          eligible_itt_subject: :none_of_the_above,
+          teaching_subject_now: false,
+          postgraduate_masters_loan: nil
+        )
+      end
+
+      context "with claim having a student loan" do
+        it "is not valid without a value for 'postgraduate_masters_loan'" do
+          expect(eligibility).not_to be_valid(:"masters-loan")
+
+          eligibility.postgraduate_masters_loan = true
+          expect(eligibility).to be_valid(:"masters-loan")
+
+          eligibility.postgraduate_masters_loan = false
+          expect(eligibility).to be_valid(:"masters-loan")
+        end
+      end
+
+      context "with claim having no_student_loan" do
+        it "is valid without a value for 'postgraduate_masters_loan'" do
+          subject.validate(on: :"masters-loan")
+          expect(subject.errors[:"masters-loan"]).to be_empty
+        end
       end
     end
 
-    context "when saving in the 'postgraduate_doctoral_loan' context" do
-      it "is not valid without a value for 'postgraduate_doctoral_loan'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"doctoral-loan")
-        expect(EarlyCareerPayments::Eligibility.new(postgraduate_doctoral_loan: true)).to be_valid(:"doctoral-loan")
-        expect(EarlyCareerPayments::Eligibility.new(postgraduate_doctoral_loan: false)).to be_valid(:"doctoral-loan")
+    describe "when saving in the 'postgraduate_doctoral_loan' context" do
+      let!(:claim) { build_stubbed(:claim, :with_student_loan, eligibility: eligibility) }
+      let(:eligibility) do
+        build_stubbed(
+          :early_career_payments_eligibility,
+          :eligible,
+          employed_as_supply_teacher: true,
+          has_entire_term_contract: false,
+          employed_directly: false,
+          pgitt_or_ugitt_course: :undergraduate,
+          eligible_itt_subject: :none_of_the_above,
+          teaching_subject_now: false,
+          postgraduate_doctoral_loan: nil
+        )
+      end
+
+      context "with claim having a student loan" do
+        it "is not valid without a value for 'postgraduate_doctoral_loan'" do
+          expect(eligibility).not_to be_valid(:"doctoral-loan")
+
+          eligibility.postgraduate_doctoral_loan = true
+          expect(eligibility).to be_valid(:"doctoral-loan")
+
+          eligibility.postgraduate_doctoral_loan = false
+          expect(eligibility).to be_valid(:"doctoral-loan")
+        end
+      end
+
+      context "with claim having no_student_loan" do
+        it "is valid without a value for 'postgraduate_doctoral_loan'" do
+          subject.validate(on: :"doctoral-loan")
+          expect(subject.errors[:"doctoral-loan"]).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
The original delivery of the Postgraduate Doctoral and Masters Loan questions and then the subsequent removal of those questions when a claim does not have a student loan left a bug in the system.
This was due to no conditional validation occurring on the attributes currently held on the EarlyCareerPayments::Eligibility model:

- `postgraduate_doctoral_loan`
- `postgraduate_masters_loan`