### PR TITLE
[CAPT-790] StatusCake monitoring

### DIFF
--- a/azure/terraform/provider.tf
+++ b/azure/terraform/provider.tf
@@ -21,5 +21,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "=3.18.0"
     }
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "2.0.5"
+    }
   }
 }

--- a/azure/terraform/status_cake.tf
+++ b/azure/terraform/status_cake.tf
@@ -1,0 +1,74 @@
+data "azurerm_key_vault" "secrets_kv" {
+  name                = format("%s-%s", var.rg_prefix, "secrets-kv")
+  resource_group_name = format("%s-%s", var.rg_prefix, "secrets")
+}
+
+data "azurerm_key_vault_secret" "StatusCakeAPIToken" {
+  name         = "StatusCakeAPIToken"
+  key_vault_id = data.azurerm_key_vault.secrets_kv.id
+}
+
+provider "statuscake" {
+  api_token = data.azurerm_key_vault_secret.StatusCakeAPIToken.value
+}
+
+resource "statuscake_uptime_check" "alert" {
+  for_each = var.statuscake_alerts
+
+  name           = each.value.website_name
+  check_interval = each.value.check_rate
+  confirmation   = 2
+  trigger_rate   = 0
+  regions        = [ "london", "dublin" ]
+  contact_groups = each.value.contact_group
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes     = [
+      "204",
+      "205",
+      "206",
+      "303",
+      "400",
+      "401",
+      "403",
+      "404",
+      "405",
+      "406",
+      "408",
+      "410",
+      "413",
+      "444",
+      "429",
+      "494",
+      "495",
+      "496",
+      "499",
+      "500",
+      "501",
+      "502",
+      "503",
+      "504",
+      "505",
+      "506",
+      "507",
+      "508",
+      "509",
+      "510",
+      "511",
+      "521",
+      "522",
+      "523",
+      "524",
+      "520",
+      "598",
+      "599"
+    ]
+  }
+
+  monitored_resource {
+    address = each.value.website_url
+  }
+}

--- a/azure/terraform/variable.tf
+++ b/azure/terraform/variable.tf
@@ -67,6 +67,12 @@ variable keyvault_cert_name {
   default     = null
 }
 
+variable statuscake_alerts {
+  type        = map
+  description = "External monitoring StatusCake checks"
+  default     = {}
+}
+
 locals {
   app_name = var.pr_number == null ? null : "pr-${var.pr_number}"
   db_name         = local.app_name == null ? var.environment : "${var.environment}-${local.app_name}"

--- a/azure/terraform/workspace_variables/production.tfvars.json
+++ b/azure/terraform/workspace_variables/production.tfvars.json
@@ -7,5 +7,13 @@
     "www.claim-additional-teaching-payment.service.gov.uk",
     "claim-additional-teaching-payment.service.gov.uk"
   ],
-  "keyvault_cert_name": "claim-additional-teaching-payment-service-gov-uk-digicert"
+  "keyvault_cert_name": "claim-additional-teaching-payment-service-gov-uk-digicert",
+  "statuscake_alerts": {
+    "claims-healthcheck": {
+      "website_name": "Teacher-Payments-Production",
+      "website_url": "https://claim-additional-teaching-payment.service.gov.uk/healthcheck",
+      "check_rate": 30,
+      "contact_group": [195955]
+    }
+  }
 }

--- a/azure/terraform/workspace_variables/test.tfvars.json
+++ b/azure/terraform/workspace_variables/test.tfvars.json
@@ -4,5 +4,13 @@
   "env_tag": "Test",
   "canonical_hostname": "test.additional-teaching-payment.education.gov.uk",
   "ssl_hostnames": ["test.additional-teaching-payment.education.gov.uk"],
-  "keyvault_cert_name": "test-claim-additional-teaching-payment-service-gov-uk-digicert"
+  "keyvault_cert_name": "test-claim-additional-teaching-payment-service-gov-uk-digicert",
+  "statuscake_alerts": {
+    "claims-healthcheck": {
+      "website_name": "Teacher-Payments-Test",
+      "website_url": "https://test.additional-teaching-payment.education.gov.uk/healthcheck",
+      "check_rate": 30,
+      "contact_group": [195955]
+    }
+  }
 }


### PR DESCRIPTION
## What
Add external monitoring via StatusCake so we are alerted via email and Slack as soon as the site goes down

## How to review
See example alert: https://ukgovernmentdfe.slack.com/archives/C02TGN3B6G2/p1670322290116119
