### PR TITLE
[CAPT-762] Remove on amend student_loan_plan validation

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -199,7 +199,6 @@ class Claim < ApplicationRecord
   validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select how many higher education courses you took out a student loan for"}
   validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: ->(object, data) { I18n.t("validation_errors.student_loan_start_date.#{object.student_loan_courses}") }}
   validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
-  validates :student_loan_plan, on: [:amendment], inclusion: {in: [Claim::NO_STUDENT_LOAN], message: "You can’t amend the student loan plan type because the claimant said they are no longer paying off their student loan"}, if: :no_student_loan?
 
   validates :has_masters_doctoral_loan, on: [:"masters-doctoral-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a postgraduate masters and/or doctoral loan"}, if: :no_student_loan?
   validates :postgraduate_masters_loan, on: [:"masters-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a Postgraduate Master’s Loan"}, unless: -> { no_masters_doctoral_loan? }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -114,17 +114,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  context "when amending a claim with no student loan" do
-    it "cannot have its student loan plan type amended to anything other than NO_STUDENT_LOAN" do
-      claim = build(:claim, :submittable, has_student_loan: false, student_loan_plan: Claim::NO_STUDENT_LOAN)
-
-      expect(claim).to be_valid(:amendment)
-
-      claim.student_loan_plan = StudentLoan::PLAN_1
-      expect(claim).not_to be_valid(:amendment)
-    end
-  end
-
   it "is not submittable without a value for the student_loan_plan present" do
     expect(build(:claim, :submittable, student_loan_plan: nil)).not_to be_valid(:submit)
     expect(build(:claim, :submittable, student_loan_plan: Claim::NO_STUDENT_LOAN)).to be_valid(:submit)

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -76,19 +76,6 @@ RSpec.describe "Admin claim amendments" do
         expect(response.body).to include("Enter an account number")
       end
 
-      it "displays a validation error and does not update the claim or create an amendment when trying to change the student loan plan when the claimant is no longer paying off their student loan" do
-        claim.update!(has_student_loan: false, student_loan_plan: Claim::NO_STUDENT_LOAN)
-
-        expect {
-          post admin_claim_amendments_url(claim, amendment: {claim: {student_loan_plan: "plan_2"},
-                                                             notes: "Contacted claimant to find out plan type"})
-        }.not_to change { [claim.reload.student_loan_plan, claim.amendments.size] }
-
-        expect(response).to have_http_status(:ok)
-
-        expect(response.body).to include("You can’t amend the student loan plan type")
-      end
-
       it "displays an error message and does not create an amendment when none of the claim’s values are changed" do
         expect {
           post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: claim.teacher_reference_number},


### PR DESCRIPTION
We need to also be aware of the reason why this validation was added: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/287501d69138047cc6c5c6cc20e9275e90469bef
