### PR TITLE
Fix postcode search auto populated value

### DIFF
--- a/app/views/claims/postcode_search.html.erb
+++ b/app/views/claims/postcode_search.html.erb
@@ -10,7 +10,7 @@
           <h1 class="govuk-heading-l"><%= I18n.t("questions.address.home.title") %></h1>
         </legend>
         <%= form_group_tag current_claim, :postcode do %>
-          <% postcode = form.object.postcode.present? ? form.object.postcode : session[:claim_postcode] %>
+          <% postcode = form.object.postcode.present? && !session[:claim_postcode] ? form.object.postcode : session[:claim_postcode] %>
           <%= label_tag :"claim_postcode", "Postcode", class: "govuk-label govuk-label--m" %>
           <%= errors_tag current_claim, :postcode %>
           <%= text_field_tag :"claim[postcode]",

--- a/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
@@ -377,6 +377,8 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
       expect(page).to have_text(I18n.t("questions.address.home.title"))
       expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
 
+      expect(page).to have_field("Postcode", with: "SO16 9FX")
+
       fill_in "Postcode", with: "SE13 7UN"
       click_on "Search"
 
@@ -401,6 +403,18 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
 
       # - Email address
       expect(page).to have_text(I18n.t("questions.email_address"))
+
+      # Check postcode search field retains the user's last input if the address was saved on the claim
+      click_link "Back"
+      click_link "Back"
+
+      expect(page).to have_field("Postcode", with: "SE13 7UN")
+      fill_in "Postcode", with: "SO16 9FX"
+      click_on "Search"
+
+      click_link "Change"
+
+      expect(page).to have_field("Postcode", with: "SO16 9FX")
     end
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-713

The postcode search value would always be auto populated with the address saved to the claim, even if the user subsequently went back to change the address and did a new search.