### PR TITLE
Fix error where the user tries to skip pages after changing a previous answer

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -21,7 +21,9 @@ class ClaimsController < BasePublicController
 
   def show
     search_schools if params[:school_search]
-    if params[:slug] == "postcode-search" && postcode
+    if params[:slug] == "teaching-subject-now" && !current_claim.eligibility.eligible_itt_subject
+      return redirect_to claim_path(current_policy_routing_name, "eligible-itt-subject")
+    elsif params[:slug] == "postcode-search" && postcode
       redirect_to claim_path(current_policy_routing_name, "select-home-address", {"claim[postcode]": params[:claim][:postcode], "claim[address_line_1]": params[:claim][:address_line_1]}) and return unless invalid_postcode?
     elsif params[:slug] == "select-home-address" && postcode
       session[:claim_postcode] = params[:claim][:postcode]

--- a/spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.feature "Combined claim journey dependent answers" do
+  before { create(:policy_configuration, :additional_payments) }
+  let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
+
+  scenario "Dependent answers reset" do
+    visit new_claim_path(EarlyCareerPayments.routing_name)
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school school
+    click_on "Continue"
+
+    # - Have you started your first year as a newly qualified teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt.heading"))
+    choose "Yes"
+    click_on "Continue"
+
+    # - Are you currently employed as a supply teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
+    choose "No"
+    click_on "Continue"
+
+    # - Poor performance
+    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+    choose "Postgraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    # - In which academic year did you complete your postgraduate ITT?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.postgraduate_itt"))
+    choose "2020 to 2021"
+    click_on "Continue"
+
+    # - Which subject did you do your undergraduate ITT in
+    expect(page).to have_text("Which subject")
+    choose "Mathematics"
+    click_on "Continue"
+
+    # - Do you teach mathematics now?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+    choose "Yes"
+    click_on "Continue"
+
+    # User goes back in the journey and changes their answer to a question which resets other dependent answers
+    visit claim_path(EarlyCareerPayments.routing_name, "qualification")
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+    choose "Undergraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+    choose "2020 to 2021"
+    click_on "Continue"
+
+    # User should be redirected to the next question which was previously answered but wiped by the attribute dependency
+    expect(page).to have_text("Which subject")
+
+    # User tries to skip ahead and not answer the question
+    visit claim_path(EarlyCareerPayments.routing_name, "teaching-subject-now")
+
+    # User should be redirected to the dependent question still unanswered
+    expect(page).to have_text("Which subject")
+  end
+end


### PR DESCRIPTION
Currently an error can occur when the user has got to the "are you teaching subject now?" question, then goes back to the qualifications page and changes their answer, and then skips ahead in the journey to the "are you teaching subject now?" question again (perhaps by pressing the back button multiple times).

This happens because changing certain answers resets other dependent answers. The user is expected to answer them again.

This change adds a check to ensure dependent answers have been completed, and if not the user is redirected.