### PR TITLE
Store policy_options_provided on to claim and display in admin

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -14,6 +14,15 @@ module Admin
       claim.policy::EligibilityAdminAnswersPresenter.new(claim.eligibility).answers
     end
 
+    def admin_policy_options_provided(claim)
+      claim.policy_options_provided.map do |option|
+        label = t(:payment_name, scope: option["policy"].constantize.locale_key)
+        answer = number_to_currency(option["award_amount"], precision: 0)
+
+        [label, answer]
+      end
+    end
+
     def personal_data_removed_text
       content_tag(:span, "Removed", class: "capt-text-quiet")
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -94,7 +94,8 @@ class Claim < ApplicationRecord
     sent_one_time_password_at: false,
     mobile_verified: false,
     one_time_password_category: false,
-    assigned_to_id: true
+    assigned_to_id: true,
+    policy_options_provided: false
   }.freeze
   DECISION_DEADLINE = 14.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -126,6 +126,7 @@ module EarlyCareerPayments
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
+    # TODO: be careful this can return BigDecimal or Integers, this isn't ideal
     def award_amount
       super || calculate_award_amount
     end

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -32,6 +32,10 @@
 
     <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
 
+    <% if @claim.has_ecp_or_lupp_policy? && @claim.policy_options_provided.present? %>
+      <%= render "admin/claims/answer_section", {heading: "Policy options provided", answers: admin_policy_options_provided(@claim)} %>
+    <% end %>
+
     <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
 
     <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,6 +277,7 @@ en:
       btn_text: Accept and send
     policy_name: "Claim Additional Payments for Teaching"
     policy_short_name: "Early-Career Payments"
+    payment_name: "Early-career payment"
     claim_description: "for an additional payment for teaching"
     claim_subject: "Early-career payment"
     purpose: "For early career teachers who teach certain subjects."
@@ -367,6 +368,7 @@ en:
   levelling_up_premium_payments:
     purpose: For early career teachers who teach certain subjects and work in disadvantaged schools.
     policy_short_name: "Levelling Up Premium Payments"
+    payment_name: "Levelling up premium payment"
     admin:
       degree_in_an_eligible_subject: "Do you have an UG or a PG degree in an eligible subject?"
       task_questions:

--- a/db/migrate/20220707120226_add_policy_options_provided_to_claims.rb
+++ b/db/migrate/20220707120226_add_policy_options_provided_to_claims.rb
@@ -1,0 +1,5 @@
+class AddPolicyOptionsProvidedToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_column :claims, :policy_options_provided, :jsonb, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_175052) do
+ActiveRecord::Schema.define(version: 2022_07_07_120226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2022_05_23_175052) do
     t.boolean "has_masters_doctoral_loan"
     t.boolean "mobile_verified", default: false
     t.string "assigned_to_id"
+    t.jsonb "policy_options_provided", default: []
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -59,6 +59,31 @@ FactoryBot.define do
       reference { Reference.new.to_s }
     end
 
+    trait :policy_options_provided_with_both do
+      policy_options_provided {
+        [
+          {"policy" => "EarlyCareerPayments", "award_amount" => "2000.0"},
+          {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+        ]
+      }
+    end
+
+    trait :policy_options_provided_ecp_only do
+      policy_options_provided {
+        [
+          {"policy" => "EarlyCareerPayments", "award_amount" => "2000.0"}
+        ]
+      }
+    end
+
+    trait :policy_options_provided_lup_only do
+      policy_options_provided {
+        [
+          {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+        ]
+      }
+    end
+
     trait :verified do
       govuk_verify_fields { %w[first_name surname address_line_1 postcode date_of_birth payroll_gender] }
     end

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -156,7 +156,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     click_on "Continue"
 
     # - Enter bank account details
-    expect(page).to have_text(I18n.t("questions.account_details", bank_or_building_society: claim.bank_or_building_society.humanize.downcase))
+    expect(page).to have_text(I18n.t("questions.account_details", bank_or_building_society: claim.reload.bank_or_building_society.humanize.downcase))
     expect(page).not_to have_text("Building society roll number")
 
     fill_in "Name on your account", with: "Jo Bloggs"
@@ -209,6 +209,13 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     expect(page).to have_text("It can take up to 13 weeks to process your application")
     expect(page).to have_text("What did you think of this service?")
     expect(page).to have_text(claim.reload.reference)
+
+    policy_options_provided = [
+      {"policy" => "EarlyCareerPayments", "award_amount" => "2000.0"},
+      {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+    ]
+
+    expect(claim.reload.policy_options_provided).to eq policy_options_provided
   end
 
   scenario "Eligible for only one" do

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -334,6 +334,13 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     expect(page).to have_text("It can take up to 13 weeks to process your application")
     expect(page).to have_text("What did you think of this service?")
     expect(page).to have_text(claim.reference)
+
+    policy_options_provided = [
+      {"policy" => "EarlyCareerPayments", "award_amount" => "7500.0"},
+      {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+    ]
+
+    expect(claim.reload.policy_options_provided).to eq policy_options_provided
   end
 
   scenario "Supply Teacher makes claim for 'Early Career Payments' with a contract to teach for entire term & employed directly by school" do
@@ -822,6 +829,13 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     expect(page).to have_text("Set a reminder for when your next application window opens")
     expect(page).to have_text("What did you think of this service?")
     expect(page).to have_text(claim.reference)
+
+    policy_options_provided = [
+      {"policy" => "EarlyCareerPayments", "award_amount" => "5000.0"},
+      {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+    ]
+
+    expect(claim.reload.policy_options_provided).to eq policy_options_provided
   end
 
   context "When auto-populating address details" do
@@ -1195,6 +1209,13 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       expect(page).to have_text("Set a reminder for when your next application window opens")
       expect(page).to have_text("What did you think of this service?")
       expect(page).to have_text(claim.reference)
+
+      policy_options_provided = [
+        {"policy" => "EarlyCareerPayments", "award_amount" => "7500.0"},
+        {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+      ]
+
+      expect(claim.reload.policy_options_provided).to eq policy_options_provided
     end
   end
 end

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -283,5 +283,11 @@ RSpec.feature "Levelling up premium payments claims" do
     expect(page).to have_text("It can take up to 13 weeks to process your application")
     expect(page).to have_text("What did you think of this service?")
     expect(page).to have_text(claim.reference)
+
+    policy_options_provided = [
+      {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+    ]
+
+    expect(claim.reload.policy_options_provided).to eq policy_options_provided
   end
 end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -465,4 +465,44 @@ describe Admin::ClaimsHelper do
       end
     end
   end
+
+  describe "#admin_policy_options_provided" do
+    context "Eligible for ECP and LUP" do
+      let(:claim) { create(:claim, :submitted, :policy_options_provided_with_both, policy: EarlyCareerPayments) }
+
+      it "returns both polices" do
+        answers = [["Early-career payment", "£2,000"], ["Levelling up premium payment", "£2,000"]]
+
+        expect(admin_policy_options_provided(claim)).to match_array answers
+      end
+    end
+
+    context "Eligible for ECP only" do
+      let(:claim) { create(:claim, :submitted, :policy_options_provided_ecp_only, policy: EarlyCareerPayments) }
+
+      it "returns ECP only" do
+        answers = [["Early-career payment", "£2,000"]]
+
+        expect(admin_policy_options_provided(claim)).to match_array answers
+      end
+    end
+
+    context "Eligible for LUP only" do
+      let(:claim) { create(:claim, :submitted, :policy_options_provided_lup_only, policy: LevellingUpPremiumPayments) }
+
+      it "returns LUP only" do
+        answers = [["Levelling up premium payment", "£2,000"]]
+
+        expect(admin_policy_options_provided(claim)).to match_array answers
+      end
+    end
+
+    context "No policy_options_provided (not ECP/LUP claim)" do
+      let(:claim) { create(:claim, :submitted) }
+
+      it "returns no options" do
+        expect(admin_policy_options_provided(claim)).to match_array []
+      end
+    end
+  end
 end


### PR DESCRIPTION
For ECP/LUP claims store the claim options presented. The policy and the award amount.

This is then visible to an admin.