### PR TITLE
[story/ECP-632] Change admin manage services accepting claims for academic year select to display four years instead of two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog]
   - Add 'Would you like to provide your phone number?' screen
   - Update payment account details for 'Enter your bank/building society account
     details' screen
+  - Change admin manage services accepting claims for academic year select to
+    display four years instead of two
 
 ## [Release 090] - 2021-06-02
 

--- a/app/helpers/admin/policy_configurations_helper.rb
+++ b/app/helpers/admin/policy_configurations_helper.rb
@@ -1,7 +1,8 @@
 module Admin
   module PolicyConfigurationsHelper
     def options_for_academic_year
-      [AcademicYear.current, (AcademicYear.current + 1)]
+      years = 4
+      (0..(years - 1)).map { |relative_year| AcademicYear.current + relative_year }
     end
   end
 end

--- a/app/views/early_career_payments/claims/eligible_later.html.erb
+++ b/app/views/early_career_payments/claims/eligible_later.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <p class="govuk-inset-text">
-      It is your responsibility to apply for each payment you are eligible for. The Department of Education cannot issue payments unless you apply for one nor can we issue payments for claims made after the window has closed.
+      It is your responsibility to apply for each payment you are eligible for. The Department for Education cannot issue payments unless you apply for one nor can we issue payments for claims made after the window has closed.
     </p>
 
     <%= button_to "Continue", new_reminder_path, method: :get, class: "govuk-button" %>

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -3,38 +3,33 @@ require "rails_helper"
 RSpec.feature "Service configuration" do
   let(:policy_configuration) { policy_configurations(:student_loans) }
 
-  # We test with and without JS because of the conditionally revealed content
-  [true, false].each do |javascript_enabled|
-    js_status = javascript_enabled ? "enabled" : "disabled"
+  scenario "Service operator closes a service for submissions" do
+    sign_in_as_service_operator
 
-    scenario "Service operator closes a service for submissions, with JavaScript #{js_status}", js: javascript_enabled do
-      sign_in_as_service_operator
+    click_on "Manage services"
 
-      click_on "Manage services"
-
-      expect(page).to have_content("Teachers: claim back your student loan repayments")
-      within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
-        expect(page).to have_content("Open")
-        expect(page).not_to have_content("Closed")
-        click_on "Change"
-      end
-
-      within_fieldset("Service status") { choose("Closed") }
-
-      fill_in "Availability message", with: "You will be able to make a claim when the service enters public beta in November."
-
-      click_on "Save"
-
-      expect(current_path).to eq(admin_policy_configurations_path)
-
-      within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
-        expect(page).to have_content("Closed")
-        expect(page).not_to have_content("Open")
-      end
-
-      expect(policy_configuration.reload.open_for_submissions).to be false
-      expect(policy_configuration.availability_message).to eq("You will be able to make a claim when the service enters public beta in November.")
+    expect(page).to have_content("Teachers: claim back your student loan repayments")
+    within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
+      expect(page).to have_content("Open")
+      expect(page).not_to have_content("Closed")
+      click_on "Change"
     end
+
+    within_fieldset("Service status") { choose("Closed") }
+
+    fill_in "Availability message", with: "You will be able to make a claim when the service enters public beta in November."
+
+    click_on "Save"
+
+    expect(current_path).to eq(admin_policy_configurations_path)
+
+    within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
+      expect(page).to have_content("Closed")
+      expect(page).not_to have_content("Open")
+    end
+
+    expect(policy_configuration.reload.open_for_submissions).to be false
+    expect(policy_configuration.availability_message).to eq("You will be able to make a claim when the service enters public beta in November.")
   end
 
   scenario "Service operator opens a service for submissions" do

--- a/spec/helpers/admin/policy_configurations_helper_spec.rb
+++ b/spec/helpers/admin/policy_configurations_helper_spec.rb
@@ -4,13 +4,28 @@ RSpec.describe Admin::PolicyConfigurationsHelper, type: :helper do
   describe "#options_for_academic_year" do
     it "returns the current and next academic year (based on September 1st being the start of the year)" do
       travel_to Date.new(2018, 8, 31) do
-        expect(helper.options_for_academic_year).to eq [AcademicYear.new(2017), AcademicYear.new(2018)]
+        expect(helper.options_for_academic_year).to eq [
+          AcademicYear.new(2017),
+          AcademicYear.new(2018),
+          AcademicYear.new(2019),
+          AcademicYear.new(2020)
+        ]
       end
       travel_to Date.new(2018, 9, 1) do
-        expect(helper.options_for_academic_year).to eq [AcademicYear.new(2018), AcademicYear.new(2019)]
+        expect(helper.options_for_academic_year).to eq [
+          AcademicYear.new(2018),
+          AcademicYear.new(2019),
+          AcademicYear.new(2020),
+          AcademicYear.new(2021)
+        ]
       end
       travel_to Date.new(2020, 9, 1) do
-        expect(helper.options_for_academic_year).to eq [AcademicYear.new(2020), AcademicYear.new(2021)]
+        expect(helper.options_for_academic_year).to eq [
+          AcademicYear.new(2020),
+          AcademicYear.new(2021),
+          AcademicYear.new(2022),
+          AcademicYear.new(2023)
+        ]
       end
     end
   end


### PR DESCRIPTION
Also, removed redundant JS spec: nothing actually changes in the spec depending on whether JS in enabled or not.