### PR TITLE
Allow LUP claims to be edited by an admin

### DIFF
--- a/app/helpers/admin/amendments_helper.rb
+++ b/app/helpers/admin/amendments_helper.rb
@@ -12,5 +12,9 @@ module Admin
 
       nested_claim_attributes_to_ids.merge(claim_changes_attribute_to_id)
     end
+
+    def editable_award_amount_policy?(policy)
+      policy.in? [EarlyCareerPayments, LevellingUpPremiumPayments]
+    end
   end
 end

--- a/app/models/award_range_validator.rb
+++ b/app/models/award_range_validator.rb
@@ -1,0 +1,11 @@
+class AwardRangeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    max_award = options[:max]
+    ActiveModel::Validations::NumericalityValidator.new({
+      attributes: attributes,
+      greater_than: 0,
+      less_than_or_equal_to: max_award,
+      message: "Enter a positive amount up to #{max_award.to_s(:currency)} (inclusive)"
+    }).validate_each(record, attribute, value)
+  end
+end

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -257,10 +257,6 @@ module EarlyCareerPayments
       super || calculate_award_amount
     end
 
-    def award_amount=(value)
-      super(value.to_s.gsub(/[£,\s]/, ""))
-    end
-
     def calculate_award_amount
       return BigDecimal("0.00") if current_school.nil?
 

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -169,6 +169,12 @@ module EarlyCareerPayments
       AcademicYear.new => AcademicYear::Type.new.serialize(AcademicYear.new)
     }
 
+    @@max_award_amount_in_pounds = AWARD_AMOUNTS.collect(&:uplift_amount).max
+
+    def self.max_award_amount_in_pounds
+      @@max_award_amount_in_pounds
+    end
+
     has_one :claim, as: :eligibility, inverse_of: :eligibility
     belongs_to :current_school, optional: true, class_name: "School"
 
@@ -185,7 +191,7 @@ module EarlyCareerPayments
     validates :itt_academic_year, on: [:"itt-year", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.itt_academic_year.blank.qualification.#{object.qualification}") }}
     validates :award_amount, on: [:submit], presence: {message: "Enter an award amount"}
     validates_numericality_of :award_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7500
-    validates :award_amount, on: :amendment, numericality: {less_than: 7501, message: "Enter an amount below £7,501"}
+    validates :award_amount, on: :amendment, award_range: {max: max_award_amount_in_pounds}
 
     before_save :set_qualification_if_trainee_teacher, if: :nqt_in_academic_year_after_itt_changed?
 

--- a/app/models/levelling_up_premium_payments/award.rb
+++ b/app/models/levelling_up_premium_payments/award.rb
@@ -1,12 +1,4 @@
 module LevellingUpPremiumPayments
-  # completely fake until information is in the public domain
-  URN_TO_AWARD_AMOUNT_IN_POUNDS = {
-    150000 => 1_000,
-    150001 => 2_000,
-    160000 => 0,
-    160001 => 0
-  }
-
   # This is concerned with the award information from the spreadsheet, which will
   # contain the pre-computed amount, thereby we don't need to check the EIA or pupil premium
   # status ourselves.
@@ -25,12 +17,26 @@ module LevellingUpPremiumPayments
       @school = school
     end
 
+    def self.max
+      @@maximum_award_amount_in_pounds
+    end
+
     def has_award?
       amount_in_pounds.positive?
     end
 
     def amount_in_pounds
-      URN_TO_AWARD_AMOUNT_IN_POUNDS.fetch(@school.urn, 0)
+      @@urn_to_award_amount_in_pounds.fetch(@school.urn, 0)
     end
+
+    # completely fake until information is in the public domain
+    @@urn_to_award_amount_in_pounds = {
+      150000 => 1_000,
+      150001 => 3_000,
+      160000 => 0,
+      160001 => 0
+    }
+
+    @@maximum_award_amount_in_pounds = @@urn_to_award_amount_in_pounds.values.max
   end
 end

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -10,13 +10,8 @@ module LevellingUpPremiumPayments
       LevellingUpPremiumPayments
     end
 
+    # maintains interface
     def ineligible?
-    end
-
-    # allows wider range of input formats like ECP (and student_loan_repayment_amount in TSLR) does
-    # (this is a copy of that code for now)
-    def award_amount=(value)
-      super(value.to_s.gsub(/[£,\s]/, ""))
     end
   end
 end

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -4,8 +4,19 @@ module LevellingUpPremiumPayments
     has_one :claim, as: :eligibility, inverse_of: :eligibility
     belongs_to :current_school, optional: true, class_name: "School"
 
+    validates :award_amount, on: :amendment, award_range: {max: LevellingUpPremiumPayments::Award.max}
+
     def policy
       LevellingUpPremiumPayments
+    end
+
+    def ineligible?
+    end
+
+    # allows wider range of input formats like ECP (and student_loan_repayment_amount in TSLR) does
+    # (this is a copy of that code for now)
+    def award_amount=(value)
+      super(value.to_s.gsub(/[£,\s]/, ""))
     end
   end
 end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -52,7 +52,7 @@ module StudentLoans
     validates :mostly_performed_leadership_duties, on: [:"mostly-performed-leadership-duties", :submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
     validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
     validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than: 0, less_than_or_equal_to: 99999
-    validates :student_loan_repayment_amount, on: :amendment, numericality: {less_than: 5000, message: "Enter an amount below £5,000"}
+    validates :student_loan_repayment_amount, on: :amendment, award_range: {max: 5_000}
 
     delegate :name, to: :claim_school, prefix: true, allow_nil: true
     delegate :name, to: :current_school, prefix: true, allow_nil: true

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -66,10 +66,6 @@ module StudentLoans
       SUBJECT_ATTRIBUTES.select { |attribute_name| public_send("#{attribute_name}?") }
     end
 
-    def student_loan_repayment_amount=(value)
-      super(value.to_s.gsub(/[£,\s]/, ""))
-    end
-
     def ineligible?
       ineligible_qts_award_year? ||
         ineligible_claim_school? ||

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -151,7 +151,7 @@
       <% end %>
     <% end %>
 
-    <% if @amendment.claim.policy == EarlyCareerPayments %>
+    <% if editable_award_amount_policy?(@claim.policy) %>
       <%= claim_form.fields_for :eligibility, @amendment.claim.eligibility, include_id: false do |eligibility_form| %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-third">

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
+# These existing specs are too complicated, so using
+# `spec/features/admin_edit_claim_spec.rb` for ECP
+# and LUP instead. Keeping these here because they
+# at least cover TSLR and Maths & Physics (which
+# themselves are slightly different from ECP and LUP).
 RSpec.feature "Admin amends a claim" do
   let(:claim) do
     create(:claim, :submitted,
@@ -126,38 +131,6 @@ RSpec.feature "Admin amends a claim" do
       expect(page).to have_content("Student loan repayment amount\nchanged from £550.00 to £300.00")
 
       expect(page).to have_content("The claimant calculated the incorrect student loan repayment amount")
-      expect(page).to have_content("by #{@signed_in_user.full_name} on #{I18n.l(Time.current)}")
-    end
-  end
-
-  context "with a Early Career Payments claim" do
-    let(:claim) do
-      create(:claim, :submitted, policy: EarlyCareerPayments, eligibility: build(:early_career_payments_eligibility, :eligible, award_amount: 5_000))
-    end
-
-    scenario "Service operator amends the award amount" do
-      visit admin_claim_url(claim)
-
-      click_on "Amend claim"
-
-      fill_in "Award amount", with: "£2,500"
-      fill_in "Change notes", with: "The claimants school is eligible for an uplift, increasing the amount to give total of $7,500"
-      expect { click_on "Amend claim" }.to change { claim.reload.amendments.size }.by(1)
-
-      amendment = claim.amendments.last
-      expect(amendment.claim_changes).to eq({
-        "award_amount" => [5_000, 2_500]
-      })
-      expect(amendment.notes).to eq("The claimants school is eligible for an uplift, increasing the amount to give total of $7,500")
-      expect(amendment.created_by).to eq(@signed_in_user)
-
-      expect(claim.eligibility.award_amount).to eq(2_500)
-
-      click_on "Claim amendments"
-
-      expect(page).to have_content("Award amount\nchanged from £5,000.00 to £2,500.00")
-
-      expect(page).to have_content("The claimants school is eligible for an uplift, increasing the amount to give total of $7,500")
       expect(page).to have_content("by #{@signed_in_user.full_name} on #{I18n.l(Time.current)}")
     end
   end

--- a/spec/features/admin_edit_claim_spec.rb
+++ b/spec/features/admin_edit_claim_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.feature "Admin edits a claim with an award amount" do
+  it_behaves_like "Admin Edit Claim Feature", LevellingUpPremiumPayments
+  it_behaves_like "Admin Edit Claim Feature", EarlyCareerPayments
+end

--- a/spec/helpers/admin/amendments_helper_spec.rb
+++ b/spec/helpers/admin/amendments_helper_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+describe Admin::AmendmentsHelper do
+  describe ".editable_award_amount_policy?" do
+    specify { expect(editable_award_amount_policy?(EarlyCareerPayments)).to be true }
+    specify { expect(editable_award_amount_policy?(LevellingUpPremiumPayments)).to be true }
+    specify { expect(editable_award_amount_policy?(StudentLoans)).to be false }
+    specify { expect(editable_award_amount_policy?(MathsAndPhysics)).to be false }
+  end
+end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Amendment, type: :model do
         let(:claim_attributes) do
           {
             eligibility_attributes: {
-              award_amount: "£2,500.00"
+              award_amount: 2_500
             }
           }
         end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -484,6 +484,11 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
   end
 
   describe "#award_amount" do
+    context "amendment" do
+      it { should_not allow_values(0, nil).for(:award_amount).on(:amendment) }
+      it { should validate_numericality_of(:award_amount).on(:amendment).is_greater_than(0).is_less_than_or_equal_to(7_500).with_message("Enter a positive amount up to £7,500.00 (inclusive)") }
+    end
+
     context "with a value of 1_000" do
       let(:eligibility) do
         create(
@@ -1309,5 +1314,9 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
         expect(EarlyCareerPayments::Eligibility.new(itt_academic_year: AcademicYear.new(2020))).to be_valid(:"itt-year")
       end
     end
+  end
+
+  describe ".max_award_amount_in_pounds" do
+    specify { expect(described_class.max_award_amount_in_pounds).to eq(7_500) }
   end
 end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -1213,7 +1213,7 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
     context "award_amount attribute" do
       it "validates the award_amount is numerical" do
         expect(EarlyCareerPayments::Eligibility.new(award_amount: "don't know")).not_to be_valid
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: "£2,000.00")).to be_valid
+        expect(EarlyCareerPayments::Eligibility.new(award_amount: "£2,000.00")).not_to be_valid
       end
 
       it "validates that award_amount is a positive number" do
@@ -1226,8 +1226,9 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
       end
 
       it "validates that the award_amount is less than £7,500 when amending a claim" do
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: "£7,501")).not_to be_valid(:amendment)
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: "£2,500")).to be_valid(:amendment)
+        expect(EarlyCareerPayments::Eligibility.new(award_amount: 7_501)).not_to be_valid(:amendment)
+        expect(EarlyCareerPayments::Eligibility.new(award_amount: 7_500)).to be_valid(:amendment)
+        expect(EarlyCareerPayments::Eligibility.new(award_amount: 7_499)).to be_valid(:amendment)
       end
     end
 

--- a/spec/models/levelling_up_premium_payments/award_spec.rb
+++ b/spec/models/levelling_up_premium_payments/award_spec.rb
@@ -23,4 +23,8 @@ RSpec.describe LevellingUpPremiumPayments::Award do
     specify { expect(described_class.new(not_found)).to_not have_award }
     specify { expect(described_class.new(not_found).amount_in_pounds).to be_zero }
   end
+
+  describe ".max" do
+    specify { expect(described_class.max).to eq(3_000) }
+  end
 end

--- a/spec/models/levelling_up_premium_payments/eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/eligibility_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe LevellingUpPremiumPayments::Eligibility, type: :model do
+  subject { build(:levelling_up_premium_payments_eligibility) }
+
+  describe "associations" do
+    it { should have_one(:claim) }
+    it { should belong_to(:current_school).class_name("School").optional(true) }
+  end
+
+  describe "#policy" do
+    specify { expect(subject.policy).to eq(LevellingUpPremiumPayments) }
+  end
+
+  describe "#ineligible?" do
+    specify { expect(subject).to respond_to(:ineligible?) }
+  end
+
+  describe "#award_amount" do
+    it { should_not allow_values(0, nil).for(:award_amount).on(:amendment) }
+    it { should validate_numericality_of(:award_amount).on(:amendment).is_greater_than(0).is_less_than_or_equal_to(3_000).with_message("Enter a positive amount up to £3,000.00 (inclusive)") }
+  end
+end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
   describe "student_loan_repayment_amount attribute" do
     it "validates that the loan repayment amount is numerical" do
       expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "£1,234.56")).to be_valid
+      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "£1,234.56")).not_to be_valid
     end
 
     it "validates that the loan repayment is under £99,999" do
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "100000000")).not_to be_valid
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "99999")).to be_valid
+      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: 100_000)).not_to be_valid
+      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: 99_999)).to be_valid
     end
 
     it "validates that the loan repayment a positive number" do
@@ -81,14 +81,6 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     it "returns an array of the subject attributes that are true" do
       expect(StudentLoans::Eligibility.new.subjects_taught).to eq []
       expect(StudentLoans::Eligibility.new(biology_taught: true, physics_taught: true, chemistry_taught: false).subjects_taught).to eq [:biology_taught, :physics_taught]
-    end
-  end
-
-  describe "#student_loan_repayment_amount=" do
-    it "sets loan repayment amount with monetary characters stripped out" do
-      eligibility = build(:student_loans_eligibility)
-      eligibility.student_loan_repayment_amount = "£ 5,000.40"
-      expect(eligibility.student_loan_repayment_amount).to eql(5000.40)
     end
   end
 
@@ -343,7 +335,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
       expect(StudentLoans::Eligibility.new).not_to be_valid(:"student-loan-amount")
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "£1,100")).to be_valid(:"student-loan-amount")
+      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: 1_100)).to be_valid(:"student-loan-amount")
     end
   end
 

--- a/spec/support/admin_edit_claim_feature_shared_examples.rb
+++ b/spec/support/admin_edit_claim_feature_shared_examples.rb
@@ -1,0 +1,102 @@
+RSpec.shared_examples "Admin Edit Claim Feature" do |policy|
+  before { @signed_in_user = sign_in_as_service_operator }
+
+  let(:signed_in_user_full_name) { @signed_in_user.full_name }
+
+  let(:moment_of_submission) { 2.minutes.ago }
+  let(:moment_of_submission_string) { I18n.l(moment_of_submission) }
+
+  let(:old_award_amount) { 3_000 }
+
+  let(:claim) do
+    create(:claim, :submitted, policy: policy, eligibility: build("#{policy.to_s.underscore}_eligibility".to_sym, :eligible, award_amount: old_award_amount))
+  end
+
+  context "non-claim attribute" do
+    let(:old_value) { claim.teacher_reference_number }
+    let(:new_value) { old_value.next }
+    let(:reason) { "Fix typo" }
+
+    scenario "amend" do
+      visit admin_claim_path(claim)
+
+      click_on "Amend claim"
+
+      fill_in "Teacher reference number", with: new_value
+      fill_in "Change notes", with: reason
+
+      travel_to(moment_of_submission) { click_on "Amend claim" }
+
+      click_on "Claim amendments"
+
+      expect(page).to have_content("Teacher reference number\nchanged from #{old_value} to #{new_value}")
+      expect(page).to have_content(reason)
+      expect(page).to have_content("by #{signed_in_user_full_name} on #{moment_of_submission_string}")
+    end
+
+    scenario "lacking reason" do
+      visit admin_claim_path(claim)
+
+      click_on "Amend claim"
+      fill_in "Teacher reference number", with: new_value
+      click_on "Amend claim"
+
+      expect(page).to have_content("Error: Enter a message to explain why you are making this amendment")
+    end
+
+    scenario "cancel" do
+      visit admin_claim_path(claim)
+
+      click_on "Amend claim"
+      fill_in "Teacher reference number", with: new_value
+      click_on "Cancel"
+
+      expect(page).to have_no_content(new_value)
+    end
+  end
+
+  context "claim attribute" do
+    let(:old_value) { old_award_amount }
+    let(:new_value) { old_value - 1 }
+    let(:old_value_string) { old_value.to_s(:currency) }
+    let(:new_value_string) { new_value.to_s(:currency) }
+    let(:reason) { "Wrong amount" }
+
+    scenario "amend" do
+      visit admin_claim_path(claim)
+
+      click_on "Amend claim"
+
+      fill_in "Award amount", with: new_value
+      fill_in "Change notes", with: reason
+
+      travel_to(moment_of_submission) { click_on "Amend claim" }
+
+      click_on "Claim amendments"
+
+      expect(page).to have_content("Award amount\nchanged from #{old_value_string} to #{new_value_string}")
+      expect(page).to have_content(reason)
+      expect(page).to have_content("by #{signed_in_user_full_name} on #{moment_of_submission_string}")
+    end
+
+    scenario "lacking reason" do
+      visit admin_claim_path(claim)
+
+      click_on "Amend claim"
+      fill_in "Award amount", with: new_value
+      click_on "Amend claim"
+
+      expect(page).to have_content("Error: Enter a message to explain why you are making this amendment")
+    end
+
+    scenario "cancel" do
+      visit admin_claim_path(claim)
+
+      click_on "Amend claim"
+      fill_in "Award amount", with: new_value
+      click_on "Cancel"
+
+      expect(page).to have_no_content(new_value)
+    end
+  end
+end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-208

Allows LUP claims to be edited by an admin in a way consistent with the other policies.

While doing this, I found that some of the validation for monetary values was inconsistent between policies so addressed that.

Also agreed with Chris Williamson to remove the string parsing on the forms for monetary amounts.