### PR TITLE
Change subject hint text to exclude ineligible subjects from ineligible policies

### DIFF
--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -115,6 +115,10 @@ module LevellingUpPremiumPayments
 
     private
 
+    def indicated_ecp_only_itt_subject?
+      eligible_itt_subject.present? && (eligible_itt_subject.to_sym == :foreign_languages)
+    end
+
     def specific_eligible_now_attributes?
       eligible_itt_subject_or_relevant_degree?
     end
@@ -142,7 +146,7 @@ module LevellingUpPremiumPayments
     end
 
     def specific_ineligible_attributes?
-      trainee_teacher_with_ineligible_itt_subject? || ineligible_itt_subject_and_no_relevant_degree?
+      indicated_ecp_only_itt_subject? || trainee_teacher_with_ineligible_itt_subject? || ineligible_itt_subject_and_no_relevant_degree?
     end
 
     def trainee_teacher_with_ineligible_itt_subject?

--- a/app/views/early_career_payments/claims/eligible_degree_subject.html.erb
+++ b/app/views/early_career_payments/claims/eligible_degree_subject.html.erb
@@ -23,7 +23,8 @@
             </legend>
 
             <span class="govuk-hint" id="has_uk_maths_or_physics_degree-hint">
-              This can be an undergraduate or postgraduate degree in chemistry, computing, mathematics or physics.
+              This can be an undergraduate or postgraduate degree in
+              <%= JourneySubjectEligibilityChecker.fixed_lup_subject_symbols.to_sentence(last_word_connector: ' or ') %>.
             </span>
 
             <%= errors_tag claim.eligibility, :eligible_degree_subject %>

--- a/spec/helpers/claims/itt_subject_helper_spec.rb
+++ b/spec/helpers/claims/itt_subject_helper_spec.rb
@@ -31,10 +31,46 @@ RSpec.describe Claims::IttSubjectHelper do
   end
 
   describe "#subjects_to_sentence" do
+    let(:ecp_claim) { build(:claim, :first_lup_claim_year, eligibility: ecp_eligibility) }
+    let(:lup_claim) { build(:claim, :first_lup_claim_year, eligibility: lup_eligibility) }
+    let(:academic_year_2019) { AcademicYear::Type.new.serialize(AcademicYear.new(2019)) }
+    let(:academic_year_2020) { AcademicYear::Type.new.serialize(AcademicYear.new(2020)) }
+
+    subject { helper.subjects_to_sentence(CurrentClaim.new(claims: [ecp_claim, lup_claim])) }
+
     context "trainee teacher" do
-      subject { helper.subjects_to_sentence(CurrentClaim.new(claims: [ecp_trainee_teacher_claim, lup_trainee_teacher_claim])) } # check calls
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :trainee_teacher) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :trainee_teacher) }
 
       it { is_expected.to eq("chemistry, computing, mathematics or physics") }
+    end
+
+    context "chosen LUP-only subject" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :common_eligible_attributes, itt_academic_year: academic_year_2020, eligible_itt_subject: :computing) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :common_eligible_attributes, itt_academic_year: academic_year_2020, eligible_itt_subject: :computing) }
+
+      it { is_expected.to eq("chemistry, computing, mathematics or physics") }
+    end
+
+    context "chosen what's both an ECP and LUP subject" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :common_eligible_attributes, itt_academic_year: academic_year_2020, eligible_itt_subject: :mathematics) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :common_eligible_attributes, itt_academic_year: academic_year_2020, eligible_itt_subject: :mathematics) }
+
+      it { is_expected.to eq("chemistry, computing, languages, mathematics or physics") }
+    end
+
+    context "chosen ECP-only subject for an ITT year where the options are Chemistry, Languages, Mathematics and Physics" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :common_eligible_attributes, itt_academic_year: academic_year_2020, eligible_itt_subject: :foreign_languages) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible, itt_academic_year: academic_year_2020, eligible_itt_subject: :foreign_languages) }
+
+      it { is_expected.to eq("chemistry, languages, mathematics or physics") }
+    end
+
+    context "chosen ECP-only subject for an ITT year where the only ECP subject is Mathematics" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :common_eligible_attributes, itt_academic_year: academic_year_2019, eligible_itt_subject: :mathematics) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible, itt_academic_year: academic_year_2019, eligible_itt_subject: :mathematics) }
+
+      it { is_expected.to eq("mathematics") }
     end
   end
 end

--- a/spec/models/levelling_up_premium_payments/eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/eligibility_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe LevellingUpPremiumPayments::Eligibility, type: :model do
   context "LUP-specific eligibility" do
     subject { eligibility.status }
 
+    context "ECP-only ITT subject" do
+      let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible_now, :ineligible_itt_subject) }
+
+      it { is_expected.to eq(:ineligible) }
+    end
+
     context "ITT subject or degree subject" do
       context "good ITT subject and no degree" do
         let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible_now, :lup_itt_subject, :no_relevant_degree) }


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-539

For the hint text after a teacher has selected a subject, filter out subjects from the other policy when they've chosen a subject specific to one policy.
