### PR TITLE
Prioritise application jobs over analytics jobs; increase worker count

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,5 @@
 class ApplicationJob < ActiveJob::Base
+  def priority
+    10
+  end
 end

--- a/azure/terraform/modules/app_service/variable.tf
+++ b/azure/terraform/modules/app_service/variable.tf
@@ -103,7 +103,7 @@ locals {
     "SECRET_KEY_BASE"                                = data.azurerm_key_vault_secret.SecretKeyBase.value
     "STORAGE_BUCKET"                                 = data.azurerm_key_vault_secret.StorageBucket.value
     "STORAGE_CREDENTIALS"                            = data.azurerm_key_vault_secret.StorageCredentials.value
-    "WORKER_COUNT"                                   = "2"
+    "WORKER_COUNT"                                   = "4"
     "DOCKER_REGISTRY_SERVER_URL"                     = "https://${local.docker_registry}"
     "BYPASS_DFE_SIGN_IN"                             = var.bypass_dfe_sign_in
     "PR_NUMBER"                                      = var.pr_number

--- a/azure/terraform/modules/container/container_group.tf
+++ b/azure/terraform/modules/container/container_group.tf
@@ -60,7 +60,7 @@ resource "azurerm_container_group" "cont_grp_01" {
       "SECRET_KEY_BASE"                                = data.azurerm_key_vault_secret.SecretKeyBase.value
       "STORAGE_BUCKET"                                 = data.azurerm_key_vault_secret.StorageBucket.value
       "STORAGE_CREDENTIALS"                            = data.azurerm_key_vault_secret.StorageCredentials.value
-      "WORKER_COUNT"                                   = "2"
+      "WORKER_COUNT"                                   = "4"
       "BYPASS_DFE_SIGN_IN"                             = var.bypass_dfe_sign_in
     }
 
@@ -138,7 +138,7 @@ resource "azurerm_container_group" "cont_grp_02" {
       "SECRET_KEY_BASE"                                = data.azurerm_key_vault_secret.SecretKeyBase.value
       "STORAGE_BUCKET"                                 = data.azurerm_key_vault_secret.StorageBucket.value
       "STORAGE_CREDENTIALS"                            = data.azurerm_key_vault_secret.StorageCredentials.value
-      "WORKER_COUNT"                                   = "2"
+      "WORKER_COUNT"                                   = "4"
       "BYPASS_DFE_SIGN_IN"                             = var.bypass_dfe_sign_in
     }
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.default_priority = 100

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -45,7 +45,7 @@ services:
     depends_on:
       - web
     environment:
-      WORKER_COUNT: 2
+      WORKER_COUNT: 4
     env_file: *default_env_files
     volumes:
       - .:/app


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-703

We're seeing async jobs related to dfe-analytics creating a large backlog in the delayed_job queue which is causing a delay to e-mail and SMS delivery as well as claim verification checks.

This change deprioritises the sending of these events to BigQuery relative to the message delivery and claim checks, and increases the number of workers.