### PR TITLE
Stop asking trainee teachers their ITT year

### DIFF
--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -130,7 +130,6 @@ module EarlyCareerPayments
       trainee_slugs = %w[
         nqt-in-academic-year-after-itt
         eligible-itt-subject
-        itt-year
         future-eligibility
         ineligible
       ]

--- a/app/views/reminders/set.html.erb
+++ b/app/views/reminders/set.html.erb
@@ -2,42 +2,44 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-grid-row" >
-    <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title" id="reminders-title">We have set your reminder</h1>
+    <div class="govuk-grid-row">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title" id="reminders-title">We have set your reminder</h1>
+      </div>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+
+      <p class="govuk-body">
+        We will send you a verification email now. If you do not receive one, contact
+        us on <%= mail_to "earlycareerteacherpayments@digital.education.gov.uk","earlycareerteacherpayments@digital.education.gov.uk", class: "govuk-link" %>.
+      </p>
+
+      <h3 class="govuk-heading-s">When will your reminder be sent?</h3>
+
+      <p class="govuk-body">
+        We will send you a reminder in September <%= current_reminder.send_year %>
+      </p>
+
+      <p class="govuk-body">
+        This is because, based on your answers, you will be able to apply for an early-career
+        payment at this time.
+      </p>
+
+      <p class="govuk-body">
+        After receiving the reminder email, you will have five months to complete an
+        application. If any of your employment circumstances change it might affect your
+        eligibility.
+      </p>
+
+      <p class="govuk-inset-text">
+        It is your responsibility to apply for the payment you are eligible for. The Department for Education cannot
+        issue payments unless you apply for one nor can we issue payments for claims made after the window has closed.
+      </p>
+
+      <p class="govuk-body">
+        <%= link_to "What did you think of this service?", done_page_url, class: "govuk-link" %>
+        (takes 30 seconds)
+      </p>
     </div>
-
-    <h2 class="govuk-heading-m">What happens next</h2>
-
-    <p class="govuk-body">
-      We will send you a verification email now. If you do not receive one, contact
-      us on <%= mail_to "earlycareerteacherpayments@digital.education.gov.uk","earlycareerteacherpayments@digital.education.gov.uk", class: "govuk-link" %>.
-    </p>
-
-    <h3 class="govuk-heading-s">When will your reminder be sent?</h3>
-
-    <p class="govuk-body">
-      We will send you a reminder in September <%= current_reminder.send_year %>
-    </p>
-
-    <p class="govuk-body">
-      This is because, based on your answers, you will be able to apply for an early-career
-      payment at this time.
-    </p>
-
-    <p class="govuk-body">
-      After receiving the reminder email, you will have five months to complete an
-      application. If any of your employment circumstances change it might affect your
-      eligibility.
-    </p>
-
-    <p class="govuk-inset-text">
-      It is your responsibility to apply for the payment you are eligible for. The Department for Education cannot issue payments unless you apply for one nor can we issue payments for claims made after the window has closed.
-    </p>
-
-    <p class="govuk-body">
-      <%= link_to "What did you think of this service?", done_page_url, class: "govuk-link" %>
-      (takes 30 seconds)
-    </p>
   </div>
 </div>

--- a/spec/features/early_career_payments_trainee_teacher_spec.rb
+++ b/spec/features/early_career_payments_trainee_teacher_spec.rb
@@ -78,22 +78,17 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
       expect(eligibility.nqt_in_academic_year_after_itt).to eql false
       expect(claim.eligibility.reload.qualification).to eq "postgraduate_itt"
 
-      # - In what academic year did you start your postgraduate ITT
-      expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
-
-      choose "2018 to 2019"
-      click_on "Continue"
-
       # - Which subject did you do your postgraduate ITT in
       expect(page).to have_text(
         I18n.t("early_career_payments.questions.eligible_itt_subject_trainee_teacher_in_2021")
       )
+
+      # for CAPT-350 will want to make sure `expect(page).to have_no_text("Foreign languages")` passes
+      # and to exercise it you could choose "Computing" instead of "Mathematics" here
       choose "Mathematics"
       click_on "Continue"
 
       expect(claim.eligibility.reload.eligible_itt_subject).to eql "mathematics"
-
-      expect(claim.eligibility.reload.itt_academic_year).to eql AcademicYear.new(2018)
 
       expect(page).to have_text(I18n.t("early_career_payments.ineligible.reason.trainee_teacher_only_in_claim_academic_year_2021"))
       expect(page).to have_text("If you’re a trainee teacher and plan to complete your studies in this academic year you might be able to apply in the next academic year.")
@@ -113,7 +108,7 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
       fill_in "reminder_one_time_password", with: get_otp_from_email
       click_on "Confirm"
 
-      expect(page).to have_text("We will send you a reminder in September 2023")
+      expect(page).to have_text("We will send you a reminder in September")
     end
 
     scenario "successfully completes the journey for chemistry 2020/21" do
@@ -141,12 +136,6 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
       expect(eligibility.nqt_in_academic_year_after_itt).to eql false
       expect(claim.eligibility.reload.qualification).to eq "postgraduate_itt"
 
-      # - In what academic year did you start your postgraduate ITT
-      expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
-
-      choose "2020 to 2021"
-      click_on "Continue"
-
       # - Which subject did you do your postgraduate ITT in
       expect(page).to have_text(
         I18n.t("early_career_payments.questions.eligible_itt_subject_trainee_teacher_in_2021")
@@ -155,8 +144,6 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
       click_on "Continue"
 
       expect(claim.eligibility.reload.eligible_itt_subject).to eql "chemistry"
-
-      expect(claim.eligibility.reload.itt_academic_year).to eql AcademicYear.new(2020)
 
       expect(page).to have_text(I18n.t("early_career_payments.ineligible.reason.trainee_teacher_only_in_claim_academic_year_2021"))
       expect(page).to have_text("If you’re a trainee teacher and plan to complete your studies in this academic year you might be able to apply in the next academic year.")
@@ -176,7 +163,7 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
       fill_in "reminder_one_time_password", with: get_otp_from_email
       click_on "Confirm"
 
-      expect(page).to have_text("We will send you a reminder in September 2022")
+      expect(page).to have_text("We will send you a reminder in September")
     end
   end
 end

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -324,22 +324,12 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
       end
     end
 
-    context "when a trainee teacher in the 2021 Academic Year" do
-      before do
-        @ecp_policy_date = PolicyConfiguration.for(EarlyCareerPayments).current_academic_year
-        PolicyConfiguration.for(EarlyCareerPayments).update(current_academic_year: AcademicYear.new(2021))
-      end
-
-      after do
-        PolicyConfiguration.for(EarlyCareerPayments).update(current_academic_year: @ecp_policy_date)
-      end
-
+    context "when a trainee teacher" do
       it "includes only the slugs related to this micro-journey" do
         claim.eligibility.nqt_in_academic_year_after_itt = false
 
         expected_slugs = %w[
           nqt-in-academic-year-after-itt
-          itt-year
           eligible-itt-subject
           future-eligibility
           ineligible


### PR DESCRIPTION
Caveat: not sure what becomes of reminders when a trainee teacher now asks for one. The page says they'll get it in September but doesn't say which year (because we never asked them those details). Could be this September or never. I don't know anything about the reminder service so can't say.