### PR TITLE
Add LUP logic without integrating

### DIFF
--- a/app/models/levelling_up_payments/academic_year_eligibility.rb
+++ b/app/models/levelling_up_payments/academic_year_eligibility.rb
@@ -1,0 +1,30 @@
+module LevellingUpPayments
+  # there'll be a better way of doing this
+  ELIGIBLE_ACADEMIC_YEARS = [
+    AcademicYear.new("2017/2018"),
+    AcademicYear.new("2018/2019"),
+    AcademicYear.new("2019/2020"),
+    AcademicYear.new("2020/2021"),
+    AcademicYear.new("2021/2022"),
+    AcademicYear.new("2022/2023"),
+    AcademicYear.new("2023/2024")
+  ]
+
+  # Checks whether an academic year is eligible for LUP. An eligible academic year
+  # is necessary but not sufficient to award LUP.
+  #
+  # This class would only need to change if the set of eligible years change.
+  #
+  # For postgrads we're talking about the start year, for undergrads it's the end year
+  class AcademicYearEligibility
+    def initialize(academic_year)
+      raise "nil academic year" if academic_year.nil?
+
+      @academic_year = academic_year
+    end
+
+    def eligible?
+      @academic_year.in? ELIGIBLE_ACADEMIC_YEARS
+    end
+  end
+end

--- a/app/models/levelling_up_payments/award.rb
+++ b/app/models/levelling_up_payments/award.rb
@@ -1,0 +1,32 @@
+module LevellingUpPayments
+  # This is concerned with the award information from the spreadsheet, which will
+  # contain the pre-computed amount, thereby we don't need to check the EIA or pupil premium
+  # status ourselves.
+  #
+  # The information from the spreadsheet could be stored in the existing `School` table,
+  # or a `School` could have an optional relationship to an award amount table.
+  #
+  # The only reason for this class to change is regarding how the monetary amount
+  # is stored.
+  class Award
+    # The spreadsheet contains the pre-computed amount as a currency string
+    # like "£2,000.00" or "No payment" and is attached to
+    # https://dfedigital.atlassian.net/browse/CAPT-253
+    #
+    # We'll need a job to perform the initial database storage of this data.
+    def initialize(school)
+      raise "nil school" if school.nil?
+
+      @school = school
+    end
+
+    def has_award?
+      amount_in_pounds.positive?
+    end
+
+    def amount_in_pounds
+      # this will come from the database after the amounts have been uploaded
+      @school.lup_amount_in_pounds
+    end
+  end
+end

--- a/app/models/levelling_up_payments/school_eligibility.rb
+++ b/app/models/levelling_up_payments/school_eligibility.rb
@@ -1,0 +1,18 @@
+module LevellingUpPayments
+  # Checks if a school is eligible for LUP. A school being
+  # eligible is necessary but not sufficient for an LUP award to be made.
+  #
+  # Whether a school is eligible for LUP could be checked via a new database
+  # column on `School`.
+  class SchoolEligibility
+    def initialize(school)
+      raise "nil school" if school.nil?
+
+      @school = school
+    end
+
+    def eligible?
+      LevellingUpPayments::Award.new(@school).has_award?
+    end
+  end
+end

--- a/app/models/levelling_up_payments/subject_eligibility.rb
+++ b/app/models/levelling_up_payments/subject_eligibility.rb
@@ -1,0 +1,53 @@
+module LevellingUpPayments
+  # Checks if the subject studied, ITT'd and a teacher's teaching timetable are eligible
+  # for LUP. This is necessary but not sufficient to award LUP.
+  #
+  # We might want to split this class because there's more than one reason this class
+  # could change (check for eligible ITT, check for related degree, change in general
+  # eligibility rules, etc.).
+  #
+  # Eligible ITT and degree codes could be stored in a table or hardcoded.
+  class SubjectEligibility
+    def initialize(itt_subject:, degree_subject:, teaching:)
+      raise "nil teaching" if teaching.nil?
+
+      @itt_subject = itt_subject
+      @degree_subject = degree_subject
+      @teaching = teaching
+    end
+
+    def eligible?
+      qualified_teacher_status? and specialist? and eligible_teaching?
+    end
+
+    private
+
+    def qualified_teacher_status?
+      @itt_subject.present? and @degree_subject.present?
+    end
+
+    def specialist?
+      eligible_itt? or eligible_degree?
+    end
+
+    # There's a spreadsheet of eligible ITT codes. Someone might know a pattern to them but
+    # it's not immediately obvious.
+    def eligible_itt?
+      @itt_subject.eligible?
+    end
+
+    # There's a spreadsheet of eligible degrees. This will be decided by the newer HECoS code
+    # (but might need the older JACS3 code). There are pattens to eligible HECoS and JACS3 codes
+    # which might mean we can exploit string matching rather than maintain an exhaustive list
+    # of all eligible codes.
+    def eligible_degree?
+      @degree_subject.eligible?
+    end
+
+    def eligible_teaching?
+      # not sure how we get the mix of subjects being taught by a particular teacher
+      # or whether we simply ask "do you spend 50% or more of your time teaching eligible subjects?"
+      @teaching.teaching_eligible_subjects_fifty_percent_or_more?
+    end
+  end
+end

--- a/spec/models/levelling_up_payments/academic_year_eligibility_spec.rb
+++ b/spec/models/levelling_up_payments/academic_year_eligibility_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe LevellingUpPayments::AcademicYearEligibility do
+  describe ".new" do
+    specify { expect { described_class.new(nil) }.to raise_error("nil academic year") }
+  end
+
+  describe "#eligible?" do
+    context "inside range" do
+      specify {
+        expect(
+          [
+            described_class.new(AcademicYear.new("2017/2018")),
+            described_class.new(AcademicYear.new("2018/2019")),
+            described_class.new(AcademicYear.new("2019/2020")),
+            described_class.new(AcademicYear.new("2020/2021")),
+            described_class.new(AcademicYear.new("2021/2022")),
+            described_class.new(AcademicYear.new("2022/2023")),
+            described_class.new(AcademicYear.new("2023/2024"))
+          ]
+        ).to all(be_eligible)
+      }
+    end
+
+    context "outside range" do
+      specify { expect(described_class.new(AcademicYear.new("2016/2017"))).to_not be_eligible }
+      specify { expect(described_class.new(AcademicYear.new("2024/2025"))).to_not be_eligible }
+    end
+  end
+end

--- a/spec/models/levelling_up_payments/award_spec.rb
+++ b/spec/models/levelling_up_payments/award_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe LevellingUpPayments::Award do
+  let(:eligible_school) { double("School", lup_amount_in_pounds: 1_000) }
+  let(:ineligible_school) { double("School", lup_amount_in_pounds: 0) }
+
+  describe ".new" do
+    specify { expect { described_class.new(nil) }.to raise_error("nil school") }
+  end
+
+  describe "#amount_in_pounds" do
+    context "eligible" do
+      specify { expect(described_class.new(eligible_school)).to have_award }
+      specify { expect(described_class.new(eligible_school).amount_in_pounds).to be_positive }
+    end
+
+    context "ineligible" do
+      specify { expect(described_class.new(ineligible_school)).to_not have_award }
+      specify { expect(described_class.new(ineligible_school).amount_in_pounds).to be_zero }
+    end
+  end
+end

--- a/spec/models/levelling_up_payments/school_eligibility_spec.rb
+++ b/spec/models/levelling_up_payments/school_eligibility_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe LevellingUpPayments::SchoolEligibility do
+  let(:eligible_school) { double("School", lup_amount_in_pounds: 1_000) }
+  let(:ineligible_school) { double("School", lup_amount_in_pounds: 0) }
+
+  describe ".new" do
+    specify { expect { described_class.new(nil) }.to raise_error("nil school") }
+  end
+
+  describe "#eligible?" do
+    context "eligible" do
+      specify { expect(described_class.new(eligible_school)).to be_eligible }
+    end
+
+    context "ineligible" do
+      specify { expect(described_class.new(ineligible_school)).to_not be_eligible }
+    end
+  end
+end

--- a/spec/models/levelling_up_payments/subject_eligibility_spec.rb
+++ b/spec/models/levelling_up_payments/subject_eligibility_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe LevellingUpPayments::SubjectEligibility do
+  let(:eligible_itt) { double("ITT", eligible?: true) }
+  let(:ineligible_itt) { double("ITT", eligible?: false) }
+  let(:eligible_degree) { double("Degree", eligible?: true) }
+  let(:ineligible_degree) { double("Degree", eligible?: false) }
+  let(:eligible_teaching) { double("TeachingMixture", teaching_eligible_subjects_fifty_percent_or_more?: true) }
+  let(:ineligible_teaching) { double("TeachingMixture", teaching_eligible_subjects_fifty_percent_or_more?: false) }
+
+  describe ".new" do
+    specify { expect { described_class.new(itt_subject: eligible_itt, degree_subject: eligible_degree, teaching: nil) }.to raise_error("nil teaching") }
+  end
+
+  describe "#eligible?" do
+    context "eligible" do
+      context "eligible ITT and eligible degree and teaching eligible subjects 50% or more" do
+        specify { expect(described_class.new(itt_subject: eligible_itt, degree_subject: eligible_degree, teaching: eligible_teaching)).to be_eligible }
+      end
+
+      context "eligible ITT but ineligible degree and teaching eligible subjects 50% or more" do
+        specify { expect(described_class.new(itt_subject: eligible_itt, degree_subject: ineligible_degree, teaching: eligible_teaching)).to be_eligible }
+      end
+
+      context "ineligible ITT but eligible degree and teaching eligible subjects 50% or more" do
+        specify { expect(described_class.new(itt_subject: ineligible_itt, degree_subject: eligible_degree, teaching: eligible_teaching)).to be_eligible }
+      end
+    end
+
+    context "ineligible" do
+      context "eligible ITT and eligible degree but teaching eligible subjects less than 50%" do
+        specify { expect(described_class.new(itt_subject: eligible_itt, degree_subject: eligible_degree, teaching: ineligible_teaching)).to_not be_eligible }
+      end
+
+      context "ineligible ITT and ineligible degree but teaching eligible subjects 50% or more" do
+        specify { expect(described_class.new(itt_subject: ineligible_itt, degree_subject: ineligible_degree, teaching: eligible_teaching)).to_not be_eligible }
+      end
+
+      context "no ITT" do
+        specify { expect(described_class.new(itt_subject: nil, degree_subject: eligible_degree, teaching: eligible_teaching)).to_not be_eligible }
+      end
+
+      context "no degree" do
+        specify { expect(described_class.new(itt_subject: eligible_itt, degree_subject: nil, teaching: eligible_teaching)).to_not be_eligible }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The beginnings of LUP eligibility. Adds small classes (which aren't integrated yet) for different aspects of LUP eligibility.
