### PR TITLE
Fix #326 NameError: uninitialized constant

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -126,7 +126,10 @@ class ClaimsController < BasePublicController
   end
 
   def check_page_is_in_sequence
-    redirect_to new_claim_path and return unless correct_policy_namespace?
+    unless correct_policy_namespace?
+      clear_claim_session
+      redirect_to new_claim_path and return
+    end
 
     raise ActionController::RoutingError.new("Not Found") unless page_sequence.in_sequence?(params[:slug])
   end
@@ -202,15 +205,6 @@ class ClaimsController < BasePublicController
   end
 
   def correct_policy_namespace?
-    case params[:policy]
-    when "additional-payments"
-      [EarlyCareerPayments, LevellingUpPremiumPayments].include?(current_claim.policy)
-    when "student-loans"
-      current_claim.policy == StudentLoans
-    when "maths-and-physics"
-      current_claim.policy == MathsAndPhysics
-    else
-      false
-    end
+    PolicyConfiguration.policies_for_routing_name(params[:policy]).include?(current_claim.policy)
   end
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -201,10 +201,10 @@ class ClaimsController < BasePublicController
     redirect_to claim_path(current_policy_routing_name, next_slug)
   end
 
-  def correct_policy?
+  def correct_policy_namespace?
     case params[:policy]
     when "additional-payments"
-      [EarlyCareerPayments].include?(current_claim.policy) # current claim should never have a LevellingUpPremiumPayments policy
+      [EarlyCareerPayments, LevellingUpPremiumPayments].include?(current_claim.policy)
     when "student-loans"
       current_claim.policy == StudentLoans
     when "maths-and-physics"

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -126,6 +126,8 @@ class ClaimsController < BasePublicController
   end
 
   def check_page_is_in_sequence
+    redirect_to new_claim_path and return unless correct_policy?
+
     raise ActionController::RoutingError.new("Not Found") unless page_sequence.in_sequence?(params[:slug])
   end
 
@@ -197,5 +199,18 @@ class ClaimsController < BasePublicController
     session[:selected_claim_policy] = policy
 
     redirect_to claim_path(current_policy_routing_name, next_slug)
+  end
+
+  def correct_policy?
+    case params[:policy]
+    when "additional-payments"
+      [EarlyCareerPayments].include?(current_claim.policy) # current claim should never have a LevellingUpPremiumPayments policy
+    when "student-loans"
+      current_claim.policy == StudentLoans
+    when "maths-and-physics"
+      current_claim.policy == MathsAndPhysics
+    else
+      false
+    end
   end
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -126,7 +126,7 @@ class ClaimsController < BasePublicController
   end
 
   def check_page_is_in_sequence
-    redirect_to new_claim_path and return unless correct_policy?
+    redirect_to new_claim_path and return unless correct_policy_namespace?
 
     raise ActionController::RoutingError.new("Not Found") unless page_sequence.in_sequence?(params[:slug])
   end

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -93,11 +93,11 @@ module EarlyCareerPayments
 
         if claim.eligibility.trainee_teacher?
           trainee_teacher_slugs(sequence)
-          sequence.delete("eligible-degree-subject") unless lup_claim.eligibility.indicated_ineligible_itt_subject?
+          sequence.delete("eligible-degree-subject") unless lup_claim&.eligibility&.indicated_ineligible_itt_subject?
         else
-          sequence.delete("ineligible") unless overall_eligibility_status == :ineligible || overall_eligibility_status == :eligible_later
+          sequence.delete("ineligible") unless [:ineligible, :eligible_later].include?(overall_eligibility_status)
           sequence.delete("future-eligibility")
-          sequence.delete("eligible-degree-subject") unless ecp_claim.eligibility.status == :ineligible && lup_claim.eligibility.indicated_ineligible_itt_subject?
+          sequence.delete("eligible-degree-subject") unless ecp_claim&.eligibility&.status == :ineligible && lup_claim&.eligibility&.indicated_ineligible_itt_subject?
         end
       end
     end

--- a/app/models/levelling_up_premium_payments/slug_sequence.rb
+++ b/app/models/levelling_up_premium_payments/slug_sequence.rb
@@ -1,0 +1,4 @@
+module LevellingUpPremiumPayments
+  class SlugSequence < EarlyCareerPayments::SlugSequence
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,6 +380,8 @@ en:
           title: Does the claimant’s subject match the schools workforce census subjects
         matching_details:
           title: "Is this claim still valid despite having matching details with other claims?"
+  additional_payments:
+    claim_description: "for an additional payment for teaching"
   activerecord:
     errors:
       models:


### PR DESCRIPTION
Fixes #326 NameError: uninitialized constant LevellingUpPremiumPayments::SlugSequence

Also adds a missing translation for `app/controllers/claims_controller.rb:64`

```ruby
new_policy_description = translate("#{params[:policy].underscore}.claim_description")
```
