### PR TITLE
Prevent the school factory to use existing URN

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -36,9 +36,11 @@ FactoryBot.define do
 
     trait :levelling_up_premium_payments_eligible do
       # this is a huge array but if it ever cycles, there'll be a message about duplicate URNs
-      sequence :urn, LevellingUpPremiumPayments::Award.urn_to_award_amount_in_pounds(AcademicYear.new(2022))
-                                                      .keys
-                                                      .cycle
+      sequence :urn, LevellingUpPremiumPayments::Award
+        .urn_to_award_amount_in_pounds(AcademicYear.new(2022))
+        .keys
+        .excluding(School.pluck(:urn))
+        .cycle
     end
 
     trait :levelling_up_premium_payments_ineligible do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -38,7 +38,6 @@ FactoryBot.define do
       # this is a huge array but if it ever cycles, there'll be a message about duplicate URNs
       sequence :urn, LevellingUpPremiumPayments::Award.urn_to_award_amount_in_pounds(AcademicYear.new(2022))
                                                       .keys
-                                                      .excluding(School.pluck(:urn))
                                                       .cycle
     end
 

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -36,7 +36,10 @@ FactoryBot.define do
 
     trait :levelling_up_premium_payments_eligible do
       # this is a huge array but if it ever cycles, there'll be a message about duplicate URNs
-      sequence :urn, LevellingUpPremiumPayments::Award.urn_to_award_amount_in_pounds(AcademicYear.new(2022)).keys.cycle
+      sequence :urn, LevellingUpPremiumPayments::Award.urn_to_award_amount_in_pounds(AcademicYear.new(2022))
+                                                      .keys
+                                                      .excluding(School.pluck(:urn))
+                                                      .cycle
     end
 
     trait :levelling_up_premium_payments_ineligible do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -36,11 +36,7 @@ FactoryBot.define do
 
     trait :levelling_up_premium_payments_eligible do
       # this is a huge array but if it ever cycles, there'll be a message about duplicate URNs
-      sequence :urn, LevellingUpPremiumPayments::Award
-        .urn_to_award_amount_in_pounds(AcademicYear.new(2022))
-        .keys
-        .excluding(School.pluck(:urn))
-        .cycle
+      sequence :urn, LevellingUpPremiumPayments::Award.urn_to_award_amount_in_pounds(AcademicYear.new(2022)).keys.cycle
     end
 
     trait :levelling_up_premium_payments_ineligible do

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -38,7 +38,7 @@ the_samuel_lister_academy:
 
 hampstead_school:
   name: Hampstead School
-  urn: 100052
+  urn: 139841
   phase: secondary
   school_type_group: la_maintained
   school_type: community_school


### PR DESCRIPTION
Fixes `db:reset` `ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_schools_on_urn"` error.

**Update:** CI runs `School.pluck(:urn)` before the database gets created. It throws: `PG::ConnectionBad: FATAL:  database "dfe-teachers-payment-service_test" does not exist`. I'll skip this approach for now and update the `urn` value to one with the same amount but closer to the end of `urn_to_award_amount_in_pounds_for_2022_to_2023`. Doing this will prevent `sequence` from getting to that number.