### PR TITLE
Add issuer value to DfE Sign-In omniauth config

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -24,7 +24,9 @@ options = {
     identifier: dfe_sign_in_identifier,
     secret: dfe_sign_in_secret,
     redirect_uri: dfe_sign_in_redirect_uri&.to_s
-  }
+  },
+  issuer:
+  ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)
 }
 
 module ::DfESignIn


### PR DESCRIPTION
This is now required due to an update to the DfE Sign-In OIDC dependency.

Fixed by other teams, see: https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/232 and https://github.com/DFE-Digital/apply-for-teacher-training/pull/8385
