### PR TITLE
[CAPT-355] Allow 2017 ITT year only for LUP claims

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -55,10 +55,16 @@ module ClaimsHelper
   # Temporary helper method for "nqt_in_academic_year_after_itt = false" route
   def eligible_itt_subjects
     remove_subjects = ["none_of_the_above"]
-
-    # Hide `foreign languages` for trainee teachers
-    remove_subjects << "foreign_languages" unless current_claim.eligibility.nqt_in_academic_year_after_itt?
+    remove_subjects << "foreign_languages" unless allows_foreign_languages?
 
     EarlyCareerPayments::Eligibility.eligible_itt_subjects.keys.reject { |subject| remove_subjects.include?(subject) }.sort
+  end
+
+  private
+
+  # Hide `foreign languages` for trainee teachers and claims not eligible for ECP
+  def allows_foreign_languages?
+    current_claim.eligibility.nqt_in_academic_year_after_itt? &&
+      !current_claim.for_policy(EarlyCareerPayments).eligibility.ineligible?
   end
 end

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -343,6 +343,8 @@ module EarlyCareerPayments
 
     def ineligible_cohort?
       return true if itt_academic_year == AcademicYear.new
+      return true if itt_academic_year == AcademicYear.new("2017/2018")
+
       return false if without_cohort?
       return false if eligible_later.present?
 

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -50,9 +50,11 @@ module LevellingUpPremiumPayments
     }, _prefix: :itt_subject
 
     enum itt_academic_year: {
+      AcademicYear.new(2017) => AcademicYear::Type.new.serialize(AcademicYear.new(2017)),
       AcademicYear.new(2018) => AcademicYear::Type.new.serialize(AcademicYear.new(2018)),
       AcademicYear.new(2019) => AcademicYear::Type.new.serialize(AcademicYear.new(2019)),
       AcademicYear.new(2020) => AcademicYear::Type.new.serialize(AcademicYear.new(2020)),
+      AcademicYear.new(2021) => AcademicYear::Type.new.serialize(AcademicYear.new(2021)),
       AcademicYear.new => AcademicYear::Type.new.serialize(AcademicYear.new)
     }
 
@@ -153,7 +155,7 @@ module LevellingUpPremiumPayments
     end
 
     def ineligible_cohort?
-      itt_academic_year == AcademicYear.new
+      itt_academic_year == AcademicYear.new # `None of the above` selected
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -370,7 +370,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         mail = ActionMailer::Base.deliveries.last
         otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
 
-        fill_in "claim_one_time_password", with: otp_in_mail_sent, fill_options: {clear: :backspace}
+        fill_in "claim_one_time_password", with: otp_in_mail_sent
         click_on "Confirm"
 
         expect(claim.reload.email_verified).to eq true

--- a/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
+++ b/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
@@ -1,21 +1,28 @@
 require "rails_helper"
 
-RSpec.feature "Selecting 2017 for LUP-only claim" do
+RSpec.feature "Claims with different eligibilities content change logic" do
+  let(:claim) { start_early_career_payments_claim }
+
   before do
-    claim = start_early_career_payments_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
   end
 
-  it "shows foreign languages only for 2017" do
+  it "shows the correct subjects for LUP-only and ECP claims" do
     visit claim_path(claim.policy.routing_name, "itt-year")
     choose "2017 to 2018"
     click_on "Continue"
-    expect(page).not_to have_text("Foreign Languages")
+    expected_subjects = ["Chemistry", "Computing", "Mathematics", "Physics", "None of the above"]
+    expect(radio_labels).to eq(expected_subjects)
 
     click_on "Back"
     choose "2018 to 2019"
     click_on "Continue"
-    expect(page).to have_text("Foreign languages")
+    expected_subjects = ["Chemistry", "Computing", "Foreign languages", "Mathematics", "Physics", "None of the above"]
+    expect(radio_labels).to eq(expected_subjects)
+  end
+
+  def radio_labels
+    all("label.govuk-radios__label").map(&:text)
   end
 end

--- a/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
+++ b/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "Selecting 2017 for LUP-only claim" do
+  before do
+    claim = start_early_career_payments_claim
+    claim.update!(attributes_for(:claim, :submittable))
+    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+  end
+
+  it "shows foreign languages only for 2017" do
+    visit claim_path(claim.policy.routing_name, "itt-year")
+    choose "2017 to 2018"
+    click_on "Continue"
+    expect(page).not_to have_text("Foreign Languages")
+
+    click_on "Back"
+    choose "2018 to 2019"
+    click_on "Continue"
+    expect(page).to have_text("Foreign languages")
+  end
+end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -432,6 +432,16 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
         end
       end
     end
+
+    context "when ITT year is 2017" do
+      before do
+        eligibility.itt_academic_year = AcademicYear::Type.new.serialize(AcademicYear.new(2017))
+      end
+
+      it "returns true" do
+        expect(eligibility.ineligible?).to eql true
+      end
+    end
   end
 
   describe "#ineligibility_reason" do

--- a/spec/models/levelling_up_premium_payments/eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/eligibility_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe LevellingUpPremiumPayments::Eligibility, type: :model do
 
   describe "#ineligible?" do
     specify { expect(subject).to respond_to(:ineligible?) }
+
+    context "when ITT year is 2017" do
+      before do
+        subject.itt_academic_year = AcademicYear::Type.new.serialize(AcademicYear.new(2017))
+      end
+
+      it "returns false" do
+        expect(subject.ineligible?).to eql false
+      end
+    end
   end
 
   describe "#eligible_now?" do


### PR DESCRIPTION
- makes 2017 ineligible for ECP
- fixes a bug introduced my my previous PR where years 2017 and 2021 were missing for LUP claims
- removes a feature spec deprecation warning