### PR TITLE
DfE Identity sign in prompt page copy updates

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -274,7 +274,7 @@ class ClaimsController < BasePublicController
   # NOTE: needs to be done before the slug_sequence is generated.
   # `logged_in_with_tid: nil` means the user had pressed "Continue without signing in", reset it to `false`.
   # `logged_in_with_tid: nil` is used to reject "teacher-details" from the slug_sequence.
-  # Handles user somehow using Back button to go back and choose "Sign in with teacher identity" option.
+  # Handles user somehow using Back button to go back and choose "Continue with DfE Identity" option.
   # Or they sign in a second time, `details_check` needs resetting in case details are different.
   def check_and_reset_if_new_tid_user_info
     DfeIdentity::ClaimUserDetailsReset.call(current_claim, :new_user_info) if session[:user_info]

--- a/app/views/claims/sign_in_or_continue.html.erb
+++ b/app/views/claims/sign_in_or_continue.html.erb
@@ -3,17 +3,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-body">
       <h1 class="govuk-heading-l">
-        You can use a DfE Identity account with this service
+        Use DfE Identity to sign in
       </h1>
       <p>
-        To create an account, you will need to provide your personal details such as your National Insurance number and teacher reference number (TRN).
+        You can sign in or set up a DfE Identity account to make it easier to claim additional payments.
       </p>
       <p>
-        Once you have created an account, you'll be able to use the same account and personal details to claim additional payments in following years.
+        You will need your National Insurance number and teacher reference number (TRN) to create an account.
       </p>
 
       <div class="govuk-button-group">
-        <%= button_to "Sign in with teacher identity", "/auth/tid", class: "govuk-button" %>
+        <%= button_to "Continue with DfE Identity", "/auth/tid", class: "govuk-button" %>
         <%= button_to "Continue without signing in", claim_path(current_policy_routing_name, "sign-in-or-continue"), method: :patch, class: "govuk-button govuk-button--secondary"%>
       </div>
     </div>

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Backlinking during a claim" do
 
     visit new_claim_path(EarlyCareerPayments.routing_name)
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     expect(page).to have_link("Back")
     click_on "Continue without signing in"
 
@@ -49,7 +49,7 @@ RSpec.feature "Backlinking during a claim" do
     visit new_claim_path(EarlyCareerPayments.routing_name)
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     expect(page).to have_link("Back")
     click_on "Continue without signing in"
 

--- a/spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Combined claim journey dependent answers" do
     visit new_claim_path(EarlyCareerPayments.routing_name)
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -264,7 +264,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     visit new_claim_path(EarlyCareerPayments.routing_name)
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at

--- a/spec/features/early_career_payments_claim_sequence_slug_spec.rb
+++ b/spec/features/early_career_payments_claim_sequence_slug_spec.rb
@@ -51,8 +51,8 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
     click_on "Start now"
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
-    click_on "Sign in with teacher identity"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
 
     # - Teacher details page
     expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))

--- a/spec/features/early_career_payments_landing_page_spec.rb
+++ b/spec/features/early_career_payments_landing_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Landing page - Early Career Payments - journey" do
     click_on "Start now"
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at

--- a/spec/features/early_career_payments_trainee_teacher_spec.rb
+++ b/spec/features/early_career_payments_trainee_teacher_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
       click_on "Start now"
 
       # - Sign in or continue page
-      expect(page).to have_text("You can use a DfE Identity account with this service")
+      expect(page).to have_text("Use DfE Identity to sign in")
       click_on "Continue without signing in"
 
       # - Which school do you teach at

--- a/spec/features/hmrc_bank_validation_spec.rb
+++ b/spec/features/hmrc_bank_validation_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Bank account validation on claim journey", :with_hmrc_bank_valida
     visit new_claim_path(EarlyCareerPayments.routing_name)
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at

--- a/spec/features/ineligible_levelling_up_premium_payments_spec.rb
+++ b/spec/features/ineligible_levelling_up_premium_payments_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
     start_levelling_up_premium_payments_claim
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at
@@ -28,7 +28,7 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
     start_levelling_up_premium_payments_claim
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at
@@ -47,7 +47,7 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
     start_levelling_up_premium_payments_claim
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -193,7 +193,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
       visit new_claim_path(LevellingUpPremiumPayments.routing_name)
 
       # - Sign in or continue page
-      expect(page).to have_text("You can use a DfE Identity account with this service")
+      expect(page).to have_text("Use DfE Identity to sign in")
       click_on "Continue without signing in"
 
       # Creates a duplicate school to test whether the school search shows closed schools

--- a/spec/features/sign_in_or_continue_spec.rb
+++ b/spec/features/sign_in_or_continue_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Start now"
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at
@@ -29,7 +29,7 @@ RSpec.feature "Teacher Identity Sign in" do
     expect(page.title).to have_text(I18n.t("questions.current_school"))
   end
 
-  scenario "Teacher makes claim for 'Early-Career Payments' claim and select Sign in with teacher identity" do
+  scenario "Teacher makes claim for 'Early-Career Payments' claim and select Continue with DfE Identity" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
     set_mock_auth("12345678")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
@@ -40,8 +40,8 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Start now"
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
-    click_on "Sign in with teacher identity"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
 
     # - Teacher details page
     expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))

--- a/spec/features/teacher_detail_page_in_user_jouney_spec.rb
+++ b/spec/features/teacher_detail_page_in_user_jouney_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature "Teacher Identity Sign in" do
     expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
     click_on "Start now"
 
-    expect(page).to have_text("You can use a DfE Identity account with this service")
-    click_on "Sign in with teacher identity"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
 
     # - Teacher details page
     expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
@@ -48,8 +48,8 @@ RSpec.feature "Teacher Identity Sign in" do
     expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
     click_on "Start now"
 
-    expect(page).to have_text("You can use a DfE Identity account with this service")
-    click_on "Sign in with teacher identity"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
 
     # - Teacher details page
     expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))

--- a/spec/features/teacher_identity_sign_in_spec.rb
+++ b/spec/features/teacher_identity_sign_in_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Start now"
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     # - Which school do you teach at
@@ -40,8 +40,8 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Start now"
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
-    click_on "Sign in with teacher identity"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
 
     # - Teacher details page
     expect(page).to have_text("Check and confirm your details")

--- a/spec/features/trainee_teacher_subjourney_for_lup_schools_spec.rb
+++ b/spec/features/trainee_teacher_subjourney_for_lup_schools_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Trainee teacher subjourney for LUP schools" do
     visit new_claim_path(LevellingUpPremiumPayments.routing_name)
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     choose_school non_lup_school
@@ -114,7 +114,7 @@ RSpec.feature "Trainee teacher subjourney for LUP schools" do
     visit new_claim_path(EarlyCareerPayments.routing_name)
 
     # - Sign in or continue page
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
 
     choose_school lup_school

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -130,7 +130,7 @@ module FeatureHelpers
   end
 
   def skip_tid
-    expect(page).to have_text("You can use a DfE Identity account with this service")
+    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue without signing in"
   end
 


### PR DESCRIPTION
Updates the copy of the `/additional-payments/sign-in-or-continue` page to the latest prototype iteration.