### PR TITLE
Rename "Levelling Up Payments" to "Levelling Up Premium Payments"

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -19,7 +19,7 @@ class Journey
     {
       routing_name: "early-career-payments",
       slugs: EarlyCareerPayments::SlugSequence::SLUGS,
-      policies: [EarlyCareerPayments, LevellingUpPayments],
+      policies: [EarlyCareerPayments, LevellingUpPremiumPayments],
       # view_path - folder where view templates are, unless folder is the same as routing-name
       view_path: "early_career_payments"
     }

--- a/app/models/levelling_up_premium_payments.rb
+++ b/app/models/levelling_up_premium_payments.rb
@@ -1,8 +1,8 @@
-module LevellingUpPayments
+module LevellingUpPremiumPayments
   extend self
 
   def short_name
-    I18n.t("levelling_up_payments.policy_short_name")
+    I18n.t("levelling_up_premium_payments.policy_short_name")
   end
 
   def routing_name

--- a/app/models/levelling_up_premium_payments/academic_year_eligibility.rb
+++ b/app/models/levelling_up_premium_payments/academic_year_eligibility.rb
@@ -1,4 +1,4 @@
-module LevellingUpPayments
+module LevellingUpPremiumPayments
   # there'll be a better way of doing this
   ELIGIBLE_ACADEMIC_YEARS = [
     AcademicYear.new("2017/2018"),

--- a/app/models/levelling_up_premium_payments/award.rb
+++ b/app/models/levelling_up_premium_payments/award.rb
@@ -1,4 +1,4 @@
-module LevellingUpPayments
+module LevellingUpPremiumPayments
   # completely fake until information is in the public domain
   URN_TO_AWARD_AMOUNT_IN_POUNDS = {
     150000 => 1_000,

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -1,11 +1,11 @@
-module LevellingUpPayments
+module LevellingUpPremiumPayments
   class Eligibility < ApplicationRecord
-    self.table_name = "levelling_up_payments_eligibilities"
+    self.table_name = "levelling_up_premium_payments_eligibilities"
     has_one :claim, as: :eligibility, inverse_of: :eligibility
     belongs_to :current_school, optional: true, class_name: "School"
 
     def policy
-      LevellingUpPayments
+      LevellingUpPremiumPayments
     end
   end
 end

--- a/app/models/levelling_up_premium_payments/school_eligibility.rb
+++ b/app/models/levelling_up_premium_payments/school_eligibility.rb
@@ -1,4 +1,4 @@
-module LevellingUpPayments
+module LevellingUpPremiumPayments
   # Checks if a school is eligible for LUP. A school being
   # eligible is necessary but not sufficient for an LUP award to be made.
   #
@@ -12,7 +12,7 @@ module LevellingUpPayments
     end
 
     def eligible?
-      LevellingUpPayments::Award.new(@school).has_award?
+      LevellingUpPremiumPayments::Award.new(@school).has_award?
     end
   end
 end

--- a/app/models/levelling_up_premium_payments/subject_eligibility.rb
+++ b/app/models/levelling_up_premium_payments/subject_eligibility.rb
@@ -1,4 +1,4 @@
-module LevellingUpPayments
+module LevellingUpPremiumPayments
   # Checks if the subject studied, ITT'd and a teacher's teaching timetable are eligible
   # for LUP. This is necessary but not sufficient to award LUP.
   #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
       heading_send_application: Now send your application
       statement: By submitting this you are confirming that, to the best of your knowledge, the details you are providing are correct.
       btn_text: Accept and send
-    policy_name: "Early-career and levelling up payment"
+    policy_name: "Early-career and levelling up premium payment"
     policy_short_name: "Early-Career Payments"
     claim_description: "for an early-career payment"
     claim_subject: "Early-career payment"
@@ -378,5 +378,5 @@ en:
                   mathematics: "Select yes if you currently teach mathematics"
                   foreign_languages: "Select yes if you currently teach foreign languages"
                   physics: "Select yes if you currently teach physics"
-  levelling_up_payments:
-    policy_short_name: "Levelling Up Payments"
+  levelling_up_premium_payments:
+    policy_short_name: "Levelling Up Premium Payments"

--- a/db/migrate/20220516095658_rename_levelling_up_payments_eligibilities_to_levelling_up_premium_payments_eligibilities.rb
+++ b/db/migrate/20220516095658_rename_levelling_up_payments_eligibilities_to_levelling_up_premium_payments_eligibilities.rb
@@ -1,0 +1,6 @@
+class RenameLevellingUpPaymentsEligibilitiesToLevellingUpPremiumPaymentsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    rename_index :levelling_up_payments_eligibilities, "index_levelling_up_payments_eligibilities_on_current_school_id", "index_lup_payments_eligibilities_on_current_school_id"
+    rename_table "levelling_up_payments_eligibilities", "levelling_up_premium_payments_eligibilities"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_11_143638) do
+ActiveRecord::Schema.define(version: 2022_05_16_095658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 2022_05_11_143638) do
     t.index ["current_school_id"], name: "index_early_career_payments_eligibilities_on_current_school_id"
   end
 
-  create_table "levelling_up_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "levelling_up_premium_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "nqt_in_academic_year_after_itt"
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 2022_05_11_143638) do
     t.uuid "current_school_id"
     t.decimal "award_amount", precision: 7, scale: 2
     t.boolean "eligible_degree_subject"
-    t.index ["current_school_id"], name: "index_levelling_up_payments_eligibilities_on_current_school_id"
+    t.index ["current_school_id"], name: "index_lup_payments_eligibilities_on_current_school_id"
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -358,7 +358,7 @@ ActiveRecord::Schema.define(version: 2022_05_11_143638) do
   add_foreign_key "claims", "payments"
   add_foreign_key "decisions", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "early_career_payments_eligibilities", "schools", column: "current_school_id"
-  add_foreign_key "levelling_up_payments_eligibilities", "schools", column: "current_school_id"
+  add_foreign_key "levelling_up_premium_payments_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "notes", "claims"
   add_foreign_key "notes", "dfe_sign_in_users", column: "created_by_id"

--- a/spec/factories/levelling_up_premium_payments/eligibilities.rb
+++ b/spec/factories/levelling_up_premium_payments/eligibilities.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
-  factory :levelling_up_payments_eligibility, class: "LevellingUpPayments::Eligibility" do
+  factory :levelling_up_premium_payments_eligibility, class: "LevellingUpPremiumPayments::Eligibility" do
     trait :eligible do
-      association :current_school, :levelling_up_payments_eligible, factory: :school
+      association :current_school, :levelling_up_premium_payments_eligible, factory: :school
       nqt_in_academic_year_after_itt { true }
       employed_as_supply_teacher { false }
       subject_to_formal_performance_action { false }
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_feature do
-      association :current_school, :levelling_up_payments_ineligible, factory: :school
+      association :current_school, :levelling_up_premium_payments_ineligible, factory: :school
     end
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -28,17 +28,17 @@ FactoryBot.define do
       phase { School::SECONDARY_PHASES.sample }
     end
 
-    trait :levelling_up_payments_eligible do
+    trait :levelling_up_premium_payments_eligible do
       # fake whilst set of eligible schools is outside public domain
       sequence(:urn, 150000)
     end
 
-    trait :levelling_up_payments_ineligible do
+    trait :levelling_up_premium_payments_ineligible do
       # fake whilst set of eligible schools is outside public domain
       sequence(:urn, 160000)
     end
 
-    trait :not_found_in_levelling_up_payments_spreadsheet do
+    trait :not_found_in_levelling_up_premium_payments_spreadsheet do
       # fake whilst set of eligible schools is outside public domain
       sequence(:urn, 170000)
     end

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Service configuration" do
 
       click_on "Manage services"
 
-      expect(page).to have_content("Early-career and levelling up payment")
+      expect(page).to have_content("Early-career and levelling up premium payment")
       within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
         expect(page).to have_content("Closed")
         expect(page).not_to have_content("Open")

--- a/spec/features/admin_search_spec.rb
+++ b/spec/features/admin_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Admin search" do
 
   let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
   let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }
-  let!(:lup_claim) { create(:claim, :submitted, surname: "Smith", policy: LevellingUpPayments) }
+  let!(:lup_claim) { create(:claim, :submitted, surname: "Smith", policy: LevellingUpPremiumPayments) }
 
   scenario "redirects a service operator to the claim if there is only one match" do
     visit search_admin_claims_path
@@ -38,6 +38,6 @@ RSpec.feature "Admin search" do
     click_button "Search"
 
     expect(page).to have_content(lup_claim.reference)
-    expect(page).to have_content("Levelling Up Payments")
+    expect(page).to have_content("Levelling Up Premium Payments")
   end
 end

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
 
   scenario "Teacher makes claim for 'Early-Career Payments' claim", js: true do
     visit landing_page_path(EarlyCareerPayments.routing_name)
-    expect(page).to have_link("Early-career and levelling up payment", href: "/early-career-payments/claim")
+    expect(page).to have_link("Early-career and levelling up premium payment", href: "/early-career-payments/claim")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
 
     # - Landing (start)

--- a/spec/models/claim/search_spec.rb
+++ b/spec/models/claim/search_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Claim::Search do
-  it_behaves_like "Admin Searchable Claim", LevellingUpPayments
+  it_behaves_like "Admin Searchable Claim", LevellingUpPremiumPayments
   it_behaves_like "Admin Searchable Claim", EarlyCareerPayments
   it_behaves_like "Admin Searchable Claim", StudentLoans
   it_behaves_like "Admin Searchable Claim", MathsAndPhysics

--- a/spec/models/levelling_up_premium_payments/academic_year_eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/academic_year_eligibility_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe LevellingUpPayments::AcademicYearEligibility do
+RSpec.describe LevellingUpPremiumPayments::AcademicYearEligibility do
   describe ".new" do
     specify { expect { described_class.new(nil) }.to raise_error("nil academic year") }
   end

--- a/spec/models/levelling_up_premium_payments/award_spec.rb
+++ b/spec/models/levelling_up_premium_payments/award_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe LevellingUpPayments::Award do
-  let(:eligible_school) { build(:school, :levelling_up_payments_eligible) }
-  let(:ineligible_school) { build(:school, :levelling_up_payments_ineligible) }
-  let(:not_found) { build(:school, :not_found_in_levelling_up_payments_spreadsheet) }
+RSpec.describe LevellingUpPremiumPayments::Award do
+  let(:eligible_school) { build(:school, :levelling_up_premium_payments_eligible) }
+  let(:ineligible_school) { build(:school, :levelling_up_premium_payments_ineligible) }
+  let(:not_found) { build(:school, :not_found_in_levelling_up_premium_payments_spreadsheet) }
 
   describe ".new" do
     specify { expect { described_class.new(nil) }.to raise_error("nil school") }

--- a/spec/models/levelling_up_premium_payments/school_eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/school_eligibility_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe LevellingUpPayments::SchoolEligibility do
-  let(:eligible_school) { build(:school, :levelling_up_payments_eligible) }
-  let(:ineligible_school) { build(:school, :levelling_up_payments_ineligible) }
-  let(:not_found) { build(:school, :not_found_in_levelling_up_payments_spreadsheet) }
+RSpec.describe LevellingUpPremiumPayments::SchoolEligibility do
+  let(:eligible_school) { build(:school, :levelling_up_premium_payments_eligible) }
+  let(:ineligible_school) { build(:school, :levelling_up_premium_payments_ineligible) }
+  let(:not_found) { build(:school, :not_found_in_levelling_up_premium_payments_spreadsheet) }
 
   describe ".new" do
     specify { expect { described_class.new(nil) }.to raise_error("nil school") }

--- a/spec/models/levelling_up_premium_payments/subject_eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/subject_eligibility_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe LevellingUpPayments::SubjectEligibility do
+RSpec.describe LevellingUpPremiumPayments::SubjectEligibility do
   let(:eligible_itt) { double("ITT", eligible?: true) }
   let(:ineligible_itt) { double("ITT", eligible?: false) }
   let(:eligible_degree) { double("Degree", eligible?: true) }


### PR DESCRIPTION
Renaming to reflect the correct domain term.

Had to shorten database index name to fit inside Postgres's 63 character limit.
