### PR TITLE
Check and confirm personal details page fixes

### DIFF
--- a/app/views/claims/_confirmation_form.html.erb
+++ b/app/views/claims/_confirmation_form.html.erb
@@ -1,39 +1,33 @@
 <% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
 <% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+  <%= form_for current_claim, url: path_for_form do |form| %>
+    <%= form.hidden_field :details_check %>
+    <%= form_group_tag current_claim do %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-      
-    <%= form_for current_claim, url: path_for_form do |form| %>
-      <%= form.hidden_field :details_check %>
-      <%= form_group_tag current_claim do %>
+    <div class="govuk-radios">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Are these details correct?</legend>
 
-        <div class="govuk-radios">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Are these details correct?</legend>
-            
-            <%= errors_tag current_claim, :details_check %>
+        <%= errors_tag current_claim, :details_check %>
 
-            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:details_check, true, class: "govuk-radios__input") %>
-                <%= form.label :details_check_true, "Yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-              <%= form.radio_button(:details_check, false, class: "govuk-radios__input") %>
-              <%= form.label :details_check_false, "No", class: "govuk-label govuk-radios__label" %>
-              </div>
-            </div>
-          </fieldset>
+        <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:details_check, true, class: "govuk-radios__input") %>
+            <%= form.label :details_check_true, "Yes", class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+          <%= form.radio_button(:details_check, false, class: "govuk-radios__input") %>
+          <%= form.label :details_check_false, "No", class: "govuk-label govuk-radios__label" %>
+          </div>
         </div>
-        
-      <% end %>
-        
-      <p class="govuk-body">By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.</p>
-      
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
-      </div>
-    <% end %>
+      </fieldset>
+    </div>
+
+  <% end %>
+
+  <p class="govuk-body">By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.</p>
+
+  <div class="govuk-form-group">
+    <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
   </div>
-</div>
+<% end %>

--- a/app/views/claims/_personal_details.html.erb
+++ b/app/views/claims/_personal_details.html.erb
@@ -11,7 +11,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Date of birth</dt>
       <dd class="govuk-summary-list__value">
-        <%= @teacher_id_user_info["birthdate"] %>
+        <%= l(Date.parse(@teacher_id_user_info["birthdate"])) %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/claims/teacher_detail.html.erb
+++ b/app/views/claims/teacher_detail.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-body" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Check and confirm your personal details</h1>
+          <h1 class="govuk-heading-l"><%=t "early_career_payments.questions.check_and_confirm_details" %></h1>
           <p>We have used your DfE Identify account to retrieve your personal details.</p>
           <p>You must check that all details are correct and confirm they are correct to continue.</p>
 

--- a/app/views/claims/teacher_detail.html.erb
+++ b/app/views/claims/teacher_detail.html.erb
@@ -1,7 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { details_check: "details_check_true" }) if current_claim.errors.any? %>  
-  </div>  
+  </div>
+</div>
     <div class="govuk-body" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/teacher_detail.html.erb
+++ b/app/views/claims/teacher_detail.html.erb
@@ -5,8 +5,8 @@
     <div class="govuk-body" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Check and confirm your details</h1>
-          <p>We have used your DfE Identify account to retrieve your personal and qualification details.</p>
+          <h1 class="govuk-heading-l">Check and confirm your personal details</h1>
+          <p>We have used your DfE Identify account to retrieve your personal details.</p>
           <p>You must check that all details are correct and confirm they are correct to continue.</p>
 
           <%= render 'personal_details' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,7 +320,7 @@ en:
         trainee_teacher_future_eligibility: "You are not eligible this year"
         generic: "Based on the answers you have provided you are not eligible for an early-career payment"
     questions:
-      check_and_confirm_details: "Check and confirm your details"
+      check_and_confirm_details: "Check and confirm your personal details"
       details_correct: "Are these details correct?" 
       current_school_search: "Which school do you teach at?"
       current_school_results: "Select the school you teach at"

--- a/spec/features/teacher_identity_sign_in_spec.rb
+++ b/spec/features/teacher_identity_sign_in_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Sign in with teacher identity"
 
     # - Teacher details page
-    expect(page).to have_text("Check and confirm your details")
+    expect(page).to have_text("Check and confirm your personal details")
     expect(page).to have_text("Are these details correct?")
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1196

Fixes some issues on the Check and confirm personal details page:

* Incorrect alignment of columns
* Date of birth displayed in human readable format
* Copy corrected to latest version of prototype following iterations