### PR TITLE
CAPT-678: Fix closed schools appearing in school search on ECP/LUPP combined journey

### DIFF
--- a/app/views/claims/_school_search_results.html.erb
+++ b/app/views/claims/_school_search_results.html.erb
@@ -25,6 +25,7 @@
         </span>
 
       <%= hidden_field_tag :school_search, params[:school_search] %>
+      <%= hidden_field_tag :exclude_closed, exclude_closed %>
 
       <%= errors_tag current_claim.eligibility, school_param %>
 

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -18,7 +18,8 @@
                  question: t("questions.current_school"),
                  ecp_question: t("early_career_payments.questions.current_school_results"),
                  school_param: :current_school,
-                 school_id_param: :current_school_id
+                 school_id_param: :current_school_id,
+                 exclude_closed: true
       %>
     <% end %>
   </div>

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -16,7 +16,8 @@
       <%= render "school_search_results",
                  question: claim_school_question(additional_school: params[:additional_school]),
                  school_param: :claim_school,
-                 school_id_param: :claim_school_id
+                 school_id_param: :claim_school_id,
+                 exclude_closed: false
       %>
     <% end %>
   </div>

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -3,165 +3,192 @@ require "rails_helper"
 RSpec.feature "Searching for school during Teacher Student Loan Repayments claims" do
   include StudentLoansHelper
 
-  scenario "doesn't select a school from the search results the first time around" do
-    claim = start_student_loans_claim
+  context "Student Loans claim" do
+    scenario "doesn't select a school from the search results the first time around" do
+      claim = start_student_loans_claim
 
-    fill_in :school_search, with: "Penistone"
-    click_on "Continue"
+      # Creates a duplicate school to test whether the school search shows closed schools
+      create(:school, :closed, :student_loan_eligible, name: "Penistone Duplicate")
 
-    click_on "Continue"
+      fill_in :school_search, with: "Penistone"
+      click_on "Continue"
 
-    expect(page).to have_text("There is a problem")
-    expect(page).to have_text("Select a school from the list")
+      click_on "Continue"
 
-    choose "Penistone Grammar School"
-    click_on "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Select a school from the list")
 
-    expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
+      expect(page).to have_text("Penistone Duplicate")
+
+      choose "Penistone Grammar School"
+      click_on "Continue"
+
+      expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
+      expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
+    end
+
+    scenario "searches again to find school" do
+      claim = start_student_loans_claim
+
+      fill_in :school_search, with: "hamp"
+      click_on "Continue"
+
+      click_on "Search again"
+
+      fill_in :school_search, with: "penistone"
+      click_on "Continue"
+
+      choose "Penistone Grammar School"
+      click_on "Continue"
+
+      expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
+      expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
+    end
+
+    scenario "Claim school search with autocomplete", js: true, flaky: true do
+      start_student_loans_claim
+
+      expect(page).to have_text(claim_school_question)
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Penistone"
+      find("li", text: schools(:penistone_grammar_school).name).click
+
+      expect(page).to have_button("Continue")
+
+      click_button "Continue"
+
+      expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
+    end
+
+    scenario "Current school search with autocomplete", js: true, flaky: true do
+      start_student_loans_claim
+
+      choose_school schools(:penistone_grammar_school)
+      choose_subjects_taught
+
+      choose_still_teaching "Yes, at another school"
+
+      expect(page).to have_text(I18n.t("questions.current_school"))
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Penistone"
+      find("li", text: schools(:penistone_grammar_school).name).click
+
+      expect(page).to have_button("Continue")
+
+      click_button "Continue"
+
+      expect(page).to have_text(leadership_position_question)
+    end
+
+    scenario "School search form still works like a normal form if submitted", js: true do
+      start_student_loans_claim
+
+      expect(page).to have_text(claim_school_question)
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Penistone"
+
+      expect(page).to have_text(schools(:penistone_grammar_school).name)
+      expect(page).to have_button("Continue")
+
+      click_button "Continue"
+
+      expect(page).to have_text("Select your school from the search results.")
+      expect(page).to have_text(schools(:penistone_grammar_school).name)
+    end
+
+    scenario "Editing school search after autocompletion clears last selection", js: true, flaky: true do
+      start_student_loans_claim
+
+      expect(page).to have_text(claim_school_question)
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Penistone"
+      find("li", text: schools(:penistone_grammar_school).name).click
+
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Hampstead"
+      expect(page).to have_text(schools(:hampstead_school).name)
+      expect(page).to have_button("Continue")
+
+      click_button "Continue"
+
+      expect(page).to have_text("Select your school from the search results.")
+      expect(page).to have_text(schools(:hampstead_school).name)
+    end
+
+    scenario "Claim school search includes closed schools" do
+      start_student_loans_claim
+
+      expect(page).to have_text(claim_school_question)
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Lister"
+      click_button "Continue"
+
+      expect(page).to have_text(schools(:the_samuel_lister_academy).name)
+    end
+
+    scenario "Current school search excludes closed schools" do
+      start_student_loans_claim
+      choose_school schools(:penistone_grammar_school)
+      choose_subjects_taught
+      choose_still_teaching "Yes, at another school"
+
+      expect(page).to have_text(I18n.t("questions.current_school"))
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Lister"
+      click_button "Continue"
+
+      expect(page).not_to have_text(schools(:the_samuel_lister_academy).name)
+    end
+
+    scenario "Claim school search with autocomplete includes closed schools", js: true do
+      start_student_loans_claim
+
+      expect(page).to have_text(claim_school_question)
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Lister"
+      expect(page).to have_text(schools(:the_samuel_lister_academy).name)
+    end
+
+    scenario "Current school search with autocomplete excludes closed schools", js: true do
+      start_student_loans_claim
+
+      choose_school schools(:penistone_grammar_school)
+      choose_subjects_taught
+      choose_still_teaching "Yes, at another school"
+
+      expect(page).to have_text(I18n.t("questions.current_school"))
+      expect(page).to have_button("Continue")
+
+      fill_in :school_search, with: "Lister"
+      expect(page).not_to have_text(schools(:the_samuel_lister_academy).name)
+    end
   end
 
-  scenario "searches again to find school" do
-    claim = start_student_loans_claim
+  context "combined ECP/LUPP journey claim" do
+    scenario "doesn't select a school from the search results the first time around" do
+      visit new_claim_path(LevellingUpPremiumPayments.routing_name)
 
-    fill_in :school_search, with: "hamp"
-    click_on "Continue"
+      # Creates a duplicate school to test whether the school search shows closed schools
+      create(:school, :closed, :early_career_payments_eligible, name: "Penistone Duplicate")
 
-    click_on "Search again"
+      fill_in :school_search, with: "Penistone"
+      click_on "Continue"
 
-    fill_in :school_search, with: "penistone"
-    click_on "Continue"
+      click_on "Continue"
 
-    choose "Penistone Grammar School"
-    click_on "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Select the school you teach at")
 
-    expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
-  end
-
-  scenario "Claim school search with autocomplete", js: true, flaky: true do
-    start_student_loans_claim
-
-    expect(page).to have_text(claim_school_question)
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Penistone"
-    find("li", text: schools(:penistone_grammar_school).name).click
-
-    expect(page).to have_button("Continue")
-
-    click_button "Continue"
-
-    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
-  end
-
-  scenario "Current school search with autocomplete", js: true, flaky: true do
-    start_student_loans_claim
-
-    choose_school schools(:penistone_grammar_school)
-    choose_subjects_taught
-
-    choose_still_teaching "Yes, at another school"
-
-    expect(page).to have_text(I18n.t("questions.current_school"))
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Penistone"
-    find("li", text: schools(:penistone_grammar_school).name).click
-
-    expect(page).to have_button("Continue")
-
-    click_button "Continue"
-
-    expect(page).to have_text(leadership_position_question)
-  end
-
-  scenario "School search form still works like a normal form if submitted", js: true do
-    start_student_loans_claim
-
-    expect(page).to have_text(claim_school_question)
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Penistone"
-
-    expect(page).to have_text(schools(:penistone_grammar_school).name)
-    expect(page).to have_button("Continue")
-
-    click_button "Continue"
-
-    expect(page).to have_text("Select your school from the search results.")
-    expect(page).to have_text(schools(:penistone_grammar_school).name)
-  end
-
-  scenario "Editing school search after autocompletion clears last selection", js: true, flaky: true do
-    start_student_loans_claim
-
-    expect(page).to have_text(claim_school_question)
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Penistone"
-    find("li", text: schools(:penistone_grammar_school).name).click
-
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Hampstead"
-    expect(page).to have_text(schools(:hampstead_school).name)
-    expect(page).to have_button("Continue")
-
-    click_button "Continue"
-
-    expect(page).to have_text("Select your school from the search results.")
-    expect(page).to have_text(schools(:hampstead_school).name)
-  end
-
-  scenario "Claim school search includes closed schools" do
-    start_student_loans_claim
-
-    expect(page).to have_text(claim_school_question)
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Lister"
-    click_button "Continue"
-
-    expect(page).to have_text(schools(:the_samuel_lister_academy).name)
-  end
-
-  scenario "Current school search excludes closed schools" do
-    start_student_loans_claim
-    choose_school schools(:penistone_grammar_school)
-    choose_subjects_taught
-    choose_still_teaching "Yes, at another school"
-
-    expect(page).to have_text(I18n.t("questions.current_school"))
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Lister"
-    click_button "Continue"
-
-    expect(page).not_to have_text(schools(:the_samuel_lister_academy).name)
-  end
-
-  scenario "Claim school search with autocomplete includes closed schools", js: true do
-    start_student_loans_claim
-
-    expect(page).to have_text(claim_school_question)
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Lister"
-    expect(page).to have_text(schools(:the_samuel_lister_academy).name)
-  end
-
-  scenario "Current school search with autocomplete excludes closed schools", js: true do
-    start_student_loans_claim
-
-    choose_school schools(:penistone_grammar_school)
-    choose_subjects_taught
-    choose_still_teaching "Yes, at another school"
-
-    expect(page).to have_text(I18n.t("questions.current_school"))
-    expect(page).to have_button("Continue")
-
-    fill_in :school_search, with: "Lister"
-    expect(page).not_to have_text(schools(:the_samuel_lister_academy).name)
+      expect(page).to have_text("Penistone Grammar School")
+      expect(page).not_to have_text("Penistone Duplicate")
+    end
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-678

Closed schools should not appear on the schools list on the ECP/LUPP combined journey, but should do on TSLR claims.