### PR TITLE
CAPT-1285 Restore generic ECP/LUP ineligibility view content

### DIFF
--- a/app/views/early_career_payments/claims/_ineligibility_generic.html.erb
+++ b/app/views/early_career_payments/claims/_ineligibility_generic.html.erb
@@ -1,8 +1,8 @@
 <p class="govuk-body">
   You are not eligible for an
-  <%= link_to("early-career payment", EarlyCareerPayments.eligibility_page_url, class: "govuk-link") %>
+  <%= link_to("early-career payments", EarlyCareerPayments.eligibility_page_url, class: "govuk-link") %>
   or a
-  <%= link_to("levelling up premium payment", LevellingUpPremiumPayments.eligibility_page_url, class: "govuk-link") %>
+  <%= link_to("levelling up premium payments", LevellingUpPremiumPayments.eligibility_page_url, class: "govuk-link") %>.
   because of the year you studied.  
 </p>
 

--- a/app/views/early_career_payments/claims/_ineligibility_generic.html.erb
+++ b/app/views/early_career_payments/claims/_ineligibility_generic.html.erb
@@ -1,9 +1,5 @@
 <p class="govuk-body">
-  You are not eligible for an
-  <%= link_to("early-career payments", EarlyCareerPayments.eligibility_page_url, class: "govuk-link") %>
-  or a
-  <%= link_to("levelling up premium payments", LevellingUpPremiumPayments.eligibility_page_url, class: "govuk-link") %>.
-  because of the year you studied.  
+  You are not eligible for any additional payments.
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1285

This PR reverts the changes introduced by these commits so that the generic ineligibility content for ECP/LUP is restored.

To address the specific scenario that the commits were trying to address, we'll probably have to create a new partial and amend the `IneligibilityReasonChecker` https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/5a6238588cd325af16bd8840c44d73f83a7a131b/lib/ineligibility_reason_checker.rb#L6-L10

But this is going to take a bit longer to implement and test.