### PR TITLE
Add translation values for LUP emails

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,9 @@ en:
     purpose: For early career teachers who teach certain subjects and work in disadvantaged schools.
     policy_short_name: "Levelling Up Premium Payments"
     payment_name: "Levelling up premium payment"
+    claim_description: "for an additional payment for teaching"
+    claim_subject: "Levelling up premium payment"
+    support_email_address: "additionalteachingpayment@digital.education.gov.uk"
     admin:
       degree_in_an_eligible_subject: "Do you have an UG or a PG degree in an eligible subject?"
       task_questions:


### PR DESCRIPTION
The emails for LUP need some work, this PR just makes it so we don't get this when testing on development:

<img width="715" alt="Screenshot 2022-07-13 at 09 57 20" src="https://user-images.githubusercontent.com/1636476/178671246-98de7481-d5df-4fc5-a60b-1087f56e0a37.png">

