### PR TITLE
Capt-1204 - Create new screen - Playback email address from Teacher ID

### DIFF
--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -1,0 +1,26 @@
+class SelectEmailForm
+  def self.extract_attributes(claim, email_address_check:)
+    new(claim, email_address_check).extract_attributes
+  end
+
+  def initialize(claim, email_address_check)
+    @claim = claim
+    @email_address_check = email_address_check
+  end
+
+  def extract_attributes
+    if @email_address_check == "true"
+      {
+        email_address: @claim.teacher_id_user_info["email"],
+        email_verified: true,
+        email_address_check: true
+      }
+    else
+      {
+        email_address: nil,
+        email_verified: nil,
+        email_address_check: false
+      }
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -38,7 +38,8 @@ class Claim < ApplicationRecord
     :building_society_roll_number,
     :one_time_password,
     :logged_in_with_tid,
-    :details_check
+    :details_check,
+    :email_address_check
   ].freeze
   AMENDABLE_ATTRIBUTES = %i[
     teacher_reference_number
@@ -105,6 +106,7 @@ class Claim < ApplicationRecord
     logged_in_with_tid: false,
     teacher_id_user_info: false,
     details_check: true,
+    email_address_check: true,
     qa_required: false,
     qa_completed_at: false
   }.freeze
@@ -205,6 +207,7 @@ class Claim < ApplicationRecord
     if: -> { surname.present? }
 
   validates :details_check, on: [:"teacher-detail"], inclusion: {in: [true, false], message: "Select an option to whether the details are correct or not"}
+  validates :email_address_check, on: [:"select-email"], inclusion: {in: [true, false], message: "Select an option to indicate whether the email is correct or not"}
   validates :address_line_1, on: [:address], presence: {message: "Enter a house number or name"}, if: :has_ecp_or_lupp_policy?
   validates :address_line_1, on: [:address, :submit], presence: {message: "Enter a building and street address"}, unless: :has_ecp_or_lupp_policy?
   validates :address_line_1, length: {maximum: 100, message: "Address lines must be 100 characters or less"}

--- a/app/models/dfe_identity/user_info.rb
+++ b/app/models/dfe_identity/user_info.rb
@@ -2,13 +2,14 @@ module DfeIdentity
   class UserInfo
     include ActiveModel::Model
 
-    attr_accessor :trn, :birthdate, :given_name, :family_name, :ni_number, :trn_match_ni_number
+    attr_accessor :trn, :birthdate, :given_name, :family_name, :ni_number, :trn_match_ni_number, :email
 
     validates :trn, presence: true
     validates :birthdate, presence: true
     validates :given_name, presence: true
     validates :family_name, presence: true
     validates_format_of :trn_match_ni_number, with: /(true|false)/i
+    validates :email, presence: false
 
     def self.validated?(user_info)
       new(from_params(user_info)).valid?

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -40,6 +40,7 @@ module EarlyCareerPayments
       "no-address-found",
       "select-home-address",
       "address",
+      "select-email",
       "email-address",
       "email-verification",
       "provide-mobile-number",
@@ -95,6 +96,12 @@ module EarlyCareerPayments
       SLUGS.dup.tap do |sequence|
         sequence.delete("teacher-detail") if claim.logged_in_with_tid.nil?
         sequence.delete("reset-claim") if [nil, true].include?(claim.logged_in_with_tid)
+
+        sequence.delete("select-email") if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["email"].nil?
+        if claim.logged_in_with_tid? && claim.email_address_check
+          sequence.delete("email-address")
+          sequence.delete("email-verification")
+        end
 
         unless claim.eligibility.employed_as_supply_teacher?
           sequence.delete("entire-term-contract")

--- a/app/views/claims/select_email.html.erb
+++ b/app/views/claims/select_email.html.erb
@@ -1,0 +1,51 @@
+<% content_for(:page_title, page_title(t("early_career_payments.questions.select_email.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { email_address: "email_address_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form do |form| %>
+      <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
+      <%= form_group_tag current_claim do %>
+
+        <fieldset class="govuk-fieldset" aria-describedby="email-address-hint">
+
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--<%= shared_view_css_size %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("early_career_payments.questions.select_email.heading") %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="email-address-hint">
+              <%= t("early_career_payments.questions.select_email.hint") %>
+          </div>
+
+          <%= errors_tag current_claim, :email_address %>
+
+          <div class="govuk-radios">
+
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:email_address_check, true, class: "govuk-radios__input", required: true) %>
+              <%= form.label :email_address_true, session[:email_address], class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__divider">or</div>
+            <div class="govuk-radios__item">
+                <%= form.radio_button(:email_address_check, false, class: "govuk-radios__input", required: true) %>
+              <%= form.label :email_address_false, "A different email address", class: "govuk-label govuk-radios__label" %>
+            </div>
+
+          </div>
+
+        </fieldset>
+
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>
+
+
+
+

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -99,6 +99,7 @@ shared:
     - qa_completed_at
     - details_check
     - teacher_id_user_info
+    - email_address_check
   :decisions:
     - id
     - result

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,6 +331,10 @@ en:
       nqt_in_academic_year_after_itt:
         heading: Are you currently teaching as a qualified teacher?
         hint: Your induction years count as long as you have your qualified teacher status (QTS).
+      select_email:
+        heading: "Which email address should we use to contact you?"
+        hint: "We recommend you use a non-work email address in case your circumstances change while we process your payment."
+        different_email: "A different email address"
       induction_completed:
         heading: Have you completed your induction as an early-career teacher?
         hint:

--- a/db/migrate/20231020160015_add_email_address_check_to_claims.rb
+++ b/db/migrate/20231020160015_add_email_address_check_to_claims.rb
@@ -1,0 +1,5 @@
+class AddEmailAddressCheckToClaims < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :email_address_check, :boolean, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_16_115534) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_160015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -87,10 +87,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_115534) do
     t.boolean "hmrc_bank_validation_succeeded", default: false
     t.json "hmrc_bank_validation_responses", default: []
     t.boolean "logged_in_with_tid", default: false
-    t.boolean "qa_required", default: false
-    t.datetime "qa_completed_at"
     t.boolean "details_check"
     t.jsonb "teacher_id_user_info", default: {}
+    t.boolean "qa_required", default: false
+    t.datetime "qa_completed_at"
+    t.boolean "email_address_check"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -250,7 +250,8 @@ FactoryBot.define do
           "trn" => "123456",
           "birthdate" => "1990-01-01",
           "ni_number" => "AB123456C",
-          "trn_match_ni_number" => "True"
+          "trn_match_ni_number" => "True",
+          "email" => "john.doe@example.com"
         }
       end
     end

--- a/spec/features/check_email_spec.rb
+++ b/spec/features/check_email_spec.rb
@@ -1,0 +1,257 @@
+require "rails_helper"
+
+RSpec.feature "Logs in with TID, confirms teacher details and displays email from DfE Identity" do
+  include OmniauthMockHelper
+
+  # create a school eligible for ECP and LUP so can walk the whole journey
+  let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+  let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
+  let(:trn) { "1234567" }
+  let(:recent_tps_full_months) { TeachersPensionsService::RECENT_TPS_FULL_MONTHS }
+  let!(:inside_tps_window) { create(:teachers_pensions_service, teacher_reference_number: trn, end_date: recent_tps_full_months.ago, school_urn: school.urn) }
+  let(:email) { "kelsie.oberbrunner@example.com" }
+  let(:new_email) { "new.email@example" }
+
+  before do
+    freeze_time
+    set_mock_auth(trn)
+    mock_address_details_address_data
+  end
+
+  after do
+    set_mock_auth(nil)
+    travel_back
+  end
+
+  scenario "Selects suggested email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text(email)
+
+    # - Select the suggested email address
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("questions.provide_mobile_number"))
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq("kelsie.oberbrunner@example.com")
+      expect(c.email_address_check).to eq(true)
+      expect(c.email_verified).to eq(true)
+    end
+  end
+
+  scenario "Select a different email address" do
+    navigate_to_check_email_page(school:)
+
+    # - current-school page
+    expect(page).to have_text("A different email address")
+
+    # - Select A different email address
+    find("#claim_email_address_check_false").click
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("questions.email_address_hint1"))
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq(nil)
+      expect(c.email_address_check).to eq(false)
+      expect(c.email_verified).to eq(nil)
+    end
+  end
+
+  scenario "Selects suggested email address and then changes to a different email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text(email)
+
+    # - Select the suggested email address
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    find("#claim_email_address_check_false").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq(nil)
+      expect(c.email_address_check).to eq(false)
+      expect(c.email_verified).to eq(nil)
+    end
+  end
+
+  scenario "Selects a different email address and then changes to the suggested email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text(email)
+
+    # - Select A different email address
+    find("#claim_email_address_check_false").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq(email)
+      expect(c.email_address_check).to eq(true)
+      expect(c.email_verified).to eq(true)
+    end
+  end
+
+  def navigate_to_check_email_page(school:)
+    visit landing_page_path(EarlyCareerPayments.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
+    click_on "Start now"
+
+    expect(page).to have_text("You can use a DfE Identity account with this service")
+    click_on "Sign in with teacher identity"
+
+    # - Teacher details page
+    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - correct-school page
+    expect(page).to have_text(school.name)
+    expect(page).not_to have_text("Enter the school name or postcode. Use at least three characters.")
+
+    # - Select the suggested school
+    choose(school.name)
+    click_on "Continue"
+
+    # - Have you started your first year as a newly qualified teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt.heading"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Have you completed your induction as an early-career teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.induction_completed.heading"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Are you currently employed as a supply teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
+
+    choose "No"
+    click_on "Continue"
+
+    # - Poor performance
+    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
+
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+
+    choose "Undergraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+    choose "2020 to 2021"
+    click_on "Continue"
+
+    # User should be redirected to the next question which was previously answered but wiped by the attribute dependency
+    expect(page).to have_text("Which subject")
+    choose "Mathematics"
+    click_on "Continue"
+
+    # - Do you teach mathematics now?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+    choose "Yes"
+    click_on "Continue"
+
+    # - Check your answers for eligibility
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    click_on("Continue")
+
+    expect(page).to have_text("You’re eligible for an additional payment")
+    choose("£2,000 levelling up premium payment")
+    click_on("Apply now")
+
+    # - How will we use the information you provide
+    expect(page).to have_text("How we will use the information you provide")
+    click_on "Continue"
+
+    # - Personal details
+    expect(page).to have_text(I18n.t("questions.personal_details"))
+    expect(page).to have_text(I18n.t("questions.name"))
+
+    fill_in "claim_first_name", with: "Russell"
+    fill_in "claim_surname", with: "Wong"
+
+    expect(page).to have_text(I18n.t("questions.date_of_birth"))
+
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+
+    expect(page).to have_text(I18n.t("questions.national_insurance_number"))
+
+    fill_in "National Insurance number", with: "PX321499A"
+    click_on "Continue"
+
+    # - What is your home address
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
+    expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
+
+    fill_in "Postcode", with: "SO16 9FX"
+    click_on "Search"
+
+    # - Select your home address
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
+
+    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+    click_on "Continue"
+  end
+
+  private
+
+  def mock_address_details_address_data
+    allow_any_instance_of(ClaimsController).to receive(:address_data) do |controller|
+      controller.instance_variable_set(:@address_data, address_data)
+      address_data
+    end
+  end
+
+  def address_data
+    [
+      {
+        address: "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 1, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      },
+      {
+        address: "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 10, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      },
+      {
+        address: "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 11, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      }
+    ]
+  end
+end

--- a/spec/features/check_email_spec.rb
+++ b/spec/features/check_email_spec.rb
@@ -7,8 +7,6 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
   let(:trn) { "1234567" }
-  let(:recent_tps_full_months) { TeachersPensionsService::RECENT_TPS_FULL_MONTHS }
-  let!(:inside_tps_window) { create(:teachers_pensions_service, teacher_reference_number: trn, end_date: recent_tps_full_months.ago, school_urn: school.urn) }
   let(:email) { "kelsie.oberbrunner@example.com" }
   let(:new_email) { "new.email@example" }
 
@@ -45,7 +43,7 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
   scenario "Select a different email address" do
     navigate_to_check_email_page(school:)
 
-    # - current-school page
+    # - select-email page
     expect(page).to have_text("A different email address")
 
     # - Select A different email address
@@ -112,8 +110,8 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
     click_on "Start now"
 
-    expect(page).to have_text("You can use a DfE Identity account with this service")
-    click_on "Sign in with teacher identity"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
 
     # - Teacher details page
     expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
@@ -122,12 +120,9 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     choose "Yes"
     click_on "Continue"
 
-    # - correct-school page
-    expect(page).to have_text(school.name)
-    expect(page).not_to have_text("Enter the school name or postcode. Use at least three characters.")
-
-    # - Select the suggested school
-    choose(school.name)
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school school
     click_on "Continue"
 
     # - Have you started your first year as a newly qualified teacher?

--- a/spec/features/teacher_detail_page_in_user_jouney_spec.rb
+++ b/spec/features/teacher_detail_page_in_user_jouney_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Teacher Identity Sign in" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "email" => "kelsie.oberbrunner@example.com", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True"})
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects no to details confirm" do

--- a/spec/models/claim/permitted_parameters_spec.rb
+++ b/spec/models/claim/permitted_parameters_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Claim::PermittedParameters do
       :one_time_password,
       :logged_in_with_tid,
       :details_check,
+      :email_address_check,
       eligibility_attributes: [
         :qts_award_year,
         :claim_school_id,

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1317,7 +1317,8 @@ RSpec.describe Claim, type: :model do
         :building_society_roll_number,
         :one_time_password,
         :assigned_to_id,
-        :details_check
+        :details_check,
+        :email_address_check
       ])
     end
   end

--- a/spec/support/omniauth_mock_helper.rb
+++ b/spec/support/omniauth_mock_helper.rb
@@ -8,7 +8,8 @@ module OmniauthMockHelper
           "given_name" => "Kelsie",
           "family_name" => "Oberbrunner",
           "ni_number" => "AB123456C",
-          "trn_match_ni_number" => "True"
+          "trn_match_ni_number" => "True",
+          "email" => "kelsie.oberbrunner@example.com"
         }
       }
     )


### PR DESCRIPTION
CAPT-1204 - Create new screen - Playback email address from Teacher ID

- Check for signed-in with teacher id and `email` from teacher id 
  - If either or both are false or missing go straight to the old email verification flow 
  - If both are true, show the select email page and pre-populate the `email` from teacher id
    - If email is confirmed set
      - the `email_address` on the claim,
      - `email_verified` to true and
      - `email_address_check` to true.
      - go to the next question
    - If email is not confirmed set
      - the `email_address` on the claim to `nil`,
      - `email_verified` to`nil`,
      - `email_address_check` to `false` and
      - go to the old email verification flow 
