### PR TITLE
CAPT-221 Admin search for LUP claims

### DIFF
--- a/app/models/early_career_payments.rb
+++ b/app/models/early_career_payments.rb
@@ -25,7 +25,7 @@ module EarlyCareerPayments
   end
 
   def routing_name
-    "early-career-payments"
+    Journey.routing_name_for_policy(self)
   end
 
   def locale_key

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -34,6 +34,10 @@ class Journey
     ALL.detect { |j| j[:routing_name] == routing_name }[:policies]&.first
   end
 
+  def self.routing_name_for_policy(policy)
+    ALL.detect { |j| policy.in? j[:policies] }[:routing_name]
+  end
+
   def self.policies_for_routing_name(routing_name)
     ALL.detect { |j| j[:routing_name] == routing_name }[:policies]
   end

--- a/app/models/levelling_up_payments.rb
+++ b/app/models/levelling_up_payments.rb
@@ -1,3 +1,11 @@
 module LevellingUpPayments
   extend self
+
+  def short_name
+    I18n.t("levelling_up_payments.policy_short_name")
+  end
+
+  def routing_name
+    Journey.routing_name_for_policy(self)
+  end
 end

--- a/app/models/levelling_up_payments/award.rb
+++ b/app/models/levelling_up_payments/award.rb
@@ -1,10 +1,15 @@
 module LevellingUpPayments
+  # completely fake until information is in the public domain
+  URN_TO_AWARD_AMOUNT_IN_POUNDS = {
+    150000 => 1_000,
+    150001 => 2_000,
+    160000 => 0,
+    160001 => 0
+  }
+
   # This is concerned with the award information from the spreadsheet, which will
   # contain the pre-computed amount, thereby we don't need to check the EIA or pupil premium
   # status ourselves.
-  #
-  # The information from the spreadsheet could be stored in the existing `School` table,
-  # or a `School` could have an optional relationship to an award amount table.
   #
   # The only reason for this class to change is regarding how the monetary amount
   # is stored.
@@ -25,8 +30,7 @@ module LevellingUpPayments
     end
 
     def amount_in_pounds
-      # this will come from the database after the amounts have been uploaded
-      @school.lup_amount_in_pounds
+      URN_TO_AWARD_AMOUNT_IN_POUNDS.fetch(@school.urn, 0)
     end
   end
 end

--- a/app/models/levelling_up_payments/eligibility.rb
+++ b/app/models/levelling_up_payments/eligibility.rb
@@ -2,5 +2,10 @@ module LevellingUpPayments
   class Eligibility < ApplicationRecord
     self.table_name = "levelling_up_payments_eligibilities"
     has_one :claim, as: :eligibility, inverse_of: :eligibility
+    belongs_to :current_school, optional: true, class_name: "School"
+
+    def policy
+      LevellingUpPayments
+    end
   end
 end

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -25,7 +25,7 @@ module MathsAndPhysics
   end
 
   def routing_name
-    "maths-and-physics"
+    Journey.routing_name_for_policy(self)
   end
 
   def locale_key

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -30,7 +30,7 @@ module StudentLoans
   end
 
   def routing_name
-    "student-loans"
+    Journey.routing_name_for_policy(self)
   end
 
   def locale_key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,3 +378,5 @@ en:
                   mathematics: "Select yes if you currently teach mathematics"
                   foreign_languages: "Select yes if you currently teach foreign languages"
                   physics: "Select yes if you currently teach physics"
+  levelling_up_payments:
+    policy_short_name: "Levelling Up Payments"

--- a/db/migrate/20220511143638_add_early_career_payment_eligibility_attributes_to_levelling_up_payments_eligibilities.rb
+++ b/db/migrate/20220511143638_add_early_career_payment_eligibility_attributes_to_levelling_up_payments_eligibilities.rb
@@ -1,0 +1,17 @@
+class AddEarlyCareerPaymentEligibilityAttributesToLevellingUpPaymentsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :levelling_up_payments_eligibilities, :nqt_in_academic_year_after_itt, :boolean
+    add_column :levelling_up_payments_eligibilities, :employed_as_supply_teacher, :boolean
+    add_column :levelling_up_payments_eligibilities, :qualification, :integer
+    add_column :levelling_up_payments_eligibilities, :has_entire_term_contract, :boolean
+    add_column :levelling_up_payments_eligibilities, :employed_directly, :boolean
+    add_column :levelling_up_payments_eligibilities, :subject_to_disciplinary_action, :boolean
+    add_column :levelling_up_payments_eligibilities, :subject_to_formal_performance_action, :boolean
+    add_column :levelling_up_payments_eligibilities, :eligible_itt_subject, :integer
+    add_column :levelling_up_payments_eligibilities, :teaching_subject_now, :boolean
+    add_column :levelling_up_payments_eligibilities, :itt_academic_year, :string, limit: 9
+    add_reference :levelling_up_payments_eligibilities, :current_school, type: :uuid, foreign_key: {to_table: :schools}, index: true
+    add_column :levelling_up_payments_eligibilities, :award_amount, :decimal, precision: 7, scale: 2
+    add_column :levelling_up_payments_eligibilities, :eligible_degree_subject, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_06_172026) do
+ActiveRecord::Schema.define(version: 2022_05_11_143638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -142,6 +142,20 @@ ActiveRecord::Schema.define(version: 2022_05_06_172026) do
   create_table "levelling_up_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "nqt_in_academic_year_after_itt"
+    t.boolean "employed_as_supply_teacher"
+    t.integer "qualification"
+    t.boolean "has_entire_term_contract"
+    t.boolean "employed_directly"
+    t.boolean "subject_to_disciplinary_action"
+    t.boolean "subject_to_formal_performance_action"
+    t.integer "eligible_itt_subject"
+    t.boolean "teaching_subject_now"
+    t.string "itt_academic_year", limit: 9
+    t.uuid "current_school_id"
+    t.decimal "award_amount", precision: 7, scale: 2
+    t.boolean "eligible_degree_subject"
+    t.index ["current_school_id"], name: "index_levelling_up_payments_eligibilities_on_current_school_id"
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -344,6 +358,7 @@ ActiveRecord::Schema.define(version: 2022_05_06_172026) do
   add_foreign_key "claims", "payments"
   add_foreign_key "decisions", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "early_career_payments_eligibilities", "schools", column: "current_school_id"
+  add_foreign_key "levelling_up_payments_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "notes", "claims"
   add_foreign_key "notes", "dfe_sign_in_users", column: "created_by_id"

--- a/spec/factories/levelling_up_payments/eligibilities.rb
+++ b/spec/factories/levelling_up_payments/eligibilities.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :levelling_up_payments_eligibility, class: "LevellingUpPayments::Eligibility" do
+    trait :eligible do
+      association :current_school, :levelling_up_payments_eligible, factory: :school
+      nqt_in_academic_year_after_itt { true }
+      employed_as_supply_teacher { false }
+      subject_to_formal_performance_action { false }
+      subject_to_disciplinary_action { false }
+      qualification { :postgraduate_itt }
+      eligible_itt_subject { :mathematics }
+      teaching_subject_now { true }
+      itt_academic_year { AcademicYear::Type.new.serialize(AcademicYear.new(2018)) }
+    end
+
+    trait :ineligible_feature do
+      association :current_school, :levelling_up_payments_ineligible, factory: :school
+    end
+  end
+end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -27,5 +27,20 @@ FactoryBot.define do
       school_type_group { School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.sample }
       phase { School::SECONDARY_PHASES.sample }
     end
+
+    trait :levelling_up_payments_eligible do
+      # fake whilst set of eligible schools is outside public domain
+      sequence(:urn, 150000)
+    end
+
+    trait :levelling_up_payments_ineligible do
+      # fake whilst set of eligible schools is outside public domain
+      sequence(:urn, 160000)
+    end
+
+    trait :not_found_in_levelling_up_payments_spreadsheet do
+      # fake whilst set of eligible schools is outside public domain
+      sequence(:urn, 170000)
+    end
   end
 end

--- a/spec/features/admin_search_spec.rb
+++ b/spec/features/admin_search_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Admin search" do
 
   let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
   let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }
+  let!(:lup_claim) { create(:claim, :submitted, surname: "Smith", policy: LevellingUpPayments) }
 
   scenario "redirects a service operator to the claim if there is only one match" do
     visit search_admin_claims_path
@@ -28,5 +29,15 @@ RSpec.feature "Admin search" do
     find("a[href='#{admin_claim_tasks_path(claim1)}']").click
 
     expect(page).to have_content(claim1.teacher_reference_number)
+  end
+
+  scenario "render LUP claim view page" do
+    visit search_admin_claims_path
+
+    fill_in :reference, with: lup_claim.surname
+    click_button "Search"
+
+    expect(page).to have_content(lup_claim.reference)
+    expect(page).to have_content("Levelling Up Payments")
   end
 end

--- a/spec/models/claim/search_spec.rb
+++ b/spec/models/claim/search_spec.rb
@@ -1,67 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Claim::Search do
-  subject(:search) { Claim::Search.new(query) }
-
-  let!(:other_claim) { create(:claim, :submitted) }
-
-  context "when searching by reference" do
-    let(:reference) { "ABC123" }
-    let(:claim) { create(:claim, :submitted, reference: reference) }
-
-    let(:query) { "ABC123" }
-
-    it "finds a claim that matches that reference" do
-      expect(search.claims).to match_array(claim)
-    end
-
-    context "when the reference is lowercase" do
-      let(:query) { "abc123" }
-
-      it "finds a claim that matches that reference" do
-        expect(search.claims).to match_array(claim)
-      end
-    end
-  end
-
-  context "when searching by email" do
-    let(:email) { "foo@example.com" }
-    let(:claim) { create(:claim, :submitted, email_address: email) }
-
-    let(:query) { "foo@example.com" }
-
-    it "finds claims that match that email address" do
-      expect(search.claims).to match_array(claim)
-    end
-  end
-
-  context "when searching by surname" do
-    let(:surname) { "Wayne" }
-    let(:claim) { create(:claim, :submitted, surname: surname) }
-
-    let(:query) { "Wayne" }
-
-    it "finds claims that match that surname" do
-      expect(search.claims).to match_array(claim)
-    end
-
-    context "when the surname is lowercase" do
-      let(:query) { "wayne" }
-
-      it "finds a claim that matches that reference" do
-        expect(search.claims).to match_array(claim)
-      end
-    end
-  end
-
-  context "when searching by teacher reference" do
-    let(:reference) { "1234567" }
-    let(:claim) { create(:claim, :submitted, teacher_reference_number: reference) }
-
-    let(:query) { "1234567" }
-
-    it "finds claims that match that email address" do
-      expect(search.claims).to match_array(claim)
-    end
-  end
+  it_behaves_like "Admin Searchable Claim", LevellingUpPayments
+  it_behaves_like "Admin Searchable Claim", EarlyCareerPayments
+  it_behaves_like "Admin Searchable Claim", StudentLoans
+  it_behaves_like "Admin Searchable Claim", MathsAndPhysics
 end

--- a/spec/models/levelling_up_payments/award_spec.rb
+++ b/spec/models/levelling_up_payments/award_spec.rb
@@ -1,22 +1,26 @@
 require "rails_helper"
 
 RSpec.describe LevellingUpPayments::Award do
-  let(:eligible_school) { double("School", lup_amount_in_pounds: 1_000) }
-  let(:ineligible_school) { double("School", lup_amount_in_pounds: 0) }
+  let(:eligible_school) { build(:school, :levelling_up_payments_eligible) }
+  let(:ineligible_school) { build(:school, :levelling_up_payments_ineligible) }
+  let(:not_found) { build(:school, :not_found_in_levelling_up_payments_spreadsheet) }
 
   describe ".new" do
     specify { expect { described_class.new(nil) }.to raise_error("nil school") }
   end
 
-  describe "#amount_in_pounds" do
-    context "eligible" do
-      specify { expect(described_class.new(eligible_school)).to have_award }
-      specify { expect(described_class.new(eligible_school).amount_in_pounds).to be_positive }
-    end
+  context "eligible" do
+    specify { expect(described_class.new(eligible_school)).to have_award }
+    specify { expect(described_class.new(eligible_school).amount_in_pounds).to be_positive }
+  end
 
-    context "ineligible" do
-      specify { expect(described_class.new(ineligible_school)).to_not have_award }
-      specify { expect(described_class.new(ineligible_school).amount_in_pounds).to be_zero }
-    end
+  context "ineligible" do
+    specify { expect(described_class.new(ineligible_school)).to_not have_award }
+    specify { expect(described_class.new(ineligible_school).amount_in_pounds).to be_zero }
+  end
+
+  context "not found" do
+    specify { expect(described_class.new(not_found)).to_not have_award }
+    specify { expect(described_class.new(not_found).amount_in_pounds).to be_zero }
   end
 end

--- a/spec/models/levelling_up_payments/school_eligibility_spec.rb
+++ b/spec/models/levelling_up_payments/school_eligibility_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe LevellingUpPayments::SchoolEligibility do
-  let(:eligible_school) { double("School", lup_amount_in_pounds: 1_000) }
-  let(:ineligible_school) { double("School", lup_amount_in_pounds: 0) }
+  let(:eligible_school) { build(:school, :levelling_up_payments_eligible) }
+  let(:ineligible_school) { build(:school, :levelling_up_payments_ineligible) }
+  let(:not_found) { build(:school, :not_found_in_levelling_up_payments_spreadsheet) }
 
   describe ".new" do
     specify { expect { described_class.new(nil) }.to raise_error("nil school") }
@@ -15,6 +16,10 @@ RSpec.describe LevellingUpPayments::SchoolEligibility do
 
     context "ineligible" do
       specify { expect(described_class.new(ineligible_school)).to_not be_eligible }
+    end
+
+    context "not found" do
+      specify { expect(described_class.new(not_found)).to_not be_eligible }
     end
   end
 end

--- a/spec/support/admin_searchable_claim_shared_examples.rb
+++ b/spec/support/admin_searchable_claim_shared_examples.rb
@@ -1,0 +1,116 @@
+RSpec.shared_examples "Admin Searchable Claim" do |policy|
+  subject(:search) { Claim::Search.new(query) }
+
+  let(:reference) { "ABC123" }
+  let(:email) { "foo@example.com" }
+  let(:surname) { "Wayne" }
+  let(:teacher_reference_number) { "1234567" }
+  let(:matches_nothing) { "blah" }
+
+  before { create(:claim, :submitted) }
+
+  context "search by reference" do
+    let(:claim) { create(:claim, :submitted, policy: policy, reference: reference) }
+
+    context "uppercase query" do
+      let(:query) { reference.upcase }
+
+      specify { expect(search.claims).to contain_exactly(claim) }
+    end
+
+    context "lowercase query" do
+      let(:query) { reference.downcase }
+
+      specify { expect(search.claims).to contain_exactly(claim) }
+    end
+
+    context "no matches" do
+      let(:query) { matches_nothing }
+
+      specify { expect(search.claims).to be_empty }
+    end
+  end
+
+  context "search by email" do
+    let(:claim) { create(:claim, :submitted, policy: policy, email_address: email) }
+
+    context "no matches" do
+      let(:query) { matches_nothing }
+
+      specify { expect(search.claims).to be_empty }
+    end
+
+    context "one match" do
+      context "uppercase query" do
+        let(:query) { email.upcase }
+
+        specify { expect(search.claims).to contain_exactly(claim) }
+      end
+
+      context "lowercase query" do
+        let(:query) { email.downcase }
+
+        specify { expect(search.claims).to contain_exactly(claim) }
+      end
+    end
+
+    context "multiple matches" do
+      let(:historical_matching_claim) { create(:claim, :submitted, policy: policy, email_address: email) }
+      let(:query) { email }
+
+      specify { expect(search.claims).to contain_exactly(claim, historical_matching_claim) }
+    end
+  end
+
+  context "search by surname" do
+    let(:claim) { create(:claim, :submitted, policy: policy, surname: surname) }
+
+    context "uppercase query" do
+      let(:query) { surname.upcase }
+
+      specify { expect(search.claims).to contain_exactly(claim) }
+    end
+
+    context "lowercase query" do
+      let(:query) { surname.downcase }
+
+      specify { expect(search.claims).to contain_exactly(claim) }
+    end
+
+    context "no matches" do
+      let(:query) { matches_nothing }
+
+      specify { expect(search.claims).to be_empty }
+    end
+
+    context "multiple matches" do
+      let(:historical_matching_claim) { create(:claim, :submitted, policy: policy, surname: surname) }
+      let(:query) { surname }
+
+      specify { expect(search.claims).to contain_exactly(claim, historical_matching_claim) }
+    end
+  end
+
+  context "search by teacher reference number" do
+    let(:claim) { create(:claim, :submitted, policy: policy, teacher_reference_number: teacher_reference_number) }
+
+    context "matches" do
+      let(:query) { teacher_reference_number }
+
+      specify { expect(search.claims).to contain_exactly(claim) }
+    end
+
+    context "no matches" do
+      let(:query) { matches_nothing }
+
+      specify { expect(search.claims).to be_empty }
+    end
+
+    context "multiple matches" do
+      let(:historical_matching_claim) { create(:claim, :submitted, policy: policy, teacher_reference_number: teacher_reference_number) }
+      let(:query) { teacher_reference_number }
+
+      specify { expect(search.claims).to contain_exactly(claim, historical_matching_claim) }
+    end
+  end
+end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-221

Adds factory to create LUP claims for testing Admin-side of application.

Adds a copy of the ECP fields to database and an extra field needed for a concurrent ticket. These fields may need to change to better suit LUP but allows things to work for now.


