### PR TITLE
[bug/ECP-1128] - Fix for address screens

### DIFF
--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -66,7 +66,6 @@ module EarlyCareerPayments
         sequence.delete("eligibility-confirmed") if claim.eligibility.ineligible? || claim.eligibility.eligible_later?
         sequence.delete("eligible-later") unless claim.eligibility.eligible_later?
         sequence.delete("ineligible") unless claim.eligibility.ineligible?
-        sequence.delete("address") unless claim.address.blank?
         sequence.delete("personal-bank-account") if claim.bank_or_building_society == "building_society"
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -70,7 +70,6 @@ module MathsAndPhysics
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
-        sequence.delete("address") unless claim.address.blank?
         sequence.delete("ineligible") unless claim.eligibility.ineligible?
       end
     end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -18,11 +18,9 @@ class PageSequence
     return "ineligible" if claim.eligibility.ineligible?
     return "check-your-answers" if claim.submittable?
 
-    # to avoid the #current_slug_index returning 0 when a slug has been deleted in policy::SlugSequence.slugs
-    # the next slug needs to be returned. Otherwise the 2nd slug (index 1) will be retuned
-    # for 'address'.
-    # This happened due to using a link to render the 'address' page from the show action on 'postcode-search'
-    return slugs[slugs.index("select-home-address") + 1] if current_slug == "address"
+    # This allows 'address' page to be skipped when the postcode is present
+    # Occurs when populated from 'postcode-search' and the subsequent 'select-home-address' screens
+    return slugs[slugs.index("select-home-address") + 2] if current_slug == "select-home-address" && claim.postcode.present?
 
     slugs[current_slug_index + 1]
   end

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -65,7 +65,6 @@ module StudentLoans
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
-        sequence.delete("address") unless claim.address.blank?
         sequence.delete("ineligible") unless claim.eligibility.ineligible?
       end
     end

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -129,22 +129,6 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
       end
     end
 
-    context "when claim has a valid postcode" do
-      it "excludes the 'address' slug" do
-        claim.postcode = "SO16 9FX"
-
-        expect(slug_sequence.slugs).not_to include("address")
-      end
-    end
-
-    context "when manual full address requested" do
-      it "includes the 'address' slug" do
-        claim.postcode = nil
-
-        expect(slug_sequence.slugs).to include("address")
-      end
-    end
-
     context "when the answer to 'paying off student loan' is 'No'" do
       it "excludes 'student-loan-country', 'student-loan-how-many-courses', 'student-loan-start-date', 'masters-loan' and 'doctoral-loan'" do
         claim.has_student_loan = false

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -101,21 +101,5 @@ RSpec.describe MathsAndPhysics::SlugSequence do
         expect(slug_sequence.slugs).not_to include("personal-bank-account")
       end
     end
-
-    context "when auto-populating address from 'postcode-search' and 'select-home-address'" do
-      it "excludes the 'address' slug" do
-        claim.postcode = "SE13 7UN"
-
-        expect(slug_sequence.slugs).not_to include("address")
-      end
-    end
-
-    context "when manual full address requested" do
-      it "includes the 'address' slug" do
-        claim.postcode = nil
-
-        expect(slug_sequence.slugs).to include("address")
-      end
-    end
   end
 end

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe PageSequence do
 
     context "when address is populated from 'select-home-address'" do
       [
-        {policy: EarlyCareerPayments, next_slug: "email-address", slug_sequence: OpenStruct.new(slugs: ["postcode-search", "select-home-address", "email-address"])},
-        {policy: MathsAndPhysics, next_slug: "date-of-birth", slug_sequence: OpenStruct.new(slugs: ["postcode-search", "select-home-address", "date-of-birth"])},
-        {policy: StudentLoans, next_slug: "date-of-birth", slug_sequence: OpenStruct.new(slugs: ["postcode-search", "select-home-address", "date-of-birth"])}
+        {policy: EarlyCareerPayments, next_slug: "email-address", slug_sequence: OpenStruct.new(slugs: ["postcode-search", "select-home-address", "address", "email-address"])},
+        {policy: MathsAndPhysics, next_slug: "date-of-birth", slug_sequence: OpenStruct.new(slugs: ["postcode-search", "select-home-address", "address", "date-of-birth"])},
+        {policy: StudentLoans, next_slug: "date-of-birth", slug_sequence: OpenStruct.new(slugs: ["postcode-search", "select-home-address", "address", "date-of-birth"])}
       ].each do |scenario|
         let(:claim) { build(:claim, policy: scenario[:policy]) }
 

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -70,21 +70,5 @@ RSpec.describe StudentLoans::SlugSequence do
         expect(slug_sequence.slugs).not_to include("personal-bank-account")
       end
     end
-
-    context "when auto-populating address from 'postcode-search' and 'select-home-address'" do
-      it "excludes the 'address' slug" do
-        claim.postcode = "SE13 7UN"
-
-        expect(slug_sequence.slugs).not_to include("address")
-      end
-    end
-
-    context "when manual full address requested" do
-      it "includes the 'address' slug" do
-        claim.postcode = nil
-
-        expect(slug_sequence.slugs).to include("address")
-      end
-    end
   end
 end


### PR DESCRIPTION
 - allows 'address' page to be skipped if postcode is present
 - allows 'address' page to be shown if claimant chooses to manually enter their address
 - allows 'address' page to be accessed from 'Check your answers links'

<!-- Do you need to update CHANGELOG.md? -->
