### PR TITLE
[CAPT-245] Add N/A to unsubmitted answers

### DIFF
--- a/app/models/admin/presenter_methods.rb
+++ b/app/models/admin/presenter_methods.rb
@@ -11,6 +11,17 @@ module Admin
       ActionController::Base.helpers.sanitize(html, tags: %w[span a], attributes: %w[href class])
     end
 
+    def display_boolean(value)
+      case value
+      when false
+        "No"
+      when true
+        "Yes"
+      else
+        "N/A"
+      end
+    end
+
     private
 
     def link_to_school(school)

--- a/app/models/levelling_up_premium_payments/eligibility_admin_answers_presenter.rb
+++ b/app/models/levelling_up_premium_payments/eligibility_admin_answers_presenter.rb
@@ -43,7 +43,7 @@ module LevellingUpPremiumPayments
     def degree_in_an_eligible_subject
       [
         translate("levelling_up_premium_payments.admin.degree_in_an_eligible_subject"),
-        (eligibility.eligible_degree_subject? ? "Yes" : "No")
+        display_boolean(eligibility.eligible_degree_subject)
       ]
     end
   end

--- a/spec/models/admin/presenter_methods_spec.rb
+++ b/spec/models/admin/presenter_methods_spec.rb
@@ -23,4 +23,26 @@ RSpec.describe Admin::PresenterMethods do
       )
     end
   end
+
+  describe "#display_boolean" do
+    subject { admin_presenter.new.display_boolean(value) }
+
+    context "when answered No" do
+      let(:value) { false }
+
+      it { is_expected.to eq("No") }
+    end
+
+    context "when answered Yes" do
+      let(:value) { true }
+
+      it { is_expected.to eq("Yes") }
+    end
+
+    context "when not answered" do
+      let(:value) { nil }
+
+      it { is_expected.to eq("N/A") }
+    end
+  end
 end

--- a/spec/models/levelling_up_premium_payments/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/levelling_up_premium_payments/eligibility_admin_answers_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe LevellingUpPremiumPayments::EligibilityAdminAnswersPresenter, typ
       expected_answers = [
         [I18n.t("early_career_payments.admin.nqt_in_academic_year_after_itt"), "Yes"],
         [I18n.t("early_career_payments.admin.employed_as_supply_teacher"), "No"],
-        [I18n.t("levelling_up_premium_payments.admin.degree_in_an_eligible_subject"), "No"]
+        [I18n.t("levelling_up_premium_payments.admin.degree_in_an_eligible_subject"), "N/A"]
       ]
 
       expect(presenter.answers).to eq expected_answers


### PR DESCRIPTION
I created a presenter for Yes/No answers to display correctly unsubmitted answers, but I am not aware of other questions that can be skipped in the wizard.

<img width="652" alt="Screenshot 2022-07-12 at 12 05 08" src="https://user-images.githubusercontent.com/1636476/178453663-31720f30-e733-40e9-ae76-3fa2ab15d4ff.png">

