### PR TITLE
Prevent race conditions when performing employment checks

### DIFF
--- a/app/models/automated_checks/claim_verifiers/employment.rb
+++ b/app/models/automated_checks/claim_verifiers/employment.rb
@@ -8,7 +8,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless awaiting_task?("employment")
+        return unless awaiting_task?
 
         no_data || no_match || matched
       end
@@ -17,8 +17,8 @@ module AutomatedChecks
 
       attr_accessor :admin_user, :claim, :teachers_pensions_service
 
-      def awaiting_task?(task_name)
-        claim.tasks.none? { |task| task.name == task_name }
+      def awaiting_task?
+        claim.tasks.where(name: "employment").count.zero?
       end
 
       def teachers_pensions_service_schools
@@ -91,15 +91,11 @@ module AutomatedChecks
       end
 
       def create_task(match:, passed: nil)
-        task = claim.tasks.build(
-          {
-            name: "employment",
-            claim_verifier_match: match,
-            passed: passed,
-            manual: false,
-            created_by: admin_user
-          }
-        )
+        task = claim.tasks.find_or_initialize_by(name: "employment")
+        task.claim_verifier_match = match
+        task.passed = passed
+        task.manual = false
+        task.created_by = admin_user
 
         task.save!(context: :claim_verifier)
 

--- a/spec/models/automated_checks/claim_verifiers/employment_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/employment_spec.rb
@@ -259,6 +259,14 @@ module AutomatedChecks
             end
           end
         end
+
+        context "when an employment task already exists" do
+          before { create(:task, name: "employment", claim: claim_arg) }
+
+          it "does not create duplicate tasks or notes" do
+            expect { perform }.not_to change { [claim_arg.reload.notes.count, claim_arg.tasks.count] }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-865

This addresses some Rollbar errors encountered when employment checks are run.

While the checker was already existing early if a `Task` record had been created, we were still seeing exceptions when creating a new `Task` later on. This is likely due to a race condition if the employment checks are being run concurrently with another process.