### PR TITLE
CAPT-1040 Users need to complete all questions again if they change one part of their personal details (bugfix)

### DIFF
--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -37,8 +37,9 @@ module PartOfClaimJourney
   def claim_from_session
     return unless session.key?(:claim_id)
 
+    selected_policy = session[:selected_claim_policy].presence&.constantize
     claims = Claim.where(id: session[:claim_id])
-    claims.present? ? CurrentClaim.new(claims: claims) : nil
+    claims.present? ? CurrentClaim.new(claims: claims, selected_policy: selected_policy) : nil
   end
 
   def build_new_claim

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -13,10 +13,13 @@
 # claims are submitted, from then on that is the claim to be acted upon after submission.
 
 class CurrentClaim
-  attr_reader :claims
+  UnselectablePolicyError = Class.new(StandardError)
 
-  def initialize(claims:)
+  attr_reader :claims, :selected_policy
+
+  def initialize(claims:, selected_policy: nil)
     @claims = claims
+    @selected_policy = selected_policy
   end
 
   def for_policy(policy)
@@ -27,9 +30,12 @@ class CurrentClaim
     claims.collect { |claim| claim.policy }
   end
 
-  # This might need to change default to ECP for now
+  # The "main" claim should to be selected carefully for combined journeys.
+  # In the post-eligibility (or claim) phase, validations are run against it
+  # to make sure the correct slug sequence is enforced, so it's important to
+  # forward to the correct (selected) claim, especially when validations differ.
   def main_claim
-    for_policy(EarlyCareerPayments) || claims.first
+    for_policy(main_policy)
   end
 
   # method_missing does not catch this
@@ -89,6 +95,11 @@ class CurrentClaim
     else
       :undetermined
     end
+  end
+
+  # Persistence should to be checked for all claims in non-combined journeys.
+  def persisted?
+    claims.all? { |c| c.persisted? }
   end
 
   # Non-combined journey code like Student Loans should really
@@ -153,6 +164,27 @@ class CurrentClaim
   end
 
   private
+
+  def single_claim?
+    claims.count == 1
+  end
+
+  def ecp_or_lupp_claims?
+    claims.any? { |c| c.has_ecp_or_lupp_policy? }
+  end
+
+  # The "main" policy should always be:
+  # - The one and only one available for non-combined journeys
+  # - The one from the claim type selected at the end of combined eligibility journeys
+  # - ECP for ECP/LUP until one is selected at the end of the eligibility journey
+  # It should raise otherwise; this may need to be updated for future combined journeys.
+  def main_policy
+    return claims.first.policy if single_claim?
+    return selected_policy if selected_policy.present?
+    return EarlyCareerPayments if ecp_or_lupp_claims?
+
+    raise UnselectablePolicyError
+  end
 
   def anything_eligible_now?
     claims.any? { |claim| claim.eligibility.status == :eligible_now }

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -80,6 +80,8 @@ module EarlyCareerPayments
       @claim = claim
     end
 
+    # Even though we are inside the ECP namespace, this method can modify the
+    # slug sequence of both LUP and ECP claims
     def slugs
       overall_eligibility_status = claim.eligibility_status
       lup_claim = claim.for_policy(LevellingUpPremiumPayments)

--- a/app/models/levelling_up_premium_payments/eligibility_answers_presenter.rb
+++ b/app/models/levelling_up_premium_payments/eligibility_answers_presenter.rb
@@ -1,0 +1,4 @@
+module LevellingUpPremiumPayments
+  class EligibilityAnswersPresenter < EarlyCareerPayments::EligibilityAnswersPresenter
+  end
+end

--- a/spec/models/current_claim_spec.rb
+++ b/spec/models/current_claim_spec.rb
@@ -1,437 +1,543 @@
 require "rails_helper"
 
 RSpec.describe CurrentClaim, type: :model do
-  context "Two claims - ECP and LUP" do
-    let(:ecp_policy) { EarlyCareerPayments }
-    let(:lup_policy) { LevellingUpPremiumPayments }
-    let(:ecp_claim) { build(:claim, academic_year: "2022/2023", policy: ecp_policy) }
-    let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy) }
-    let(:school) { create(:school) }
+  subject(:current_claim) { described_class.new(claims: claims, selected_policy: selected_policy) }
 
-    describe "#attributes=" do
-      it "sets the attributes on both claims" do
-        cc = described_class.new(claims: [ecp_claim, lup_claim])
+  let(:ecp_policy) { EarlyCareerPayments }
+  let(:lup_policy) { LevellingUpPremiumPayments }
+  let(:maths_and_physics_policy) { MathsAndPhysics }
+  let(:student_loans_policy) { StudentLoans }
 
-        expect { cc.attributes = {"eligibility_attributes" => {"current_school_id" => school.id}} }
-          .to change { cc.claims.first.school&.id }.from(nil).to(school.id)
-          .and change { cc.claims.last.school&.id }.from(nil).to(school.id)
-      end
+  let(:school) { create(:school) }
+
+  let(:ecp_claim) { build(:claim, academic_year: "2022/2023", policy: ecp_policy) }
+  let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy) }
+
+  let(:maths_and_physics_claim) { build(:claim, academic_year: "2022/2023", policy: maths_and_physics_policy) }
+  let(:student_loans_claim) { build(:claim, academic_year: "2022/2023", policy: student_loans_policy) }
+
+  let(:claims) { [ecp_claim, lup_claim] }
+  let(:selected_policy) { nil }
+
+  describe "#attributes=" do
+    let!(:first_claim) { current_claim.claims.first }
+    let!(:second_claim) { current_claim.claims.last }
+
+    subject(:set_attributes) do
+      current_claim.attributes = {"eligibility_attributes" => {"current_school_id" => school.id}}
     end
 
-    describe "#save!" do
-      it "saves both claims" do
-        cc = described_class.new(claims: [ecp_claim, lup_claim])
-        cc.attributes = {"eligibility_attributes" => {"current_school_id" => school.id}}
+    it "sets the attributes on both claims" do
+      expect { set_attributes }
+        .to change { first_claim.school&.id }.from(nil).to(school.id)
+        .and change { second_claim.school&.id }.from(nil).to(school.id)
+    end
+  end
 
-        cc.save!
-
-        expect(ecp_claim.reload.school.id).to eq(school.id)
-        expect(lup_claim.reload.school.id).to eq(school.id)
-      end
+  describe "#save!" do
+    before do
+      current_claim.attributes = {"eligibility_attributes" => {"current_school_id" => school.id}}
+      current_claim.save!
     end
 
-    describe "#save" do
-      subject { current_claim.save }
+    it "saves both claims" do
+      expect(ecp_claim.reload.school.id).to eq(school.id)
+      expect(lup_claim.reload.school.id).to eq(school.id)
+    end
+  end
 
-      let(:current_claim) { described_class.new(claims: [ecp_claim, lup_claim]) }
+  describe "#save" do
+    subject(:save) { current_claim.save }
 
-      context "when claim attributes are invalid" do
-        let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "invalid") }
+    context "when claim attributes are invalid" do
+      let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "invalid") }
 
-        it "calls save on both claims" do
-          expect(lup_claim).to receive(:save)
-          expect(ecp_claim).to receive(:save)
-          subject
-        end
+      it "calls save on both claims" do
+        expect(lup_claim).to receive(:save)
+        expect(ecp_claim).to receive(:save)
 
-        it { is_expected.to be false }
+        save
       end
 
-      context "when claim attributes are valid" do
-        let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "email@example.com") }
-
-        it "calls save on both claims" do
-          expect(lup_claim).to receive(:save)
-          expect(ecp_claim).to receive(:save)
-          subject
-        end
-
-        it { is_expected.to be true }
-      end
+      it { is_expected.to be false }
     end
 
-    describe "#reset_dependent_answers" do
-      it "calls reset reset_dependent_answers on both claims" do
-        cc = described_class.new(claims: [ecp_claim, lup_claim])
+    context "when claim attributes are valid" do
+      let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, email_address: "email@example.com") }
 
-        expect(ecp_claim).to receive(:reset_dependent_answers)
-        expect(lup_claim).to receive(:reset_dependent_answers)
-
-        cc.reset_dependent_answers
+      it "calls save on both claims" do
+        expect(lup_claim).to receive(:save)
+        expect(ecp_claim).to receive(:save)
+        subject
       end
+
+      it { is_expected.to be true }
     end
+  end
 
-    describe "#eligibility.reset_dependent_answers" do
-      let(:ecp_claim) { build(:claim, academic_year: "2022/2023", policy: ecp_policy) }
-      let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy) }
+  describe "#reset_dependent_answers" do
+    subject(:reset_dependent_answers) { current_claim.reset_dependent_answers }
 
-      it "calls reset_dependent_answers on both claims' eligibility" do
-        expect(ecp_claim.eligibility).to receive(:reset_dependent_answers)
-        expect(lup_claim.eligibility).to receive(:reset_dependent_answers)
+    it "calls reset reset_dependent_answers on both claims" do
+      expect(ecp_claim).to receive(:reset_dependent_answers)
+      expect(lup_claim).to receive(:reset_dependent_answers)
 
-        cc = described_class.new(claims: [ecp_claim, lup_claim])
-        cc.reset_eligibility_dependent_answers
-      end
+      reset_dependent_answers
     end
+  end
 
-    describe "#for_policy" do
-      let(:maths_and_physics_policy) { MathsAndPhysics }
-      let(:student_loans_policy) { StudentLoans }
-      let(:maths_and_physics_claim) { build(:claim, academic_year: "2022/2023", policy: maths_and_physics_policy) }
-      let(:student_loans_claim) { build(:claim, academic_year: "2022/2023", policy: student_loans_policy) }
+  describe "#eligibility.reset_dependent_answers" do
+    subject(:reset_eligibility_dependent_answers) { current_claim.reset_eligibility_dependent_answers }
+
+    it "calls reset_dependent_answers on both claims' eligibility" do
+      expect(ecp_claim.eligibility).to receive(:reset_dependent_answers)
+      expect(lup_claim.eligibility).to receive(:reset_dependent_answers)
+
+      reset_eligibility_dependent_answers
+    end
+  end
+
+  describe "#for_policy" do
+    subject(:for_policy) { current_claim.for_policy(policy) }
+
+    context "maths and physics claim" do
+      let(:policy) { maths_and_physics_policy }
+      let(:claims) { [maths_and_physics_claim] }
 
       it "returns the single maths and physics claim" do
-        cc = described_class.new(claims: [maths_and_physics_claim])
-        expect(cc.for_policy(MathsAndPhysics)).to eq(maths_and_physics_claim)
+        is_expected.to eq(maths_and_physics_claim)
       end
+    end
+
+    context "student loans claim" do
+      let(:policy) { student_loans_policy }
+      let(:claims) { [student_loans_claim] }
 
       it "returns the single student loans claims" do
-        cc = described_class.new(claims: [student_loans_claim])
-        expect(cc.for_policy(StudentLoans)).to eq(student_loans_claim)
+        is_expected.to eq(student_loans_claim)
       end
+    end
 
-      context "multiple claims" do
-        let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
+    context "ECP/LUP multiple claims" do
+      let(:claims) { [ecp_claim, lup_claim] }
 
-        it "returns the ECP claim with 2 claims" do
-          expect(cc.for_policy(EarlyCareerPayments)).to eq(ecp_claim)
+      context "when passing ECP as policy" do
+        let(:policy) { ecp_policy }
+
+        it "returns the ECP claim" do
+          is_expected.to eq(ecp_claim)
         end
+      end
 
-        it "returns the LUP claim with 2 claims" do
-          expect(cc.for_policy(LevellingUpPremiumPayments)).to eq(lup_claim)
+      context "when passing LUP as policy" do
+        let(:policy) { lup_policy }
+
+        it "returns the LUP claim" do
+          is_expected.to eq(lup_claim)
+        end
+      end
+    end
+  end
+
+  describe "#policies" do
+    specify { expect(current_claim.policies).to contain_exactly(ecp_policy, lup_policy) }
+  end
+
+  describe "#main_claim" do
+    subject(:main_claim) { current_claim.main_claim }
+
+    context "maths and physics claim" do
+      let(:policy) { maths_and_physics_policy }
+      let(:claims) { [maths_and_physics_claim] }
+
+      context "when no policy is selected" do
+        let(:selected_policy) { nil }
+
+        it "returns the single maths and physics" do
+          is_expected.to eq(maths_and_physics_claim)
+        end
+      end
+
+      context "when maths and physics is selected as a policy" do
+        let(:selected_policy) { maths_and_physics_policy }
+
+        it "returns the single maths and physics claim" do
+          is_expected.to eq(maths_and_physics_claim)
         end
       end
     end
 
-    describe "#policies" do
-      let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
+    context "student loans claim" do
+      let(:policy) { student_loans_policy }
+      let(:claims) { [student_loans_claim] }
 
-      specify { expect(cc.policies).to contain_exactly(EarlyCareerPayments, LevellingUpPremiumPayments) }
-    end
+      context "when no policy is selected" do
+        let(:selected_policy) { nil }
 
-    describe "#ineligible?" do
-      subject { cc.ineligible? }
-
-      let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
-
-      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
-      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
-
-      let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, academic_year: "2021/2022", eligibility: ecp_eligibility) }
-      let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, academic_year: "2022/2023", eligibility: lup_eligibility) }
-
-      let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
-
-      context "when both claims are eligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
-
-        it { is_expected.to be false }
+        it "returns the single student loans" do
+          is_expected.to eq(student_loans_claim)
+        end
       end
 
-      context "when ECP claims is ineligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      context "when student loans is selected as a policy" do
+        let(:selected_policy) { student_loans_policy }
 
-        it { is_expected.to be false }
-      end
-
-      context "when LUP claims is ineligible" do
-        let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
-
-        it { is_expected.to be false }
-      end
-
-      context "when both claims are ineligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
-        let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
-
-        it { is_expected.to be true }
+        it "returns the single student loans claim" do
+          is_expected.to eq(student_loans_claim)
+        end
       end
     end
 
-    describe "#eligible_now?" do
-      subject { cc.eligible_now? }
+    context "ECP/LUP multiple claims" do
+      context "when no policy is selected" do
+        let(:selected_policy) { nil }
 
-      let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
-
-      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
-      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
-
-      let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
-      let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
-
-      let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
-
-      context "when both claims are eligible" do
-        it { is_expected.to be true }
+        it "returns the ECP claim by default" do
+          is_expected.to eq(ecp_claim)
+        end
       end
 
-      context "when ECP claim is ineligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      context "when ECP is selected a policy" do
+        let(:selected_policy) { ecp_policy }
 
-        it { is_expected.to be true }
+        it { is_expected.to eq(ecp_claim) }
       end
 
-      context "when LUP claim is ineligible" do
-        let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+      context "when LUP is selected a policy" do
+        let(:selected_policy) { lup_policy }
 
-        it { is_expected.to be true }
-      end
-
-      context "when both claims are ineligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
-        let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
-
-        it { is_expected.to be false }
+        it { is_expected.to eq(lup_claim) }
       end
     end
 
-    describe "#editable_attributes" do
-      subject { cc.editable_attributes }
+    context "no claims" do
+      let(:claims) { [] }
 
-      let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+      it { expect { main_claim }.to raise_error(described_class::UnselectablePolicyError) }
+    end
+  end
 
-      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
-      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
+  describe "#persisted?" do
+    subject { current_claim.persisted? }
 
-      let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, academic_year: "2022/2023", eligibility: ecp_eligibility) }
-      let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, academic_year: "2022/2023", eligibility: lup_eligibility) }
-
-      let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
-
-      context "when current claim has ECP and LUP claims" do
-        expected = [
-          :nqt_in_academic_year_after_itt,
-          :current_school_id,
-          :employed_as_supply_teacher,
-          :has_entire_term_contract,
-          :employed_directly,
-          :subject_to_formal_performance_action,
-          :subject_to_disciplinary_action,
-          :qualification,
-          :eligible_itt_subject,
-          :teaching_subject_now,
-          :itt_academic_year,
-          :eligible_degree_subject
-        ]
-
-        it { is_expected.to eq expected }
+    context "when all claims are persisted" do
+      before do
+        claims.each(&:save!)
       end
 
-      context "when current claim has an ECP claim" do
-        let(:cc) { described_class.new(claims: [ecp_claim]) }
-
-        expected = [
-          :nqt_in_academic_year_after_itt,
-          :current_school_id,
-          :employed_as_supply_teacher,
-          :has_entire_term_contract,
-          :employed_directly,
-          :subject_to_formal_performance_action,
-          :subject_to_disciplinary_action,
-          :qualification,
-          :eligible_itt_subject,
-          :teaching_subject_now,
-          :itt_academic_year
-        ]
-
-        it { is_expected.to eq expected }
-      end
-
-      context "when current claim has an LUP claim" do
-        let(:cc) { described_class.new(claims: [lup_claim]) }
-
-        expected = [
-          :nqt_in_academic_year_after_itt,
-          :current_school_id,
-          :employed_as_supply_teacher,
-          :has_entire_term_contract,
-          :employed_directly,
-          :subject_to_formal_performance_action,
-          :subject_to_disciplinary_action,
-          :qualification,
-          :eligible_itt_subject,
-          :teaching_subject_now,
-          :itt_academic_year,
-          :eligible_degree_subject
-        ]
-
-        it { is_expected.to eq expected }
-      end
+      it { is_expected.to eq(true) }
     end
 
-    describe "#eligible_now" do
-      subject(:result) { cc.eligible_now }
+    context "when one of the claims is not persisted" do
+      before do
+        allow(ecp_claim).to receive(:save).and_return(false)
+        claims.each(&:save)
+      end
 
-      let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+      it { is_expected.to eq(false) }
+    end
+  end
 
+  describe "#ineligible?" do
+    subject { current_claim.ineligible? }
+
+    let!(:policy_configuration_ecp_lupp) { create(:policy_configuration, :additional_payments) }
+
+    let(:ecp_claim) { build(:claim, academic_year: "2022/2023", policy: ecp_policy, eligibility: ecp_eligibility) }
+    let(:lup_claim) { build(:claim, academic_year: "2022/2023", policy: lup_policy, eligibility: lup_eligibility) }
+
+    let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
+    let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
+
+    context "when both claims are eligible" do
+      it { is_expected.to be false }
+    end
+
+    context "when the ECP claim is ineligible" do
       let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
-      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
 
-      let(:ecp_claim) { create(:claim, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
-      let(:lup_claim) { create(:claim, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
+      it { is_expected.to be false }
+    end
 
-      let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
+    context "when the LUP claim is ineligible" do
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
 
-      context "when one claim is eligible and one is ineligible" do
-        it "returns only the eligible claim" do
-          expect(result).to contain_exactly(lup_claim)
-        end
-      end
+      it { is_expected.to be false }
+    end
 
-      context "when both claims are eligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
+    context "when both claims are ineligible" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
 
-        it "returns both claims" do
-          expect(result).to contain_exactly(ecp_claim, lup_claim)
-        end
-      end
+      it { is_expected.to be true }
+    end
+  end
 
-      context "when both claims are ineligible" do
-        let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+  describe "#eligible_now?" do
+    subject { current_claim.eligible_now? }
 
-        it { is_expected.to be_empty }
+    let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+
+    let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
+    let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
+
+    let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
+    let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
+
+    context "when both claims are eligible" do
+      it { is_expected.to be true }
+    end
+
+    context "when the ECP claim is ineligible" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the LUP claim is ineligible" do
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when both claims are ineligible" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#editable_attributes" do
+    subject { current_claim.editable_attributes }
+
+    let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+
+    let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
+    let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
+
+    let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, academic_year: "2022/2023", eligibility: ecp_eligibility) }
+    let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, academic_year: "2022/2023", eligibility: lup_eligibility) }
+
+    context "when current claim has both ECP and LUP claims" do
+      expected = [
+        :nqt_in_academic_year_after_itt,
+        :current_school_id,
+        :employed_as_supply_teacher,
+        :has_entire_term_contract,
+        :employed_directly,
+        :subject_to_formal_performance_action,
+        :subject_to_disciplinary_action,
+        :qualification,
+        :eligible_itt_subject,
+        :teaching_subject_now,
+        :itt_academic_year,
+        :eligible_degree_subject
+      ]
+
+      it { is_expected.to eq expected }
+    end
+
+    context "when current claim has an ECP claim only" do
+      let(:claims) { [ecp_claim] }
+
+      expected = [
+        :nqt_in_academic_year_after_itt,
+        :current_school_id,
+        :employed_as_supply_teacher,
+        :has_entire_term_contract,
+        :employed_directly,
+        :subject_to_formal_performance_action,
+        :subject_to_disciplinary_action,
+        :qualification,
+        :eligible_itt_subject,
+        :teaching_subject_now,
+        :itt_academic_year
+      ]
+
+      it { is_expected.to eq expected }
+    end
+
+    context "when current claim has an LUP claim only" do
+      let(:claims) { [lup_claim] }
+
+      expected = [
+        :nqt_in_academic_year_after_itt,
+        :current_school_id,
+        :employed_as_supply_teacher,
+        :has_entire_term_contract,
+        :employed_directly,
+        :subject_to_formal_performance_action,
+        :subject_to_disciplinary_action,
+        :qualification,
+        :eligible_itt_subject,
+        :teaching_subject_now,
+        :itt_academic_year,
+        :eligible_degree_subject
+      ]
+
+      it { is_expected.to eq expected }
+    end
+  end
+
+  describe "#eligible_now" do
+    subject(:eligible_now) { current_claim.eligible_now }
+
+    let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+
+    let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+    let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
+
+    let(:ecp_claim) { create(:claim, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
+    let(:lup_claim) { create(:claim, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
+
+    context "when one claim is eligible and one is ineligible" do
+      it "returns only the eligible claim" do
+        is_expected.to contain_exactly(lup_claim)
       end
     end
 
-    describe "#eligible_now_and_sorted" do
-      subject(:result) { cc.eligible_now_and_sorted }
+    context "when both claims are eligible" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible) }
 
-      let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
-
-      let(:ecp_claim) { create(:claim, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
-      let(:lup_claim) { create(:claim, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
-      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible, award_amount: ecp_amount) }
-      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, award_amount: lup_amount) }
-
-      let(:cc) { described_class.new(claims: [ecp_claim, lup_claim]) }
-
-      context "with identical award amounts" do
-        let(:ecp_amount) { 2000.0 }
-        let(:lup_amount) { ecp_amount }
-
-        it "orders the claims by name" do
-          expect(result).to eq([ecp_claim, lup_claim])
-        end
-      end
-
-      context "with different award amounts" do
-        let(:ecp_amount) { 1000.0 }
-        let(:lup_amount) { 2000.0 }
-
-        it "orders the claims by highest award amount" do
-          expect(result).to eq([lup_claim, ecp_claim])
-        end
-      end
-
-      context "with different award amounts other way around" do
-        let(:ecp_amount) { 3000.0 }
-        let(:lup_amount) { 2000.0 }
-
-        it "orders the claims by highest award amount" do
-          expect(result).to eq([ecp_claim, lup_claim])
-        end
+      it "returns both claims" do
+        is_expected.to contain_exactly(ecp_claim, lup_claim)
       end
     end
 
-    describe "#submit!" do
-      let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
-      let!(:ecp_claim) { create(:claim, :submittable, policy: ecp_policy, eligibility: ecp_eligibility) }
-      let!(:lup_claim) { create(:claim, :submittable, policy: lup_policy, eligibility: lup_eligibility) }
+    context "when both claims are ineligible" do
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
 
-      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible, award_amount: 1000.0) }
-      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, award_amount: 2000.0) }
+      it { is_expected.to be_empty }
+    end
+  end
 
-      let(:cc) { described_class.new(claims: Claim.all) }
+  describe "#eligible_now_and_sorted" do
+    subject(:eligible_now_and_sorted) { current_claim.eligible_now_and_sorted }
 
-      context "when a claim for the supplied policy is found" do
-        let(:policy) { ecp_claim.policy }
+    let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
 
-        before { cc.submit!(policy) }
+    let(:ecp_claim) { create(:claim, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
+    let(:lup_claim) { create(:claim, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
+    let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible, award_amount: ecp_amount) }
+    let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, award_amount: lup_amount) }
 
-        it "destroys the other claims" do
-          expect { lup_claim.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        end
+    context "with identical award amounts" do
+      let(:ecp_amount) { 2000.0 }
+      let(:lup_amount) { ecp_amount }
 
-        it "removes the other claims from the set" do
-          expect(cc.claims.map(&:policy)).to eq([policy])
-        end
+      it "orders the claims by name" do
+        is_expected.to eq([ecp_claim, lup_claim])
+      end
+    end
 
-        it "submits the specified claim" do
-          expect(ecp_claim.reload).to be_submitted
-        end
+    context "with different award amounts" do
+      let(:ecp_amount) { 1000.0 }
+      let(:lup_amount) { 2000.0 }
 
-        it "stores the policy options provided on submission for both eligible policies" do
-          policy_options_provided = [
-            {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"},
-            {"policy" => "EarlyCareerPayments", "award_amount" => "1000.0"}
-          ]
+      it "orders the claims by highest award amount" do
+        is_expected.to eq([lup_claim, ecp_claim])
+      end
+    end
 
-          expect(ecp_claim.reload.policy_options_provided).to eq policy_options_provided
-        end
+    context "with different award amounts other way around" do
+      let(:ecp_amount) { 3000.0 }
+      let(:lup_amount) { 2000.0 }
+
+      it "orders the claims by highest award amount" do
+        is_expected.to eq([ecp_claim, lup_claim])
+      end
+    end
+  end
+
+  describe "#submit!" do
+    subject(:submit!) { current_claim.submit!(policy) }
+
+    let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+    let!(:ecp_claim) { create(:claim, :submittable, policy: ecp_policy, eligibility: ecp_eligibility) }
+    let!(:lup_claim) { create(:claim, :submittable, policy: lup_policy, eligibility: lup_eligibility) }
+
+    let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible, award_amount: 1000.0) }
+    let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, award_amount: 2000.0) }
+
+    let(:claims) { Claim.where(id: [ecp_claim, lup_claim].map(&:id)) }
+
+    context "when a claim for the supplied policy is found" do
+      let(:policy) { ecp_claim.policy }
+
+      before { submit! }
+
+      it "destroys the other claims" do
+        expect { lup_claim.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      context "when only ECP is eligible" do
-        let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
-        let!(:lup_claim) { create(:claim, :submittable, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
-        let(:cc) { described_class.new(claims: Claim.where(id: [ecp_claim.id, lup_claim.id])) }
-        let(:policy) { ecp_claim.policy }
-
-        before { cc.submit!(policy) }
-
-        it "stores the policy option provided on submission just for the ECP policy" do
-          policy_options_provided = [
-            {"policy" => "EarlyCareerPayments", "award_amount" => "1000.0"}
-          ]
-
-          expect(ecp_claim.reload.policy_options_provided).to eq policy_options_provided
-        end
+      it "removes the other claims from the set" do
+        expect(current_claim.claims.map(&:policy)).to eq([policy])
       end
 
-      context "when only LUP is eligible" do
-        let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
-        let!(:ecp_claim) { create(:claim, :submittable, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
-        let(:cc) { described_class.new(claims: Claim.where(id: [ecp_claim.id, lup_claim.id])) }
-        let(:policy) { lup_claim.policy }
-
-        before { cc.submit!(policy) }
-
-        it "stores the policy option provided on submission just for the LUP policy" do
-          policy_options_provided = [
-            {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
-          ]
-
-          expect(lup_claim.reload.policy_options_provided).to eq policy_options_provided
-        end
+      it "submits the specified claim" do
+        expect(ecp_claim.reload).to be_submitted
       end
 
-      context "when nil policy is supplied" do
-        let(:policy) { nil }
+      it "stores the policy options provided on submission for both eligible policies" do
+        policy_options_provided = [
+          {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"},
+          {"policy" => "EarlyCareerPayments", "award_amount" => "1000.0"}
+        ]
 
-        before { cc.submit!(policy) }
-
-        it "submits the main claim" do
-          expect(ecp_claim.reload).to be_submitted
-        end
+        expect(ecp_claim.reload.policy_options_provided).to eq policy_options_provided
       end
+    end
 
-      context "when a claim for the supplied policy is not found" do
-        subject(:result) { cc.submit!(policy) }
+    context "when only ECP is eligible" do
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+      let!(:lup_claim) { create(:claim, :submittable, policy: LevellingUpPremiumPayments, eligibility: lup_eligibility) }
+      let(:policy) { ecp_claim.policy }
 
-        let(:policy) { "not_found" }
+      before { submit! }
 
-        it "raises an Exception" do
-          expect { result }.to raise_error(NoMethodError)
-        end
+      it "stores the policy option provided on submission just for the ECP policy" do
+        policy_options_provided = [
+          {"policy" => "EarlyCareerPayments", "award_amount" => "1000.0"}
+        ]
+
+        expect(ecp_claim.reload.policy_options_provided).to eq policy_options_provided
+      end
+    end
+
+    context "when only LUP is eligible" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      let!(:ecp_claim) { create(:claim, :submittable, policy: EarlyCareerPayments, eligibility: ecp_eligibility) }
+      let(:policy) { lup_claim.policy }
+
+      before { submit! }
+
+      it "stores the policy option provided on submission just for the LUP policy" do
+        policy_options_provided = [
+          {"policy" => "LevellingUpPremiumPayments", "award_amount" => "2000.0"}
+        ]
+
+        expect(lup_claim.reload.policy_options_provided).to eq policy_options_provided
+      end
+    end
+
+    context "when nil policy is supplied" do
+      let(:policy) { nil }
+
+      before { submit! }
+
+      it "submits the main claim" do
+        expect(ecp_claim.reload).to be_submitted
+      end
+    end
+
+    context "when a claim for the supplied policy is not found" do
+      subject(:submit!) { current_claim.submit!(policy) }
+
+      let(:policy) { "not_found" }
+
+      it "raises an Exception" do
+        expect { submit! }.to raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1040

The bug reported above affects ECP/LUP journeys where the applicant is eligible or selected to claim for LUP.

The problem is described in detail in the commit message and, in essence, is caused by how the `CurrentClaim` wrapper currently picks the "main" `Claim` and forwards validations to it. Instead of defaulting to ECP, we should make sure the LUP claim is used as "main" when it's the one selected by the user or our controller at the end of the eligibility phase.

Easier to review using https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2402/files?diff=unified&w=1