### PR TITLE
[support/CSM-12] - Update local authority for Northamptonshire to reflect boundary changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog]
       when on the two address auto-population screens
   - Add posgraduate loans questions to M+P / TSLR journeys
   - Hiding mobile/SMS related OTP screens
+  - Update Northamptonshire local authority to reflect GIAS changes 1st April
+    2021
 - ECP policies
 - DAC Accessiblity Report fixes
   - Incorrect aria value

--- a/app/models/early_career_payments/school_eligibility.rb
+++ b/app/models/early_career_payments/school_eligibility.rb
@@ -174,12 +174,13 @@ module EarlyCareerPayments
       "E07000147", # North Norfolk
       "E07000148", # Norwich
       "E07000149", # South Norfolk
-      "E07000150", # Corby
       "E07000151", # Daventry
       "E07000152", # East Northamptonshire
       "E07000153", # Kettering
       "E07000154", # Northampton
       "E07000155", # South Northamptonshire
+      "E06000061", # North Northamptonshire (North Northants)
+      "E06000062", # West Northamptonshire (West Northants)
       "E07000156", # Wellingborough
       "E07000163", # Craven
       "E07000164", # Hambleton

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -16,8 +16,8 @@ module StudentLoans
       806, # Middlesbrough
       926, # Norfolk
       812, # North-east Lincolnshire
+      940, # North Northamptonshire (North Northants)
       815, # North Yorkshire
-      928, # Northamptonshire
       929, # Northumberland
       353, # Oldham
       874, # Peterborough
@@ -26,7 +26,8 @@ module StudentLoans
       343, # Sefton
       342, # St Helens
       861, # Stoke-on-Trent
-      935 # Suffolk
+      935, # Suffolk
+      941 # West Northamptonshire (West Northants)
     ].freeze
 
     def initialize(school)


### PR DESCRIPTION
On the evening of 31 March 2021 GIAS will be updated to reflect the Northamptonshire local authority boundary changes (opens in new tab), which are for scheduled for 1 April 2021. The update will:
- Add two new local authorities to GIAS:
   - 940 – North Northamptonshire Council
   - 941 – West Northamptonshire Council

- Rename the existing 928 – Northamptonshire local authority to Pre-LGR 2021 Northamptonshire.