### PR TITLE
Remove unnecessary send when using Ruby 2.7

### DIFF
--- a/lib/ordnance_survey/client.rb
+++ b/lib/ordnance_survey/client.rb
@@ -20,13 +20,12 @@ module OrdnanceSurvey
 
     attr_accessor :api_key, :base_url, :headers, :params
 
-    # Accessing readers with send because < Ruby 2.7
     def request(method:, path: "/", params: {}, body: {})
       headers = {
         "Content-Type": "application/json"
       }
 
-      params = params.merge(send(:params))
+      params = params.merge(self.params)
 
       response = Response.new(
         response: Typhoeus.public_send(


### PR DESCRIPTION
This wasn't updated when we upgraded to Ruby 2.7. There's no need to use `send` for private methods anymore. On Ruby 2.6 this would have thrown `NoMethodError: private method params` called.