### PR TITLE
Tweak to restart claim page

### DIFF
--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -21,7 +21,7 @@
 }
 
 .govuk-panel--interruption {
-  background-color: $govuk-link-colour;
+  background-color: $govuk-brand-colour;
   text-align: left;
 
   * {

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -31,7 +31,7 @@
 
         </fieldset>
 
-        <%= form.submit "Submit", class: "govuk-button" %>
+        <%= form.submit "Submit", class: "govuk-button govuk-button--secondary" %>
 
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,7 +277,7 @@ en:
       btn_text: Accept and send
     policy_name: "Early-career and levelling up premium payment"
     policy_short_name: "Early-Career Payments"
-    claim_description: "for an early-career payment"
+    claim_description: "for an additional payment for teaching"
     claim_subject: "Early-career payment"
     purpose: "For early career teachers who teach certain subjects."
     support_email_address: "earlycareerteacherpayments@digital.education.gov.uk"


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-396

Implements small tweaks to the restart claim prompt page:

* Change the background colour
* Change the button to a secondary type
* Change the service name

**Before**
<img width="979" alt="Screenshot 2022-06-23 at 15 43 28" src="https://user-images.githubusercontent.com/408371/175327002-1a13f4aa-e436-4684-b82d-7b1ad84e7faa.png">

**After**
<img width="987" alt="Screenshot 2022-06-23 at 15 42 40" src="https://user-images.githubusercontent.com/408371/175326862-76ed5e7f-f6ca-4efc-b7cb-aa2176b0a1f0.png">

