### PR TITLE
[CAPT-583] Amend the order of 'route into teaching' options

### DIFF
--- a/app/views/early_career_payments/claims/qualification.html.erb
+++ b/app/views/early_career_payments/claims/qualification.html.erb
@@ -23,16 +23,17 @@
             <div class="govuk-radios">
 
               <div class="govuk-radios__item">
+                <%= fields.radio_button(:qualification, :postgraduate_itt, class: "govuk-radios__input") %>
+                <%= fields.label :qualification_postgraduate_itt, t("early_career_payments.answers.qualification.postgraduate_itt"), class: "govuk-label govuk-radios__label" %>
+                <div class="govuk-hint govuk-radios__hint"><%= t("early_career_payments.questions.qualification.hint.postgraduate_itt") %></div>
+              </div>
+
+              <div class="govuk-radios__item">
                 <%= fields.radio_button(:qualification, :undergraduate_itt, class: "govuk-radios__input") %>
                 <%= fields.label :qualification_undergraduate_itt, t("early_career_payments.answers.qualification.undergraduate_itt"), class: "govuk-label govuk-radios__label" %>
                 <div class="govuk-hint govuk-radios__hint"><%= t("early_career_payments.questions.qualification.hint.undergraduate_itt") %></div>
               </div>
 
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:qualification, :postgraduate_itt, class: "govuk-radios__input") %>
-                <%= fields.label :qualification_postgraduate_itt, t("early_career_payments.answers.qualification.postgraduate_itt"), class: "govuk-label govuk-radios__label" %>
-                <div class="govuk-hint govuk-radios__hint"><%= t("early_career_payments.questions.qualification.hint.postgraduate_itt") %></div>
-              </div>
 
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qualification, :assessment_only, class: "govuk-radios__input") %>


### PR DESCRIPTION
Before:
<img width="602" alt="Screenshot 2022-09-29 at 12 09 01" src="https://user-images.githubusercontent.com/1636476/193016366-f716a18b-3585-4cf1-ba42-b00fe0510670.png">

After:
<img width="631" alt="Screenshot 2022-09-29 at 12 08 19" src="https://user-images.githubusercontent.com/1636476/193016165-21dfbf1e-7740-41d8-aa14-de598d74ba26.png">
