### PR TITLE
[task/ECP-1218] - Fix deprecation warning: Passing the keyword argument as the last hash parameter is deprecated

### DIFF
--- a/app/views/admin/claims/_tabs.html.erb
+++ b/app/views/admin/claims/_tabs.html.erb
@@ -1,16 +1,15 @@
 <ul class="govuk-tabs__list" role="tablist">
-  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "tasks") %>" role="presentation">
-    <%= link_to_unless_current "Tasks", admin_claim_tasks_path(claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "tasks") } %>
+  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?({controller: "tasks"}) %>" role="presentation">
+    <%= link_to_unless_current "Tasks", admin_claim_tasks_path(claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?({controller: "tasks"}) } %>
   </li>
 
-  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "notes") %>" role="presentation">
-    <%= link_to_unless_current "Notes and support", admin_claim_notes_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "notes") } %>
+  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?({controller: "notes"}) %>" role="presentation">
+    <%= link_to_unless_current "Notes and support", admin_claim_notes_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?({controller: "notes"}) } %>
     <%= "(#{claim.notes.count})" if claim.notes.any? %>
   </li>
 
-  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?(controller: "amendments") %>" role="presentation">
-    <%= link_to_unless_current "Claim amendments", admin_claim_amendments_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?(controller: "amendments") } %>
+  <li class="govuk-tabs__list-item govuk-tabs__list-item--<%= "selected" if current_page?({controller: "amendments"}) %>" role="presentation">
+    <%= link_to_unless_current "Claim amendments", admin_claim_amendments_path(@claim), class: "govuk-tabs__tab", role: "tabs", aria: { controls: "task", selected: current_page?({controller: "amendments"}) } %>
     <%= "(#{claim.amendments.count})" if claim.amendments.any? %>
   </li>
 </ul>
-


### PR DESCRIPTION
 - this was appearing when attempting the upgrade to 2.7 series
