### PR TITLE
Change payment confirmation email content

### DIFF
--- a/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
+++ b/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
@@ -4,16 +4,16 @@ You will receive <%=number_to_currency(@payment.net_pay) %> on Friday <%= @payme
 
 # Breakdown of payment
 
-<% if @payment.student_loan_repayment.present? || @payment.postgraduate_loan_repayment.present? %>
+<% if @payment.student_loan_repayment&.nonzero? || @payment.postgraduate_loan_repayment&.nonzero? %>
 This payment is treated as pay and is therefore subject to a student loan contribution, if applicable.
 
 <% @payment.claims.each do |claim| %>
 * <%= I18n.t("#{claim.policy.locale_key}.claim_amount_description") %>: <%= number_to_currency(claim.award_amount) %>
 <% end %>
 * Amount you applied for: <%= number_to_currency(@payment.award_amount) %>
-<% if @payment.student_loan_repayment.present? %>* Student loan contribution: <%= number_to_currency(@payment.student_loan_repayment) %>
+<% if @payment.student_loan_repayment&.nonzero? %>* Student loan contribution: <%= number_to_currency(@payment.student_loan_repayment) %>
 You told us you’re currently repaying a student loan. This amount is deducted from your payment and goes towards repaying your loan.
-<% end %><% if @payment.postgraduate_loan_repayment.present? %>* Postgraduate Master’s or PhD loan contribution: <%= number_to_currency(@payment.postgraduate_loan_repayment) %>
+<% end %><% if @payment.postgraduate_loan_repayment&.nonzero? %>* Postgraduate Master’s or PhD loan contribution: <%= number_to_currency(@payment.postgraduate_loan_repayment) %>
 You told us you’re currently repaying a Postgraduate Master’s Loan or Postgraduate Doctoral Loan. This amount is deducted from your payment and goes towards repaying your loan.
 <% end %>* Payment you receive: <%= number_to_currency(@payment.net_pay) %>
 

--- a/app/views/payment_mailer/confirmation_for_single_claim.text.erb
+++ b/app/views/payment_mailer/confirmation_for_single_claim.text.erb
@@ -4,13 +4,13 @@ You will receive <%=number_to_currency(@payment.net_pay) %> on Friday <%= @payme
 
 # Breakdown of payment
 
-<% if @payment.student_loan_repayment.present? || @payment.postgraduate_loan_repayment.present? %>
+<% if @payment.student_loan_repayment&.nonzero? || @payment.postgraduate_loan_repayment&.nonzero? %>
 This payment is treated as pay and is therefore subject to a student loan contribution, if applicable.
 
 * Amount you applied for: <%= number_to_currency(@payment.award_amount) %>
-<% if @payment.student_loan_repayment.present? %>* Student loan contribution: <%= number_to_currency(@payment.student_loan_repayment) %>
+<% if @payment.student_loan_repayment&.nonzero? %>* Student loan contribution: <%= number_to_currency(@payment.student_loan_repayment) %>
 You told us you’re currently repaying a student loan. This amount is deducted from your payment and goes towards repaying your loan.
-<% end %><% if @payment.postgraduate_loan_repayment.present? %>* Postgraduate Master’s or PhD loan contribution: <%= number_to_currency(@payment.postgraduate_loan_repayment) %>
+<% end %><% if @payment.postgraduate_loan_repayment&.nonzero? %>* Postgraduate Master’s or PhD loan contribution: <%= number_to_currency(@payment.postgraduate_loan_repayment) %>
 You told us you’re currently repaying a Postgraduate Master’s Loan or Postgraduate Doctoral Loan. This amount is deducted from your payment and goes towards repaying your loan.
 <% end %>* Payment you receive: <%= number_to_currency(@payment.net_pay) %>
 

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         context "when user does not currently have a student loan or a postgraduate loan" do
-          let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, postgraduate_loan_repayment: nil, claims: [claim]) }
+          let(:payment) { create(:payment, :with_figures, student_loan_repayment: 0, postgraduate_loan_repayment: 0, claims: [claim]) }
 
           it "does not mention the content relating to student loan deductions" do
             expect(mail.body.encoded).to_not include("subject to a student loan contribution")
@@ -65,7 +65,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         context "when user has a student loan and no postgraduate loan" do
-          let(:payment) { create(:payment, :with_figures, student_loan_repayment: 10, postgraduate_loan_repayment: nil, claims: [claim]) }
+          let(:payment) { create(:payment, :with_figures, student_loan_repayment: 10, postgraduate_loan_repayment: 0, claims: [claim]) }
 
           it "mentions the student loan deduction content and lists their contribution" do
             expect(mail.body.encoded).to include("Student loan contribution: £10.00")
@@ -78,7 +78,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         context "when user has no student loan and a postgraduate loan" do
-          let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, postgraduate_loan_repayment: 8, claims: [claim]) }
+          let(:payment) { create(:payment, :with_figures, student_loan_repayment: 0, postgraduate_loan_repayment: 8, claims: [claim]) }
 
           it "does not include the student loan deduction content" do
             expect(mail.body.encoded).not_to include("Student loan contribution")
@@ -144,7 +144,7 @@ RSpec.describe PaymentMailer, type: :mailer do
       end
 
       context "when user does not currently have a student loan or a postgraduate loan" do
-        let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, postgraduate_loan_repayment: nil, claims: claims) }
+        let(:payment) { create(:payment, :with_figures, student_loan_repayment: 0, postgraduate_loan_repayment: 0, claims: claims) }
 
         it "does not mention the content relating to student loan deductions" do
           expect(mail.body.encoded).to_not include("subject to a student loan contribution")
@@ -166,7 +166,7 @@ RSpec.describe PaymentMailer, type: :mailer do
       end
 
       context "when user has a student loan and no postgraduate loan" do
-        let(:payment) { create(:payment, :with_figures, student_loan_repayment: 10, postgraduate_loan_repayment: nil, claims: claims) }
+        let(:payment) { create(:payment, :with_figures, student_loan_repayment: 10, postgraduate_loan_repayment: 0, claims: claims) }
 
         it "mentions the student loan deduction content and lists their contribution" do
           expect(mail.body.encoded).to include("Student loan contribution: £10.00")
@@ -179,7 +179,7 @@ RSpec.describe PaymentMailer, type: :mailer do
       end
 
       context "when user has no student loan and a postgraduate loan" do
-        let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, postgraduate_loan_repayment: 8, claims: claims) }
+        let(:payment) { create(:payment, :with_figures, student_loan_repayment: 0, postgraduate_loan_repayment: 8, claims: claims) }
 
         it "does not include the student loan deduction content" do
           expect(mail.body.encoded).not_to include("Student loan contribution")


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-846

Copy changes to the payment confirmation email.

Hides the postgraduate loan contribution copy and amount if none deducted from the payment.