### PR TITLE
CAPT-497: Modify PII data purge timing

### DIFF
--- a/spec/jobs/delete_personal_data_from_old_claims_job_spec.rb
+++ b/spec/jobs/delete_personal_data_from_old_claims_job_spec.rb
@@ -2,14 +2,15 @@ require "rails_helper"
 
 RSpec.describe DeletePersonalDataFromOldClaimsJob do
   describe "#perform" do
-    let(:over_two_months_ago) { 2.months.ago - 1.day }
+    let(:current_academic_year) { AcademicYear.for(Date.today) }
+    let(:last_academic_year) { Time.zone.local(current_academic_year.start_year, 8, 1) }
 
     it "deletes the personal data from eligible claims" do
       submitted_claim = create(:claim, :submitted)
       rejected_claim = create(:claim, :submitted)
-      create(:decision, :rejected, claim: rejected_claim, created_at: over_two_months_ago)
+      create(:decision, :rejected, claim: rejected_claim, created_at: last_academic_year)
       paid_claim = create(:claim, :approved)
-      create(:payment, :with_figures, claims: [paid_claim], scheduled_payment_date: over_two_months_ago)
+      create(:payment, :with_figures, claims: [paid_claim], scheduled_payment_date: last_academic_year)
 
       DeletePersonalDataFromOldClaimsJob.new.perform
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-497

Changes the timing of the job which purges personally-identifiable information.

Previously, data was purged regularly when it was 2 months old.

Now, it will be retained until the following academic year begins (on 1st September).

I had considered removing the cron job and making this run only when the next claim window was opened, but this creates a risk of PII not being scrubbed when the service is eventually retired or redundant.