### PR TITLE
Intercept current_claim and delegate

### DIFF
--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -37,13 +37,12 @@ module PartOfClaimJourney
   end
 
   def build_new_claim
-    # hack to keep old single claim journeys, will need refactoring to be cleaner
-    build_new_claims.first
+    CurrentClaim.new(claims: build_new_claims)
   end
 
   # Beginning of setting up multiple claims in a combined journey
   def build_new_claims
-    @claims = Journey.policies_for_routing_name(current_policy_routing_name).map do |policy|
+    Journey.policies_for_routing_name(current_policy_routing_name).map do |policy|
       Claim.new(
         eligibility: policy::Eligibility.new,
         academic_year: policy_configuration.current_academic_year

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -1,0 +1,29 @@
+class CurrentClaim
+  attr_reader :claims
+
+  def initialize(claims:)
+    @claims = claims
+  end
+
+  def main_claim
+    claims.first
+  end
+
+  # method_missing does not catch this
+  def to_param
+    main_claim.to_param
+  end
+
+  def method_missing(method_name, *args, &block)
+    Rails.logger.info("======<CurrentClaim#method_missing>======")
+    Rails.logger.info(method_name.inspect)
+    result = main_claim.send(method_name, *args, &block)
+    Rails.logger.info(result.inspect)
+    Rails.logger.info("======<END>==============================")
+    result
+  end
+
+  def respond_to_missing?(method_name, *args)
+    main_claim.respond_to?(method_name, *args)
+  end
+end


### PR DESCRIPTION
We need the ability to handle multiple claims in the same journey, currently all flows are centred around `current_claim`.

`current_claim` is sprinkled everywhere, in controllers, views and helpers. We don't want to disrupt the single claim journeys as they are working and they all use the ClaimsController.

Most of the forms in the journey are tightly coupled to a single claim model object. Rather than changing all the forms to be independent of a claim, CurrentClaim would delegate to a claim, however going forward CurrentClaim would need to manage loading and updating multiple claims in a combined journey situation.

Notes of next steps, not exhaustive:

- [ ] Session handling multiple claims
- [ ] How we deal with updates to multiple claims
- [ ] Access to the claim we want out of the multiple claims
- [ ] Error handling of multiple claims
- [ ] Transactions?