### PR TITLE
[CAPT-269] Reset dependant answers from params

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -41,7 +41,7 @@ class ClaimsController < BasePublicController
     end
 
     current_claim.reset_dependent_answers
-    current_claim.reset_eligibility_dependent_answers
+    current_claim.reset_eligibility_dependent_answers(reset_attrs)
     one_time_password
 
     if current_claim.save(context: page_sequence.current_slug.to_sym)
@@ -175,5 +175,11 @@ class ClaimsController < BasePublicController
 
   def otp
     @otp ||= OneTimePassword::Generator.new
+  end
+
+  def reset_attrs
+    return [] unless claim_params["eligibility_attributes"]
+
+    claim_params["eligibility_attributes"].keys
   end
 end

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -37,9 +37,9 @@ class CurrentClaim
     claims.map(&:id)
   end
 
-  def reset_eligibility_dependent_answers
+  def reset_eligibility_dependent_answers(reset_attrs = [])
     claims.each do |c|
-      c.eligibility.reset_dependent_answers
+      c.eligibility.reset_dependent_answers(reset_attrs)
     end
   end
 

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -303,10 +303,12 @@ module EarlyCareerPayments
       find_cohorts(match_criteria: :partial_find)&.itt_academic_year
     end
 
-    def reset_dependent_answers
+    def reset_dependent_answers(reset_attrs = [])
+      attrs = ineligible? ? changed.concat(reset_attrs) : changed
+
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
-          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+          write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
         end
       end
     end

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -85,10 +85,12 @@ module LevellingUpPremiumPayments
       calculate_award_amount
     end
 
-    def reset_dependent_answers
+    def reset_dependent_answers(reset_attrs = [])
+      attrs = ineligible? ? changed.concat(reset_attrs) : changed
+
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
-          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+          write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
         end
       end
     end

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -96,10 +96,12 @@ module MathsAndPhysics
       BigDecimal("2000.00")
     end
 
-    def reset_dependent_answers
+    def reset_dependent_answers(reset_attrs = [])
+      attrs = ineligible? ? changed.concat(reset_attrs) : changed
+
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
-          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+          write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
         end
       end
     end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -93,10 +93,12 @@ module StudentLoans
     def eligible_itt_subject
     end
 
-    def reset_dependent_answers
+    def reset_dependent_answers(reset_attrs = [])
+      attrs = ineligible? ? changed.concat(reset_attrs) : changed
+
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
-          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+          write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
         end
       end
       self.current_school = inferred_current_school if employment_status_changed?

--- a/spec/features/resetting_dependant_attributes_spec.rb
+++ b/spec/features/resetting_dependant_attributes_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
+  let(:claim) { start_early_career_payments_claim }
+
+  before do
+    claim.update!(attributes_for(:claim, :submittable))
+    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+  end
+
+  it "resets `teaching_subject_now` when `eligible_itt_subject` gets submitted" do
+    visit claim_path(claim.policy.routing_name, "eligible-itt-subject")
+
+    choose "None of the above"
+    click_on "Continue"
+    expect(page).to have_text("Do you have an undergraduate or postgraduate degree in an eligible subject?")
+
+    choose "No"
+    click_on "Continue"
+    expect(page).to have_text("You are not eligible")
+
+    visit claim_path(claim.policy.routing_name, "eligible-itt-subject")
+    choose "None of the above"
+    click_on "Continue"
+    expect(page).to have_text("Do you have an undergraduate or postgraduate degree in an eligible subject?")
+  end
+end


### PR DESCRIPTION
This PR fixes the issue of getting stuck on the ineligible page when you are submitting the same answer. It adds the form params to the list of attributes that need to be reset because the `changed` object does not contain those keys. This is not an issue when the claim is eligible.