### PR TITLE
CAPT-931 Consume induction data as part of DQT API return for ECP only

### DIFF
--- a/app/models/early_career_payments/dqt_record.rb
+++ b/app/models/early_career_payments/dqt_record.rb
@@ -10,6 +10,9 @@ module EarlyCareerPayments
       :itt_start_date,
       :degree_codes,
       :qualification_name,
+      :induction_start_date,
+      :induction_completion_date,
+      :induction_status,
       to: :record
     )
 
@@ -24,6 +27,10 @@ module EarlyCareerPayments
         eligible_itt_year? &&
         qts_award_date_after_itt_start_date? &&
         award_due?
+    end
+
+    def eligible_induction?
+      InductionData.new(itt_year:, induction_status:, induction_start_date:).eligible?
     end
 
     private

--- a/app/models/early_career_payments/induction_data.rb
+++ b/app/models/early_career_payments/induction_data.rb
@@ -1,0 +1,33 @@
+module EarlyCareerPayments
+  class InductionData
+    PASS_INDUCTION_STATUSES = ["pass", "exempt"]
+    IN_PROGRESS_INDUCTION_STATUSES = ["in progress", "not yet completed", "induction extended"]
+    private_constant :PASS_INDUCTION_STATUSES, :IN_PROGRESS_INDUCTION_STATUSES
+
+    def initialize(itt_year:, induction_status:, induction_start_date:)
+      @itt_year = itt_year
+      @induction_status = induction_status
+      @induction_start_date = induction_start_date
+    end
+
+    def eligible?
+      case AcademicYear.new(itt_year)
+      when AcademicYear.new(2018), AcademicYear.new(2019)
+        valid_induction_status?(PASS_INDUCTION_STATUSES)
+      when AcademicYear.new(2020)
+        valid_induction_status?(PASS_INDUCTION_STATUSES + IN_PROGRESS_INDUCTION_STATUSES) &&
+          induction_start_date.before?(1.year.ago)
+      else
+        false
+      end
+    end
+
+    private
+
+    attr_reader :itt_year, :induction_status, :induction_start_date
+
+    def valid_induction_status?(array)
+      array.include?(induction_status&.strip&.downcase)
+    end
+  end
+end

--- a/lib/dqt/objects/teacher.rb
+++ b/lib/dqt/objects/teacher.rb
@@ -16,6 +16,18 @@ module Dqt
       end
     end
 
+    def induction_start_date
+      date_reader(induction&.start_date)
+    end
+
+    def induction_completion_date
+      date_reader(induction&.completion_date)
+    end
+
+    def induction_status
+      string_reader(induction&.status)
+    end
+
     def qts_award_date
       date_reader(qualified_teacher_status&.qts_date)
     end

--- a/spec/lib/dqt/objects/teacher_spec.rb
+++ b/spec/lib/dqt/objects/teacher_spec.rb
@@ -376,6 +376,24 @@ RSpec.describe Dqt::Teacher do
     end
   end
 
+  describe "#induction_start_date" do
+    subject(:induction_start_date) { qualified_teaching_status.induction_start_date }
+
+    it_behaves_like "date reader", "induction/start_date"
+  end
+
+  describe "#induction_completion_date" do
+    subject(:induction_completion_date) { qualified_teaching_status.induction_completion_date }
+
+    it_behaves_like "date reader", "induction/completion_date"
+  end
+
+  describe "#induction_status" do
+    subject(:induction_status) { qualified_teaching_status.induction_status }
+
+    it_behaves_like "string reader", "induction/status"
+  end
+
   describe "#date_of_birth" do
     subject(:date_of_birth) { qualified_teaching_status.date_of_birth }
 

--- a/spec/models/early_career_payments/dqt_record_spec.rb
+++ b/spec/models/early_career_payments/dqt_record_spec.rb
@@ -1929,4 +1929,34 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
       end
     end
   end
+
+  describe "#eligible_induction?" do
+    subject(:eligible_induction?) { dqt_record.eligible_induction? }
+
+    let(:record) do
+      OpenStruct.new(
+        itt_year: calculated_itt_year,
+        induction_start_date: Date.parse("1/9/2017"),
+        induction_completion_date: Date.parse("1/9/2018"),
+        induction_status: "Pass"
+      )
+    end
+    let(:calculated_itt_year) { AcademicYear.new(2021) }
+    let(:claim_academic_year) { AcademicYear.new(2023) }
+    let(:induction_data) do
+      instance_double(EarlyCareerPayments::InductionData, eligible?: "true_or_false")
+    end
+
+    let(:expected_attributes) { record.to_h.except(:induction_completion_date) }
+    let(:expected_result) { induction_data.eligible? }
+
+    before do
+      allow(dqt_record).to receive(:itt_year).and_return(calculated_itt_year)
+      allow(EarlyCareerPayments::InductionData).to receive(:new)
+        .with(expected_attributes)
+        .and_return(induction_data)
+    end
+
+    it { expect(eligible_induction?).to eq(expected_result) }
+  end
 end

--- a/spec/models/early_career_payments/induction_data_spec.rb
+++ b/spec/models/early_career_payments/induction_data_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe EarlyCareerPayments::InductionData do
+  subject { described_class.new(itt_year:, induction_status:, induction_start_date:) }
+  let(:induction_start_date) { nil }
+
+  shared_examples :eligible? do |statuses, expected|
+    subject { super().eligible? }
+
+    statuses.each do |status|
+      context "when the status is '#{status}'" do
+        let(:induction_status) { status }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+
+  describe "#eligible?" do
+    context "when the ITT year is 2018" do
+      let(:itt_year) { AcademicYear.new(2018) }
+
+      include_examples :eligible?, ["pass", "exempt"], true
+      include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
+      include_examples :eligible?, ["required to complete", "failed"], false
+    end
+
+    context "when the ITT year is 2019" do
+      let(:itt_year) { AcademicYear.new(2019) }
+
+      include_examples :eligible?, ["pass", "exempt"], true
+      include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
+      include_examples :eligible?, ["required to complete", "failed"], false
+    end
+
+    context "when the ITT year is 2020" do
+      let(:itt_year) { AcademicYear.new(2020) }
+
+      context "when the start date is more than 1 year old" do
+        let(:induction_start_date) { 1.year.ago }
+
+        include_examples :eligible?, ["pass", "exempt"], true
+        include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], true
+        include_examples :eligible?, ["required to complete", "failed"], false
+      end
+
+      context "when the start date is less than 1 year old" do
+        let(:induction_start_date) { 1.year.ago + 1.day }
+
+        include_examples :eligible?, ["pass", "exempt"], false
+        include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
+        include_examples :eligible?, ["required to complete", "failed"], false
+      end
+    end
+
+    context "when the ITT year is after 2020" do
+      let(:itt_year) { AcademicYear.new(2021) }
+
+      include_examples :eligible?, ["pass", "exempt"], false
+      include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
+      include_examples :eligible?, ["required to complete", "failed"], false
+    end
+  end
+end


### PR DESCRIPTION
Broken down from: https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-931

To be used by: https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1093 (PR: #2425, not ready for final review)

The wider context is that we're adding a new question to the ECP/LUP journey, which is being worked on as part of https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2420 (Prototype, not ready for review)