### PR TITLE
CAPT-1331 GIAS - 'Select your school' not listing school searched for with post code only

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@ require "simplecov"
 require "faker"
 require "rack_session_access/capybara"
 
+Faker::Config.locale = "en-GB"
+
 SimpleCov.start do
   add_filter %r{^/spec/.*$}
   add_filter %r{^/db/migrate/.*$}


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1331

This is one way of addressing the issue above, please refer to the commit description for the rationale; attaching some performance stats below.

```
Warming up --------------------------------------
new search: one word     7.000  i/100ms
new search: two words
                         6.000  i/100ms
new search: postcode (partial)
                         6.000  i/100ms
new search: postcode (full)
                         6.000  i/100ms
current search: one word
                         5.000  i/100ms
current search: two words
                         5.000  i/100ms
current search: postcode (partial)
                         5.000  i/100ms
current search: postcode (full)
                         5.000  i/100ms
Calculating -------------------------------------
new search: one word     70.287  (± 2.8%) i/s -      2.114k in  30.093702s
new search: two words
                         69.787  (± 2.9%) i/s -      2.094k in  30.031095s
new search: postcode (partial)
                         69.262  (± 2.9%) i/s -      2.082k in  30.081994s
new search: postcode (full)
                         69.517  (± 2.9%) i/s -      2.088k in  30.058818s
current search: one word
                         58.648  (± 1.7%) i/s -      1.760k in  30.027850s
current search: two words
                         58.066  (± 1.7%) i/s -      1.745k in  30.070886s
current search: postcode (partial)
                         58.643  (± 3.4%) i/s -      1.760k in  30.038784s
current search: postcode (full)
                         58.608  (± 1.7%) i/s -      1.760k in  30.047958s

Comparison:
new search: one word:       70.3 i/s
new search: two words:       69.8 i/s - same-ish: difference falls within error
new search: postcode (full):       69.5 i/s - same-ish: difference falls within error
new search: postcode (partial):       69.3 i/s - same-ish: difference falls within error
current search: one word:       58.6 i/s - 1.20x  slower
current search: postcode (partial):       58.6 i/s - 1.20x  slower
current search: postcode (full):       58.6 i/s - 1.20x  slower
current search: two words:       58.1 i/s - 1.21x  slower
```
