### PR TITLE
Only validate amendable fields when amending a claim

### DIFF
--- a/app/models/amendment.rb
+++ b/app/models/amendment.rb
@@ -33,7 +33,7 @@ class Amendment < ApplicationRecord
     Claim.transaction do
       claim.assign_attributes(claim_attributes)
 
-      unless claim.save(context: [:submit, :amendment])
+      unless claim.save(context: :amendment)
         amendment.valid?
         amendment.errors.merge!(claim.errors)
         amendment.errors.delete(:claim_changes)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -186,19 +186,19 @@ class Claim < ApplicationRecord
   validates :postcode, length: {maximum: 11, message: "Postcode must be 11 characters or less"}
   validate :postcode_is_valid, if: -> { postcode.present? }
 
-  validate :date_of_birth_criteria, on: [:"personal-details", :submit]
+  validate :date_of_birth_criteria, on: [:"personal-details", :submit, :amendment]
 
-  validates :teacher_reference_number, on: [:"teacher-reference-number", :submit], presence: {message: "Enter your teacher reference number"}
+  validates :teacher_reference_number, on: [:"teacher-reference-number", :submit, :amendment], presence: {message: "Enter your teacher reference number"}
   validate :trn_must_be_seven_digits
 
-  validates :national_insurance_number, on: [:"personal-details", :submit], presence: {message: "Enter a National Insurance number in the correct format"}
+  validates :national_insurance_number, on: [:"personal-details", :submit, :amendment], presence: {message: "Enter a National Insurance number in the correct format"}
   validate :ni_number_is_correct_format
 
   validates :has_student_loan, on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a student loan"}
   validates :student_loan_country, on: [:"student-loan-country"], presence: {message: "Select where your home address was when you applied for your student loan"}
   validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select how many higher education courses you took out a student loan for"}
   validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: ->(object, data) { I18n.t("validation_errors.student_loan_start_date.#{object.student_loan_courses}") }}
-  validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
+  validates :student_loan_plan, on: [:submit, :amendment], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
 
   validates :has_masters_doctoral_loan, on: [:"masters-doctoral-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a postgraduate masters and/or doctoral loan"}, if: :no_student_loan?
   validates :postgraduate_masters_loan, on: [:"masters-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a Postgraduate Master’s Loan"}, unless: -> { no_masters_doctoral_loan? }
@@ -217,10 +217,10 @@ class Claim < ApplicationRecord
     }, if: -> { provide_mobile_number == true && mobile_number.present? && has_ecp_or_lupp_policy? }
 
   validates :bank_or_building_society, on: [:"bank-or-building-society", :submit], presence: {message: "Select if you want the money paid in to a personal bank account or building society"}
-  validates :banking_name, on: [:"personal-bank-account", :"building-society-account", :submit], presence: {message: "Enter a name on the account"}
-  validates :bank_sort_code, on: [:"personal-bank-account", :"building-society-account", :submit], presence: {message: "Enter a sort code"}
-  validates :bank_account_number, on: [:"personal-bank-account", :"building-society-account", :submit], presence: {message: "Enter an account number"}
-  validates :building_society_roll_number, on: [:"building-society-account", :submit], presence: {message: "Enter a roll number"}, if: -> { building_society? }
+  validates :banking_name, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter a name on the account"}
+  validates :bank_sort_code, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter a sort code"}
+  validates :bank_account_number, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter an account number"}
+  validates :building_society_roll_number, on: [:"building-society-account", :submit, :amendment], presence: {message: "Enter a roll number"}, if: -> { building_society? }
 
   validates :payroll_gender, on: [:"payroll-gender-task", :submit], presence: {message: "You must select a gender that will be passed to HMRC"}
 

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -139,4 +139,25 @@ RSpec.feature "Admin amends a claim" do
       expect(page).to have_content("by #{@signed_in_user.full_name} on #{I18n.l(Time.current)}")
     end
   end
+
+  context "with a submitted claim that would now fail validation on submit context" do
+    let(:claim) { create(:claim, :submitted, policy: StudentLoans) }
+
+    before do
+      claim.eligibility.claim_school = create(:school, :student_loans_ineligible)
+      claim.eligibility.save!
+    end
+
+    scenario "Service operator amends the claim" do
+      visit admin_claim_url(claim)
+      click_on "Amend claim"
+
+      fill_in "Student loan repayment amount", with: "300"
+      fill_in "Change notes", with: "The claimant calculated the incorrect student loan repayment amount"
+      click_on "Amend claim"
+
+      expect(page).not_to have_text "There is a problem"
+      expect(page).to have_content("Claim has been amended successfully")
+    end
+  end
 end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -224,6 +224,36 @@ RSpec.describe Amendment, type: :model do
         end
       end
 
+      context "when the claim would no longer be valid in the submit context" do
+        let(:claim) { create(:claim, :submitted, policy: StudentLoans) }
+        let(:ineligible_school) { create(:school, :student_loans_ineligible) }
+
+        let(:claim_attributes) do
+          {
+            eligibility_attributes: {
+              student_loan_repayment_amount: 555
+            }
+          }
+        end
+        let(:amendment_attributes) do
+          {
+            notes: "This is a change",
+            created_by: dfe_signin_user
+          }
+        end
+
+        before do
+          claim.eligibility.claim_school = ineligible_school
+          claim.eligibility.save!
+        end
+
+        subject(:amendment) { described_class.amend_claim(claim, claim_attributes, amendment_attributes) }
+
+        it "reports no errors" do
+          expect(amendment.errors).to be_empty
+        end
+      end
+
       context "with a Early Career Payments claim" do
         let(:note) do
           <<~NOTE_TEXT


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-808

This change means that only fields which are present on the amend claim form are validated when the form is submitted. Previously, the validation was run in the `submit` context as if the claim was being submitted as new.

This prevented amendments being made in certain scenarios, for example when the school closed after the claim was submitted.

This change extends the `amendment` validation context.

Confirmed that payroll can still be run in this scenario so it was not necessary to change any validations in the payroll run.