### PR TITLE
[CAPT-717] Move employment checks to job

### DIFF
--- a/app/controllers/admin/tps_data_uploads_controller.rb
+++ b/app/controllers/admin/tps_data_uploads_controller.rb
@@ -15,29 +15,12 @@ module Admin
         if @tps_data_importer.errors.any?
           render :new and return
         end
-        perform_employment_checks
+        EmploymentCheckJob.perform_later
         redirect_to admin_claims_path, notice: "Teachers Pensions Service data uploaded successfully"
       end
     rescue ActiveRecord::RecordInvalid => e
       Rollbar.error(e)
       redirect_to new_admin_tps_data_upload_path, alert: "There was a problem, please try again"
-    end
-
-    private
-
-    def perform_employment_checks
-      delete_no_data_employment_tasks
-      claims = Claim.awaiting_task("employment")
-
-      claims.each do |claim|
-        AutomatedChecks::ClaimVerifiers::Employment.new(
-          claim: claim
-        ).perform
-      end
-    end
-
-    def delete_no_data_employment_tasks
-      Task.where(name: "employment", claim_verifier_match: nil).delete_all
     end
   end
 end

--- a/app/jobs/employment_check_job.rb
+++ b/app/jobs/employment_check_job.rb
@@ -1,0 +1,34 @@
+class EmploymentCheckJob < ApplicationJob
+  def perform
+    delete_no_data_employment_tasks
+    claims = current_year_claims.awaiting_task("employment")
+
+    claims.each do |claim|
+      AutomatedChecks::ClaimVerifiers::Employment.new(
+        claim: claim
+      ).perform
+    end
+  end
+
+  private
+
+  def delete_no_data_employment_tasks
+    claim_ids = current_year_claims_with_no_data_employment_tasks.pluck(:id)
+
+    claim_ids.each_slice(500) do |ids|
+      Task.where(claim_id: ids, name: "employment", claim_verifier_match: nil).delete_all
+    end
+  end
+
+  def current_year_claims_with_no_data_employment_tasks
+    current_year_claims.joins(:tasks).where(tasks: {name: "employment", claim_verifier_match: nil})
+  end
+
+  def current_year_claims
+    Claim.by_academic_year(current_academic_year)
+  end
+
+  def current_academic_year
+    PolicyConfiguration.for(EarlyCareerPayments).current_academic_year
+  end
+end


### PR DESCRIPTION
This PR also adds the code that prevents tasks for claims from previous years to run on TPS upload.
