### PR TITLE
Update ITT subject question when there's only one choice and fix tense for trainee teachers

### DIFF
--- a/app/helpers/early_career_payments_helper.rb
+++ b/app/helpers/early_career_payments_helper.rb
@@ -5,34 +5,34 @@ module EarlyCareerPaymentsHelper
     pluralize(OneTimePassword::Base::DRIFT / 60, "minute")
   end
 
+  def graduate_itt?(claim)
+    %w[undergraduate_itt postgraduate_itt].include? claim.eligibility.qualification
+  end
+
   def eligible_itt_subject_translation(claim)
     if claim.eligibility.trainee_teacher?
       return I18n.t("early_career_payments.questions.eligible_itt_subject_trainee_teacher")
     end
 
-    case qualification_name(claim.eligibility.qualification)
-    when "assessment only"
-      I18n.t("early_career_payments.questions.eligible_itt_subject_assessment_only")
-    when "overseas recognition qualification"
-      I18n.t("early_career_payments.questions.eligible_itt_subject_overseas_recognition")
+    qualification_symbol = claim.eligibility.qualification.to_sym
+    subjects = subject_symbols(claim)
+
+    if subjects.many?
+      I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_to_substring(qualification_symbol))
     else
-      I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification))
+      subject_symbol = subjects.first
+      I18n.t("early_career_payments.questions.eligible_itt_subject_one_option", qualification: qualification_to_substring(qualification_symbol), subject: subject_symbol)
     end
   end
 
-  def graduate_itt?(claim)
-    %w[undergraduate_itt postgraduate_itt].include? claim.eligibility.qualification
-  end
+  private
 
-  def qts?(claim)
-    %w[assessment_only overseas_recognition].include? claim.eligibility.qualification
-  end
-
-  def qualification_name(qualification)
-    return qualification.gsub("_itt", " initial teaching training") if qualification.split("_").last == "itt"
-
-    qualification_attained = qualification.humanize.downcase
-
-    qualification_attained == "assessment only" ? qualification_attained : qualification_attained + " qualification"
+  def qualification_to_substring(qualification_symbol)
+    {
+      undergraduate_itt: "undergraduate initial teacher training (ITT)",
+      postgraduate_itt: "postgraduate initial teacher training (ITT)",
+      assessment_only: "assessment",
+      overseas_recognition: "teaching qualification"
+    }[qualification_symbol]
   end
 end

--- a/app/views/early_career_payments/claims/eligible_itt_subject.html.erb
+++ b/app/views/early_career_payments/claims/eligible_itt_subject.html.erb
@@ -19,7 +19,7 @@
               </h1>
             </legend>
 
-            <% if current_claim.eligibility.nqt_in_academic_year_after_itt %>
+            <% if current_claim.eligibility.nqt_in_academic_year_after_itt && subject_symbols.many? %>
               <span class="govuk-hint">
                 <%= t("early_career_payments.questions.eligible_itt_subject_hint") %>
               </span>
@@ -28,19 +28,31 @@
             <%= errors_tag current_claim.eligibility, :eligible_itt_subject %>
 
             <div class="govuk-radios">
-              <% subject_symbols.each do |option| %>
+              <% if subject_symbols.many? %>
+                <% subject_symbols.each do |option| %>
+                  <div class="govuk-radios__item">
+                    <%= fields.radio_button(:eligible_itt_subject, option, class: "govuk-radios__input") %>
+                    <%= fields.label "eligible_itt_subject_#{option}", t("early_career_payments.answers.eligible_itt_subject.#{option}"), class: "govuk-label govuk-radios__label" %>
+                  </div>
+                <% end %>
+
+                <div class="govuk-radios__divider">or</div>
+
                 <div class="govuk-radios__item">
-                  <%= fields.radio_button(:eligible_itt_subject, option, class: "govuk-radios__input") %>
-                  <%= fields.label "eligible_itt_subject_#{option}", t("early_career_payments.answers.eligible_itt_subject.#{option}"), class: "govuk-label govuk-radios__label" %>
+                  <%= fields.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
+                  <%= fields.label "eligible_itt_subject_none_of_the_above", t("early_career_payments.answers.eligible_itt_subject.none_of_the_above"), class: "govuk-label govuk-radios__label" %>
+                </div>
+              <% else %>
+                <% subject_symbol = subject_symbols.first %>
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:eligible_itt_subject, subject_symbol, class: "govuk-radios__input") %>
+                  <%= fields.label "eligible_itt_subject_#{subject_symbol}", "Yes", class: "govuk-label govuk-radios__label" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
+                  <%= fields.label "eligible_itt_subject_none_of_the_above", "No", class: "govuk-label govuk-radios__label" %>
                 </div>
               <% end %>
-
-              <div class="govuk-radios__divider">or</div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
-                <%= fields.label "eligible_itt_subject_none_of_the_above", t("early_career_payments.answers.eligible_itt_subject.none_of_the_above"), class: "govuk-label govuk-radios__label" %>
-              </div>
             </div>
           </fieldset>
         <% end %>
@@ -50,16 +62,29 @@
           <br/>
 
           <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
+            <% if current_claim.eligibility.nqt_in_academic_year_after_itt? %>
+              <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">
                 If you qualified with science
               </span>
-            </summary>
-            <div class="govuk-details__text">
-              <p class="govuk-body">
-                You will need to have specialised in either chemistry or physics to be eligible. If you specialised in biology then you will not be eligible. If you’re unsure, you can get this from the certificate you received when you qualified as a teacher.
-              </p>
-            </div>
+              </summary>
+              <div class="govuk-details__text">
+                <p class="govuk-body">
+                  You will need to have specialised in either chemistry or physics to be eligible. If you specialised in biology then you will not be eligible. If you’re unsure, you can get this from the certificate you received when you qualified as a teacher.
+                </p>
+              </div>
+            <% else %>
+              <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                If you qualify with science
+              </span>
+              </summary>
+              <div class="govuk-details__text">
+                <p class="govuk-body">
+                  You will need to specialise in either chemistry or physics to be eligible for an additional payment. If you specialise in biology then you will not be eligible.
+                </p>
+              </div>
+            <% end %>
           </details>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,9 +310,8 @@ en:
         hint:
           postgraduate_itt: "Postgraduate Certificate of Education (PGCE), Teach First, School Direct ITT and School Centered ITT (SCITT)."
           undergraduate_itt: "Bachelor of Arts (BA) or Bachelor of Science (BSc) degrees."
-      eligible_itt_subject: "Which subject did you do your %{qualification} (ITT) in?"
-      eligible_itt_subject_assessment_only: "Which subject did you do your assessment in?"
-      eligible_itt_subject_overseas_recognition: "Which subject did you do your teaching qualification in?"
+      eligible_itt_subject: "Which subject did you do your %{qualification} in?"
+      eligible_itt_subject_one_option: "Did you do your %{qualification} in %{subject}?"
       eligible_itt_subject_trainee_teacher: "Which subject are you currently doing your initial teacher training (ITT) in?"
       eligible_itt_subject_hint: "The subjects listed are eligible for additional payment based on the school you teach in and the year you studied."
       teaching_subject_now: "Do you spend at least half of your contracted hours teaching eligible subjects?"

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     click_on "Continue"
 
     # - Which subject did you do your undergraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "postgraduate initial teaching training"))
+    expect(page).to have_text("Which subject")
     choose "Mathematics"
     click_on "Continue"
 
@@ -257,8 +257,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     choose "2020 to 2021"
     click_on "Continue"
 
-    # - Which subject did you do your undergraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "postgraduate initial teaching training"))
+    expect(page).to have_text("Which subject")
     choose "Mathematics"
     click_on "Continue"
 

--- a/spec/features/early_career_payments_claim_lupp_ineligible_spec.rb
+++ b/spec/features/early_career_payments_claim_lupp_ineligible_spec.rb
@@ -65,12 +65,11 @@ RSpec.feature "Early-Career Payments claims with school ineligible for Levelling
     choose "#{itt_year.start_year} to #{itt_year.end_year}"
     click_on "Continue"
 
-    # - Which subject did you do your postgraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification)))
+    expect(page).to have_text("Did you do your undergraduate initial teacher training (ITT) in mathematics?")
 
     expect(page).not_to have_text("If you qualified with science")
 
-    choose "Mathematics"
+    choose "Yes"
     click_on "Continue"
 
     # - Do you teach maths now

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -85,8 +85,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     choose "#{itt_year.start_year} to #{itt_year.end_year}"
     click_on "Continue"
 
-    # - Which subject did you do your postgraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification)))
+    expect(page).to have_text("Which subject")
 
     choose "Mathematics"
     click_on "Continue"
@@ -439,8 +438,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       choose "#{itt_year.start_year} to #{itt_year.end_year}"
       click_on "Continue"
 
-      # - Which subject did you do your postgraduate ITT in
-      expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject_assessment_only"))
+      expect(page).to have_text("Which subject")
 
       choose "Mathematics"
       click_on "Continue"
@@ -488,8 +486,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
       choose "#{itt_year.start_year} to #{itt_year.end_year}"
       click_on "Continue"
 
-      # - Which subject did you do your postgraduate ITT in
-      expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject_overseas_recognition"))
+      expect(page).to have_text("Which subject")
 
       choose "Mathematics"
       click_on "Continue"
@@ -588,8 +585,7 @@ RSpec.feature "Teacher Early-Career Payments claims" do
     choose "#{itt_year.start_year} to #{itt_year.end_year}"
     click_on "Continue"
 
-    # - Which subject did you do your postgraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification)))
+    expect(page).to have_text("Which subject")
 
     choose "Mathematics"
     click_on "Continue"

--- a/spec/features/ineligibility_reason_spec.rb
+++ b/spec/features/ineligibility_reason_spec.rb
@@ -172,7 +172,8 @@ RSpec.feature "Ineligibility reason" do
     scenario "2018 ITT" do
       select_itt_year(AcademicYear.new(2018))
 
-      choose "None of the above"
+      # subject
+      choose "No"
       click_on "Continue"
 
       expect(page).to have_css("div#bad_itt_year_for_ecp")
@@ -181,7 +182,8 @@ RSpec.feature "Ineligibility reason" do
     scenario "2019 ITT" do
       select_itt_year(AcademicYear.new(2019))
 
-      choose "None of the above"
+      # subject
+      choose "No"
       click_on "Continue"
 
       expect(page).to have_css("div#bad_itt_year_for_ecp")

--- a/spec/features/ineligible_early_career_payments_claims_spec.rb
+++ b/spec/features/ineligible_early_career_payments_claims_spec.rb
@@ -221,10 +221,9 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims" do
     choose "2018 to 2019"
     click_on "Continue"
 
-    # - Which subject did you do your undergraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification)))
+    expect(page).to have_text("Did you do your undergraduate initial teacher training (ITT) in mathematics?")
 
-    choose "None of the above"
+    choose "No"
     click_on "Continue"
 
     expect(claim.eligibility.reload.eligible_itt_subject).to eql "none_of_the_above"
@@ -278,7 +277,7 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims" do
     click_on "Continue"
 
     # - Which subject did you do your undergraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification)))
+    expect(page).to have_text("Which subject")
 
     choose "Mathematics"
     click_on "Continue"

--- a/spec/features/ineligible_early_career_payments_in_2022_and_future_years_spec.rb
+++ b/spec/features/ineligible_early_career_payments_in_2022_and_future_years_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims by cohort" do
           expect(claim.eligibility.reload.itt_academic_year).to eql scenario[:itt_academic_year]
 
           # - Which subject did you do your undergraduate ITT in
-          expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: qualification_name(claim.eligibility.qualification)))
+          expect(page).to have_text("Which subject")
 
           subject_name = scenario[:itt_subject].humanize
 

--- a/spec/features/ineligible_levelling_up_premium_payments_spec.rb
+++ b/spec/features/ineligible_levelling_up_premium_payments_spec.rb
@@ -70,8 +70,7 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
     choose "2018 to 2019"
     click_on "Continue"
 
-    # - Which subject did you do your undergraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teaching training"))
+    expect(page).to have_text("Which subject")
     choose "None of the above"
     click_on "Continue"
 

--- a/spec/features/itt_subject_selection_spec.rb
+++ b/spec/features/itt_subject_selection_spec.rb
@@ -137,12 +137,12 @@ RSpec.feature "ITT subject selection" do
         end
 
         scenario "choose ineligible subject" do
-          select_subject("None of the above")
+          select_subject("No")
           expect(page).to have_text(I18n.t("early_career_payments.ineligible.heading"))
         end
 
         scenario "choose eligible subject and teach now" do
-          select_subject("Mathematics")
+          select_subject("Yes")
           expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
 
           choose "Yes"
@@ -154,7 +154,7 @@ RSpec.feature "ITT subject selection" do
         end
 
         scenario "choose eligible subject but don't teach now" do
-          select_subject("Mathematics")
+          select_subject("Yes")
           expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
 
           choose "No"
@@ -172,12 +172,12 @@ RSpec.feature "ITT subject selection" do
         end
 
         scenario "choose ineligible subject" do
-          select_subject("None of the above")
+          select_subject("No")
           expect(page).to have_text(I18n.t("early_career_payments.ineligible.heading"))
         end
 
         scenario "choose eligible subject" do
-          select_subject("Mathematics")
+          select_subject("Yes")
           expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
         end
       end
@@ -260,15 +260,20 @@ RSpec.feature "ITT subject selection" do
   end
 
   def expect_displayed_subjects(displayed_subject_display_strings)
-    displayed_subject_display_strings.each do |subject_display_string|
-      expect(page).to have_field(subject_display_string)
-    end
+    if displayed_subject_display_strings.one?
+      question_text = find("h1.govuk-fieldset__heading").text
+      expect(question_text).to include(displayed_subject_display_strings.first.downcase)
+    else
+      displayed_subject_display_strings.each do |subject_display_string|
+        expect(page).to have_field(subject_display_string)
+      end
 
-    entire_set_of_lup_and_ecp_subject_display_strings = ["Chemistry", "Computing", "Languages", "Mathematics", "Physics"]
-    missing_subject_display_strings = entire_set_of_lup_and_ecp_subject_display_strings - displayed_subject_display_strings
+      entire_set_of_lup_and_ecp_subject_display_strings = ["Chemistry", "Computing", "Languages", "Mathematics", "Physics"]
+      missing_subject_display_strings = entire_set_of_lup_and_ecp_subject_display_strings - displayed_subject_display_strings
 
-    missing_subject_display_strings.each do |missing_subject_display_string|
-      expect(page).to have_no_field(missing_subject_display_string)
+      missing_subject_display_strings.each do |missing_subject_display_string|
+        expect(page).to have_no_field(missing_subject_display_string)
+      end
     end
   end
 end

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Levelling up premium payments claims" do
     click_on "Continue"
 
     # - Which subject did you do your undergraduate ITT in
-    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teaching training"))
+    expect(page).to have_text("Which subject")
   end
 
   scenario "When subject 'none of the above' and user has an eligible degree" do

--- a/spec/features/resetting_dependant_attributes_spec.rb
+++ b/spec/features/resetting_dependant_attributes_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
     expect(page).to have_text("You are not eligible")
 
     visit claim_path(claim.policy.routing_name, "eligible-itt-subject")
-    choose "None of the above"
+    choose "No"
     click_on "Continue"
     expect(page).to have_text("Do you have a degree in an eligible subject?")
   end

--- a/spec/helpers/claims/itt_subject_helper_spec.rb
+++ b/spec/helpers/claims/itt_subject_helper_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe Claims::IttSubjectHelper do
   describe "#subjects_to_sentence_for_hint_text" do
     let(:ecp_claim) { build(:claim, :first_lup_claim_year, eligibility: ecp_eligibility) }
     let(:lup_claim) { build(:claim, :first_lup_claim_year, eligibility: lup_eligibility) }
-    let(:academic_year_2019) { AcademicYear::Type.new.serialize(AcademicYear.new(2019)) }
-    let(:academic_year_2020) { AcademicYear::Type.new.serialize(AcademicYear.new(2020)) }
 
     subject { helper.subjects_to_sentence_for_hint_text(CurrentClaim.new(claims: [ecp_claim, lup_claim])) }
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-438

Changes ITT subject question for when there's only one subject.

Also includes changes to the tense for trainee teachers which doesn't seem to have made it's way into an implementation ticket
