### PR TITLE
Fix current claim validation on save

### DIFF
--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -64,7 +64,7 @@ class CurrentClaim
   end
 
   def save(*args)
-    claims.all? { |c| c.save(*args) }
+    claims.map { |c| c.save(*args) }.all?
   end
 
   def respond_to_missing?(method_name, *args)

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -54,13 +54,17 @@ class CurrentClaim
   end
 
   def method_missing(method_name, *args, &block)
-    if [:attributes=, :save, :save!, :update, :update!, :reset_dependent_answers].include?(method_name)
+    if [:attributes=, :save!, :update, :update!, :reset_dependent_answers].include?(method_name)
       claims.each do |c|
         c.send(method_name, *args, &block) unless c == main_claim
       end
     end
 
     main_claim.send(method_name, *args, &block)
+  end
+
+  def save(*args)
+    claims.all? { |c| c.save(*args) }
   end
 
   def respond_to_missing?(method_name, *args)

--- a/spec/features/ineligible_levelling_up_premium_payments_spec.rb
+++ b/spec/features/ineligible_levelling_up_premium_payments_spec.rb
@@ -77,6 +77,9 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
 
     # Do you have an undergraduate or postgraduate degree in an eligible subject?
     expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_degree_subject"))
+    click_on "Continue"
+    expect(page).to have_text("Select yes if you have a degree in an eligible subject")
+
     choose "No"
 
     expect(eligibility.ineligible?).to be false

--- a/spec/models/current_claim_spec.rb
+++ b/spec/models/current_claim_spec.rb
@@ -38,11 +38,23 @@ RSpec.describe CurrentClaim, type: :model do
       context "when claim attributes are invalid" do
         let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "invalid") }
 
+        it "calls save on both claims" do
+          expect(lup_claim).to receive(:save)
+          expect(ecp_claim).to receive(:save)
+          subject
+        end
+
         it { is_expected.to be false }
       end
 
       context "when claim attributes are valid" do
         let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "email@example.com") }
+
+        it "calls save on both claims" do
+          expect(lup_claim).to receive(:save)
+          expect(ecp_claim).to receive(:save)
+          subject
+        end
 
         it { is_expected.to be true }
       end

--- a/spec/models/current_claim_spec.rb
+++ b/spec/models/current_claim_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe CurrentClaim, type: :model do
       end
     end
 
+    describe "#save" do
+      subject { current_claim.save }
+
+      let(:current_claim) { described_class.new(claims: [ecp_claim, lup_claim]) }
+
+      context "when claim attributes are invalid" do
+        let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "invalid") }
+
+        it { is_expected.to be false }
+      end
+
+      context "when claim attributes are valid" do
+        let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "email@example.com") }
+
+        it { is_expected.to be true }
+      end
+    end
+
     describe "#reset_dependent_answers" do
       it "calls reset reset_dependent_answers on both claims" do
         cc = described_class.new(claims: [ecp_claim, lup_claim])


### PR DESCRIPTION
Fix that shows validation error messages for LUP claims. Eg.

<img width="607" alt="Screenshot 2022-06-23 at 14 04 08" src="https://user-images.githubusercontent.com/1636476/175325014-f2da281c-ede5-4d68-b717-acb99e53e94c.png">