### PR TITLE
[CAPT-607] Manage SSL certificates via terraform

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
 terraform 1.2.4
+ruby 3.0.4
+nodejs 16.17.0

--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -38,8 +38,10 @@ module "app_service" {
   db_name                 = local.db_name
   environment             = var.environment
   canonical_hostname      = var.canonical_hostname
+  ssl_hostnames           = var.ssl_hostnames
   bypass_dfe_sign_in      = var.bypass_dfe_sign_in
   pr_number               = var.pr_number
   suppress_dfe_analytics_init = var.suppress_dfe_analytics_init
   enable_basic_auth       = var.enable_basic_auth
+  keyvault_cert_name      = var.keyvault_cert_name
 }

--- a/azure/terraform/modules/app_service/app_service.tf
+++ b/azure/terraform/modules/app_service/app_service.tf
@@ -13,3 +13,35 @@ resource "azurerm_linux_web_app" "app_as" {
 
   tags = var.common_tags
 }
+
+data "azurerm_key_vault_certificate" "app" {
+  for_each     = local.cert_set
+  name         = var.keyvault_cert_name
+  key_vault_id = data.azurerm_key_vault.secrets_kv.id
+}
+
+resource "azurerm_app_service_certificate" "app" {
+  for_each            = local.cert_set
+  name                = "${data.azurerm_key_vault.secrets_kv.name}-${var.keyvault_cert_name}"
+  resource_group_name = var.app_rg_name
+  location            = var.rg_location
+  key_vault_secret_id = data.azurerm_key_vault_certificate.app[var.keyvault_cert_name].id
+
+   lifecycle {
+    ignore_changes = [ tags ]
+  }
+}
+
+resource "azurerm_app_service_custom_hostname_binding" "app" {
+  for_each            = toset(var.ssl_hostnames)
+  hostname            = each.key
+  app_service_name    = local.app_service_name
+  resource_group_name = var.app_rg_name
+}
+
+resource "azurerm_app_service_certificate_binding" "app" {
+  for_each            = toset(var.ssl_hostnames)
+  hostname_binding_id = azurerm_app_service_custom_hostname_binding.app[each.key].id
+  certificate_id      = azurerm_app_service_certificate.app[var.keyvault_cert_name].id
+  ssl_state           = "SniEnabled"
+}

--- a/azure/terraform/modules/app_service/variable.tf
+++ b/azure/terraform/modules/app_service/variable.tf
@@ -44,6 +44,10 @@ variable "canonical_hostname" {
   description = "External domain name for the app service"
   default     = null
 }
+variable "ssl_hostnames" {
+  type        = list
+  description = "External domain names for the app service. They must be declared as SANs on the SSL certificate"
+}
 variable "bypass_dfe_sign_in" {
   type        = bool
   description = "Bypass DFE Sign-In authentication and use a default role"
@@ -64,6 +68,11 @@ variable "enable_basic_auth" {
   type        = bool
   description = "Enable basic HTTP authentication"
   default     = false
+}
+
+variable keyvault_cert_name {
+  type        = string
+  description = "Key vault certificate for app service"
 }
 
 locals {
@@ -125,4 +134,6 @@ locals {
       BASIC_AUTH_USERNAME = data.azurerm_key_vault_secret.BasicAuthUsername[0].value
       BASIC_AUTH_PASSWORD = data.azurerm_key_vault_secret.BasicAuthPassword[0].value
     }) : local.default_environment_variables
+  cert_set = var.keyvault_cert_name != null ? toset([var.keyvault_cert_name]) : toset([])
+  # app_service_cert_name = "${data.azurerm_key_vault.secrets_kv.name}-${var.keyvault_cert_name}"
 }

--- a/azure/terraform/variable.tf
+++ b/azure/terraform/variable.tf
@@ -25,6 +25,12 @@ variable "canonical_hostname" {
   default     = null
 }
 
+variable "ssl_hostnames" {
+  type        = list
+  description = "External domain names for the app service. They must be declared as SANs on the SSL certificate"
+  default     = []
+}
+
 variable "create_database" {
   type        = bool
   description = "Create database via this terraform as opposed to the infrastructure terraform"
@@ -53,6 +59,12 @@ variable "enable_basic_auth" {
   type        = bool
   description = "Enable basic HTTP authentication"
   default     = false
+}
+
+variable keyvault_cert_name {
+  type        = string
+  description = "Key vault certificate for app service"
+  default     = null
 }
 
 locals {

--- a/azure/terraform/workspace_variables/development.tfvars.json
+++ b/azure/terraform/workspace_variables/development.tfvars.json
@@ -2,5 +2,7 @@
   "rg_prefix": "s118d01",
   "environment": "development",
   "env_tag": "Dev",
-  "canonical_hostname": "development.additional-teaching-payment.education.gov.uk"
+  "canonical_hostname": "development.additional-teaching-payment.education.gov.uk",
+  "ssl_hostnames": ["development.additional-teaching-payment.education.gov.uk"],
+  "keyvault_cert_name": "development-additional-teaching-payment-education-gov-uk-digicert-2"
 }

--- a/azure/terraform/workspace_variables/production.tfvars.json
+++ b/azure/terraform/workspace_variables/production.tfvars.json
@@ -2,5 +2,10 @@
   "rg_prefix": "s118p01",
   "environment": "production",
   "env_tag": "Prod",
-  "canonical_hostname": "www.claim-additional-teaching-payment.service.gov.uk"
+  "canonical_hostname": "www.claim-additional-teaching-payment.service.gov.uk",
+  "ssl_hostnames": [
+    "www.claim-additional-teaching-payment.service.gov.uk",
+    "claim-additional-teaching-payment.service.gov.uk"
+  ],
+  "keyvault_cert_name": "claim-additional-teaching-payment-service-gov-uk-digicert"
 }

--- a/azure/terraform/workspace_variables/test.tfvars.json
+++ b/azure/terraform/workspace_variables/test.tfvars.json
@@ -2,5 +2,7 @@
   "rg_prefix": "s118t01",
   "environment": "test",
   "env_tag": "Test",
-  "canonical_hostname": "test.additional-teaching-payment.education.gov.uk"
+  "canonical_hostname": "test.additional-teaching-payment.education.gov.uk",
+  "ssl_hostnames": ["test.additional-teaching-payment.education.gov.uk"],
+  "keyvault_cert_name": "test-claim-additional-teaching-payment-service-gov-uk-digicert"
 }


### PR DESCRIPTION
## What
Certificates are generated and auto renewed in Keyvault. But they are configures manually on app service. This PR brings them under terraform control.

Depends on: https://github.com/DFE-Digital/claim-additional-payments-for-teaching-infrastructure/pull/54

## Before merge
- Stop merging to main so the pipeline is clear
- Import certificates in test and production environments into terraform