### PR TITLE
CAPT-1271 Payroll is limited to 3000 payments per month

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -18,7 +18,7 @@ module Admin
       # Ideally, we should limit topups as well, as some may be related to claims
       # paid in a previous payroll run, but we wouldn't have any topups at the beginning.
       #
-      # This capping is expected to be removed by the opening of the next window.
+      # TODO: Remove this capping once the payroll software is upgraded.
       if @claims.size > PayrollRun::MAX_MONTHLY_PAYMENTS
         flash[:notice] = "The number of payments entering this payrun will be capped to #{PayrollRun::MAX_MONTHLY_PAYMENTS}"
         @claims = @claims.limit(PayrollRun::MAX_MONTHLY_PAYMENTS)

--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -10,6 +10,20 @@ module Admin
 
     def new
       @claims = Claim.payrollable
+
+      # Due to limitations with the current payroll software we need a temporary
+      # cap on the number of claims that can enter payroll, especially expecting
+      # a high volume of approved claims in the first few months.
+      #
+      # Ideally, we should limit topups as well, as some may be related to claims
+      # paid in a previous payroll run, but we wouldn't have any topups at the beginning.
+      #
+      # This capping is expected to be removed by the opening of the next window.
+      if @claims.size > PayrollRun::MAX_MONTHLY_PAYMENTS
+        flash[:notice] = "The number of payments entering this payrun will be capped to #{PayrollRun::MAX_MONTHLY_PAYMENTS}"
+        @claims = @claims.limit(PayrollRun::MAX_MONTHLY_PAYMENTS)
+      end
+
       @topups = Topup.payrollable
       @total_award_amount = @claims.sum(&:award_amount) + @topups.sum(&:award_amount)
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -297,7 +297,7 @@ class Claim < ApplicationRecord
 
   delegate :award_amount, to: :eligibility
 
-  scope :payrollable, -> { approved.not_awaiting_qa.left_joins(:payments).where(payments: nil) }
+  scope :payrollable, -> { approved.not_awaiting_qa.left_joins(:payments).where(payments: nil).order(submitted_at: :asc) }
   scope :not_awaiting_qa, -> { approved.where("qa_required = false OR (qa_required = true AND qa_completed_at IS NOT NULL)") }
   scope :awaiting_qa, -> { approved.qa_required.where(qa_completed_at: nil) }
   scope :qa_required, -> { where(qa_required: true) }

--- a/spec/factories/payroll_runs.rb
+++ b/spec/factories/payroll_runs.rb
@@ -44,5 +44,13 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_payments do
+      transient do
+        count { 0 }
+      end
+
+      payments { build_list(:payment, count) }
+    end
   end
 end

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -61,6 +61,25 @@ RSpec.feature "Payroll" do
     end
   end
 
+  scenario "Limiting the maximum number of claims entering payroll" do
+    click_on "Payroll"
+
+    expected_claims = create_list(:claim, 3, :approved)
+    stubbed_max_payments = stub_const("PayrollRun::MAX_MONTHLY_PAYMENTS", 2)
+
+    month_name = Date.today.strftime("%B")
+    click_on "Run #{month_name} payroll"
+
+    expect(page).to have_content("The number of payments entering this payrun will be capped to #{stubbed_max_payments}")
+
+    click_on "Confirm and submit"
+
+    expect(page).to have_content("Approved claims 2")
+
+    payroll_run = PayrollRun.order(:created_at).last
+    expect(payroll_run.claims).to match_array(expected_claims.first(stubbed_max_payments))
+  end
+
   scenario "Any claims approved in the meantime are not included" do
     click_on "Payroll"
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1022,7 +1022,7 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "qa_completed?" do
+  describe "#qa_completed?" do
     subject { claim.qa_completed? }
 
     context "when the qa_completed_at is set" do
@@ -1038,7 +1038,7 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "awaiting_qa?" do
+  describe "#awaiting_qa?" do
     subject { claim.awaiting_qa? }
 
     context "when the qa_required is false" do
@@ -1347,7 +1347,7 @@ RSpec.describe Claim, type: :model do
         it { is_expected.to eq(false) }
       end
 
-      context "with 2 previously approved claim (1 flagged for QA)" do
+      context "with 2 previously approved claims (1 flagged for QA)" do
         let!(:claims_flagged_for_qa) { create_list(:claim, 1, :approved, :flagged_for_qa, academic_year: AcademicYear.current) }
         let!(:claims_not_flagged_for_qa) { create_list(:claim, 1, :approved, academic_year: AcademicYear.current) }
 
@@ -1400,15 +1400,18 @@ RSpec.describe Claim, type: :model do
     let(:claim_awaiting_qa) { create(:claim, :approved, :flagged_for_qa) }
     let(:claim_with_qa_completed) { create(:claim, :approved, :qa_completed) }
 
-    it "returns approved claims that are not associated with a payroll run" do
-      is_expected.to match_array([first_unpayrolled_claim, second_unpayrolled_claim])
+    let!(:first_unpayrolled_claim) { create(:claim, :approved, submitted_at: 2.days.ago) }
+    let!(:second_unpayrolled_claim) { create(:claim, :approved, submitted_at: 1.day.ago) }
+
+    it "returns approved claims not associated with a payroll run and ordered by submission date" do
+      is_expected.to eq([first_unpayrolled_claim, second_unpayrolled_claim])
     end
 
     it "excludes claims that are awaiting QA" do
       claim_awaiting_qa
       claim_with_qa_completed
 
-      is_expected.to match_array([first_unpayrolled_claim, second_unpayrolled_claim, claim_with_qa_completed])
+      is_expected.to eq([first_unpayrolled_claim, second_unpayrolled_claim, claim_with_qa_completed])
     end
   end
 

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe "Admin payroll runs" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("£100")
       end
+
+      it "limits the number of claims entering payroll when exceeding the maximum allowed" do
+        stubbed_max_payments = stub_const("PayrollRun::MAX_MONTHLY_PAYMENTS", 2)
+
+        create(:claim, :approved, eligibility: create(:student_loans_eligibility, student_loan_repayment_amount: 100), submitted_at: 3.days.ago)
+        create(:claim, :approved, eligibility: create(:student_loans_eligibility, student_loan_repayment_amount: 50), submitted_at: 1.days.ago)
+        create(:claim, :approved, eligibility: create(:student_loans_eligibility, student_loan_repayment_amount: 10), submitted_at: 2.days.ago)
+
+        get new_admin_payroll_run_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("The number of payments entering this payrun will be capped to #{stubbed_max_payments}")
+        expect(response.body).to include("£110")
+      end
     end
 
     describe "admin_payroll_runs#create" do


### PR DESCRIPTION
Due to limitations with the current upstream payroll software we need a temporary cap on the number of claims that can enter payroll, especially since we expect a high volume of approved claims in the first few months. It's also possible we'll never really need it. The capping can be removed once it is not required anymore. Another alternative solution could be to limit the number of approved claims monthly. In one way or another, a constraint must be introduced for now.