### PR TITLE
Fix admin claim tasks update with DQT API without matching DQT identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog]
     later journey
   - Add 'Mobile number' screen
   - Update DQT client qualified teacher status to handle 404 response
+  - Fix admin claim tasks update with DQT API without matching DQT identity
 
 ## [Release 091] - 2021-06-24
 

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -14,9 +14,10 @@ module AutomatedChecks
       def perform
         return unless awaiting_task?("identity_confirmation")
 
-        complete_match ||
-          partial_match ||
-          no_match
+        # Order matters so that subsequent conditions in methods fall through to execute the right thing
+        no_match ||
+          complete_match ||
+          partial_match
       end
 
       private
@@ -70,7 +71,7 @@ module AutomatedChecks
       end
 
       def no_match
-        return unless !trn_matched? && !national_insurance_number_matched?
+        return unless dqt_teacher_status.nil?
 
         ClaimMailer.identity_confirmation(claim).deliver_later
 

--- a/app/models/automated_checks/claim_verifiers/qualifications.rb
+++ b/app/models/automated_checks/claim_verifiers/qualifications.rb
@@ -14,9 +14,10 @@ module AutomatedChecks
       def perform
         return unless awaiting_task?("qualifications")
 
-        complete_match ||
-          partial_match ||
-          no_match
+        # Order matters so that subsequent conditions in methods fall through to execute the right thing
+        no_match ||
+          complete_match ||
+          partial_match
       end
 
       private
@@ -54,7 +55,11 @@ module AutomatedChecks
       end
 
       def no_match
-        return unless !claim.policy::DqtRecord.new(dqt_teacher_status).eligible?
+        return unless dqt_teacher_status.nil? ||
+          (
+            !claim.policy::DqtRecord.new(dqt_teacher_status).eligible_qts_date? &&
+            !claim.policy::DqtRecord.new(dqt_teacher_status).eligible_qualification_subject?
+          )
 
         create_note
       end


### PR DESCRIPTION
We were returning the wrong response when stubbing the request, ie, worked locally but not when deployed.

ECP-1056