### PR TITLE
Rename Payroll status label

### DIFF
--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -113,7 +113,7 @@
 
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Payroll status
+        Status
       </dt>
 
       <dd class="govuk-summary-list__value">

--- a/spec/features/admin_views_completed_claim_spec.rb
+++ b/spec/features/admin_views_completed_claim_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Admin can view completed claims" do
 
     visit admin_claim_tasks_path(claim_with_payment)
 
-    expect(page).to have_content("Payroll status #{payroll_run_date}")
+    expect(page).to have_content("Status #{payroll_run_date}")
     expect(page).to have_link(payroll_run_date, href: admin_payroll_run_path(payroll_run))
   end
 
@@ -40,6 +40,6 @@ RSpec.feature "Admin can view completed claims" do
 
     visit admin_claim_tasks_path(claim_with_decision)
 
-    expect(page).to have_content("Payroll status Approved awaiting payroll")
+    expect(page).to have_content("Status Approved awaiting payroll")
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-740

Renames the 'Payroll status' label back to 'Status'.