### PR TITLE
CAPT-948 flash message shows chosen AY not current AY

### DIFF
--- a/app/controllers/admin/levelling_up_premium_payments_awards_controller.rb
+++ b/app/controllers/admin/levelling_up_premium_payments_awards_controller.rb
@@ -10,7 +10,7 @@ module Admin
       @csv_upload = LevellingUpPremiumPayments::AwardCsvImporter.new(**upload_params.to_h.symbolize_keys)
 
       if @csv_upload.process
-        flash[:notice] = "Award amounts for #{policy_configuration.current_academic_year} successfully updated."
+        flash[:notice] = "Award amounts for #{@csv_upload.academic_year} successfully updated."
         return redirect_to edit_admin_policy_configuration_path(policy_configuration)
       end
 

--- a/spec/features/admin_manage_lupp_school_awards_spec.rb
+++ b/spec/features/admin_manage_lupp_school_awards_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Managing Levelling Up Premium Payments school awards" do
 
     click_on "Manage services"
 
-    expect(page).to have_content("Claim Additional Payments for Teaching")
+    expect(page).to have_content("Claim additional payments for teaching")
     within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
       click_on "Change"
     end
@@ -64,6 +64,17 @@ RSpec.feature "Managing Levelling Up Premium Payments school awards" do
     end
 
     expect(page).to have_text "Award amounts for #{policy_configuration.current_academic_year} successfully updated."
+
+    # Different academic year
+
+    within "#upload" do
+      select "2024/2025", from: "upload_academic_year"
+
+      attach_file("CSV file", csv_file)
+      click_button "Upload CSV"
+    end
+
+    expect(page).to have_text "Award amounts for 2024/2025 successfully updated."
 
     # CSV file with bad data
     within "#upload" do


### PR DESCRIPTION
In addition:
- For some reason the spec file had `_spec` missing so file renamed.