### PR TITLE
CAPT-730: Fix school sync

### DIFF
--- a/app/jobs/school_data_importer_job.rb
+++ b/app/jobs/school_data_importer_job.rb
@@ -1,5 +1,5 @@
 class SchoolDataImporterJob < CronJob
-  self.cron_expression = "0 6 * * *"
+  self.cron_expression = "0 12 * * *"
 
   queue_as :school_data
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -232,6 +232,8 @@ class Claim < ApplicationRecord
 
   validate :claim_must_not_be_ineligible, on: :submit
 
+  validate :school_must_be_open, on: :submit
+
   before_save :normalise_trn, if: :teacher_reference_number_changed?
   before_save :normalise_ni_number, if: :national_insurance_number_changed?
   before_save :normalise_bank_account_number, if: :bank_account_number_changed?
@@ -491,6 +493,10 @@ class Claim < ApplicationRecord
 
   def claim_must_not_be_ineligible
     errors.add(:base, "You’re not eligible for this payment") if eligibility.ineligible?
+  end
+
+  def school_must_be_open
+    errors.add(:base, "The selected school is closed") if !school&.open?
   end
 
   def determine_student_loan_plan

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -42,5 +42,15 @@ FactoryBot.define do
     trait :levelling_up_premium_payments_ineligible do
       sequence(:urn, 170000)
     end
+
+    trait :closed do
+      open_date { 100.days.ago }
+      close_date { 10.days.ago }
+    end
+
+    trait :open do
+      open_date { 10.days.ago }
+      close_date { nil }
+    end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -144,6 +144,30 @@ RSpec.describe Claim, type: :model do
     expect(claim).to be_valid(:submit)
   end
 
+  context "with an open school" do
+    it "is submittable" do
+      claim = build(:claim, :submittable)
+      claim.eligibility.current_school = build(:school, :open)
+      expect(claim).to be_valid(:submit)
+    end
+  end
+
+  context "with no school" do
+    it "is not submittable" do
+      claim = build(:claim, :submittable)
+      claim.eligibility.current_school = nil
+      expect(claim).not_to be_valid(:submit)
+    end
+  end
+
+  context "with a closed school" do
+    it "is not submittable" do
+      claim = build(:claim, :submittable)
+      claim.eligibility.current_school = build(:school, :closed)
+      expect(claim).not_to be_valid(:submit)
+    end
+  end
+
   context "with student loans policy eligibility" do
     let(:claim) { build(:claim, policy: StudentLoans) }
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-730

School sync job fails most of the time when run at 6am due to 500 and 404 errors on the server side. We have been advised to run the job after 7am. I have moved the job to 12pm when we can be more sure that it will succeed.

I have also added a check when the claim is submitted to cover an edge case where the school could be updated to closed state when the claim is in progress. It will also cover other edge cases where no school is present or a closed school is somehow otherwise selected.