### PR TITLE
Multi-policy PolicyConfigurations

### DIFF
--- a/app/controllers/admin/policy_configurations_controller.rb
+++ b/app/controllers/admin/policy_configurations_controller.rb
@@ -5,7 +5,7 @@ module Admin
     after_action :send_reminders, only: [:update]
 
     def index
-      @policy_configurations = PolicyConfiguration.order(:policy_type)
+      @policy_configurations = PolicyConfiguration.order(created_at: :desc)
     end
 
     def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,8 +23,8 @@ module ApplicationHelper
     t(translation_key)
   end
 
-  def policy_service_name(policy = nil)
-    policy ? t("#{policy.underscore}.policy_name") : t("service_name")
+  def policy_service_name(routing_name = nil)
+    routing_name ? t("#{routing_name.underscore}.policy_name") : t("service_name")
   end
 
   def policy_description(policy)

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -1,4 +1,6 @@
 # Module providing access to all the currently active policies for the service.
+
+# TODO: Add LUP here
 module Policies
   POLICIES = [
     StudentLoans,

--- a/app/models/policy_configuration.rb
+++ b/app/models/policy_configuration.rb
@@ -15,18 +15,19 @@ class PolicyConfiguration < ApplicationRecord
   # Use AcademicYear as custom ActiveRecord attribute type
   attribute :current_academic_year, AcademicYear::Type.new
 
-  validates :policy_type, inclusion: {in: Policies.all.map(&:name)}
   validates :current_academic_year_before_type_cast, format: {with: ACADEMIC_YEAR_REGEXP}
 
   def self.for(policy)
-    find_by policy_type: policy.name
+    where("? = ANY (policy_types)", policy.name).first
   end
 
-  def policy
-    policy_type.constantize
+  # TODO: Journey class can be merged into PolicyConfiguration, it's really serving the same purpose
+  def routing_name
+    Journey.routing_name_for_policy(policy_types.first.constantize)
   end
 
+  # TODO: Eventually this shouldn't be used
   def early_career_payments?
-    policy == EarlyCareerPayments
+    policy_types.include?(EarlyCareerPayments.name)
   end
 end

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title) { page_title("Manage #{policy_service_name(@policy_configuration.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Manage #{policy_service_name(@policy_configuration.routing_name)}") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl">Manage services</span>
-      <%= policy_service_name(@policy_configuration.policy.routing_name) %>
+      <%= policy_service_name(@policy_configuration.routing_name) %>
     </h1>
 
     <div class="govuk-panel govuk-panel--informational">

--- a/app/views/admin/policy_configurations/index.html.erb
+++ b/app/views/admin/policy_configurations/index.html.erb
@@ -27,12 +27,12 @@
       <tbody class="govuk-table__body">
         <% @policy_configurations.each do |policy_configuration| %>
           <tr class="govuk-table__row" data-policy-configuration-id="<%= policy_configuration.id %>">
-            <th scope="row" class="govuk-table__header"><%= policy_service_name(policy_configuration.policy.routing_name) %></th>
+            <th scope="row" class="govuk-table__header"><%= policy_service_name(policy_configuration.routing_name) %></th>
             <td class="govuk-table__cell"><%= policy_configuration.current_academic_year %></td>
             <td class="govuk-table__cell"><%= policy_configuration.open_for_submissions? ? "Open" : "Closed" %></td>
             <td class="govuk-table__cell">
               <%= link_to edit_admin_policy_configuration_path(policy_configuration), class: "govuk-link" do %>
-                Change <span class="govuk-visually-hidden"><%= policy_service_name(policy_configuration.policy.routing_name) %></span>
+                Change <span class="govuk-visually-hidden"><%= policy_service_name(policy_configuration.routing_name) %></span>
               <% end %>
             </td>
           </tr>

--- a/db/migrate/20220523175052_change_policy_configuration_policy_type.rb
+++ b/db/migrate/20220523175052_change_policy_configuration_policy_type.rb
@@ -1,0 +1,28 @@
+class ChangePolicyConfigurationPolicyType < ActiveRecord::Migration[6.0]
+  def up
+    add_column :policy_configurations, :policy_types, :text, array: true, default: []
+
+    PolicyConfiguration.reset_column_information
+    PolicyConfiguration.all.each do |pc|
+      policy_types = [pc.policy_type]
+      policy_types << "LevellingUpPremiumPayments" if pc.policy_type == "EarlyCareerPayments"
+      pc.update!(policy_types: policy_types)
+    end
+
+    remove_column :policy_configurations, :policy_type
+  end
+
+  def down
+    add_column :policy_configurations, :policy_type, :text
+
+    PolicyConfiguration.reset_column_information
+    PolicyConfiguration.all.each do |pc|
+      pc.update!(policy_type: pc.policy_types.first)
+    end
+
+    change_column :policy_configurations, :policy_type, :text, null: false
+    add_index :policy_configurations, :policy_type, unique: true
+
+    remove_column :policy_configurations, :policy_types
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_095658) do
+ActiveRecord::Schema.define(version: 2022_05_23_175052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -233,14 +233,13 @@ ActiveRecord::Schema.define(version: 2022_05_16_095658) do
   end
 
   create_table "policy_configurations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "policy_type", null: false
     t.boolean "open_for_submissions", default: true, null: false
     t.string "availability_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "current_academic_year", limit: 9
+    t.text "policy_types", default: [], array: true
     t.index ["created_at"], name: "index_policy_configurations_on_created_at"
-    t.index ["policy_type"], name: "index_policy_configurations_on_policy_type", unique: true
   end
 
   create_table "reminders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-PolicyConfiguration.create!(policy_type: StudentLoans, current_academic_year: AcademicYear.current)
-PolicyConfiguration.create!(policy_type: MathsAndPhysics, current_academic_year: AcademicYear.current)
-PolicyConfiguration.create!(policy_type: EarlyCareerPayments, current_academic_year: AcademicYear.current)
+PolicyConfiguration.create!(policy_types: [StudentLoans], current_academic_year: AcademicYear.current)
+PolicyConfiguration.create!(policy_types: [MathsAndPhysics], current_academic_year: AcademicYear.current)
+PolicyConfiguration.create!(policy_types: [EarlyCareerPayments, LevellingUpPremiumPayments], current_academic_year: AcademicYear.current)
 
 if Rails.env.development? || ENV["ENVIRONMENT_NAME"] == "review"
   ENV["FIXTURES_PATH"] = "spec/fixtures"

--- a/spec/fixtures/policy_configurations.yml
+++ b/spec/fixtures/policy_configurations.yml
@@ -1,11 +1,12 @@
+# TODO: FactoryBot this fixture
 student_loans:
-  policy_type: StudentLoans
   current_academic_year: "2025/2026"
+  policy_types: ["StudentLoans"]
 
 maths_and_physics:
-  policy_type: MathsAndPhysics
   current_academic_year: "2020/2021"
+  policy_types: ["MathsAndPhysics"]
 
 early_career_payments:
-  policy_type: EarlyCareerPayments
   current_academic_year: "2021/2022"
+  policy_types: ["EarlyCareerPayments", "LevellingUpPremiumPayments"]

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1333,7 +1333,7 @@ RSpec.describe Claim, type: :model do
     context "with important notes" do
       let(:notes) { create_list(:note, 2, important: true) }
 
-      it { is_expected.to eq notes }
+      it { is_expected.to match_array notes }
     end
   end
 

--- a/spec/models/levelling_up_premium_payments_spec.rb
+++ b/spec/models/levelling_up_premium_payments_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe LevellingUpPremiumPayments, type: :model do
-  let(:policy_configuration) { policy_configurations(:levelling_up_premium_payments) }
-
   specify {
     expect(subject).to have_attributes(routing_name: "early-career-payments",
       short_name: "Levelling Up Premium Payments",

--- a/spec/models/policy_configuration_spec.rb
+++ b/spec/models/policy_configuration_spec.rb
@@ -7,19 +7,27 @@ RSpec.describe PolicyConfiguration do
     it "returns the configuration for a given policy" do
       expect(PolicyConfiguration.for(StudentLoans)).to eq policy_configurations(:student_loans)
       expect(PolicyConfiguration.for(MathsAndPhysics)).to eq policy_configurations(:maths_and_physics)
-      expect(PolicyConfiguration.for(EarlyCareerPayments)).to eq policy_configurations(:early_career_payments)
-    end
-  end
 
-  describe "#policy" do
-    it "returns the policy class" do
-      expect(PolicyConfiguration.new(policy_type: StudentLoans).policy).to eq(StudentLoans)
+      # Same PolicyConfiguration for ECP and LUP
+      expect(PolicyConfiguration.for(EarlyCareerPayments)).to eq policy_configurations(:early_career_payments)
+      expect(PolicyConfiguration.for(LevellingUpPremiumPayments)).to eq policy_configurations(:early_career_payments)
     end
   end
 
   it "validates academic years are formated like '2020/2021'" do
-    expect(PolicyConfiguration.new(policy_type: StudentLoans)).not_to be_valid
-    expect(PolicyConfiguration.new(policy_type: StudentLoans, current_academic_year: "2020-2021")).not_to be_valid
-    expect(PolicyConfiguration.new(policy_type: StudentLoans, current_academic_year: "2020/2021")).to be_valid
+    expect(PolicyConfiguration.new(policy_types: [StudentLoans])).not_to be_valid
+    expect(PolicyConfiguration.new(policy_types: [StudentLoans], current_academic_year: "2020-2021")).not_to be_valid
+    expect(PolicyConfiguration.new(policy_types: [StudentLoans], current_academic_year: "2020/2021")).to be_valid
+  end
+
+  describe "#routing_name" do
+    it "returns routing for PolicyConfiguration" do
+      expect(PolicyConfiguration.for(StudentLoans).routing_name).to eq "student-loans"
+      expect(PolicyConfiguration.for(MathsAndPhysics).routing_name).to eq "maths-and-physics"
+
+      # Same routing_name for ECP and LUP
+      expect(PolicyConfiguration.for(EarlyCareerPayments).routing_name).to eq "early-career-payments"
+      expect(PolicyConfiguration.for(LevellingUpPremiumPayments).routing_name).to eq "early-career-payments"
+    end
   end
 end


### PR DESCRIPTION
PolicyConfiguration drives the Service and the Journey, ECP and LUP being a combined journey needs to support multiple `policy_types` and not just a single `policy_type`.

Main things of note:
- Migration
- Adding LUP to the ECP PolicyConfiguration
- Refactoring bits that expected a single policy for a policy configuration