### PR TITLE
CAPT-1163 Add payroll run payments pagination

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class PayrollRunsController < BaseAdminController
+    include Pagy::Backend
+
     before_action :ensure_service_operator
 
     def index
@@ -31,6 +33,7 @@ module Admin
     # NOTE: Optimisation - preload payments, claims and eligibility
     def show
       @payroll_run = PayrollRun.where(id: params[:id]).includes({claims: [:eligibility]}, {payments: [{claims: [:eligibility]}]}).first
+      @pagy, @payments = pagy(@payroll_run.payments.ordered.includes(claims: [:eligibility]).includes(:topups))
     end
   end
 end

--- a/app/views/admin/payroll_runs/_pagination.html.erb
+++ b/app/views/admin/payroll_runs/_pagination.html.erb
@@ -1,0 +1,41 @@
+<% link = pagy_link_proc(pagy) -%>
+
+<nav class="govuk-pagination" role="navigation" aria-label="results">
+<% if pagy.prev %>
+  <div class="govuk-pagination__prev">
+    <a class="govuk-link govuk-pagination__link" href="<%== pagy_prev_url(pagy) %>" rel="prev">
+      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+      </svg>
+      <span class="govuk-pagination__link-title">Previous</span></a>
+  </div>
+<% end %>
+
+<ul class="govuk-pagination__list">
+  <% pagy.series.each do |item| %>
+    <% if item.is_a?(Integer) %>
+      <li class="govuk-pagination__item">
+        <%== link.call(item, item, "class=\"govuk-link govuk-pagination__link\" aria-label=\"Page #{item}\"") %>
+      </li>
+    <% elsif item.is_a?(String) %>
+        <li class="govuk-pagination__item govuk-pagination__item--current">
+        <a class="govuk-link govuk-pagination__link" href="#" aria-label="Page <%= item %>" aria-current="page">
+          <%= item %>
+        </a>
+      </li>
+    <% elsif item == :gap %>
+      <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
+    <% end %>
+  <% end %>
+</ul>
+
+<% if pagy.next %>
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="<%== pagy_next_url(pagy) %>" rel="next">
+      <span class="govuk-pagination__link-title">Next</span>
+      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg>
+    </a>
+  </div>
+<% end %>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -123,7 +123,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @payroll_run.payments.ordered.includes(claims: [:eligibility]).includes(:topups).each do |payment| %>
+      <% @payments.each do |payment| %>
         <% payment.claims.each_with_index do |claim, index| %>
           <% number_of_claims = payment.claims.size %>
           <% topup_claim_ids = payment.topups.pluck(:claim_id) %>
@@ -154,5 +154,7 @@
       <% end %>
     </tbody>
     </table>
+
+    <%== render partial: 'pagination', locals: { pagy: @pagy } %>
   </div>
 </div>


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1163

This PR uses the [pagination component from the GOV.UK design kit](https://design-system.service.gov.uk/components/pagination/). A similar view was introduced [here](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/025df3fee764098a772cf9ef7fc2a6dcf15a5f57/app/views/admin/claims/_pagination.html.erb).

[CAPT-1163]: https://dfedigital.atlassian.net/browse/CAPT-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ