### PR TITLE
[story/ECP-908] - change to using correct award amounts in eligible later 2022 screen

### DIFF
--- a/app/helpers/claims/show_helper.rb
+++ b/app/helpers/claims/show_helper.rb
@@ -11,5 +11,21 @@ module Claims
     def shared_view_css_class_size(claim)
       claim.has_ecp_policy? ? "l" : "xl"
     end
+
+    def base_and_uplift_award_amounts(claim, year)
+      return nil unless claim.has_ecp_policy?
+
+      base_amount = MATRIX.dig(claim.eligibility.eligible_itt_subject, claim.eligibility.itt_academic_year, year)
+      uplifted = case base_amount
+      when 0
+        0
+      when 2000
+        3000
+      when 5000
+        7500
+      end
+
+      {base: BigDecimal(base_amount), uplifted: BigDecimal(uplifted)}
+    end
   end
 end

--- a/app/models/early_career_payments/eligibility_matrix_calculator.rb
+++ b/app/models/early_career_payments/eligibility_matrix_calculator.rb
@@ -1,12 +1,5 @@
 module EarlyCareerPayments
   class EligibilityMatrixCalculator
-    MATRIX = {
-      mathematics: ["2018_2019", "2019_2020", "2020_2021"],
-      physics: ["2020_2021"],
-      chemistry: ["2020_2021"],
-      foreign_languages: ["2020_2021"]
-    }.freeze
-
     attr_reader :eligibility
 
     def initialize(eligibility)
@@ -16,7 +9,7 @@ module EarlyCareerPayments
     def eligible_later?
       return false if subject == :mathematics && itt_academic_year == "2018_2019"
 
-      MATRIX.dig(subject)&.include?(itt_academic_year) ? true : false
+      MATRIX.dig(subject.to_s, itt_academic_year).nil? ? false : true
     end
 
     private

--- a/app/views/early_career_payments/claims/eligible_later.html.erb
+++ b/app/views/early_career_payments/claims/eligible_later.html.erb
@@ -1,11 +1,12 @@
 <% content_for(:page_title, page_title("You will be eligible for an early-career payment in 2022", policy: current_policy_routing_name)) %>
+<% year = 2022 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">You will be eligible <%= I18n.t("early_career_payments.claim_description") %> in 2022</h1>
     <p class="govuk-body">
       So long as your circumstances remain the same, you’ll be able to claim
-      £2,000 in autumn 2022. This could increase to £3,000 if the school you
+      <%= number_to_currency(base_and_uplift_award_amounts(current_claim, year)[:base], precision: 0) %> in autumn 2022. This could increase to <%= number_to_currency(base_and_uplift_award_amounts(current_claim, year)[:uplifted], precision: 0) %> if the school you
       teach at is considered to be in an uplift area.
     </p>
 

--- a/config/initializers/early_career_payments/eligibility_matrix.yml
+++ b/config/initializers/early_career_payments/eligibility_matrix.yml
@@ -1,0 +1,45 @@
+# determines if a teachers claim:
+# - is eligible in which year
+# - OR - if it is ineligible
+# - OR - eligible later
+
+# file format for ECP eligibility matrix
+# subject
+#   itt_academic_year
+#     the next level down reprsents the base award amount for
+#     each of the specific years
+
+mathematics:
+  "2018_2019":
+    2021: 5000
+    2022: 0
+    2023: 5000
+    2024: 0
+  "2019_2020":
+    2021: 0
+    2022: 5000
+    2023: 0
+    2024: 5000
+  "2020_2021":
+    2021: 0
+    2022: 2000
+    2023: 2000
+    2024: 2000
+physics:
+  "2020_2021":
+    2021: 0
+    2022: 2000
+    2023: 2000
+    2024: 2000
+chemistry:
+  "2020_2021":
+    2021: 0
+    2022: 2000
+    2023: 2000
+    2024: 2000
+foreign_languages:
+  "2020_2021":
+    2021: 0
+    2022: 2000
+    2023: 2000
+    2024: 2000

--- a/config/initializers/early_career_payments/eligibility_matrix_calculator.rb
+++ b/config/initializers/early_career_payments/eligibility_matrix_calculator.rb
@@ -1,0 +1,1 @@
+MATRIX = YAML.safe_load(File.read(File.expand_path("../eligibility_matrix.yml", __FILE__))).freeze

--- a/spec/features/eligible_later_for_early_career_payments_spec.rb
+++ b/spec/features/eligible_later_for_early_career_payments_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+RSpec.feature "Teacher makes Early-Career Payments claim that is Eligible Later (2022)" do
+  scenario "subject is 'mathematics' with 'route into teaching' set as '2018_2019'" do
+    claim = start_early_career_payments_claim
+    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    claim.eligibility.itt_subject_mathematics!
+    claim.eligibility.itt_academic_year_2018_2019!
+    # claim.eligibility.public_send("itt_academic_year_#{route_into_teaching_year}!")
+
+    visit claim_path(claim.policy.routing_name, "check-your-answers-part-one")
+
+    # [PAGE - Check your answers for eligibility]
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+    %w[Identity\ details Payment\ details Student\ loan\ details].each do |section_heading|
+      expect(page).not_to have_text section_heading
+    end
+
+    within(".govuk-summary-list") do
+      expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_masters_loan"))
+      expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_doctoral_loan"))
+    end
+
+    click_on("Continue")
+
+    expect(page).not_to have_text("You will be eligible for an early-career payment in 2022")
+  end
+
+  scenario "subject is 'mathematics' with 'route into teaching' set as '2019_2020'" do
+    claim = start_early_career_payments_claim
+    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    claim.eligibility.itt_subject_mathematics!
+    claim.eligibility.itt_academic_year_2019_2020!
+
+    visit claim_path(claim.policy.routing_name, "check-your-answers-part-one")
+
+    # [PAGE - Check your answers for eligibility]
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+    %w[Identity\ details Payment\ details Student\ loan\ details].each do |section_heading|
+      expect(page).not_to have_text section_heading
+    end
+
+    within(".govuk-summary-list") do
+      expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_masters_loan"))
+      expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_doctoral_loan"))
+    end
+
+    click_on("Continue")
+
+    expect(page).to have_text("You will be eligible for an early-career payment in 2022")
+    expect(page).to have_text("you’ll be able to claim £5,000")
+    expect(page).to have_text("This could increase to £7,500")
+  end
+
+  scenario "subject is 'mathematics' with 'route into teaching' set as '2020_2021'" do
+    claim = start_early_career_payments_claim
+    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    claim.eligibility.itt_subject_mathematics!
+    claim.eligibility.itt_academic_year_2020_2021!
+
+    visit claim_path(claim.policy.routing_name, "check-your-answers-part-one")
+
+    # [PAGE - Check your answers for eligibility]
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+    %w[Identity\ details Payment\ details Student\ loan\ details].each do |section_heading|
+      expect(page).not_to have_text section_heading
+    end
+
+    within(".govuk-summary-list") do
+      expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_masters_loan"))
+      expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_doctoral_loan"))
+    end
+
+    click_on("Continue")
+
+    expect(page).to have_text("You will be eligible for an early-career payment in 2022")
+    expect(page).to have_text("you’ll be able to claim £2,000")
+    expect(page).to have_text("This could increase to £3,000")
+  end
+
+  %w[chemistry foreign_languages physics].each do |subject|
+    scenario "subject is '#{subject}' with 'route into teaching' set as '2020_2021'" do
+      claim = start_early_career_payments_claim
+      claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+      claim.eligibility.public_send("itt_subject_#{subject}!")
+      claim.eligibility.itt_academic_year_2020_2021!
+
+      visit claim_path(claim.policy.routing_name, "check-your-answers-part-one")
+
+      # [PAGE - Check your answers for eligibility]
+      expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+      expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+      expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+      %w[Identity\ details Payment\ details Student\ loan\ details].each do |section_heading|
+        expect(page).not_to have_text section_heading
+      end
+
+      within(".govuk-summary-list") do
+        expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_masters_loan"))
+        expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_doctoral_loan"))
+      end
+
+      click_on("Continue")
+
+      expect(page).to have_text("You will be eligible for an early-career payment in 2022")
+      expect(page).to have_text("you’ll be able to claim £2,000")
+      expect(page).to have_text("This could increase to £3,000")
+    end
+  end
+
+  %w[chemistry foreign_languages physics].each do |subject|
+    %w[2018_2019 2019_2020].each do |route_into_teaching_year|
+      scenario "subject is '#{subject}' with 'route into teaching' set as '#{route_into_teaching_year}'" do
+        claim = start_early_career_payments_claim
+        claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+        claim.eligibility.public_send("itt_subject_#{subject}!")
+        claim.eligibility.public_send("itt_academic_year_#{route_into_teaching_year}!")
+
+        visit claim_path(claim.policy.routing_name, "check-your-answers-part-one")
+
+        # [PAGE - Check your answers for eligibility]
+        expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+        expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+        expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+        %w[Identity\ details Payment\ details Student\ loan\ details].each do |section_heading|
+          expect(page).not_to have_text section_heading
+        end
+
+        within(".govuk-summary-list") do
+          expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_masters_loan"))
+          expect(page).not_to have_text(I18n.t("early_career_payments.questions.postgraduate_doctoral_loan"))
+        end
+
+        click_on("Continue")
+
+        expect(page).not_to have_text("You will be eligible for an early-career payment in 2022")
+      end
+    end
+  end
+end

--- a/spec/helpers/claims/show_helper_spec.rb
+++ b/spec/helpers/claims/show_helper_spec.rb
@@ -38,4 +38,76 @@ RSpec.describe Claims::ShowHelper do
       end
     end
   end
+
+  describe "#base_and_uplift_award_amounts(claim)" do
+    context "with a StudentLoans policy" do
+      let(:policy) { StudentLoans }
+
+      it "returns nil" do
+        expect(helper.base_and_uplift_award_amounts(claim, nil)).to be_nil
+      end
+    end
+
+    context "with a EarlyCareerPayments policy" do
+      let(:policy) { EarlyCareerPayments }
+
+      describe "Chemistry/Physics/Foreign Languages" do
+        it "returns 2000.00 and 3000.00 for claim academic year 2021/2022" do
+          claim.eligibility.itt_academic_year_2020_2021!
+          claim.eligibility.itt_subject_chemistry!
+          year = 2021
+
+          expect(helper.base_and_uplift_award_amounts(claim, year)).to include({base: 0.0}, {uplifted: 0.0})
+        end
+
+        it "returns 2000.00 and 3000.00 for claim academic year 2022/2023" do
+          claim.eligibility.itt_academic_year_2020_2021!
+          claim.eligibility.itt_subject_foreign_languages!
+          year = 2022
+
+          expect(helper.base_and_uplift_award_amounts(claim, year)).to include({base: 2000.00}, {uplifted: 3000.0})
+        end
+      end
+
+      describe "Mathematics" do
+        context "with itt_academic_year '2018 to 2019'" do
+          it "returns 5000.00 and 7500.00 for claim academic year 2021/2022" do
+            claim.eligibility.itt_academic_year_2018_2019!
+            claim.eligibility.itt_subject_mathematics!
+            year = 2021
+
+            expect(helper.base_and_uplift_award_amounts(claim, year)).to include({base: 5000.00}, {uplifted: 7500.0})
+          end
+
+          it "returns 5000.00 and 7500.00 for claim academic year 2022/2023" do
+            claim.eligibility.itt_academic_year_2018_2019!
+            claim.eligibility.itt_subject_mathematics!
+            year = 2022
+
+            expect(helper.base_and_uplift_award_amounts(claim, year)).to include({base: 0.0}, {uplifted: 0.0})
+          end
+        end
+
+        context "with itt_academic_year '2019 to 2020'" do
+          it "returns 5000.00 and 7500.00" do
+            claim.eligibility.itt_academic_year_2019_2020!
+            claim.eligibility.itt_subject_mathematics!
+            year = 2022
+
+            expect(helper.base_and_uplift_award_amounts(claim, year)).to include({base: 5000.00}, {uplifted: 7500.0})
+          end
+        end
+
+        context "with itt_academic_year '2020 to 2021'" do
+          it "returns 2000.00 and 3000.00" do
+            claim.eligibility.itt_academic_year_2020_2021!
+            claim.eligibility.itt_subject_mathematics!
+            year = 2022
+
+            expect(helper.base_and_uplift_award_amounts(claim, year)).to include({base: 2000.0}, {uplifted: 3000.0})
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Show the base amount and the uplifted amount based on subject and academic ITT year
Add details of criteria in an initializer file