### PR TITLE
CAPT-401 - Copy change: Foreign languages > Languages

### DIFF
--- a/app/views/early_career_payments/claims/_ineligibility_reason_itt_subject_none_of_the_above.html.erb
+++ b/app/views/early_career_payments/claims/_ineligibility_reason_itt_subject_none_of_the_above.html.erb
@@ -6,5 +6,5 @@
   <li>Mathematics</li>
   <li>Chemistry</li>
   <li>Physics</li>
-  <li>Foreign Languages</li>
+  <li>Languages</li>
 </ul>

--- a/app/views/early_career_payments/claims/_ineligibility_reason_not_teaching_now_in_eligible_itt_subject.html.erb
+++ b/app/views/early_career_payments/claims/_ineligibility_reason_not_teaching_now_in_eligible_itt_subject.html.erb
@@ -5,6 +5,6 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>Chemistry</li>
   <li>Mathematics</li>
-  <li>Foreign Languages</li>
+  <li>Languages</li>
   <li>Physics</li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -354,7 +354,7 @@ en:
         chemistry: "Chemistry"
         computing: "Computing"
         mathematics: "Mathematics"
-        foreign_languages: "Foreign languages"
+        foreign_languages: "Languages"
         physics: "Physics"
         none_of_the_above: "None of the above"
     reminders:

--- a/spec/features/early_career_payments_trainee_teacher_spec.rb
+++ b/spec/features/early_career_payments_trainee_teacher_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
         I18n.t("early_career_payments.questions.eligible_itt_subject_trainee_teacher")
       )
 
-      expect(page).to have_no_text("Foreign languages")
+      expect(page).to have_no_text("Languages")
 
       choose "Computing"
       click_on "Continue"

--- a/spec/features/ineligible_early_career_payments_claims_spec.rb
+++ b/spec/features/ineligible_early_career_payments_claims_spec.rb
@@ -273,13 +273,13 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims" do
     # - In which academic year did you start your undergraduate ITT
     expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))
 
-    choose "2020 to 2021" # Have to select one that's eligible for foreign languages
+    choose "2020 to 2021" # Have to select one that's eligible for languages
     click_on "Continue"
 
     # - Which subject did you do your undergraduate ITT in
     expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: claim.eligibility.qualification_name))
 
-    choose "Foreign languages"
+    choose "Languages"
     click_on "Continue"
 
     expect(claim.eligibility.reload.eligible_itt_subject).to eql "foreign_languages"

--- a/spec/features/subject_teaching_question_spec.rb
+++ b/spec/features/subject_teaching_question_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       visit claim_path(claim.policy.routing_name, "teaching-subject-now")
-      expect(page).to have_text("chemistry, computing, foreign languages, mathematics or physics")
+      expect(page).to have_text("chemistry, computing, languages, mathematics or physics")
 
       click_on "Continue"
       expect(page).to have_text("Select yes if you currently spend at least half of your contracted hours teaching eligible subjects")
@@ -54,7 +54,7 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       visit claim_path(claim.policy.routing_name, "teaching-subject-now")
-      expect(page).to have_text("chemistry, foreign languages, mathematics or physics.")
+      expect(page).to have_text("chemistry, languages, mathematics or physics.")
     end
   end
 

--- a/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
+++ b/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter, type: :model do
         ],
         [
           I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: eligibility.qualification_name),
-          "Foreign languages",
+          "Languages",
           "eligible-itt-subject"
         ],
         [

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -1289,10 +1289,11 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :none_of_the_above)).to be_valid(:"eligible-itt-subject")
       end
 
-      it "is valid when the value for 'eligible_itt_subject' is one of 'chemistry, languages, mathematics or physics'" do
+      it "is valid when the value for 'eligible_itt_subject' is one of 'chemistry, foreign_languages, mathematics or physics'" do
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :chemistry)).to be_valid(:"eligible-itt-subject")
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :physics)).to be_valid(:"eligible-itt-subject")
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :foreign_languages)).to be_valid(:"eligible-itt-subject")
+        expect(-> { EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :languages) }).to raise_error(ArgumentError)
       end
     end
 

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -1289,7 +1289,7 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :none_of_the_above)).to be_valid(:"eligible-itt-subject")
       end
 
-      it "is valid when the value for 'eligible_itt_subject' is one of 'chemistry, foreign languages, mathematics or physics'" do
+      it "is valid when the value for 'eligible_itt_subject' is one of 'chemistry, languages, mathematics or physics'" do
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :chemistry)).to be_valid(:"eligible-itt-subject")
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :physics)).to be_valid(:"eligible-itt-subject")
         expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :foreign_languages)).to be_valid(:"eligible-itt-subject")


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-401

Changes copy from 'Foreign languages' to 'Languages'.

Note: does not migrate the database enum key as this does not change the semantics or the relative sort order of the subject option. Data migration would introduce unnecessary complexity and risk.