### PR TITLE
Reset filters form if filters have been applied

### DIFF
--- a/app/assets/stylesheets/components/admin_filters.scss
+++ b/app/assets/stylesheets/components/admin_filters.scss
@@ -15,7 +15,7 @@
 
 .button-link {
   padding: 0;
-
+  display: inline-block;
   // optional
   font-family: arial, sans-serif; //input has OS specific font-family
   font: inherit;

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -38,7 +38,11 @@
         </div>
         <div>
           <%= form.submit "Apply filters", class: "govuk-button govuk-button--secondary admin-filter-group__button" %>
-          <%= form.submit "Clear filters", type: "reset", class: "button-link admin-filter-group__button" %>
+          <% if params[:commit].present? %>
+            <%= link_to "Clear filters", admin_claims_path, class: "button-link admin-filter-group__button" %>
+          <% else %>
+            <%= form.submit "Clear filters", type: "reset", class: "button-link admin-filter-group__button" %>
+          <% end %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-738

If the users selects filters and clicks 'Apply filters', the'Clear fitlers' link will now reset the form to the default state, rather than the applied filters state.

In order to avoid a Javascript dependency the link is an anchor if filters are applied, otherwise a reset button. It could be improved by conditionally using JS if available, but it's probably overkill.