### PR TITLE
Revert "[story/ECP-1393] - Add defensive exits to prevent accidently running DqT CSV data/Payroll UAT test data loaders running in PROD"

### DIFF
--- a/db/test_seeders/base_importer.rb
+++ b/db/test_seeders/base_importer.rb
@@ -11,9 +11,6 @@ if ENV["ENVIRONMENT_NAME"] == "development" ||
   Faker::Config.locale = "en-GB"
   Faker::UniqueGenerator.clear
   Random.new(srand(1234))
-else
-  puts "#{ENV["ENVIRONMENT_NAME"]} is not a valid environment"
-  exit
 end
 
 class BaseImporter
@@ -38,7 +35,6 @@ class BaseImporter
     :quantity
 
   def clear_data
-    exit if ENV["ENVIRONMENT_NAME"] == "production"
     Note.delete_all
     Task.delete_all
     Amendment.delete_all


### PR DESCRIPTION
Reverts DFE-Digital/claim-additional-payments-for-teaching#1861

Its broken the Asset Pipeline with the exit