### PR TITLE
Allow deletion of claims with associated records

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -120,7 +120,7 @@ class Claim < ApplicationRecord
   enum student_loan_plan: STUDENT_LOAN_PLAN_OPTIONS
   enum bank_or_building_society: {personal_bank_account: 0, building_society: 1}
 
-  has_many :decisions, dependent: :delete_all # Cannot destroy due to objects being readonly
+  has_many :decisions, dependent: :destroy
   has_many :tasks, dependent: :destroy
   has_many :amendments, dependent: :destroy
   has_many :notes, dependent: :destroy

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -120,11 +120,11 @@ class Claim < ApplicationRecord
   enum student_loan_plan: STUDENT_LOAN_PLAN_OPTIONS
   enum bank_or_building_society: {personal_bank_account: 0, building_society: 1}
 
-  has_many :decisions
-  has_many :tasks
-  has_many :amendments
-  has_many :notes
-  has_one :support_ticket
+  has_many :decisions, dependent: :delete_all # Cannot destroy due to objects being readonly
+  has_many :tasks, dependent: :destroy
+  has_many :amendments, dependent: :destroy
+  has_many :notes, dependent: :destroy
+  has_one :support_ticket, dependent: :destroy
 
   belongs_to :eligibility, polymorphic: true, inverse_of: :claim, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -14,6 +14,7 @@ class Decision < ApplicationRecord
   }
 
   def readonly?
+    return false if destroyed_by_association
     persisted? && !undone
   end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1340,10 +1340,10 @@ RSpec.describe Claim, type: :model do
   describe "#destroy" do
     let!(:claim) { create(:claim, :submitted, policy: EarlyCareerPayments) }
 
-    let!(:notes) { create_list(:note, 1, claim: claim) }
-    let!(:tasks) { create_list(:task, 1, claim: claim) }
-    let!(:amendments) { create_list(:amendment, 1, claim: claim) }
-    let!(:decisions) { create_list(:decision, 1, :approved, claim: claim) }
+    let!(:notes) { create(:note, claim: claim) }
+    let!(:tasks) { create(:task, claim: claim) }
+    let!(:amendments) { create(:amendment, claim: claim) }
+    let!(:decisions) { create(:decision, :approved, claim: claim) }
     let!(:support_ticket) { create(:support_ticket, claim: claim) }
 
     it "destroys associated records" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1338,13 +1338,15 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "#destroy" do
-    let!(:claim) { create(:claim, :submitted, policy: EarlyCareerPayments) }
+    let(:claim) { create(:claim, :submitted, policy: EarlyCareerPayments) }
 
-    let!(:notes) { create(:note, claim: claim) }
-    let!(:tasks) { create(:task, claim: claim) }
-    let!(:amendments) { create(:amendment, claim: claim) }
-    let!(:decisions) { create(:decision, :approved, claim: claim) }
-    let!(:support_ticket) { create(:support_ticket, claim: claim) }
+    before do
+      create(:note, claim: claim)
+      create(:task, claim: claim)
+      create(:amendment, claim: claim)
+      create(:decision, :approved, claim: claim)
+      create(:support_ticket, claim: claim)
+    end
 
     it "destroys associated records" do
       claim.reload.destroy!

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1336,4 +1336,24 @@ RSpec.describe Claim, type: :model do
       it { is_expected.to eq notes }
     end
   end
+
+  describe "#destroy" do
+    let!(:claim) { create(:claim, :submitted, policy: EarlyCareerPayments) }
+
+    let!(:notes) { create_list(:note, 1, claim: claim) }
+    let!(:tasks) { create_list(:task, 1, claim: claim) }
+    let!(:amendments) { create_list(:amendment, 1, claim: claim) }
+    let!(:decisions) { create_list(:decision, 1, :approved, claim: claim) }
+    let!(:support_ticket) { create(:support_ticket, claim: claim) }
+
+    it "destroys associated records" do
+      claim.reload.destroy!
+      expect(EarlyCareerPayments::Eligibility.count).to be_zero
+      expect(Note.count).to be_zero
+      expect(Task.count).to be_zero
+      expect(Amendment.count).to be_zero
+      expect(Decision.count).to be_zero
+      expect(SupportTicket.count).to be_zero
+    end
+  end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-307

This allows one to call `Claim#destroy` without orphaned data being left or being blocked by foreign key constraints on child records. Now the child records are destroyed as well.