### PR TITLE
Rename method to indicate it's not only looking at the next policy year

### DIFF
--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -109,11 +109,10 @@ class CurrentClaim
     claims.any? { |c| c.eligibility.eligible_later? }
   end
 
-  # This is for cases when you *know* they're eligible later (given
-  # a teacher's circumstances don't change). Use this when a teacher
-  # is eligible now and wants a reminder to claim *again* in a future year.
-  def eligible_next_year_too?
-    claims.any? { |c| c.eligibility.eligible_next_year_too? }
+  # Use this when a teacher is eligible now and wants a reminder to
+  # claim *again* in a future year.
+  def eligible_now_and_again_sometime?
+    claims.any? { |c| c.eligibility.eligible_now_and_again_sometime? }
   end
 
   def editable_attributes

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -103,8 +103,8 @@ module EarlyCareerPayments
       qualification_attained == "assessment only" ? qualification_attained : qualification_attained + " qualification"
     end
 
-    def eligible_next_year_too?
-      any_future_policy_years? and common_eligible_now_attributes? and newly_qualified_teacher? and itt_subject_eligible_later?
+    def eligible_now_and_again_sometime?
+      eligible_now? && any_future_policy_years? && common_eligible_now_attributes? && itt_subject_eligible_later?
     end
 
     def eligible_later_year

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -95,8 +95,8 @@ module LevellingUpPremiumPayments
       save!
     end
 
-    def eligible_next_year_too?
-      any_future_policy_years? && eligible_now?
+    def eligible_now_and_again_sometime?
+      eligible_now? && any_future_policy_years?
     end
 
     def indicated_ineligible_itt_subject?

--- a/app/views/submissions/_completion.html.erb
+++ b/app/views/submissions/_completion.html.erb
@@ -1,6 +1,6 @@
 <%= render 'confirmation' %>
 
-<% if current_claim.eligible_next_year_too? %>
+<% if current_claim.eligible_now_and_again_sometime? %>
   <h2 class="govuk-heading-m">Set a reminder for when your next application window opens</h2>
 
   <p class="govuk-body">

--- a/spec/factories/early_career_payments/eligibilities.rb
+++ b/spec/factories/early_career_payments/eligibilities.rb
@@ -10,10 +10,24 @@ FactoryBot.define do
       eligible_itt_subject_now
     end
 
-    trait :eligible_next_year_too do
+    trait :eligible_now_with_mathematics do
       eligible_now
-      itt_academic_year { AcademicYear::Type.new.serialize(AcademicYear.new(2020)) }
       eligible_itt_subject { :mathematics }
+    end
+
+    trait :ineligible_now_but_eligible_next_year do
+      eligible_now_with_mathematics
+      itt_academic_year { AcademicYear::Type.new.serialize(AcademicYear.new(2018)) } # this makes it ineligible
+    end
+
+    trait :eligible_now_and_again_but_two_years_later do
+      eligible_now_with_mathematics
+      itt_academic_year { AcademicYear::Type.new.serialize(AcademicYear.new(2019)) }
+    end
+
+    trait :eligible_next_year_too do
+      eligible_now_with_mathematics
+      itt_academic_year { AcademicYear::Type.new.serialize(AcademicYear.new(2020)) }
     end
 
     trait :eligible_school do

--- a/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
+++ b/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
@@ -27,12 +27,6 @@ end
 RSpec.feature "Completed Applications - Reminders" do
   [
     {
-      policy_year: AcademicYear.new(2021),
-      eligible_now: [
-        {itt_subject: "mathematics", itt_academic_year: AcademicYear.new(2018), invited_to_set_reminder: true}
-      ]
-    },
-    {
       policy_year: AcademicYear.new(2022),
       eligible_now: [
         {itt_subject: "mathematics", itt_academic_year: AcademicYear.new(2019), invited_to_set_reminder: true},

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -422,4 +422,34 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
       it { is_expected.to eq(:ineligible) }
     end
   end
+
+  describe "#eligible_now_and_again_sometime?" do
+    subject { eligibility }
+
+    context "ineligible now but eligible next year" do
+      let(:eligibility) { build(:early_career_payments_eligibility, :ineligible_now_but_eligible_next_year) }
+
+      specify { expect(subject.status).to eq(:eligible_later) }
+
+      it "is not eligible *again* in the future because it's not even eligible now" do
+        is_expected.not_to be_eligible_now_and_again_sometime
+      end
+    end
+
+    context "eligible now and again next year" do
+      let(:eligibility) { build(:early_career_payments_eligibility, :eligible_next_year_too) }
+
+      specify { expect(subject.status).to eq(:eligible_now) }
+
+      it { is_expected.to be_eligible_now_and_again_sometime }
+    end
+
+    context "eligible now and again but two years later (so not next year)" do
+      let(:eligibility) { build(:early_career_payments_eligibility, :eligible_now_and_again_but_two_years_later) }
+
+      specify { expect(subject.status).to eq(:eligible_now) }
+
+      it { is_expected.to be_eligible_now_and_again_sometime }
+    end
+  end
 end

--- a/spec/support/eligibility_status_shared_examples.rb
+++ b/spec/support/eligibility_status_shared_examples.rb
@@ -87,7 +87,7 @@ RSpec.shared_examples "Eligibility status" do |eligibility_factory_symbol|
     end
   end
 
-  describe "#eligible_next_year_too?" do
+  describe "#eligible_now_and_again_sometime?" do
     subject { eligibility }
 
     context "eligible both now and later" do
@@ -95,7 +95,7 @@ RSpec.shared_examples "Eligibility status" do |eligibility_factory_symbol|
 
       specify { expect(subject.status).to eq(:eligible_now) }
       it { is_expected.to be_eligible_now }
-      it { is_expected.to be_eligible_next_year_too }
+      it { is_expected.to be_eligible_now_and_again_sometime }
     end
   end
 end


### PR DESCRIPTION
Make method name more explicit.

Added some factories and specs to show what it's doing: this will be handy for future reminder work.
