### PR TITLE
[CAPT-655] Fix error message for missing email

### DIFF
--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -12,7 +12,7 @@ class Reminder < ApplicationRecord
 
   validates :email_address, on: [:"personal-details"], presence: {message: "Enter an email address"}
   validates :email_address, format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},
-    length: {maximum: 256, message: "Email address must be 256 characters or less"}
+    length: {maximum: 256, message: "Email address must be 256 characters or less"}, if: -> { email_address.present? }
 
   scope :email_verified, -> { where(email_verified: true) }
   scope :not_yet_sent, -> { where(email_sent_at: nil) }


### PR DESCRIPTION
With this change you can create a reminder without an email, but not on the `personal-details` page, similar to claims' (`on: [:"email-address", :submit]`). Behaviour tested here: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/spec/models/claim_spec.rb#L21. I replicated this for reminders, meaning the error won't show up on the page, but you can create a reminder without an email anywhere else. To avoid this I'd have to have a duplicate `validates :email_address row` adding `on: [:"personal-details"]` and `if: -> { email_address.present? }`