### PR TITLE
release-093

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+## [Release 093] - 2021-09-02
+
 - Admin
   - Show admin claim identity confirmation task questions when claim verifier
     identity not fully matched
@@ -852,7 +854,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-092...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-093...HEAD
+[release 093]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-092...release-093
 [release 092]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-091...release-092
 [release 091]:


### PR DESCRIPTION
- Admin
  - Show admin claim identity confirmation task questions when claim verifier
    identity not fully matched
  - Add ECP admin claim identity confirmation task screen
  - Create admin claim note when identity confirmation mailer is sent
  - Amend admin timeout from 30 mins to 60 mins
  - Add ECP admin claim qualifications task screen
  - Warning added upon changing ECP to open
  - Reminder emails triggered upon opening ECP
  - Add ECP admin claim employment task screen
  - Remove verify notice from claim summary
  - Add a note if DQT active alert flag is set to true
  - Add important notes to claim summary (DQT active alert)
  - Add ECP admin claim matching details task screen
  - DQT identity check mailer removed
  - Add admin claim verifier ECP qualifications
  - Update claim verifiers to handle multiple partial matches
  - Add identity claim verifier admin claim notes claimant vs DQT mismatch
    information
  - Fix ECP admin claim qualifications task question to first claim year
    eligibility (Mathematics 2018)
  - Make admin claim verifier qualifications matching comparable to previous CSV
    matching
  - Update ECP admin claim verifier qualifications eligibility to use dates
    based on qualification type
  - Add new DQT fields to admin claim verifier qualifications notes
- All policies
  - Home Address selection
    - Add home address search screen to claim journey
    - Add screen to allow claimant to select address from API provided results
      presented as radio buttons
    - Add links that allow claimant to manually enter their address information
      when on the two address auto-population screens
  - Add postgraduate loans questions to M+P / TSLR journeys
  - Hiding mobile/SMS related OTP screens
  - Update Northamptonshire local authority to reflect GIAS changes 1st April
    2021
  - Add ECP link in README for developers to use
  - Add normalisation to claim name fields
  - Claim received template content change
  - Claim rejected template content change
  - ECP OTP email content change
  - Claim approved template content change
  - Claim submitted content change
  - 'What gender does your school's payroll system associate with you?' content
    change
  - Update subject heading on TSLR and ECP OTP email
  - Split Postgraduate loans (ITT course) from Postgraduate Masters/Doctoral
    loans
  - Update Postgraduate Masters and Doctoral Loans questions to be only being
    asked if the answer to 'Do you have postgraduate masters and/or doctoral'
    loans is 'Yes'
  - Remove HTML 5 validation messages on national insurance number
  - Update references to DQT with Teaching Regulation Agency
- ECP policies
  - Adds set reminder flow to eligible now flow
  - Fix no validation occurring on 'Personal Details' screens
  - Fix typo on 'How we will use the information you provide' page
  - Content change for 'Performance issues' screen
  - Content change for 'Application complete' page
- TSLR policies
  - Move PG screens in the user journey (student loan amount)
  - Update location of student loan amount question in check your answers
- DAC Accessibility Report fixes
  - Incorrect aria value
  - Links opening in a new window
  - Incorrect ID in 'for' attribute for one time password
  - Multiple level 1 headings
  - Error skip links
  - Non-descriptive links
- Google Analytics
  - Add Google Tag Manager to admin and application
- Claims
  - Stop claim full name adding redundant spaces when middle name is an empty or
    blank string
- Student Loan Plan Types
  - Add plan type 3 - Postgraduate Masters and/or Doctoral loan
  - Add plan type 4 - Scotland
