### PR TITLE
[CAPT-165] Add eligible degree subject page

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -135,7 +135,7 @@ class ClaimsController < BasePublicController
   end
 
   def claim_in_progress?
-    session[:claim_id].present? && !current_claim.eligibility.ineligible?
+    session[:claim_id].present? && !current_claim.ineligible?
   end
 
   def page_sequence

--- a/app/models/claim/permitted_parameters.rb
+++ b/app/models/claim/permitted_parameters.rb
@@ -21,7 +21,7 @@ class Claim
     end
 
     def eligibility_attributes
-      {eligibility_attributes: claim.eligibility.class::EDITABLE_ATTRIBUTES.dup}
+      {eligibility_attributes: claim.editable_attributes}
     end
   end
 end

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -145,6 +145,10 @@ module EarlyCareerPayments
       "itt_academic_year" => ["eligible_itt_subject"]
     }.freeze
 
+    IGNORED_ATTRIBUTES = [
+      "eligible_degree_subject"
+    ]
+
     self.table_name = "early_career_payments_eligibilities"
 
     enum qualification: {
@@ -201,6 +205,13 @@ module EarlyCareerPayments
 
     def policy
       EarlyCareerPayments
+    end
+
+    def assign_attributes(*args)
+      super
+    rescue ActiveRecord::UnknownAttributeError
+      all_attributes_ignored = (args.first.keys - IGNORED_ATTRIBUTES).empty?
+      raise unless all_attributes_ignored
     end
 
     def trainee_teacher_in_2021?

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -207,6 +207,8 @@ module EarlyCareerPayments
       EarlyCareerPayments
     end
 
+    # Rescues from errors for assignments coming from LUP-only fields
+    # eg. `claim.eligibility.eligible_degree_subject = true` will get ignored
     def assign_attributes(*args)
       super
     rescue ActiveRecord::UnknownAttributeError

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -297,6 +297,10 @@ module EarlyCareerPayments
       end
     end
 
+    def eligible_none_of_the_above?
+      false
+    end
+
     private
 
     def find_cohorts(match_criteria:)

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -80,7 +80,7 @@ module EarlyCareerPayments
         remove_student_loan_country_slugs(sequence)
         trainee_teacher_slugs(sequence) if claim.eligibility.trainee_teacher_in_2021?
         sequence.delete("future-eligibility") unless claim.eligibility.trainee_teacher_in_2021?
-        sequence.delete("eligible-degree-subject") unless claim.for_policy(LevellingUpPremiumPayments).eligibility.eligible_none_of_the_above?
+        sequence.delete("eligible-degree-subject") unless claim.for_policy(LevellingUpPremiumPayments)&.eligibility&.eligible_none_of_the_above?
       end
     end
 

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -21,6 +21,7 @@ module EarlyCareerPayments
       "qualification",
       "itt-year",
       "eligible-itt-subject",
+      "eligible-degree-subject",
       "teaching-subject-now",
       "check-your-answers-part-one",
       "eligibility-confirmed",
@@ -79,6 +80,7 @@ module EarlyCareerPayments
         remove_student_loan_country_slugs(sequence)
         trainee_teacher_slugs(sequence) if claim.eligibility.trainee_teacher_in_2021?
         sequence.delete("future-eligibility") unless claim.eligibility.trainee_teacher_in_2021?
+        sequence.delete("eligible-degree-subject") unless claim.eligibility.eligible_none_of_the_above?
       end
     end
 

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -80,7 +80,7 @@ module EarlyCareerPayments
         remove_student_loan_country_slugs(sequence)
         trainee_teacher_slugs(sequence) if claim.eligibility.trainee_teacher_in_2021?
         sequence.delete("future-eligibility") unless claim.eligibility.trainee_teacher_in_2021?
-        sequence.delete("eligible-degree-subject") unless claim.for_policy(LevellingUpPremiumPayments)&.eligibility&.eligible_none_of_the_above?
+        sequence.delete("eligible-degree-subject") unless claim.for_policy(LevellingUpPremiumPayments).eligibility.eligible_none_of_the_above?
       end
     end
 

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -69,7 +69,7 @@ module EarlyCareerPayments
         sequence.delete("employed-directly") unless claim.eligibility.employed_as_supply_teacher?
         sequence.delete("eligibility-confirmed") unless claim.eligibility.eligible_now?
         sequence.delete("eligible-later") unless claim.eligibility.eligible_later? && !claim.eligibility.eligible_now?
-        sequence.delete("ineligible") unless claim.eligibility.ineligible? || claim.eligibility.trainee_teacher_in_2021?
+        sequence.delete("ineligible") unless claim.ineligible? || claim.eligibility.trainee_teacher_in_2021?
         sequence.delete("personal-bank-account") if claim.bank_or_building_society == "building_society"
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false
@@ -80,7 +80,7 @@ module EarlyCareerPayments
         remove_student_loan_country_slugs(sequence)
         trainee_teacher_slugs(sequence) if claim.eligibility.trainee_teacher_in_2021?
         sequence.delete("future-eligibility") unless claim.eligibility.trainee_teacher_in_2021?
-        sequence.delete("eligible-degree-subject") unless claim.eligibility.eligible_none_of_the_above?
+        sequence.delete("eligible-degree-subject") unless claim.for_policy(LevellingUpPremiumPayments).eligibility.eligible_none_of_the_above?
       end
     end
 

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -82,7 +82,6 @@ module LevellingUpPremiumPayments
       calculate_award_amount
     end
 
-    # TODO - this need implementing later
     def reset_dependent_answers
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
@@ -153,9 +152,7 @@ module LevellingUpPremiumPayments
     end
 
     def ineligible_cohort?
-      return true if itt_academic_year == AcademicYear.new
-
-      false
+      itt_academic_year == AcademicYear.new
     end
   end
 end

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -65,7 +65,6 @@ module LevellingUpPremiumPayments
         no_entire_term_contract? ||
         not_employed_directly? ||
         poor_performance? ||
-        ineligible_itt_subject? ||
         with_eligible_none_of_the_above_without_eligible_degree_subject? ||
         with_eligible_degree_subject_not_teaching_subject_now? ||
         ineligible_cohort?
@@ -93,7 +92,7 @@ module LevellingUpPremiumPayments
     end
 
     def eligible_none_of_the_above?
-      itt_subject_none_of_the_above? && postgraduate_itt?
+      itt_subject_none_of_the_above?
     end
 
     private
@@ -110,10 +109,6 @@ module LevellingUpPremiumPayments
     def calculate_award_amount
       # use first year of LUP for now but this must come from a PolicyConfiguration
       BigDecimal LevellingUpPremiumPayments::Award.new(school: current_school, year: AcademicYear.new(2022)).amount_in_pounds if current_school.present?
-    end
-
-    def ineligible_itt_subject?
-      itt_subject_none_of_the_above? && !postgraduate_itt?
     end
 
     def with_eligible_none_of_the_above_without_eligible_degree_subject?
@@ -159,16 +154,8 @@ module LevellingUpPremiumPayments
 
     def ineligible_cohort?
       return true if itt_academic_year == AcademicYear.new
-      return false if without_cohort?
+
+      false
     end
-
-    def without_cohort?
-      [eligible_itt_subject, itt_academic_year].any?(nil)
-    end
-
-    # End LUP duplicates
-
-    # TODO: cohort logic should be tweaked to pass none of the above option:
-    # award_amount.itt_subject.to_s == eligible_itt_subject || eligible_none_of_the_above?
   end
 end

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -71,7 +71,7 @@ module MathsAndPhysics
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
-        sequence.delete("ineligible") unless claim.eligibility.ineligible?
+        sequence.delete("ineligible") unless claim.ineligible?
       end
     end
   end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -15,7 +15,7 @@ class PageSequence
   end
 
   def next_slug
-    return "ineligible" if claim.eligibility.ineligible?
+    return "ineligible" if claim.ineligible?
     return "check-your-answers" if claim.submittable?
 
     # This allows 'address' page to be skipped when the postcode is present

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -66,7 +66,7 @@ module StudentLoans
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
-        sequence.delete("ineligible") unless claim.eligibility.ineligible?
+        sequence.delete("ineligible") unless claim.ineligible?
       end
     end
   end

--- a/app/views/early_career_payments/claims/eligible-degree-subject.html.erb
+++ b/app/views/early_career_payments/claims/eligible-degree-subject.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:page_title, page_title(t("early_career_payments.questions.eligible_degree_subject"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.eligible_degree_subject": "claim_eligibility_attributes_eligible_degree_subject_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :eligible_degree_subject %>
+
+          <fieldset class="govuk-fieldset" aria-describedby="eligible_degree_subject-hint" role="group">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--<%= shared_view_css_size %>">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("early_career_payments.questions.eligible_degree_subject") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim.eligibility, :eligible_degree_subject %>
+
+            <div class="govuk-radios govuk-radios--inline">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:eligible_degree_subject, true, class: "govuk-radios__input") %>
+                <%= fields.label :eligible_degree_subject_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:eligible_degree_subject, false, class: "govuk-radios__input") %>
+                <%= fields.label :eligible_degree_subject_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/early_career_payments/claims/eligible_degree_subject.html.erb
+++ b/app/views/early_career_payments/claims/eligible_degree_subject.html.erb
@@ -1,12 +1,15 @@
-<% content_for(:page_title, page_title(t("early_career_payments.questions.eligible_degree_subject"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
-<% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+<% claim = current_claim.for_policy(LevellingUpPremiumPayments) %>
+
+<% content_for(:page_title, page_title(t("early_career_payments.questions.eligible_degree_subject"), policy: current_policy_routing_name, show_error: claim.errors.any?)) %>
+
+<% path_for_form = claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% shared_view_css_size = claim.policy == EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.eligible_degree_subject": "claim_eligibility_attributes_eligible_degree_subject_true" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form do |form| %>
-      <%= form_group_tag current_claim do %>
+    <%= render("shared/error_summary", instance: claim, errored_field_id_overrides: { "eligibility.eligible_degree_subject": "claim_eligibility_attributes_eligible_degree_subject_true" }) if claim.errors.any? %>
+    <%= form_for claim, url: path_for_form do |form| %>
+      <%= form_group_tag claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
 
           <%= fields.hidden_field :eligible_degree_subject %>
@@ -19,7 +22,7 @@
               </h1>
             </legend>
 
-            <%= errors_tag current_claim.eligibility, :eligible_degree_subject %>
+            <%= errors_tag claim.eligibility, :eligible_degree_subject %>
 
             <div class="govuk-radios govuk-radios--inline">
 

--- a/app/views/early_career_payments/claims/ineligible.html.erb
+++ b/app/views/early_career_payments/claims/ineligible.html.erb
@@ -4,11 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= ineligible_heading(current_claim) %>
 
-    <% if current_claim.for_policy(LevellingUpPremiumPayments).eligibility.ineligible? %>
-      <%= render "ineligibility_reason_generic_ineligibility" %>
-    <% else %>
-      <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
-    <% end %>
+    <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
 
     <% if current_claim.eligibility.ineligibility_reason != :ineligible_current_school && current_claim.eligibility.ineligibility_reason != :ineligible_nqt_in_academic_year_after_itt %>
       <p class="govuk-body">

--- a/app/views/early_career_payments/claims/ineligible.html.erb
+++ b/app/views/early_career_payments/claims/ineligible.html.erb
@@ -4,7 +4,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= ineligible_heading(current_claim) %>
 
-    <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
+    <% if current_claim.for_policy(LevellingUpPremiumPayments).eligibility.ineligible? %>
+      <%= render "ineligibility_reason_generic_ineligibility" %>
+    <% else %>
+      <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
+    <% end %>
 
     <% if current_claim.eligibility.ineligibility_reason != :ineligible_current_school && current_claim.eligibility.ineligibility_reason != :ineligible_nqt_in_academic_year_after_itt %>
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,7 @@ en:
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
       has_entire_term_contract: "Do you have a contract to teach at the same school for an entire term or longer?"
       employed_directly: "Are you employed directly by your school?"
+      eligible_degree_subject: "Do you have an undergraduate or postgraduate degree in an eligible subject?"
       nqt_in_academic_year_after_itt:
         heading: Have you %{started_or_completed} your first year as an early career teacher?
         hint: This is sometimes referred to as your induction %{year_or_period} or newly qualified teacher (NQT) and is the first year after you have gained your qualified teacher status (QTS).

--- a/spec/factories/early_career_payments/eligibilities.rb
+++ b/spec/factories/early_career_payments/eligibilities.rb
@@ -20,5 +20,10 @@ FactoryBot.define do
       subject_to_disciplinary_action { false }
       qualification { :postgraduate_itt }
     end
+
+    trait :ineligible do
+      eligible
+      eligible_itt_subject { "foreign_languages" }
+    end
   end
 end

--- a/spec/features/ineligible_early_career_payments_in_2021_and_future_years_spec.rb
+++ b/spec/features/ineligible_early_career_payments_in_2021_and_future_years_spec.rb
@@ -79,13 +79,7 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims by cohort" do
           click_on "Continue"
 
           expect(claim.eligibility.reload.eligible_itt_subject).to eq scenario[:itt_subject]
-
-          expect(page).to have_text(I18n.t("early_career_payments.ineligible.heading"))
-          expect(page).to have_link(href: "#{EarlyCareerPayments.eligibility_page_url}#eligibility-criteria")
-          expect(page).to have_text("Based on the answers you have provided you are not eligible #{I18n.t("early_career_payments.claim_description")}")
-
-          expect(page).not_to have_text("You will be eligible for a ")
-          expect(page).not_to have_text("you’ll be able to claim")
+          expect(claim.eligibility.ineligible?).to be true
         end
       end
     end

--- a/spec/features/ineligible_levelling_up_premium_payments_spec.rb
+++ b/spec/features/ineligible_levelling_up_premium_payments_spec.rb
@@ -68,7 +68,6 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
     click_on "Continue"
     expect(eligibility.reload.ineligible?).to be true
 
-    expect(page).to have_text(I18n.t("early_career_payments.ineligible.reason.generic"))
     expect(page).to have_text(I18n.t("early_career_payments.ineligible.heading"))
     expect(page).to have_link(href: "#{EarlyCareerPayments.eligibility_page_url}#eligibility-criteria")
   end

--- a/spec/features/ineligible_levelling_up_premium_payments_spec.rb
+++ b/spec/features/ineligible_levelling_up_premium_payments_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.feature "Ineligible Levelling up premium payments claims" do
+  let(:eligibility) { LevellingUpPremiumPayments::Eligibility.order(:created_at).last }
+
+  scenario "When the school selected is LUP ineligible" do
+    start_levelling_up_premium_payments_claim
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    expect(eligibility.ineligible?).to be false
+    choose_school schools(:penistone_grammar_school)
+    click_on "Continue"
+    expect(eligibility.reload.ineligible?).to be true
+  end
+
+  scenario "When subject 'none of the above' and user does not have an eligible degree" do
+    start_levelling_up_premium_payments_claim
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school schools(:hampstead_school)
+    click_on "Continue"
+
+    # - Have you started your first year as a newly qualified teacher?
+    expect(page).to have_text("your first year as an early career teacher?")
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Are you currently employed as a supply teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
+
+    choose "No"
+    click_on "Continue"
+
+    # - Poor performance
+    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
+
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+
+    choose "Undergraduate initial teacher training (ITT)"
+
+    click_on "Continue"
+
+    # - In what academic year did you complete your undergraduate ITT?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+
+    choose "2018 to 2019"
+    click_on "Continue"
+
+    # - Which subject did you do your undergraduate ITT in
+    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teacher training (ITT)"))
+    choose "None of the above"
+    click_on "Continue"
+
+    # Do you have an undergraduate or postgraduate degree in an eligible subject?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_degree_subject"))
+    choose "No"
+
+    expect(eligibility.ineligible?).to be false
+    click_on "Continue"
+    expect(eligibility.reload.ineligible?).to be true
+
+    expect(page).to have_text(I18n.t("early_career_payments.ineligible.reason.generic"))
+    expect(page).to have_text(I18n.t("early_career_payments.ineligible.heading"))
+    expect(page).to have_link(href: "#{EarlyCareerPayments.eligibility_page_url}#eligibility-criteria")
+  end
+end

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.feature "Levelling up premium payments claims" do
+  let(:eligibility) { LevellingUpPremiumPayments::Eligibility.order(:created_at).last }
+
+  scenario "When subject 'none of the above' and user has an eligible degree" do
+    start_levelling_up_premium_payments_claim
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school schools(:hampstead_school)
+    click_on "Continue"
+
+    # - Have you started your first year as a newly qualified teacher?
+    expect(page).to have_text("your first year as an early career teacher?")
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Are you currently employed as a supply teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
+
+    choose "No"
+    click_on "Continue"
+
+    # - Poor performance
+    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
+
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+
+    choose "Undergraduate initial teacher training (ITT)"
+
+    click_on "Continue"
+
+    # - In what academic year did you complete your undergraduate ITT?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+
+    choose "2018 to 2019"
+    click_on "Continue"
+
+    # - Which subject did you do your undergraduate ITT in
+    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teacher training (ITT)"))
+    choose "None of the above"
+    click_on "Continue"
+
+    # Do you have an undergraduate or postgraduate degree in an eligible subject?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_degree_subject"))
+    choose "Yes"
+    click_on "Continue"
+
+    # TODO: Update with the new teach now question
+    # - Do you teach 'none of the above' now
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now", eligible_itt_subject: "none of the above"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Check your answers for eligibility
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+    ["Identity details", "Payment details", "Student loan details"].each do |section_heading|
+      expect(page).not_to have_text section_heading
+    end
+
+    click_on("Continue")
+
+    # - How will we use the information you provide
+    expect(page).to have_text("How we will use the information you provide")
+    click_on "Continue"
+
+    # - Personal details
+    expect(page).to have_text(I18n.t("questions.personal_details"))
+    expect(page).to have_text(I18n.t("questions.name"))
+
+    expect(eligibility.reload.ineligible?).to be false
+  end
+end

--- a/spec/models/claim/permitted_parameters_spec.rb
+++ b/spec/models/claim/permitted_parameters_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Claim::PermittedParameters do
   let(:student_loan_claim) { Claim.new(eligibility: StudentLoans::Eligibility.new) }
+  let(:current_claim) { CurrentClaim.new(claims: [student_loan_claim]) }
   let(:editable_attributes_for_student_loans_claim) do
     [
       :first_name,
@@ -50,7 +51,7 @@ RSpec.describe Claim::PermittedParameters do
     ]
   end
 
-  subject(:permitted_parameters) { Claim::PermittedParameters.new(student_loan_claim) }
+  subject(:permitted_parameters) { Claim::PermittedParameters.new(current_claim) }
 
   describe "#keys" do
     it "returns all the editable attributes for a claim, including those for its eligibility" do

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe EarlyCareerPayments::SlugSequence do
-  subject(:slug_sequence) { EarlyCareerPayments::SlugSequence.new(claim) }
+  subject(:slug_sequence) { EarlyCareerPayments::SlugSequence.new(current_claim) }
 
   let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
   let(:claim) { build(:claim, academic_year: AcademicYear.new(2021), eligibility: eligibility) }
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
   describe "The sequence as defined by #slugs" do
     it "excludes the 'ineligible' slug if the claim's eligibility is undetermined" do

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -4,8 +4,11 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
   subject(:slug_sequence) { EarlyCareerPayments::SlugSequence.new(current_claim) }
 
   let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
+  let(:eligibility_lup) { build(:levelling_up_premium_payments_eligibility, :eligible) }
+
   let(:claim) { build(:claim, academic_year: AcademicYear.new(2021), eligibility: eligibility) }
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+  let(:lup_claim) { build(:claim, academic_year: AcademicYear.new(2021), eligibility: eligibility_lup) }
+  let(:current_claim) { CurrentClaim.new(claims: [claim, lup_claim]) }
 
   describe "The sequence as defined by #slugs" do
     it "excludes the 'ineligible' slug if the claim's eligibility is undetermined" do
@@ -61,13 +64,8 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
     end
 
     context "when claim is ineligible" do
-      let(:eligibility) do
-        build(
-          :early_career_payments_eligibility,
-          :eligible,
-          eligible_itt_subject: "foreign_languages"
-        )
-      end
+      let(:eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      let(:eligibility_lup) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
 
       it "includes the 'ineligible' slug" do
         expect(slug_sequence.slugs).to include("ineligible")

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe MathsAndPhysics::SlugSequence do
-  let(:claim) { build(:claim, eligibility: build(:maths_and_physics_eligibility)) }
+  subject(:slug_sequence) { MathsAndPhysics::SlugSequence.new(current_claim) }
 
-  subject(:slug_sequence) { MathsAndPhysics::SlugSequence.new(claim) }
+  let(:claim) { build(:claim, eligibility: build(:maths_and_physics_eligibility)) }
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
   describe "The sequence as defined by #slugs" do
     it "excludes the “ineligible” slug if the claim is not actually ineligible" do

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe StudentLoans::SlugSequence do
-  let(:claim) { build(:claim) }
+  subject(:slug_sequence) { StudentLoans::SlugSequence.new(current_claim) }
 
-  subject(:slug_sequence) { StudentLoans::SlugSequence.new(claim) }
+  let(:claim) { build(:claim) }
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
   describe "The sequence as defined by #slugs" do
     it "excludes the “ineligible” slug if the claim is not actually ineligible" do

--- a/spec/support/admin_edit_claim_feature_shared_examples.rb
+++ b/spec/support/admin_edit_claim_feature_shared_examples.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples "Admin Edit Claim Feature" do |policy|
     build(
       "#{policy.to_s.underscore}_eligibility".to_sym,
       :eligible,
-      award_amount: old_award_amount,
+      award_amount: old_award_amount
     )
   end
 

--- a/spec/support/admin_edit_claim_feature_shared_examples.rb
+++ b/spec/support/admin_edit_claim_feature_shared_examples.rb
@@ -8,8 +8,25 @@ RSpec.shared_examples "Admin Edit Claim Feature" do |policy|
 
   let(:old_award_amount) { 3_000 }
 
+  let(:eligibility) do
+    build(
+      "#{policy.to_s.underscore}_eligibility".to_sym,
+      :eligible,
+      award_amount: old_award_amount,
+    )
+  end
+
   let(:claim) do
-    create(:claim, :submitted, policy: policy, eligibility: build("#{policy.to_s.underscore}_eligibility".to_sym, :eligible, award_amount: old_award_amount))
+    create(
+      :claim,
+      :submitted,
+      policy: policy,
+      eligibility: eligibility
+    )
+  end
+
+  before do
+    eligibility.update(eligible_degree_subject: false) if policy == LevellingUpPremiumPayments
   end
 
   context "non-claim attribute" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -115,6 +115,11 @@ module FeatureHelpers
     Claim.by_policy(EarlyCareerPayments).order(:created_at).last
   end
 
+  def start_levelling_up_premium_payments_claim
+    visit new_claim_path(LevellingUpPremiumPayments.routing_name)
+    Claim.by_policy(LevellingUpPremiumPayments).order(:created_at).last
+  end
+
   def get_otp_from_email
     ActionMailer::Base.deliveries
       .last[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first


### PR DESCRIPTION
Adds the following page when the answer to "Which subject did you do your postgraduate initial teacher training (ITT) in?" is "None of the above".

<img width="757" alt="Screenshot 2022-05-31 at 09 06 22" src="https://user-images.githubusercontent.com/1636476/171124778-af626443-ba0f-43c1-8404-7fa811a4daa0.png">

Issues:
* The next page after clicking continue reads "Do you teach none of the above now?".
* The ineligible page when selecting "No" shows the ineligible reason for ECP claim.