### PR TITLE
Fix ineligible page bug on ITT year / subject combination

### DIFF
--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -141,7 +141,8 @@ module EarlyCareerPayments
     ATTRIBUTE_DEPENDENCIES = {
       "employed_as_supply_teacher" => ["has_entire_term_contract", "employed_directly"],
       "qualification" => ["eligible_itt_subject", "teaching_subject_now"],
-      "eligible_itt_subject" => ["teaching_subject_now"]
+      "eligible_itt_subject" => ["teaching_subject_now"],
+      "itt_academic_year" => ["eligible_itt_subject"]
     }.freeze
 
     self.table_name = "early_career_payments_eligibilities"

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
         click_on "Continue"
 
         # - Which subject did you do your postgraduate initial teacher training (ITT) in?
+        choose I18n.t("early_career_payments.answers.eligible_itt_subject.#{args[:subject]}")
         click_on "Continue"
 
         # - Do you teach subject now?
@@ -109,6 +110,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
 
           expect(claim.eligibility.reload.itt_academic_year).to eql args[:academic_year]
 
+          choose I18n.t("early_career_payments.answers.eligible_itt_subject.#{args[:subject]}")
           click_on "Continue"
 
           # - Do you teach subject now?


### PR DESCRIPTION
When selecting a certain ineligible combination (eg Foreign languages degree and year <> 2020) and go back you can get stuck in the "not eligible" state.