### PR TITLE
Add additional database indexes on schools table

### DIFF
--- a/db/migrate/20230925163438_add_date_indexes_to_schools.rb
+++ b/db/migrate/20230925163438_add_date_indexes_to_schools.rb
@@ -1,0 +1,6 @@
+class AddDateIndexesToSchools < ActiveRecord::Migration[7.0]
+  def change
+    add_index :schools, :open_date
+    add_index :schools, :close_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_25_095916) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_25_163438) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -350,10 +350,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_095916) do
     t.string "phone_number", limit: 20
     t.date "open_date"
     t.string "postcode_sanitised"
+    t.index ["close_date"], name: "index_schools_on_close_date"
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"
     t.index ["name"], name: "index_schools_on_name", opclass: :gin_trgm_ops, using: :gin
+    t.index ["open_date"], name: "index_schools_on_open_date"
     t.index ["postcode_sanitised"], name: "index_schools_on_postcode_sanitised", opclass: :gin_trgm_ops, using: :gin
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end


### PR DESCRIPTION
Further to #2451 an additional two columns were identified which required indexing. Adding these indexes yields approx. 2.5x performance boost compared to previously, and 25x in total.

Before:

```
> Benchmark.measure { 500.times { School.search("Pen").count }}
 => #<Benchmark::Tms:0x000000010aab6d68 @cstime=0.0, @cutime=0.0, @label="", @real=2.881784999743104, @stime=0.128483, @total=0.6241749999999999, @utime=0.49569199999999997>
```

After:

```
> Benchmark.measure { 500.times { School.search("Pen").count }}
 => #<Benchmark::Tms:0x0000000115a0bcc8 @cstime=0.0, @cutime=0.0, @label="", @real=1.125266999937594, @stime=0.08306800000000003, @total=0.4131690000000001, @utime=0.3301010000000001>
```