### PR TITLE
Fix govuk-hint component displaying inline following govuk-frontend upgrade

### DIFF
--- a/app/assets/javascripts/components/school_search.js.erb
+++ b/app/assets/javascripts/components/school_search.js.erb
@@ -97,18 +97,18 @@ document.addEventListener("DOMContentLoaded", function () {
           '<label class="govuk-label govuk-label--s">' +
           school.name +
           "</label>" +
-          '<span class="govuk-hint">' +
+          '<div class="govuk-hint">' +
           school.address +
-          "</span>" +
+          "</div>" +
           "</div>";
 
         if (school.closeDate) {
           suggestion +=
             '<div class="school-search__closed-status">' +
-            '<span class="govuk-hint govuk-!-margin-bottom-1">' +
+            '<div class="govuk-hint govuk-!-margin-bottom-1">' +
             "Closed on<br>" +
             school.closeDate +
-            "</span>" +
+            "</div>" +
             "</div>";
         }
 

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -213,9 +213,9 @@
     </div>
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group">
-        <span class="govuk-hint">
+        <div class="govuk-hint">
           Please explain why you are making this amendment. Do not include personal data about the claimant.
-        </span>
+        </div>
         <%= f.text_area :notes, class: "govuk-textarea" %>
       </div>
     </div>

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -40,9 +40,9 @@
       </div>
     </fieldset>
     <%= form.label :notes, "Decision notes", class: "govuk-label govuk-label--m" %>
-    <span class="govuk-hint" id="notes-hint">
+    <div class="govuk-hint" id="notes-hint">
       Please write a brief note explaining why this claim has been rejected or approved.
-    </span>
+    </div>
     <%= form.text_area :notes, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
     <%= form.submit "Confirm decision", class: "govuk-button" %>
   <% end %>

--- a/app/views/admin/decisions_undo/new.html.erb
+++ b/app/views/admin/decisions_undo/new.html.erb
@@ -23,9 +23,9 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group">
         <%= f.label :notes, "Change notes", class: "govuk-label" %>
-        <span class="govuk-hint">
+        <div class="govuk-hint">
           Please write a brief note to explain why you're undoing this decision.
-        </span>
+        </div>
         <%= f.text_area :notes, class: "govuk-textarea", rows: 5 %>
       </div>
     </div>

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -2,9 +2,9 @@
   <%= form_group_tag note, :body do %>
     <%= form.label :body, "Add note", class: "govuk-label govuk-label--m" %>
     <%= errors_tag note, :body %>
-    <span class="govuk-hint" id="notes-hint">
+    <div class="govuk-hint" id="notes-hint">
       Write a brief update. Do not include any personal data about the claimant.
-    </span>
+    </div>
     <%= form.text_area :body, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
   <% end %>
 

--- a/app/views/admin/support_tickets/_widget.html.erb
+++ b/app/views/admin/support_tickets/_widget.html.erb
@@ -11,9 +11,9 @@
     <%= form_group_tag support_ticket, :url do %>
       <%= errors_tag support_ticket, :url %>
       <%= form.label :url, "Support ticket", class: "govuk-label govuk-label--m" %>
-      <span class="govuk-hint" id="ticket-hint">
+      <div class="govuk-hint" id="ticket-hint">
         Create a ticket on Zendesk and enter the URL here.
-      </span>
+      </div>
       <%= form.text_field :url, class: "govuk-input govuk-input", autocomplete: "off", "aria-describedby" => "ticket-hint" %>
     <% end %>
 

--- a/app/views/claims/_account_details.html.erb
+++ b/app/views/claims/_account_details.html.erb
@@ -11,9 +11,9 @@
 
     <%= form_group_tag current_claim, :banking_name do %>
       <%= form.label :banking_name, "Name on your account", class: "govuk-label" %>
-      <span class="govuk-hint" id="name-on-the-account-hint">
+      <div class="govuk-hint" id="name-on-the-account-hint">
         <%= t("questions.account_hint", bank_or_building_society: account_hint, card: account_card) %>
-      </span>
+      </div>
       <%= errors_tag current_claim, :banking_name %>
       <%= form.text_field :banking_name,
         class: css_classes_for_input(current_claim, :banking_name),
@@ -23,7 +23,7 @@
 
     <%= form_group_tag current_claim, :bank_sort_code do %>
       <%= form.label :bank_sort_code, "Sort code", class: "govuk-label" %>
-      <span id="sort-code-hint" class="govuk-hint">For example: 44 00 26</span>
+      <div id="sort-code-hint" class="govuk-hint">For example: 44 00 26</div>
       <%= errors_tag current_claim, :bank_sort_code %>
       <%= form.text_field :bank_sort_code,
         class: css_classes_for_input(current_claim, :bank_sort_code, "govuk-!-width-one-quarter"),
@@ -33,7 +33,7 @@
 
     <%= form_group_tag current_claim, :bank_account_number do %>
       <%= form.label :bank_account_number, "Account number", class: "govuk-label" %>
-      <span id="account-number-hint" class="govuk-hint">For example: 70872490</span>
+      <div id="account-number-hint" class="govuk-hint">For example: 70872490</div>
       <%= errors_tag current_claim, :bank_account_number %>
       <%= form.text_field :bank_account_number,
         class: css_classes_for_input(current_claim, :bank_account_number, "govuk-input--width-20"),
@@ -44,7 +44,7 @@
     <% if bank_or_building_society == "building society" %>
       <%= form_group_tag current_claim, :building_society_roll_number do %>
         <%= form.label :building_society_roll_number, "Building society roll number", class: "govuk-label" %>
-        <span id="roll-number-hint" class="govuk-hint">You can find it on your card, statement or passbook</span>
+        <div id="roll-number-hint" class="govuk-hint">You can find it on your card, statement or passbook</div>
         <%= errors_tag current_claim, :building_society_roll_number %>
         <%= form.text_field :building_society_roll_number,
           class: css_classes_for_input(current_claim, :building_society_roll_number, "govuk-input--width-20"),

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -37,13 +37,13 @@
         <strong>No results match that search term. Try again.</strong>
       </p>
     <% else %>
-      <span class="govuk-hint" id="school_search-hint">
+      <div class="govuk-hint" id="school_search-hint">
         Enter the school name or postcode. Use at least three characters.
         <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
           <br><br>
           If you taught at multiple schools during this period, enter the first school you think might be eligible.
         <% end %>
-      </span>
+      </div>
     <% end %>
 
     <div id="school-search-container">

--- a/app/views/claims/_school_search_results.html.erb
+++ b/app/views/claims/_school_search_results.html.erb
@@ -20,9 +20,9 @@
         </legend>
       <% end %>  
     
-      <span id="school-search-result-hint" class="govuk-hint">
+        <div id="school-search-result-hint" class="govuk-hint">
           Select your school from the search results.
-        </span>
+        </div>
 
       <%= hidden_field_tag :school_search, params[:school_search] %>
       <%= hidden_field_tag :exclude_closed, exclude_closed %>
@@ -40,11 +40,11 @@
                     <div class="govuk-label govuk-radios__label govuk-label--s">
                       <%= b.text %>
                     </div>
-                    <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
+                    <div class="govuk-hint govuk-radios__hint"><%= b.object.address %></div>
                   </div>
                   <% if b.object.close_date.present? && b.object.close_date < Date.current %>
                     <div class="school-search__closed-status">
-                      <span class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></span>
+                      <div class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></div>
                     </div>
                   <% end %>
                 </div>

--- a/app/views/claims/bank_or_building_society.html.erb
+++ b/app/views/claims/bank_or_building_society.html.erb
@@ -14,9 +14,9 @@
             </h1>
           </legend>
 
-          <span class="govuk-hint" id="bank_details-hint">
+          <div class="govuk-hint" id="bank_details-hint">
             Some places are both a bank and a building society. If your account requires a roll number your account with them is through the building society.
-          </span>
+          </div>
 
           <%= errors_tag current_claim, :bank_or_building_society %>
 

--- a/app/views/claims/doctoral_loan.html.erb
+++ b/app/views/claims/doctoral_loan.html.erb
@@ -16,9 +16,9 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="doctoral-loan-hint">
+            <div class="govuk-hint" id="doctoral-loan-hint">
               If you took out a Postgraduate Doctoral Loan, such as for a PhD, a deduction will automatically go towards repaying it.
-            </span>
+            </div>
 
             <%= errors_tag current_claim, :postgraduate_doctoral_loan %>
 

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -13,12 +13,12 @@
             </h1>
           </legend>
 
-          <span class="govuk-hint" id="payroll_gender-hint">
+          <div class="govuk-hint" id="payroll_gender-hint">
             This is not us asking how you identify. HMRC only records male or female and
             we need to match their records to make tax contributions on your behalf. If
             you don't know what gender is held on record we will contact HMRC or the
             Teachers Pension Scheme.
-          </span>
+          </div>
 
           <%= errors_tag current_claim, :payroll_gender %>
 

--- a/app/views/claims/masters_loan.html.erb
+++ b/app/views/claims/masters_loan.html.erb
@@ -16,9 +16,9 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="masters-loan-hint">
+            <div class="govuk-hint" id="masters-loan-hint">
               If you took out a Master’s Loan then a deduction will automatically go towards repaying it.
-            </span>
+            </div>
 
             <%= errors_tag current_claim, :postgraduate_masters_loan %>
 

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -16,9 +16,9 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="student_loan_courses-hint">
+            <div class="govuk-hint" id="student_loan_courses-hint">
               This includes university degrees, PGCE and ITT courses.
-            </span>
+            </div>
 
             <%= errors_tag current_claim, :student_loan_courses %>
 

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -11,9 +11,9 @@
           <%= form.label :teacher_reference_number, t("questions.teacher_reference_number"), class: "govuk-label govuk-label--#{shared_view_css_size}" %>
         </h1>
 
-        <span class="govuk-hint" id="teacher_reference_number-hint">
+        <div class="govuk-hint" id="teacher_reference_number-hint">
           You can get this from your payslip, teacher pension statement or teacher training records.
-        </span>
+        </div>
 
         <div class="govuk-form-group">
           <%= errors_tag current_claim, :teacher_reference_number %>

--- a/app/views/early_career_payments/claims/eligible_degree_subject.html.erb
+++ b/app/views/early_career_payments/claims/eligible_degree_subject.html.erb
@@ -22,10 +22,10 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="has_uk_maths_or_physics_degree-hint">
+            <div class="govuk-hint" id="has_uk_maths_or_physics_degree-hint">
               This can be an undergraduate or postgraduate degree in
               <%= JourneySubjectEligibilityChecker.fixed_lup_subject_symbols.to_sentence(last_word_connector: ' or ') %>.
-            </span>
+            </div>
 
             <%= errors_tag claim.eligibility, :eligible_degree_subject %>
 

--- a/app/views/early_career_payments/claims/eligible_itt_subject.html.erb
+++ b/app/views/early_career_payments/claims/eligible_itt_subject.html.erb
@@ -20,9 +20,9 @@
             </legend>
 
             <% if current_claim.eligibility.nqt_in_academic_year_after_itt && subject_symbols.many? %>
-              <span class="govuk-hint">
+              <div class="govuk-hint">
                 <%= t("early_career_payments.questions.eligible_itt_subject_hint") %>
-              </span>
+              </div>
             <% end %>
 
             <%= errors_tag current_claim.eligibility, :eligible_itt_subject %>

--- a/app/views/early_career_payments/claims/nqt_in_academic_year_after_itt.html.erb
+++ b/app/views/early_career_payments/claims/nqt_in_academic_year_after_itt.html.erb
@@ -19,9 +19,9 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
+            <div class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
               <%= t("early_career_payments.questions.nqt_in_academic_year_after_itt.hint") %>
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :nqt_in_academic_year_after_itt %>
 

--- a/app/views/early_career_payments/claims/teaching_subject_now.html.erb
+++ b/app/views/early_career_payments/claims/teaching_subject_now.html.erb
@@ -22,10 +22,10 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="teaching_subject_now-hint">
+            <div class="govuk-hint" id="teaching_subject_now-hint">
              At least 50% of your contracted hours allocated to teaching must be spent
              teaching <%= subjects_to_sentence_for_hint_text(current_claim) %>.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :teaching_subject_now %>
 

--- a/app/views/maths_and_physics/claims/disciplinary_action.html.erb
+++ b/app/views/maths_and_physics/claims/disciplinary_action.html.erb
@@ -18,11 +18,11 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="subject_to_disciplinary_action-hint">
+            <div class="govuk-hint" id="subject_to_disciplinary_action-hint">
               For example, if you are under an investigation or have been given
               a warning that has not expired yet. We only use this information
               to check your eligibility.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :subject_to_disciplinary_action %>
 

--- a/app/views/maths_and_physics/claims/formal_performance_action.html.erb
+++ b/app/views/maths_and_physics/claims/formal_performance_action.html.erb
@@ -18,11 +18,11 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="formal_performance_action-hint">
+            <div class="govuk-hint" id="formal_performance_action-hint">
               For example, under your school’s capability or performance
               management policy. We only use this information to check your
               eligibility.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :subject_to_formal_performance_action %>
 

--- a/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
+++ b/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
@@ -18,14 +18,14 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="has_uk_maths_or_physics_degree-hint">
+            <div class="govuk-hint" id="has_uk_maths_or_physics_degree-hint">
               <p>You must have specialised in maths or physics to be able to
               claim. If you studied maths or physics for less than 50% of your
               degree, please select No.</p>
 
               <p>For more information on which subjects are eligible, see the
               <%= link_to "qualifications criteria", "https://www.gov.uk/guidance/apply-for-mathematics-and-physics-teacher-retention-payments#opportinity-area", class: "govuk-link" %> for this service.</p>
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :has_uk_maths_or_physics_degree %>
 

--- a/app/views/maths_and_physics/claims/initial_teacher_training_subject_specialism.html.erb
+++ b/app/views/maths_and_physics/claims/initial_teacher_training_subject_specialism.html.erb
@@ -18,9 +18,9 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="initial_teacher_training_subject_specialism-hint">
+            <div class="govuk-hint" id="initial_teacher_training_subject_specialism-hint">
               Your specialism is normally the science you spent the most time training to teach.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :initial_teacher_training_subject_specialism %>
 
@@ -50,12 +50,12 @@
               </div>
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-availability-message-conditional">
                 <div class="govuk-form-group">
-                  <span class="govuk-hint" id="initial_teacher_training_subject_specialism_not_sure-hint">
+                  <div class="govuk-hint" id="initial_teacher_training_subject_specialism_not_sure-hint">
                     <p>
                       If you’re not sure, we’ll check this for you. Your claim may be rejected
                       if your initial teacher training in science did not specialise in physics.
                     </p>
-                  </span>
+                  </div>
                 </div>
             </div>
 

--- a/app/views/maths_and_physics/claims/teaching_maths_or_physics.html.erb
+++ b/app/views/maths_and_physics/claims/teaching_maths_or_physics.html.erb
@@ -18,10 +18,10 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="teaching_maths_or_physics-hint">
+            <div class="govuk-hint" id="teaching_maths_or_physics-hint">
               You are still eligible to claim if you usually teach another
               subject but sometimes teach maths or physics.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :teaching_maths_or_physics %>
 

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -18,10 +18,10 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="had_leadership_position-hint">
+            <div class="govuk-hint" id="had_leadership_position-hint">
               This includes head of subject, head of year, head of department,
               deputy head, head teacher or other middle leader role.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :had_leadership_position %>
 

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -16,9 +16,9 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint" id="mostly_performed_leadership_duties-hint">
+            <div class="govuk-hint" id="mostly_performed_leadership_duties-hint">
               If you were off on long-term leave or sick, include the time you would have spent.
-            </span>
+            </div>
 
             <%= errors_tag current_claim.eligibility, :mostly_performed_leadership_duties %>
 


### PR DESCRIPTION
This change https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2137/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519 upgraded govuk-frontend which removed the `display: block` property from the `govuk-hint` CSS class. This resulted in some broken page layout.

I have fixed this by changing all inline `span` elements to `div` which reverts the hints to block-level elements.

**Before:**
<img width="793" alt="Screenshot 2022-10-06 at 14 46 04" src="https://user-images.githubusercontent.com/408371/194338374-beeb31bc-9064-4383-8f42-effe1257bd1d.png">

**After**
<img width="800" alt="Screenshot 2022-10-06 at 14 46 10" src="https://user-images.githubusercontent.com/408371/194338396-e9576983-1e2d-4d96-b232-aa7c121a2820.png">

**Before:**
<img width="805" alt="Screenshot 2022-10-06 at 15 23 53" src="https://user-images.githubusercontent.com/408371/194338681-f1f3e6d2-8585-4d67-ac30-b1d89d7275fc.png">

**After:**
<img width="801" alt="Screenshot 2022-10-06 at 15 23 59" src="https://user-images.githubusercontent.com/408371/194338715-828c93a5-f0e8-4c7e-8677-ee084d2dcf5a.png">

