### PR TITLE
CAPT-1286 Fix method returning hint text with subject list for ECP/LUP

### DIFF
--- a/spec/helpers/claims/itt_subject_helper_spec.rb
+++ b/spec/helpers/claims/itt_subject_helper_spec.rb
@@ -72,5 +72,12 @@ RSpec.describe Claims::IttSubjectHelper do
 
       it { is_expected.to eq("chemistry, computing, mathematics or physics") }
     end
+
+    context "LUP ineligible and ECP eligible_later" do
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible_later) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+
+      it { is_expected.to eq("chemistry, languages, mathematics or physics") }
+    end
   end
 end


### PR DESCRIPTION
When an ECP-only school is selected and at the point in the journey where the `subjects_to_sentence_for_hint_text` helper method is used, it returns an empty list of subjects.

This commit addresses that by running a second check on the status of the ECP claim; if it's marked as "eligible_later", then:

- Use the LUP list if the LUP claim is potentially eligible too
- Use the ECP list if the LUP claim is not eligible

Follows https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2387