### PR TITLE
CAPT-1175 Amend payment confirmation emails (Currently says Friday, days change depending on payment date)

### DIFF
--- a/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
+++ b/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-You will receive <%=number_to_currency(@payment.net_pay) %> on Friday <%= @payment_date.to_fs(:custom_ordinal) %>.
+You will receive <%=number_to_currency(@payment.net_pay) %> on <%= @payment_date.to_fs(:custom_ordinal) %>.
 
 # Breakdown of payment
 

--- a/app/views/payment_mailer/confirmation_for_single_claim.text.erb
+++ b/app/views/payment_mailer/confirmation_for_single_claim.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-You will receive <%=number_to_currency(@payment.net_pay) %> on Friday <%= @payment_date.to_fs(:custom_ordinal) %>.
+You will receive <%=number_to_currency(@payment.net_pay) %> on <%= @payment_date.to_fs(:custom_ordinal) %>.
 
 # Breakdown of payment
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,1 @@
-DateTime::DATE_FORMATS[:custom_ordinal] = lambda { |time| time.strftime("#{time.day.ordinalize} %B %Y") }
+DateTime::DATE_FORMATS[:custom_ordinal] = lambda { |time| time.strftime("%A #{time.day.ordinalize} %B %Y") }

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         it "includes the NET pay amount and payment date in the body" do
-          expect(mail.body.encoded).to include("You will receive £500.00 on Friday 1st January 2019")
+          expect(mail.body.encoded).to include("You will receive £500.00 on Tuesday 1st January 2019")
         end
 
         context "when user does not currently have a student loan or a postgraduate loan" do
@@ -125,7 +125,7 @@ RSpec.describe PaymentMailer, type: :mailer do
       end
 
       it "includes the NET pay amount and payment date in the body" do
-        expect(mail.body.encoded).to include("You will receive £2,500.00 on Friday 1st January 2019")
+        expect(mail.body.encoded).to include("You will receive £2,500.00 on Tuesday 1st January 2019")
       end
 
       it "mentions the type of claim in the body" do


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1175

This is a consequence of #2407. In short, we would previously always send a payment on the last Friday of the month. With batching, this is not the case anymore, and the scheduled payment date for each claim is saved as part of the confirmation statement upload. Previous calculation: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2407/files#diff-998b01cd74114e4a520c747ef35924646b7983f441ecd143df06be0cb4551ce3L41-L45