### PR TITLE
Fix DQT API limit error

### DIFF
--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -17,7 +17,7 @@ class Admin::TasksController < Admin::BaseAdminController
         note.body =~ %r{National Insurance|Teacher reference|First name or surname|Date of birth|Not matched}
       end
     elsif params[:name] == "qualifications"
-      @claim.notes.order(created_at: :desc).select { |note| note.body.include?("ligible") && note.body.include?("ITT start date") }
+      @claim.notes.order(created_at: :desc).select { |note| note.body.include?("ligible") && note.body.include?("ITT start date") }.uniq { |n| n.body }
     elsif params[:name] == "census_subjects_taught"
       @claim.notes.order(created_at: :desc).select { |note| note.body.include?("ligible") && note.body.include?("Subject 1") }
     elsif params[:name] == "employment"

--- a/app/jobs/qualifications_no_match_check_job.rb
+++ b/app/jobs/qualifications_no_match_check_job.rb
@@ -5,7 +5,9 @@
 
 class QualificationsNoMatchCheckJob < ApplicationJob
   def perform
-    claims_with_no_match_qualification_tasks.each_slice(300) do |claims|
+    claims_with_no_match_qualification_tasks.each_slice(1).with_index do |claims, index|
+      sleep 60 unless index.zero?
+
       Task.where(claim_id: claims.pluck(:id), name: "qualifications").delete_all
 
       claims.each do |claim|
@@ -18,8 +20,6 @@ class QualificationsNoMatchCheckJob < ApplicationJob
           )
         ).perform
       end
-
-      sleep 60
     end
   end
 

--- a/app/jobs/qualifications_no_match_check_job.rb
+++ b/app/jobs/qualifications_no_match_check_job.rb
@@ -1,5 +1,6 @@
 # This job is not called anywhere in the code but can be used manually to re-run
 # NO MATCH claims that initially got an incorrect response from the DQT API.
+# DQT API has a limit of 300 requests/minute
 # QualificationsNoMatchCheckJob.perform_later
 
 class QualificationsNoMatchCheckJob < ApplicationJob
@@ -17,7 +18,13 @@ class QualificationsNoMatchCheckJob < ApplicationJob
           )
         ).perform
       end
+
+      sleep 60
     end
+  end
+
+  def max_attempts
+    1
   end
 
   private


### PR DESCRIPTION
DQT API has a limit of 300 requests/minute. When that limit gets reached, the client throws a `"Net::ReadTimeout with #<TCPSocket:(closed)>` error. This was causing the job to retry and process eligibility checks on the same claims multiple times. I added a gap of 60 seconds between requests, removed retries and filtered out identical DQT check notes.