### PR TITLE
Induction check failing when the induction start date is missing (ITT year 2020)

### DIFF
--- a/app/models/early_career_payments/induction_data.rb
+++ b/app/models/early_career_payments/induction_data.rb
@@ -1,8 +1,8 @@
 module EarlyCareerPayments
   class InductionData
-    PASS_INDUCTION_STATUSES = ["pass", "exempt"]
-    IN_PROGRESS_INDUCTION_STATUSES = ["in progress", "not yet completed", "induction extended"]
-    private_constant :PASS_INDUCTION_STATUSES, :IN_PROGRESS_INDUCTION_STATUSES
+    VALID_INDUCTION_STATUSES_2018_2019 = ["pass", "exempt"]
+    VALID_INDUCTION_STATUSES_2020 = ["pass", "exempt", "in progress", "not yet completed", "induction extended"]
+    private_constant :VALID_INDUCTION_STATUSES_2018_2019, :VALID_INDUCTION_STATUSES_2020
 
     def initialize(itt_year:, induction_status:, induction_start_date:)
       @itt_year = itt_year
@@ -11,20 +11,37 @@ module EarlyCareerPayments
     end
 
     def eligible?
-      case AcademicYear.new(itt_year)
-      when AcademicYear.new(2018), AcademicYear.new(2019)
-        valid_induction_status?(PASS_INDUCTION_STATUSES)
-      when AcademicYear.new(2020)
-        valid_induction_status?(PASS_INDUCTION_STATUSES + IN_PROGRESS_INDUCTION_STATUSES) &&
-          induction_start_date.before?(1.year.ago)
+      if itt_year_2018_or_2019?
+        valid_status?
+      elsif itt_year_2020?
+        valid_status? && induction_start_date.present? && induction_start_date.before?(1.year.ago)
       else
         false
       end
     end
 
+    def incomplete?
+      induction_status.nil? || (itt_year_2020? && valid_status? && induction_start_date.nil?)
+    end
+
     private
 
     attr_reader :itt_year, :induction_status, :induction_start_date
+
+    def valid_status?
+      return valid_induction_status?(VALID_INDUCTION_STATUSES_2018_2019) if itt_year_2018_or_2019?
+      return valid_induction_status?(VALID_INDUCTION_STATUSES_2020) if itt_year_2020?
+
+      false
+    end
+
+    def itt_year_2018_or_2019?
+      itt_year == AcademicYear.new(2018) || itt_year == AcademicYear.new(2019)
+    end
+
+    def itt_year_2020?
+      itt_year == AcademicYear.new(2020)
+    end
 
     def valid_induction_status?(array)
       array.include?(induction_status&.strip&.downcase)

--- a/spec/models/automated_checks/claim_verifiers/induction_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/induction_spec.rb
@@ -107,6 +107,37 @@ module AutomatedChecks
           it_behaves_like :successful_execution
         end
 
+        context "with incomplete induction data" do
+          let(:data) do
+            {
+              induction: {
+                start_date: nil,
+                completion_date: nil,
+                status: "Pass"
+              },
+              initial_teacher_training: {
+                programme_start_date: "2020-09-01T00:00:00Z",
+                qualification: "Degree"
+              }
+            }
+          end
+
+          let(:expected_to_pass?) { nil }
+          let(:expected_match_value) { nil }
+          let(:expected_note) do
+            <<~HTML
+              [DQT Induction] - No data:
+              <pre>
+                Start date:      N/A
+                Completion date: N/A
+                Status:          Pass
+              </pre>
+            HTML
+          end
+
+          it_behaves_like :successful_execution
+        end
+
         context "with ineligible induction data from the DQT response" do
           let(:data) do
             {

--- a/spec/models/early_career_payments/induction_data_spec.rb
+++ b/spec/models/early_career_payments/induction_data_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe EarlyCareerPayments::InductionData do
         include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
         include_examples :eligible?, ["required to complete", "failed"], false
       end
+
+      context "when the start date is missing" do
+        let(:induction_start_date) { nil }
+
+        include_examples :eligible?, ["pass", "exempt"], false
+        include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
+        include_examples :eligible?, ["required to complete", "failed"], false
+      end
     end
 
     context "when the ITT year is after 2020" do
@@ -59,6 +67,65 @@ RSpec.describe EarlyCareerPayments::InductionData do
       include_examples :eligible?, ["pass", "exempt"], false
       include_examples :eligible?, ["in progress", "not yet completed", "induction extended"], false
       include_examples :eligible?, ["required to complete", "failed"], false
+    end
+  end
+
+  describe "#incomplete?" do
+    subject { super().incomplete? }
+
+    context "when the status is missing" do
+      let(:induction_status) { nil }
+
+      context "with ITT year 2018" do
+        let(:itt_year) { AcademicYear.new(2018) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "with ITT year 2019" do
+        let(:itt_year) { AcademicYear.new(2019) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "with ITT year 2020" do
+        let(:itt_year) { AcademicYear.new(2020) }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context "when the status is present but the start date is missing" do
+      let(:induction_status) { "Pass" }
+      let(:induction_start_date) { nil }
+
+      context "with ITT year 2018" do
+        let(:itt_year) { AcademicYear.new(2018) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "with ITT year 2019" do
+        let(:itt_year) { AcademicYear.new(2019) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "with ITT year 2020" do
+        let(:itt_year) { AcademicYear.new(2020) }
+
+        context "when the status is valid" do
+          let(:induction_status) { "Pass" }
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "when the status is not valid" do
+          let(:induction_status) { "Failed" }
+
+          it { is_expected.to eq(false) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1289

In some cases, the response from DQT does not contain the induction start date: this value may need to be compared with the current date when the ITT year is 2020; if it's null or missing, the check should fail with NO DATA and still record the response from DQT.

This PR's commit includes minor refactoring of the `InductionData` object to increase readability.
