### PR TITLE
Task to simplify deletion of a PayrollRun

### DIFF
--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -1,7 +1,7 @@
 class PayrollRun < ApplicationRecord
   DOWNLOAD_FILE_TIMEOUT = 30
 
-  has_many :payments
+  has_many :payments, dependent: :destroy
   has_many :claims, through: :payments
 
   belongs_to :created_by, class_name: "DfeSignIn::User"

--- a/docs/payroll.md
+++ b/docs/payroll.md
@@ -1,0 +1,22 @@
+# Payroll
+
+## Deleting a payroll run
+
+While testing the service it may be useful to delete a payroll run.
+
+To do so, execute the following command in the relevant environment:
+
+```bash
+bin/rake delete_payroll_run\[<UUID of PayrollRun>\]
+```
+
+The UUID can be found in the URL of the payroll run on the admin site.
+
+To delete the _last_ payroll run, you can simply run:
+
+```bash
+bin/rake delete_payroll_run
+```
+
+Of course, this command should probably not ever be run in the production
+environment.

--- a/lib/tasks/delete_payroll_run.rake
+++ b/lib/tasks/delete_payroll_run.rake
@@ -1,0 +1,10 @@
+# This supports testing of the payroll run functionality. It probably shouldn't ever be run in production.
+# Specify a PayrollRun ID - defaults to the last PayrollRun record
+desc "Delete payroll run"
+task :delete_payroll_run, [:payroll_run_id] => :environment do |t, args|
+  args.with_defaults(payroll_run_id: PayrollRun.last.id)
+  logger = Logger.new($stdout)
+  logger.info "Deleting payroll run with ID #{args.payroll_run_id}"
+
+  PayrollRun.find(args.payroll_run_id).destroy!
+end


### PR DESCRIPTION
This task automates and simplifies the deletion of `PayrollRun` records to support testing of the service.