### PR TITLE
Reject invalid `AcademicYear` strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -59,8 +59,29 @@ class AcademicYear
     end
   end
 
-  def initialize(start_year = nil)
-    self.years = start_year
+  def initialize(year_or_academic_year_or_string = nil)
+    if year_or_academic_year_or_string.nil?
+      # would have thought this should be an error really but maintaining interface for now
+      @start_year = @end_year = nil
+    elsif year_or_academic_year_or_string.is_a? Integer
+      @start_year = year_or_academic_year_or_string
+      @end_year = @start_year + 1
+    elsif year_or_academic_year_or_string.is_a? AcademicYear
+      @start_year = year_or_academic_year_or_string.start_year
+      @end_year = year_or_academic_year_or_string.end_year
+    elsif year_or_academic_year_or_string.match?(/^\d{4}$/)
+      @start_year = year_or_academic_year_or_string.to_i
+      @end_year = @start_year + 1
+    elsif /^(?<start_year_string>\d{4})\/(?<end_year_string>\d{4})$/ =~ year_or_academic_year_or_string
+      start_year_i, end_year_i = start_year_string.to_i, end_year_string.to_i
+
+      if end_year_i == start_year_i + 1
+        @start_year = start_year_i
+        @end_year = end_year_i
+      else
+        raise "#{year_or_academic_year_or_string} are not increasing consecutive years"
+      end
+    end
   end
 
   def eql?(other)
@@ -100,16 +121,5 @@ class AcademicYear
 
   def +(other)
     AcademicYear.new(start_year + other)
-  end
-
-  private
-
-  def years=(start_year)
-    if start_year.nil?
-      @start_year = @end_year = nil
-    else
-      @start_year = start_year.to_s.split("/").first.to_i
-      @end_year = self.start_year + 1
-    end
   end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -85,15 +85,23 @@ RSpec.describe AcademicYear do
   end
 
   it "can be initialised with the full academic year as a String" do
-    expect(AcademicYear.new("2014/2015").start_year).to eq 2014
+    expect(AcademicYear.new("2014/2015")).to have_attributes(start_year: 2014, end_year: 2015)
+  end
+
+  it "errors when the years are not consecutive" do
+    expect { AcademicYear.new("2014/2016") }.to raise_error("2014/2016 are not increasing consecutive years")
+  end
+
+  it "errors when the years are not increasing" do
+    expect { AcademicYear.new("2014/2013") }.to raise_error("2014/2013 are not increasing consecutive years")
   end
 
   it "can be initialised with a single Integer year" do
-    expect(AcademicYear.new(2020).start_year).to eq 2020
+    expect(AcademicYear.new(2020)).to have_attributes(start_year: 2020, end_year: 2021)
   end
 
   it "can be initialised with a single String year" do
-    expect(AcademicYear.new("2019").start_year).to eq 2019
+    expect(AcademicYear.new("2019")).to have_attributes(start_year: 2019, end_year: 2020)
   end
 
   it "is comparable" do


### PR DESCRIPTION
Add check to reject invalid academic year strings like '2014/2016' (not consecutive years) or '2014/2013' (decreasing years) which would have been silently accepted before 
