### PR TITLE
CAPT-1031 Extend ITT year eligibility by 2 weeks for PG route only

### DIFF
--- a/lib/dqt/matchers/general.rb
+++ b/lib/dqt/matchers/general.rb
@@ -70,7 +70,15 @@ module Dqt
         when :undergraduate_itt, :assessment_only, :overseas_recognition
           qts_award_date
         when :postgraduate_itt
-          itt_start_date
+          # For Postgraduate programs, the ITT start date is sometimes recorded a few days before the beginning of the
+          # new academic year, which makes it fall, mistakenly, within the *previous* academic year. Based on the
+          # situation, this can also cause the qualifications and induction checks to pass or fail automatically when
+          # they shouldn't. One way around it is to assume that the new academic year can start up to 2 weeks earlier.
+          if itt_start_date.between?(Date.new(itt_start_date.year, 8, 18), Date.new(itt_start_date.year, 8, 31))
+            Date.new(itt_start_date.year, 9, 1)
+          else
+            itt_start_date
+          end
         end
       end
 

--- a/spec/models/early_career_payments/dqt_record_spec.rb
+++ b/spec/models/early_career_payments/dqt_record_spec.rb
@@ -1281,8 +1281,118 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
         eligible_itt_subject: :mathematics,
         qualification: :undergraduate_itt,
         itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2018))
-      }
+      },
       # end of QTS award date is before ITT start date for non postgrad
+
+      # start of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2023)
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2018"), # deemed to fall within 2018/19 AY rather than 2017/18
+        record_qts_date: Date.parse("31/12/2018"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2018))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2018"), # deemed to fall within 2018/19 AY rather than 2017/18
+        record_qts_date: Date.parse("31/12/2018"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2018))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2020"), # deemed to fall within 2020/21 AY rather than 2019/20
+        record_qts_date: Date.parse("31/12/2020"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2020"), # deemed to fall within 2020/21 AY rather than 2019/20
+        record_qts_date: Date.parse("31/12/2020"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      # end of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2023)
+
+      # start of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2024)
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2019"), # deemed to fall within 2019/20 AY rather than 2018/19
+        record_qts_date: Date.parse("31/12/2019"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2019))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2019"), # deemed to fall within 2019/20 AY rather than 2018/19
+        record_qts_date: Date.parse("31/12/2019"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2019))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2020"), # deemed to fall within 2019/20 AY rather than 2018/19
+        record_qts_date: Date.parse("31/12/2020"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2020"), # deemed to fall within 2019/20 AY rather than 2018/19
+        record_qts_date: Date.parse("31/12/2020"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the following and eligible ITT AY that matches our ITT year calculation as well:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      }
+      # end of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2024)
     ].each do |context|
       context "when claim academic year #{context[:claim_academic_year]}" do
         let(:claim_academic_year) { context[:claim_academic_year] }
@@ -1892,8 +2002,118 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
         eligible_itt_subject: :mathematics,
         qualification: :postgraduate_itt,
         itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2018))
-      }
+      },
       # end of QTS award date is equal to ITT start date for postgrad
+
+      # start of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2023)
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2019"), # deemed to fall within 2019/20 AY rather than 2018/19
+        record_qts_date: Date.parse("31/12/2019"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2018))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2019"), # deemed to fall within 2019/20 AY rather than 2018/19
+        record_qts_date: Date.parse("31/12/2019"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2018))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2021"), # deemed to fall within 2021/22 AY rather than 2020/21
+        record_qts_date: Date.parse("31/12/2021"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2023),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2021"), # deemed to fall within 2021/22 AY rather than 2020/21
+        record_qts_date: Date.parse("31/12/2021"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      # end of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2023)
+
+      # start of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2024)
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2020"), # deemed to fall within 2020/21 AY rather than 2019/20
+        record_qts_date: Date.parse("31/12/2020"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2019))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2020"), # deemed to fall within 2020/21 AY rather than 2019/20
+        record_qts_date: Date.parse("31/12/2020"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2019))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("18/8/2021"), # deemed to fall within 2021/22 AY rather than 2020/21
+        record_qts_date: Date.parse("31/12/2021"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      },
+      {
+        claim_academic_year: AcademicYear.new(2024),
+        record_degree_codes: [],
+        record_itt_subjects: ["mathematics"],
+        record_itt_subject_codes: ["100403"],
+        record_itt_date: Date.parse("31/8/2021"), # deemed to fall within 2021/22 AY rather than 2020/21
+        record_qts_date: Date.parse("31/12/2021"),
+        record_qualification_name: "Degree",
+        eligible_itt_subject: :mathematics,
+        qualification: :postgraduate_itt,
+        # user selects the previous and eligible ITT AY that does NOT match our ITT year calculation:
+        itt_academic_year: AcademicYear::Type.new.serialize(AcademicYear.new(2020))
+      }
+      # end of PG ITT year 2-week allowance: ITT start date treated as falling inside following AY (2024)
     ].each do |context|
       context "when claim academic year #{context[:claim_academic_year]}" do
         let(:claim_academic_year) { context[:claim_academic_year] }


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1031

The actual code change and description of the issue are [here](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2483/files#diff-57487b7ec5109fb49e83ddb8312be70fc97fc0f6322616574b0d38a6ec2358f7). This is for ECP/LUP and PG route only.

Tests are verbose and may seem repetitive, but it's necessary to test all the remaining ITT year/claim year combinations. Refer to the test spreadsheet on the ticket for cross-referencing. 

Please note: tests in the review app have been executed stubbing [this test data from DQT](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/3f37dd9dcb9caea5de711e02315ac59fe9071d48)