### PR TITLE
release-108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+## [Release 108] - 2022-01-06
+
 - Admin
   - Display results of Dqt API qualification matching status
   - Fix ITT year and ITT subject for future years admin ECP qualifications task
@@ -1034,7 +1036,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-107...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-108...HEAD
+[release 108]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-107...release-108
 [release 107]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-106...release-107
 [release 106]:


### PR DESCRIPTION
- Admin
  - Display results of Dqt API qualification matching status
  - Fix ITT year and ITT subject for future years admin ECP qualifications task
  - Fix Manual checks to display updated time, not time of claim submission
- Early Career Payments
  - DqT temporary use of subject(n) in response to report JACS/HECOS codes used
    in the determination of matching DqT response with claim ITT subject
  - use QTS Award Date for qualification matching for:
    - EEA
    - Northern Ireland
    - OTT
    - OTT Recognition
    - QTS Assessment only
    - QTS Award only
    - Scotland
- Transition to use GOVUK Notify Mail Templates to allow business users to
  modify wording
  - OTP email verification - All Policies
  - OTP ECP Reminders
