### PR TITLE
Remove RSpec deprecation warnings (seen when running `bundle exec rake`)

### DIFF
--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -31,19 +31,19 @@ RSpec.feature "Backlinking during a claim" do
     scenario "backlink is not present on pages that exclude it" do
       # ecp journey
       %w[claim eligibility-confirmed eligible-later ineligible].each do |slug|
-        ClaimsController.any_instance.stub(:current_template).and_return(slug)
+        allow_any_instance_of(ClaimsController).to receive(:current_template).and_return(slug)
         visit "/early-career-payments/#{slug}"
         expect(page).to_not have_link("Back")
       end
       # student loan journey
       %w[claim eligibility-confirmed ineligible].each do |slug|
-        ClaimsController.any_instance.stub(:current_template).and_return(slug)
+        allow_any_instance_of(ClaimsController).to receive(:current_template).and_return(slug)
         visit "/student-loans/#{slug}"
         expect(page).to_not have_link("Back")
       end
       # maths and physics journey
       %w[claim eligibility-confirmed ineligible].each do |slug|
-        ClaimsController.any_instance.stub(:current_template).and_return(slug)
+        allow_any_instance_of(ClaimsController).to receive(:current_template).and_return(slug)
         visit "/maths-and-physics/#{slug}"
         expect(page).to_not have_link("Back")
       end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe School, type: :model do
     end
 
     it "raises an ArgumentError when the search term has fewer than 3 characters" do
-      expect(lambda { School.search("Pe") }).to raise_error(ArgumentError, School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR)
+      expect { School.search("Pe") }.to raise_error(ArgumentError, School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR)
     end
 
     it "limits the results" do


### PR DESCRIPTION
Removes some RSpec deprecation warnings. Hopefully this will make an eventual RSpec gem upgrade easier.
