### PR TITLE
lower dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 3
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 3
   ignore:
   - dependency-name: a11y-dialog
     versions:


### PR DESCRIPTION
## What
Lower the limit for dependabot open Pull Requests.
From 10 to 3 for bundler and npm

## Why
The dev App Service plan is sized for around 10-12 app services running max.
Each PR creates a review app, so dependabot is causing resource issues if too many open PR's exist.  

## How to review
check update logs after merge
https://github.com/DFE-Digital/claim-additional-payments-for-teaching/network/updates

