### PR TITLE
[story/ECP-1339] - Change static email content for OTP email verification to use the GOVUK notify OTP template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog]
     - QTS Assessment only
     - QTS Award only
     - Scotland
+- Transition to use GOVUK Notify Mail Templates to allow business users to
+  modify wording
+  - OTP email verification - All Policies
+  - OTP ECP Reminders
 
 ## [Release 107] - 2021-12-09
 

--- a/app/helpers/early_career_payments_helper.rb
+++ b/app/helpers/early_career_payments_helper.rb
@@ -1,4 +1,6 @@
 module EarlyCareerPaymentsHelper
+  include ActionView::Helpers::TextHelper
+
   def ineligible_heading(claim)
     if claim.eligibility.ineligibility_reason == :poor_performance
       content_tag(:h1, I18n.t("early_career_payments.ineligible.poor_performance_heading"), class: "govuk-heading-xl")

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "d72e2ff9-b228-4f16-9099-fd9d411c0334".freeze
-  OTP_EMAIL_NOTIFY_TEMPLATE_ID = "5edc6235-833d-4795-b627-2548ef5bdbee".freeze
+  OTP_EMAIL_NOTIFY_TEMPLATE_ID = "89e8c33a-1863-4fdd-a73c-1ca01efc0c76".freeze
   GENERIC_NOTIFY_REPLY_TO_ID = "2b8fbdcf-16da-49dc-ad07-4a4c45f0e7e6".freeze
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "d72e2ff9-b228-4f16-9099-fd9d411c0334".freeze
+  OTP_EMAIL_NOTIFY_TEMPLATE_ID = "5edc6235-833d-4795-b627-2548ef5bdbee".freeze
   GENERIC_NOTIFY_REPLY_TO_ID = "2b8fbdcf-16da-49dc-ad07-4a4c45f0e7e6".freeze
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -1,4 +1,5 @@
 class ClaimMailer < ApplicationMailer
+  include EarlyCareerPaymentsHelper
   helper :application
   helper :early_career_payments
 
@@ -35,9 +36,13 @@ class ClaimMailer < ApplicationMailer
     set_common_instance_variables(claim)
     @subject = "#{@claim_subject} email verification"
     @one_time_password = one_time_password
+    support_email_address = translate("#{@claim.policy.locale_key}.support_email_address")
     personalisation = {
+      email_subject: @subject,
       first_name: @claim.first_name,
-      one_time_password: @one_time_password
+      one_time_password: @one_time_password,
+      support_email_address: support_email_address,
+      validity_duration: one_time_password_validity_duration
     }
 
     send_mail(:notify, OTP_EMAIL_NOTIFY_TEMPLATE_ID, personalisation)
@@ -62,7 +67,6 @@ class ClaimMailer < ApplicationMailer
         reply_to_id: @policy.notify_reply_to_id
       )
     else
-      puts "Using GOVUK Notify templating - template_id: #{template_id}"
       template_mail(
         template_id,
         to: @claim.email_address,

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -7,7 +7,12 @@ class ReminderMailer < ApplicationMailer
     @one_time_password = one_time_password
     @display_name = reminder.full_name
     @subject = "Please verify your reminder email"
-    send_mail
+    personalisation = {
+      first_name: @display_name,
+      one_time_password: @one_time_password
+    }
+
+    send_mail(:notify, OTP_EMAIL_NOTIFY_TEMPLATE_ID, personalisation)
   end
 
   def reminder_set(reminder)
@@ -24,11 +29,21 @@ class ReminderMailer < ApplicationMailer
 
   private
 
-  def send_mail
-    view_mail(
-      NOTIFY_TEMPLATE_ID,
-      to: @reminder.email_address,
-      subject: @subject
-    )
+  def send_mail(templating = :rails, template_id = :default, personalisation = {})
+    if templating == :rails
+      view_mail(
+        NOTIFY_TEMPLATE_ID,
+        to: @reminder.email_address,
+        subject: @subject
+      )
+    else
+      puts "Using GOVUK Notify templating - template_id: #{template_id}"
+      template_mail(
+        template_id,
+        to: @reminder.email_address,
+        subject: @subject,
+        personalisation: personalisation
+      )
+    end
   end
 end

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -1,4 +1,6 @@
 class ReminderMailer < ApplicationMailer
+  include EarlyCareerPaymentsHelper
+
   helper :application
   helper :early_career_payments
 
@@ -7,9 +9,13 @@ class ReminderMailer < ApplicationMailer
     @one_time_password = one_time_password
     @display_name = reminder.full_name
     @subject = "Please verify your reminder email"
+    support_email_address = translate("early_career_payments.support_email_address")
     personalisation = {
+      email_subject: @subject,
       first_name: @display_name,
-      one_time_password: @one_time_password
+      one_time_password: @one_time_password,
+      support_email_address: support_email_address,
+      validity_duration: one_time_password_validity_duration
     }
 
     send_mail(:notify, OTP_EMAIL_NOTIFY_TEMPLATE_ID, personalisation)
@@ -37,10 +43,10 @@ class ReminderMailer < ApplicationMailer
         subject: @subject
       )
     else
-      puts "Using GOVUK Notify templating - template_id: #{template_id}"
       template_mail(
         template_id,
         to: @reminder.email_address,
+        reply_to_id: EarlyCareerPayments.notify_reply_to_id,
         subject: @subject,
         personalisation: personalisation
       )

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -368,7 +368,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         expect(page).to have_content("Email address verification")
 
         mail = ActionMailer::Base.deliveries.last
-        otp_in_mail_sent = mail.body.decoded.scan(/\b[0-9]{6}\b/).first
+        otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
         fill_in "claim_one_time_password", with: otp_in_mail_sent, fill_options: {clear: :backspace}
         click_on "Confirm"

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -189,7 +189,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     expect(page).to have_text("We recommend you copy and paste the password from the email.")
 
     mail = ActionMailer::Base.deliveries.last
-    otp_in_mail_sent = mail.body.decoded.scan(/\b[0-9]{6}\b/).first
+    otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
     # - One time password wrong
     fill_in "claim_one_time_password", with: "000000"
@@ -641,7 +641,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     expect(page).to have_text("We recommend you copy and paste the password from the email.")
 
     mail = ActionMailer::Base.deliveries.last
-    otp_in_mail_sent = mail.body.decoded.scan(/\b[0-9]{6}\b/).first
+    otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
     fill_in "claim_one_time_password", with: otp_in_mail_sent
     click_on "Confirm"
@@ -1005,7 +1005,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       expect(page).to have_text("We recommend you copy and paste the password from the email.")
 
       mail = ActionMailer::Base.deliveries.last
-      otp_in_mail_sent = mail.body.decoded.scan(/\b[0-9]{6}\b/).first
+      otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
       fill_in "claim_one_time_password", with: otp_in_mail_sent
       click_on "Confirm"

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -146,7 +146,7 @@ RSpec.feature "Maths & Physics claims" do
       expect(page).to have_text("Enter the 6-digit password")
 
       mail = ActionMailer::Base.deliveries.last
-      otp_in_mail_sent = mail.body.decoded.scan(/\b[0-9]{6}\b/).first
+      otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
       fill_in "claim_one_time_password", with: otp_in_mail_sent
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(page).to have_text("Enter the 6-digit password")
 
       mail = ActionMailer::Base.deliveries.last
-      otp_in_mail_sent = mail.body.decoded.scan(/\b[0-9]{6}\b/).first
+      otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
       fill_in "claim_one_time_password", with: otp_in_mail_sent
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ClaimMailer, type: :mailer do
       let(:one_time_password) { 123124 }
 
       it "mentions the personalisation keys one time password and first_name" do
-        expect(mail[:personalisation].decoded).to eq("{:first_name=>\"Ellie\", :one_time_password=>123124}")
+        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"Early-career payment email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"earlycareerteacherpayments@digital.education.gov.uk\", :validity_duration=>\"15 minutes\"}")
         expect(mail.body.encoded).to be_empty
       end
     end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -110,15 +110,14 @@ RSpec.describe ClaimMailer, type: :mailer do
   end
 
   context "with an EarlyCareerPayments claim" do
-    describe "#ecp_email_verification" do
-      let(:claim) { build(:claim, policy: EarlyCareerPayments) }
+    describe "#email_verification" do
+      let(:claim) { build(:claim, policy: EarlyCareerPayments, first_name: "Ellie") }
       let(:mail) { ClaimMailer.email_verification(claim, one_time_password) }
       let(:one_time_password) { 123124 }
 
-      it "mentions the one time password and its duration of validity" do
-        expect(mail.body.encoded).to include("This is your 6-digit one time password:")
-        expect(mail.body.encoded).to include(one_time_password.to_s)
-        expect(mail.body.encoded).to include("It is valid for 15 minutes.")
+      it "mentions the personalisation keys one time password and first_name" do
+        expect(mail[:personalisation].decoded).to eq("{:first_name=>\"Ellie\", :one_time_password=>123124}")
+        expect(mail.body.encoded).to be_empty
       end
     end
   end

--- a/spec/mailers/previews/claim_mailer_preview.rb
+++ b/spec/mailers/previews/claim_mailer_preview.rb
@@ -15,8 +15,8 @@ class ClaimMailerPreview < ActionMailer::Preview
     ClaimMailer.update_after_three_weeks(claim_for(Claim.approved))
   end
 
-  def ecp_email_verification
-    ClaimMailer.ecp_email_verification(claim_for(Claim.unsubmitted), "@one_time_password")
+  def email_verification
+    ClaimMailer.email_verification(claim_for(Claim.unsubmitted), OneTimePassword::Generator.new.code)
   end
 
   private

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -123,6 +123,6 @@ module FeatureHelpers
 
   def get_otp_from_email
     ActionMailer::Base.deliveries
-      .last.body.decoded.scan(/\b[0-9]{6}\b/).first
+      .last[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
   end
 end


### PR DESCRIPTION
- for M+P/TSLR/ECP Claim user journey
- for ECP Reminder journey
