### PR TITLE
Add back link to school search results page

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -105,6 +105,7 @@ class ClaimsController < BasePublicController
   end
 
   def search_schools
+    @backlink_path = page_sequence.current_slug
     schools = ActiveModel::Type::Boolean.new.cast(params[:exclude_closed]) ? School.open : School
     @schools = schools.search(params[:school_search])
   rescue ArgumentError => e

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -182,6 +182,8 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
       fill_in :school_search, with: "Penistone"
       click_on "Continue"
 
+      expect(page).to have_link("Back")
+
       click_on "Continue"
 
       expect(page).to have_text("There is a problem")


### PR DESCRIPTION
Adds a 'Back' link to the school search results page.

The reason it wasn't working before was because the results page has the same slug as the search form, which remains the first in the page sequence. The back link is retrieved by getting the previous slug in the sequence. This change overrides that behaviour so we just link back to the same slug without parameters.