### PR TITLE
CAPT-976 - DQT API logic for multiple subject codes/names for LUP and ECP

### DIFF
--- a/app/models/early_career_payments/dqt_record.rb
+++ b/app/models/early_career_payments/dqt_record.rb
@@ -46,7 +46,9 @@ module EarlyCareerPayments
           ELIGIBLE_HECOS_CODES.find { |key, values| values.include?(subject_code) }&.first ||
           ELIGIBLE_JAC_NAMES.find { |key, values| values.include?(subject_code) }&.first ||
           ELIGIBLE_HECOS_NAMES.find { |key, values| values.include?(subject_code) }&.first
-      end.compact.uniq.first
+      end.compact.uniq.find do |group|
+        group == claim.eligibility.eligible_itt_subject.to_sym
+      end
     end
 
     def eligible_subject?

--- a/spec/models/early_career_payments/dqt_record_spec.rb
+++ b/spec/models/early_career_payments/dqt_record_spec.rb
@@ -1204,6 +1204,30 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
         qualification: :overseas_recognition,
         itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
       },
+      {
+        claim_academic_year: AcademicYear.new(2022),
+        record_degree_codes: [],
+        record_itt_subjects: ["physics", "mathematics"],
+        record_itt_subject_codes: ["100425", "100403"],
+        record_itt_date: Date.parse("3/9/2019"),
+        record_qts_date: Date.parse("7/12/2020"),
+        record_qualification_name: "QTS Award",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2019))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2022),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100425", "100403"],
+        record_itt_date: Date.parse("3/9/2019"),
+        record_qts_date: Date.parse("7/12/2020"),
+        record_qualification_name: "QTS Award",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2019))
+      },
       # end of multiple ITT subjects/codes with at least one valid
 
       # start of testing for HECOS/JAC Names for 2021

--- a/spec/models/early_career_payments/dqt_record_spec.rb
+++ b/spec/models/early_career_payments/dqt_record_spec.rb
@@ -1155,6 +1155,57 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
       },
       # end of foreign_languages for 2024
 
+      # start of multiple ITT subjects/codes with at least one valid
+      {
+        claim_academic_year: AcademicYear.new(2022),
+        record_degree_codes: [],
+        record_itt_subjects: ["biology", "chemistry"],
+        record_itt_subject_codes: ["100346", "100417"],
+        record_itt_date: Date.parse("3/9/2010"),
+        record_qts_date: Date.parse("6/10/2020"),
+        record_qualification_name: "Scotland",
+        eligible_itt_subject: :chemistry,
+        qualification: :overseas_recognition,
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2022),
+        record_degree_codes: [],
+        record_itt_subjects: ["biology", "chemistry"],
+        record_itt_subject_codes: ["100417"],
+        record_itt_date: Date.parse("3/9/2010"),
+        record_qts_date: Date.parse("6/10/2020"),
+        record_qualification_name: "Scotland",
+        eligible_itt_subject: :chemistry,
+        qualification: :overseas_recognition,
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2022),
+        record_degree_codes: [],
+        record_itt_subjects: ["biology", "chemistry"],
+        record_itt_subject_codes: ["100346"],
+        record_itt_date: Date.parse("3/9/2010"),
+        record_qts_date: Date.parse("6/10/2020"),
+        record_qualification_name: "Scotland",
+        eligible_itt_subject: :chemistry,
+        qualification: :overseas_recognition,
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2022),
+        record_degree_codes: [],
+        record_itt_subjects: ["biology", "chemistry"],
+        record_itt_subject_codes: [],
+        record_itt_date: Date.parse("3/9/2010"),
+        record_qts_date: Date.parse("6/10/2020"),
+        record_qualification_name: "Scotland",
+        eligible_itt_subject: :chemistry,
+        qualification: :overseas_recognition,
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      # end of multiple ITT subjects/codes with at least one valid
+
       # start of testing for HECOS/JAC Names for 2021
       {
         claim_academic_year: AcademicYear.new(2021),


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-976

This PR will affect ECP only, as the same result is being achieved for LUP in #2397 already.

See commit message for more info; also, some credit goes to @slorek for changes to the `DqtRecord` model.

<!-- Do you need to update CHANGELOG.md? -->
