### PR TITLE
CAPT-975 - API logic for LUP qualifications include subject name match as well as subject code match

### DIFF
--- a/app/models/levelling_up_premium_payments/dqt_record.rb
+++ b/app/models/levelling_up_premium_payments/dqt_record.rb
@@ -5,6 +5,8 @@ module LevellingUpPremiumPayments
     include Dqt::Matchers::General
     include Dqt::Matchers::LevellingUpPremiumPayments
 
+    ELIGIBLE_CODES = ELIGIBLE_JAC_CODES | ELIGIBLE_HECOS_CODES
+
     delegate(
       :qts_award_date,
       :itt_subjects,
@@ -26,25 +28,55 @@ module LevellingUpPremiumPayments
         eligible_itt_year? &&
         qts_award_date_after_itt_start_date?
 
-      policy_year = PolicyConfiguration.for(claim.policy).current_academic_year
-      eligible_itt_years = JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_year)
-
-      (eligible_code?(itt_subject_codes) || eligible_code?(degree_codes)) && eligible_itt_years.include?(itt_year)
+      # In the absence of a valid ITT subject code or degree, the subject name
+      # is checked against the list of eligible subjects; in this scenario,
+      # there must be no invalid subject codes returned from the DQT.
+      eligible_codes? || (eligible_subject? && no_invalid_subject_codes?)
     end
 
     private
 
     attr_reader :record, :claim
 
-    def eligible_code?(code)
-      ((Dqt::Matchers::LevellingUpPremiumPayments::ELIGIBLE_JAC_CODES | Dqt::Matchers::LevellingUpPremiumPayments::ELIGIBLE_HECOS_CODES) & code).any?
+    def eligible_code?(codes)
+      (ELIGIBLE_CODES & codes).any?
+    end
+
+    def eligible_codes?
+      eligible_code?(itt_subject_codes) || eligible_code?(degree_codes)
     end
 
     def eligible_subject_and_none_of_the_above?
-      return false if claim.eligibility.itt_subject_none_of_the_above? && (ELIGIBLE_ITT_SUBJECTS.values.flatten & itt_subjects).any?
+      return false if claim.eligibility.itt_subject_none_of_the_above? && eligible_subject?
       return true if claim.eligibility.itt_subject_none_of_the_above?
 
-      (ELIGIBLE_ITT_SUBJECTS[claim.eligibility.eligible_itt_subject.to_sym] & itt_subjects).any?
+      eligible_subject?
+    end
+
+    def eligible_itt_year?
+      return unless super
+
+      itt_year_within_allowed_range?
+    end
+
+    def itt_year_within_allowed_range?
+      policy_year = PolicyConfiguration.for(claim.policy).current_academic_year
+      eligible_itt_years = JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_year)
+      eligible_itt_years.include?(itt_year)
+    end
+
+    def applicable_eligible_subjects
+      return ELIGIBLE_ITT_SUBJECTS.values.flatten if claim.eligibility.itt_subject_none_of_the_above?
+
+      ELIGIBLE_ITT_SUBJECTS[claim.eligibility.eligible_itt_subject.to_sym]
+    end
+
+    def eligible_subject?
+      (applicable_eligible_subjects & itt_subjects).any?
+    end
+
+    def no_invalid_subject_codes?
+      (itt_subject_codes - ELIGIBLE_CODES).empty?
     end
   end
 end

--- a/spec/models/levelling_up_premium_payments/dqt_record_spec.rb
+++ b/spec/models/levelling_up_premium_payments/dqt_record_spec.rb
@@ -51,15 +51,84 @@ RSpec.describe LevellingUpPremiumPayments::DqtRecord do
   let(:qualification_name) { "Postgraduate Certificate in Education" }
 
   describe "#eligible?" do
-    context "without ITT and degree codes" do
-      it { is_expected.not_to be_eligible }
+    context "without ITT subject code" do
+      let(:itt_subject_codes) { [] }
+
+      context "without ITT subject name" do
+        let(:itt_subjects) { [] }
+
+        it { is_expected.not_to be_eligible }
+      end
+
+      context "with an invalid ITT subject name" do
+        let(:itt_subjects) { ["biology"] }
+
+        it { is_expected.not_to be_eligible }
+      end
+
+      context "with a valid ITT subject name" do
+        let(:itt_subjects) { ["mathematics"] }
+
+        it { is_expected.to be_eligible }
+
+        context "with an invalid degree code" do
+          let(:degree_codes) { ["X100"] }
+
+          it { is_expected.to be_eligible }
+        end
+
+        context "with a valid degree code" do
+          let(:degree_codes) { ["I100"] }
+
+          it { is_expected.to be_eligible }
+        end
+      end
+
+      context "with any valid ITT subject name" do
+        let(:itt_subjects) { ["mathematics", "biology"] }
+
+        it { is_expected.to be_eligible }
+      end
     end
 
-    context "with invalid ITT and degree codes" do
-      let(:itt_subject_codes) { ["123"] }
-      let(:degree_codes) { ["321"] }
+    context "with an invalid ITT subject code" do
+      let(:itt_subject_codes) { ["B100"] }
 
-      it { is_expected.not_to be_eligible }
+      context "without ITT subject name" do
+        let(:itt_subjects) { [] }
+
+        it { is_expected.not_to be_eligible }
+      end
+
+      context "with an invalid ITT subject name" do
+        let(:itt_subjects) { ["biology"] }
+
+        it { is_expected.not_to be_eligible }
+      end
+
+      context "with a valid ITT subject name" do
+        let(:itt_subjects) { ["mathematics"] }
+
+        it { is_expected.not_to be_eligible }
+
+        context "with an invalid degree code" do
+          let(:degree_codes) { ["X100"] }
+
+          it { is_expected.not_to be_eligible }
+        end
+
+        context "with a valid degree code" do
+          let(:degree_codes) { ["I100"] }
+
+          it { is_expected.to be_eligible }
+        end
+      end
+
+      context "with any valid ITT subject name" do
+        let(:itt_subjects) { ["mathematics", "biology"] }
+
+        it { is_expected.not_to be_eligible }
+      end
     end
 
     context "with valid ITT code" do


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-975

* Refactor LUP DQT record model for readability
* Consolidate eligible ITT years check in one method
* Add fallback check when no ITT code or degree code is returned
* Make sure the fallback check works only in the absence of ITT codes (in other words, an invalid ITT code should prevail and FAIL the check anyway)
* Add more tests around invalid ITT invalid codes/subjects/degree codes

<!-- Do you need to update CHANGELOG.md? -->
