### PR TITLE
Allow entire RSpec suite to pass whilst running app locally

### DIFF
--- a/config/initializers/dfe_sign_in.rb
+++ b/config/initializers/dfe_sign_in.rb
@@ -1,5 +1,5 @@
 DfeSignIn.configure do |config|
   config.client_id = ENV.fetch("DFE_SIGN_IN_API_CLIENT_ID")
-  config.secret = ENV.fetch("DFE_SIGN_IN_API_SECRET")
+  config.secret = Rails.env.production? ? ENV.fetch("DFE_SIGN_IN_API_SECRET") : ENV.fetch("DFE_SIGN_IN_API_SECRET", "secret")
   config.base_url = ENV.fetch("DFE_SIGN_IN_API_ENDPOINT")
 end

--- a/spec/lib/dfe_sign_in/dfe_sign_in_spec.rb
+++ b/spec/lib/dfe_sign_in/dfe_sign_in_spec.rb
@@ -2,10 +2,8 @@ require "rails_helper"
 
 RSpec.describe DfeSignIn do
   describe "#configure" do
-    it "should make configuration variables available globally" do
-      expect(DfeSignIn.configuration.client_id).to eq(ENV["DFE_SIGN_IN_API_CLIENT_ID"])
-      expect(DfeSignIn.configuration.secret).to eq(ENV["DFE_SIGN_IN_API_SECRET"])
-      expect(DfeSignIn.configuration.base_url).to eq(ENV["DFE_SIGN_IN_API_ENDPOINT"])
-    end
+    specify { expect(DfeSignIn.configuration.client_id).to eq(ENV["DFE_SIGN_IN_API_CLIENT_ID"]).and be_present }
+    specify { expect(DfeSignIn.configuration.secret).to eq(ENV["DFE_SIGN_IN_API_SECRET"]).and be_present }
+    specify { expect(DfeSignIn.configuration.base_url).to eq(ENV["DFE_SIGN_IN_API_ENDPOINT"]).and be_present }
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-155

Allows the entire spec suite to pass whilst running the app in development. Before this change, two sign-in related specs were failing or you had to comment out two classes.

It still means you need Internet access to sign into the Admin site during local development. This will need to be addressed in the future.
