### PR TITLE
[story/ECP-836] - Add home address manual screen to ECP journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog]
 - ECP policies
   - Add screen to allow claimant to select address from API provided results
     presented as radio buttons
+  - Add links that allow claimant to manually enter their address information
+    when on the two address auto-population screens
 
 ## [Release 092] - 2021-07-22
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -11,7 +11,7 @@ module ClaimsHelper
         a << [translate("questions.name"), claim.full_name, "name"] unless claim.name_verified?
       end
 
-      a << [translate("questions.address"), claim.address, "address"] unless claim.address_from_govuk_verify?
+      a << [translate("questions.address.generic.title"), claim.address, "address"] unless claim.address_from_govuk_verify?
 
       if claim.has_ecp_policy?
         a << [translate("questions.date_of_birth"), date_of_birth_string(claim), "personal-details"] unless claim.date_of_birth_verified?

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.address"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.generic.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,7 +11,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <span class="govuk-caption-xl">Personal details</span>
             <h1 class="govuk-heading-xl">
-              What is your address?
+              <%= t("questions.address.generic.title") %>
             </h1>
           </legend>
 
@@ -35,7 +35,7 @@
         <% else %>
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--<%= shared_view_css_class_size(current_claim) %>">
             <h1 class="govuk-fieldset__heading">
-              <%= t("questions.address") %>
+              <%= t("questions.address.generic.title") %>
             </h1>
           </legend>
 

--- a/app/views/claims/postcode_search.html.erb
+++ b/app/views/claims/postcode_search.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.home_address"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.home.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -7,7 +7,7 @@
     <%= form_for current_claim, url: claim_path(current_policy_routing_name), method: :get do |form| %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-heading-l"><%= I18n.t("questions.home_address") %></h1>
+          <h1 class="govuk-heading-l"><%= I18n.t("questions.address.home.title") %></h1>
         </legend>
         <%= form_group_tag current_claim, :postcode do %>
           <%= label_tag :"claim_postcode", "Postcode", class: "govuk-label govuk-label--m" %>
@@ -32,7 +32,7 @@
             "aria-describedby" => "address_line_1-hint"
           %>
         <% end %>
-        <%= link_to "#{I18n.t("questions.link_to_manual_address")}", claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": "#{I18n.t("questions.link_to_manual_address")}" %>
+        <%= link_to I18n.t("questions.address.home.link_to_manual_address"), claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.link_to_manual_address") %>
       </fieldset>
       <p class="govuk-!-padding-top-6">
         <%= form.submit "Search", class: "govuk-button" %>

--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -8,29 +8,31 @@
       <div class="govuk-!-margin-bottom-5">
         <h1 class="govuk-heading-xl"><%= t("questions.home_address") %></h1>
         <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Postcode</h2>
+        <%= form_group_tag current_claim do %>
+          <fieldset class="govuk-fieldset" aria-describedby="address-search-result-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h2 class="govuk-fieldset__heading govuk-!-margin-top-3">
+                Select an address
+              </h2>
+            </legend>
+            <div class="govuk-radios">
+              <% @address_data.each do |option| %>
+                <% address = option[:address].gsub(",", "").gsub(" ", "_").downcase %>
+                <% checked = params.dig(:claim, :address_line_1) == option[:address_line_1] %>
+
+                <div class="govuk-radios__item">
+                  <%= radio_button_tag :address, [option[:address], option[:address_line_1]].join(":"), checked, class: "govuk-radios__input", id: address %>
+                  <%= label_tag address, "#{option[:address]}", class: "govuk-label govuk-radios__label", id: address %>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
+        <% end %>
+        <%= link_to "#{I18n.t("questions.i_cannot_find")}", claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": "#{I18n.t("questions.i_cannot_find")}" %>
       </div>
-
-      <%= form_group_tag current_claim do %>
-        <fieldset class="govuk-fieldset" aria-describedby="address-search-result-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading govuk-!-margin-top-3">
-              Select an address
-            </h2>
-          </legend>
-          <div class="govuk-radios">
-            <% @address_data.each do |option| %>
-              <% address = option[:address].gsub(",", "").gsub(" ", "_").downcase %>
-              <% checked = params.dig(:claim, :address_line_1) == option[:address_line_1] %>
-
-              <div class="govuk-radios__item">
-                <%= radio_button_tag :address, [option[:address], option[:address_line_1]].join(":"), checked, class: "govuk-radios__input", id: address %>
-                <%= label_tag address, "#{option[:address]}", class: "govuk-label govuk-radios__label", id: address %>
-              </div>
-            <% end %>
-          </div>
-        </fieldset>
-      <% end %>
-      <%= form.submit "Continue", class: "govuk-button" %>
+      <p class="govuk-!-padding-top-3">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.home_address"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.home.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -6,7 +6,7 @@
 
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <div class="govuk-!-margin-bottom-5">
-        <h1 class="govuk-heading-xl"><%= t("questions.home_address") %></h1>
+        <h1 class="govuk-heading-xl"><%= t("questions.address.home.title") %></h1>
         <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Postcode</h2>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" aria-describedby="address-search-result-hint">
@@ -28,7 +28,7 @@
             </div>
           </fieldset>
         <% end %>
-        <%= link_to "#{I18n.t("questions.i_cannot_find")}", claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": "#{I18n.t("questions.i_cannot_find")}" %>
+        <%= link_to I18n.t("questions.address.home.i_cannot_find"), claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.i_cannot_find") %>
       </div>
       <p class="govuk-!-padding-top-3">
         <%= form.submit "Continue", class: "govuk-button" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,10 +56,13 @@ en:
     current_school: "Which school are you currently employed to teach at?"
     qts_award_year: "When did you complete your initial teacher training?"
     name: "What is your full name?"
-    address: "What is your address?"
-    home_address: "What is your home address?"
-    link_to_manual_address: "Enter your address manually"
-    i_cannot_find: "I can't find my address in the list"
+    address:
+      generic:
+        title: "What is your address?"
+      home:
+        title: "What is your home address?"
+        link_to_manual_address: "Enter your address manually"
+        i_cannot_find: "I can't find my address in the list"
     date_of_birth: "What is your date of birth?"
     teacher_reference_number: "What is your teacher reference number (TRN)?"
     national_insurance_number: "What's your National Insurance number?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,8 +47,6 @@ en:
     heading_send_application: Confirm and send your application
     statement: By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
     btn_text: Confirm and send
-
-
   one_time_password:
     title: "One time password"
     hint1_html: "We have sent an %{email_or_mobile_message} to <b><strong>%{email_or_mobile_value}</strong></b> with a 6-digit password."
@@ -61,6 +59,7 @@ en:
     address: "What is your address?"
     home_address: "What is your home address?"
     link_to_manual_address: "Enter your address manually"
+    i_cannot_find: "I can't find my address in the list"
     date_of_birth: "What is your date of birth?"
     teacher_reference_number: "What is your teacher reference number (TRN)?"
     national_insurance_number: "What's your National Insurance number?"

--- a/spec/features/auto_populating_home_address_from_postcode_search.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search.rb
@@ -147,14 +147,14 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       visit claim_path(claim.policy.routing_name, "postcode-search")
 
       # - What is your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
       fill_in "Postcode", with: "SO16 9FX"
       click_on "Search"
 
       # - Select your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
 
       choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
       click_on "Continue"
@@ -176,21 +176,21 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       visit claim_path(claim.policy.routing_name, "postcode-search")
 
       # - What is your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
       fill_in "Postcode", with: "SO16 9FX"
       click_on "Search"
 
       # - Select your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_text("Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX")
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
-      click_link(I18n.t("questions.i_cannot_find"))
+      click_link(I18n.t("questions.address.home.i_cannot_find"))
 
       # - What is your address
-      expect(page).to have_text(I18n.t("questions.address"))
+      expect(page).to have_text(I18n.t("questions.address.generic.title"))
 
       fill_in :claim_address_line_1, with: "Penthouse Apartment, Millbrook Tower"
       fill_in :claim_address_line_2, with: "Windermere Avenue"
@@ -287,7 +287,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       visit claim_path(claim.policy.routing_name, "postcode-search")
 
       # - What is your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
       fill_in "Postcode", with: "SE13 7UN"
@@ -295,7 +295,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       click_on "Search"
 
       # - Select your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
 
       choose "38a_wearside_road_london_se13_7un"
       click_on "Continue"
@@ -306,7 +306,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       expect(claim.postcode).to eql "SE13 7UN"
 
       # - What is your address
-      expect(page).not_to have_text(I18n.t("questions.address"))
+      expect(page).not_to have_text(I18n.t("questions.address.generic.title"))
 
       # - Email address
       expect(page).to have_text(I18n.t("questions.email_address"))
@@ -360,7 +360,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       visit claim_path(claim.policy.routing_name, "postcode-search")
 
       # - What is your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
       fill_in "Postcode", with: "SE13 7UN"
@@ -368,7 +368,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       click_on "Search"
 
       # - Select your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_text("There is a problem")
       expect(page).to have_text("Postcode not found")
 

--- a/spec/features/auto_populating_home_address_from_postcode_search.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search.rb
@@ -142,7 +142,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       claim
     end
 
-    scenario "with Ordnance Survey API" do
+    scenario "with Ordnance Survey API data" do
       expect(claim.valid?(:submit)).to eq false
       visit claim_path(claim.policy.routing_name, "postcode-search")
 
@@ -165,7 +165,43 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       expect(claim.postcode).to eql "SO16 9FX"
 
       # - What is your address
-      expect(page).not_to have_text(I18n.t("questions.address"))
+      expect(page).not_to have_text(I18n.t("questions.address.generic.title"))
+
+      # - Email address
+      expect(page).to have_text(I18n.t("questions.email_address"))
+    end
+
+    scenario "Claimant cannot find the correct address so chooses to manually enter address" do
+      expect(claim.valid?(:submit)).to eq false
+      visit claim_path(claim.policy.routing_name, "postcode-search")
+
+      # - What is your home address
+      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
+
+      fill_in "Postcode", with: "SO16 9FX"
+      click_on "Search"
+
+      # - Select your home address
+      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text("Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX")
+      expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
+
+      click_link(I18n.t("questions.i_cannot_find"))
+
+      # - What is your address
+      expect(page).to have_text(I18n.t("questions.address"))
+
+      fill_in :claim_address_line_1, with: "Penthouse Apartment, Millbrook Tower"
+      fill_in :claim_address_line_2, with: "Windermere Avenue"
+      fill_in "Town or city", with: "Southampton"
+      fill_in "Postcode", with: "SO16 9FX"
+      click_on "Continue"
+
+      expect(claim.reload.address_line_1).to eql("Penthouse Apartment, Millbrook Tower")
+      expect(claim.address_line_2).to eql("Windermere Avenue")
+      expect(claim.address_line_3).to eql("Southampton")
+      expect(claim.postcode).to eql("SO16 9FX")
 
       # - Email address
       expect(page).to have_text(I18n.t("questions.email_address"))
@@ -246,7 +282,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       claim
     end
 
-    scenario "with Ordnance Survey API" do
+    scenario "with Ordnance Survey API data" do
       expect(claim.valid?(:submit)).to eq false
       visit claim_path(claim.policy.routing_name, "postcode-search")
 
@@ -319,7 +355,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       claim
     end
 
-    scenario "with Ordnance Survey API" do
+    scenario "when no results returned from the API display error message" do
       expect(claim.valid?(:submit)).to eq false
       visit claim_path(claim.policy.routing_name, "postcode-search")
 

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -204,7 +204,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       visit claim_path(StudentLoans.routing_name, "check-your-answers")
 
       expect(page).to have_content(I18n.t("questions.name"))
-      expect(page).to have_content(I18n.t("questions.address"))
+      expect(page).to have_content(I18n.t("questions.address.generic.title"))
       expect(page).to have_content(I18n.t("questions.date_of_birth"))
       expect(page).to have_content(I18n.t("questions.payroll_gender"))
       expect(page).to have_selector(:css, "a[href='#{claim_path(StudentLoans.routing_name, "name")}']")

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -142,13 +142,13 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     expect(claim.reload.national_insurance_number).to eq("PX321499A")
 
     # - What is your home address
-    expect(page).to have_text(I18n.t("questions.home_address"))
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
     expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
-    click_link(I18n.t("questions.link_to_manual_address"))
+    click_link(I18n.t("questions.address.home.link_to_manual_address"))
 
     # - What is your address
-    expect(page).to have_text(I18n.t("questions.address"))
+    expect(page).to have_text(I18n.t("questions.address.generic.title"))
 
     fill_in :claim_address_line_1, with: "57"
     fill_in :claim_address_line_2, with: "Walthamstow Drive"
@@ -600,13 +600,13 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     expect(claim.reload.national_insurance_number).to eq("PX321499A")
 
     # - What is your home address
-    expect(page).to have_text(I18n.t("questions.home_address"))
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
     expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
-    click_link(I18n.t("questions.link_to_manual_address"))
+    click_link(I18n.t("questions.address.home.link_to_manual_address"))
 
     # - What is your address
-    expect(page).to have_text(I18n.t("questions.address"))
+    expect(page).to have_text(I18n.t("questions.address.generic.title"))
 
     fill_in :claim_address_line_1, with: "88"
     fill_in :claim_address_line_2, with: "Deanborough Street"
@@ -972,14 +972,14 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       expect(claim.reload.national_insurance_number).to eq("PX321499A")
 
       # - What is your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
       fill_in "Postcode", with: "SO16 9FX"
       click_on "Search"
 
       # - Select your home address
-      expect(page).to have_text(I18n.t("questions.home_address"))
+      expect(page).to have_text(I18n.t("questions.address.home.title"))
 
       choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
       click_on "Continue"
@@ -990,7 +990,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       expect(claim.postcode).to eql "SO16 9FX"
 
       # - What is your address
-      expect(page).not_to have_text(I18n.t("questions.address"))
+      expect(page).not_to have_text(I18n.t("questions.address.generic.title"))
 
       # - Email address
       expect(page).to have_text(I18n.t("questions.email_address"))

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Maths & Physics claims" do
       expect(claim.middle_name).to eql("Jennifer")
       expect(claim.surname).to eql("Winstanley")
 
-      expect(page).to have_text(I18n.t("questions.address"))
+      expect(page).to have_text(I18n.t("questions.address.generic.title"))
       fill_in_address
 
       expect(claim.reload.address_line_1).to eql("123 Main Street")

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.middle_name).to eql("Percival")
       expect(claim.surname).to eql("Hillary")
 
-      expect(page).to have_text(I18n.t("questions.address"))
+      expect(page).to have_text(I18n.t("questions.address.generic.title"))
       fill_in_address
 
       expect(claim.reload.address_line_1).to eql("123 Main Street")

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -45,7 +45,7 @@ describe ClaimsHelper do
       it "returns an array of identity-related questions and answers for displaying to the user for review" do
         expected_answers = [
           [I18n.t("questions.name"), "Jo Bloggs", "name"],
-          [I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+          [I18n.t("questions.address.generic.title"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
           [I18n.t("questions.date_of_birth"), "10 January 1980", "date-of-birth"],
           [I18n.t("questions.payroll_gender"), "Don’t know", "gender"],
           [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
@@ -73,7 +73,7 @@ describe ClaimsHelper do
 
         expected_answers = [
           [I18n.t("questions.name"), "Jo Bloggs", "name"],
-          [I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+          [I18n.t("questions.address.generic.title"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
           [I18n.t("questions.date_of_birth"), nil, "date-of-birth"],
           [I18n.t("questions.payroll_gender"), "Don’t know", "gender"],
           [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
@@ -94,7 +94,7 @@ describe ClaimsHelper do
 
         expected_answers = [
           [I18n.t("questions.name"), "Jo Bloggs", "personal-details"],
-          [I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+          [I18n.t("questions.address.generic.title"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
           [I18n.t("questions.date_of_birth"), "10 January 1980", "personal-details"],
           [I18n.t("questions.payroll_gender"), "Don’t know", "gender"],
           [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
@@ -112,7 +112,7 @@ describe ClaimsHelper do
 
         expected_answers = [
           [I18n.t("questions.name"), "Jo Bloggs", "personal-details"],
-          [I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+          [I18n.t("questions.address.generic.title"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
           [I18n.t("questions.date_of_birth"), nil, "personal-details"],
           [I18n.t("questions.payroll_gender"), "Don’t know", "gender"],
           [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],


### PR DESCRIPTION
 - provide links on the address auto-population pages that allow the claimant to enter their address manually
