### PR TITLE
[CAPT-702] Fix destroy review app workflow

### DIFF
--- a/azure/delete_review_app.yml
+++ b/azure/delete_review_app.yml
@@ -71,7 +71,7 @@ steps:
         command: destroy
         workingDirectory: $(Agent.BuildDirectory)/s/azure/terraform
         environmentServiceName: azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef
-        commandOptions: '-var="input_region=westeurope" -var="input_container_version=ignored" -var-file workspace_variables/review.tfvars.json -var="app_name=$(app_name)"'
+        commandOptions: '-var="pr_number=$(pr_number)" -var="input_region=westeurope" -var="input_container_version=ignored" -var-file workspace_variables/review.tfvars.json -var="app_name=$(app_name)"'
 
     - task: AzurePowerShell@5
       displayName: Enable KV network firewall rule

--- a/azure/delete_review_app.yml
+++ b/azure/delete_review_app.yml
@@ -21,7 +21,18 @@ variables:
   - name: KeyVaultId
     value: /subscriptions/8655985a-2f87-44d7-a541-0be9a8c2779d/resourceGroups/s118d02-secrets/providers/Microsoft.KeyVault/vaults/s118d02-secrets-kv
 
+# Force checking out the master branch to avoid fetching a non existing branch when a PR is closed
+resources:
+  repositories:
+  - repository: claim
+    type: github
+    endpoint: DFE-Digital
+    name: DFE-Digital/claim-additional-payments-for-teaching
+    ref: master
+
 steps:
+    - checkout: claim
+
     - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
       displayName: Pin terraform version
       inputs:


### PR DESCRIPTION
## What
The destroy review app workflow was getting cancelled after 60min because terraform was missing an input variable

Also, we now force checking out master on destroy to avoid the default behaviour of checking out a non existing branch