### PR TITLE
CAPT-261: Radio button change on QTS years page

### DIFF
--- a/app/helpers/early_career_payments_helper.rb
+++ b/app/helpers/early_career_payments_helper.rb
@@ -61,4 +61,12 @@ module EarlyCareerPaymentsHelper
     year_or_period = policy_year > last_academic_year_to_display_as_year ? :period : :year
     I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt.hint", year_or_period: year_or_period)
   end
+
+  def graduate_itt?(claim)
+    %w[undergraduate_itt postgraduate_itt].include? claim.eligibility.qualification
+  end
+
+  def qts?(claim)
+    %w[assessment_only overseas_recognition].include? claim.eligibility.qualification
+  end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -1,4 +1,4 @@
-# Used to model an academic year, which is normally dispayed in the format
+# Used to model an academic year, which is normally displayed in the format
 # "YYYY/YYYY". Supports comparison and basic arithmetic operations.
 #
 # Can be initialised both with a single start year, or the academic year as a

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -163,9 +163,11 @@ module EarlyCareerPayments
     }, _prefix: :itt_subject
 
     enum itt_academic_year: {
+      AcademicYear.new(2017) => AcademicYear::Type.new.serialize(AcademicYear.new(2017)),
       AcademicYear.new(2018) => AcademicYear::Type.new.serialize(AcademicYear.new(2018)),
       AcademicYear.new(2019) => AcademicYear::Type.new.serialize(AcademicYear.new(2019)),
       AcademicYear.new(2020) => AcademicYear::Type.new.serialize(AcademicYear.new(2020)),
+      AcademicYear.new(2021) => AcademicYear::Type.new.serialize(AcademicYear.new(2021)),
       AcademicYear.new => AcademicYear::Type.new.serialize(AcademicYear.new)
     }
 

--- a/app/views/early_career_payments/claims/itt_year.html.erb
+++ b/app/views/early_career_payments/claims/itt_year.html.erb
@@ -22,6 +22,13 @@
             <%= errors_tag current_claim.eligibility, :itt_academic_year %>
 
             <div class="govuk-radios">
+              <% if qts?(current_claim) %>
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:itt_academic_year, AcademicYear.new(2017), class: "govuk-radios__input") %>
+                  <%= fields.label "itt_academic_year_20172018", AcademicYear.new(2017).to_s(:long), class: "govuk-label govuk-radios__label" %>
+                </div>
+              <% end %>
+
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:itt_academic_year, AcademicYear.new(2018), class: "govuk-radios__input") %>
                 <%= fields.label "itt_academic_year_20182019", AcademicYear.new(2018).to_s(:long), class: "govuk-label govuk-radios__label" %>
@@ -37,6 +44,12 @@
                 <%= fields.label "itt_academic_year_20202021", AcademicYear.new(2020).to_s(:long), class: "govuk-label govuk-radios__label" %>
               </div>
 
+              <% if qts?(current_claim) %>
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:itt_academic_year, AcademicYear.new(2021), class: "govuk-radios__input") %>
+                  <%= fields.label "itt_academic_year_20212022", AcademicYear.new(2021).to_s(:long), class: "govuk-label govuk-radios__label" %>
+                </div>
+              <% end %>
               <div class="govuk-radios__divider">or</div>
 
               <div class="govuk-radios__item">
@@ -50,7 +63,7 @@
         <% end %>
         <br/>
         <br/>
-        <% if %w[undergraduate_itt postgraduate_itt].include? current_claim.eligibility.qualification %>
+        <% if graduate_itt?(current_claim) %>
           <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,8 +320,8 @@ en:
         qualification:
           undergraduate_itt: In what academic year did you complete your undergraduate ITT?
           postgraduate_itt: In what academic year did you start your postgraduate ITT?
-          assessment_only: What academic year did you earn your qualified teacher status (QTS)?
-          overseas_recognition: What academic year did you earn your qualified teacher status (QTS)?
+          assessment_only: In which academic year did you earn your qualified teacher status (QTS)?
+          overseas_recognition: In which academic year did you earn your qualified teacher status (QTS)?
     admin:
       employed_as_supply_teacher: "Employed as a supply teacher?"
       nqt_in_academic_year_after_itt: "NQT the academic year after ITT"

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -74,6 +74,11 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     # - In what academic year did you start your undergraduate ITT
     expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
     expect(page).to have_text("If you did a part time ITT")
+    expect(page).not_to have_text("2017 to 2018")
+    expect(page).to have_text("2018 to 2019")
+    expect(page).to have_text("2019 to 2020")
+    expect(page).to have_text("2020 to 2021")
+    expect(page).not_to have_text("2021 to 2022")
 
     choose "2018 to 2019"
     click_on "Continue"
@@ -405,6 +410,11 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       # - In what academic year did you start your undergraduate ITT
       expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
       expect(page).not_to have_text("You might still be eligible to claim if your ITT coincided with one of the academic years stated, even if it didn’t start or complete in one of those years.")
+      expect(page).to have_text("2017 to 2018")
+      expect(page).to have_text("2018 to 2019")
+      expect(page).to have_text("2019 to 2020")
+      expect(page).to have_text("2020 to 2021")
+      expect(page).to have_text("2021 to 2022")
 
       choose "2018 to 2019"
       click_on "Continue"
@@ -444,6 +454,11 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       # - In what academic year did you you earn your qualified teacher status (QTS)?
       expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
       expect(page).not_to have_text("You might still be eligible to claim if your ITT coincided with one of the academic years stated, even if it didn’t start or complete in one of those years.")
+      expect(page).to have_text("2017 to 2018")
+      expect(page).to have_text("2018 to 2019")
+      expect(page).to have_text("2019 to 2020")
+      expect(page).to have_text("2020 to 2021")
+      expect(page).to have_text("2021 to 2022")
 
       choose "2018 to 2019"
       click_on "Continue"
@@ -528,6 +543,11 @@ RSpec.feature "Teacher Early-Career Payments claims" do
 
     # - In what academic year did you start your postgraduate ITT
     expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
+    expect(page).not_to have_text("2017 to 2018")
+    expect(page).to have_text("2018 to 2019")
+    expect(page).to have_text("2019 to 2020")
+    expect(page).to have_text("2020 to 2021")
+    expect(page).not_to have_text("2021 to 2022")
 
     choose "2018 to 2019"
     click_on "Continue"

--- a/spec/helpers/early_career_payments_helper_spec.rb
+++ b/spec/helpers/early_career_payments_helper_spec.rb
@@ -182,5 +182,64 @@ describe EarlyCareerPaymentsHelper do
         expect(helper.guidance_eligibility_page_link(claim)).to include("#{EarlyCareerPayments.eligibility_page_url}#supply-private-school-and-sixth-form-college-teachers")
       end
     end
+
+    describe "#graduate_itt?" do
+      subject { helper.graduate_itt?(claim) }
+
+      let(:policy) { EarlyCareerPayments }
+
+      context "when the qualification is UG degree" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :undergraduate_itt) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the qualification is PG degree" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :postgraduate_itt) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the qualification is assessment only" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :assessment_only) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the qualification is overseas recognition" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :overseas_recognition) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe "#qts?" do
+      subject { helper.qts?(claim) }
+      let(:policy) { EarlyCareerPayments }
+
+      context "when the qualification is UG degree" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :undergraduate_itt) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the qualification is PG degree" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :postgraduate_itt) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the qualification is assessment only" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :assessment_only) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the qualification is overseas recognition" do
+        let(:eligibility) { build(:early_career_payments_eligibility, qualification: :overseas_recognition) }
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end


### PR DESCRIPTION
I updated the radio buttons to include the requested years, but selecting them will make the claim not eligible because I haven't added any new awards. I hijacked the feature specs for the claim to test this. I would appreciate any ideas to make this cleaner.

<img width="784" alt="Screenshot 2022-05-20 at 14 43 20" src="https://user-images.githubusercontent.com/1636476/169541280-c0d787b0-572e-4e93-8889-bd7fd465bd66.png">

