### PR TITLE
CAPT-1205-playback-phone-number-from-tid

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -35,6 +35,8 @@ class ClaimsController < BasePublicController
       update_session_with_tps_school
     elsif params[:slug] == "nqt-in-academic-year-after-itt" && page_sequence.in_sequence?("correct-school")
       @backlink_path = claim_path(current_policy_routing_name, "correct-school")
+    elsif params[:slug] == "select-mobile"
+      session[:phone_number] = current_claim.teacher_id_user_info["phone_number"]
     elsif params[:slug] == "postcode-search" && postcode
       redirect_to claim_path(current_policy_routing_name, "select-home-address", {"claim[postcode]": params[:claim][:postcode], "claim[address_line_1]": params[:claim][:address_line_1]}) and return unless invalid_postcode?
     elsif params[:slug] == "select-home-address" && postcode
@@ -77,11 +79,13 @@ class ClaimsController < BasePublicController
       check_correct_school_params
     when "select-email"
       check_email_params
+    when "select-mobile"
+      check_mobile_number_params
     else
       current_claim.attributes = claim_params
     end
 
-    current_claim.reset_dependent_answers unless params[:slug] == "select-email"
+    current_claim.reset_dependent_answers unless params[:slug] == "select-email" || params[:slug] == "select-mobile"
     current_claim.reset_eligibility_dependent_answers(reset_attrs)
     one_time_password
 
@@ -311,6 +315,10 @@ class ClaimsController < BasePublicController
 
   def check_email_params
     current_claim.attributes = SelectEmailForm.extract_attributes(current_claim, email_address_check: params.dig(:claim, :email_address_check))
+  end
+
+  def check_mobile_number_params
+    current_claim.attributes = SelectMobileNumberForm.extract_attributes(current_claim, mobile_check: params.dig(:claim, :mobile_check))
   end
 
   def update_session_with_tps_school

--- a/app/forms/select_mobile_number_form.rb
+++ b/app/forms/select_mobile_number_form.rb
@@ -1,0 +1,33 @@
+class SelectMobileNumberForm
+  def self.extract_attributes(claim, mobile_check:)
+    new(claim, mobile_check).extract_attributes
+  end
+
+  def initialize(claim, mobile_check)
+    @claim = claim
+    @mobile_check = mobile_check
+  end
+
+  def extract_attributes
+    case @mobile_check
+    when "use"
+      {
+        mobile_number: @claim.teacher_id_user_info["phone_number"],
+        provide_mobile_number: true,
+        mobile_check: @mobile_check
+      }
+    when "alternative"
+      {
+        mobile_number: nil,
+        provide_mobile_number: nil,
+        mobile_check: @mobile_check
+      }
+    when "declined"
+      {
+        mobile_number: nil,
+        provide_mobile_number: false,
+        mobile_check: @mobile_check
+      }
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -39,7 +39,8 @@ class Claim < ApplicationRecord
     :one_time_password,
     :logged_in_with_tid,
     :details_check,
-    :email_address_check
+    :email_address_check,
+    :mobile_check
   ].freeze
   AMENDABLE_ATTRIBUTES = %i[
     teacher_reference_number
@@ -107,6 +108,7 @@ class Claim < ApplicationRecord
     teacher_id_user_info: false,
     details_check: true,
     email_address_check: true,
+    mobile_check: true,
     qa_required: false,
     qa_completed_at: false
   }.freeze
@@ -208,6 +210,7 @@ class Claim < ApplicationRecord
 
   validates :details_check, on: [:"teacher-detail"], inclusion: {in: [true, false], message: "Select an option to whether the details are correct or not"}
   validates :email_address_check, on: [:"select-email"], inclusion: {in: [true, false], message: "Select an option to indicate whether the email is correct or not"}
+  validates :mobile_check, on: [:"select-mobile"], inclusion: {in: ["use", "alternative", "declined"], message: "Select an option to indicate whether the mobile number is correct or not"}
   validates :address_line_1, on: [:address], presence: {message: "Enter a house number or name"}, if: :has_ecp_or_lupp_policy?
   validates :address_line_1, on: [:address, :submit], presence: {message: "Enter a building and street address"}, unless: :has_ecp_or_lupp_policy?
   validates :address_line_1, length: {maximum: 100, message: "Address lines must be 100 characters or less"}

--- a/app/models/dfe_identity/user_info.rb
+++ b/app/models/dfe_identity/user_info.rb
@@ -2,7 +2,7 @@ module DfeIdentity
   class UserInfo
     include ActiveModel::Model
 
-    attr_accessor :trn, :birthdate, :given_name, :family_name, :ni_number, :trn_match_ni_number, :email
+    attr_accessor :trn, :birthdate, :given_name, :family_name, :ni_number, :trn_match_ni_number, :email, :phone_number
 
     validates :trn, presence: true
     validates :birthdate, presence: true
@@ -10,6 +10,7 @@ module DfeIdentity
     validates :family_name, presence: true
     validates_format_of :trn_match_ni_number, with: /(true|false)/i
     validates :email, presence: false
+    validates :phone_number, presence: false
 
     def self.validated?(user_info)
       new(from_params(user_info)).valid?

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -43,6 +43,7 @@ module EarlyCareerPayments
       "select-email",
       "email-address",
       "email-verification",
+      "select-mobile",
       "provide-mobile-number",
       "mobile-number",
       "mobile-verification"
@@ -101,6 +102,16 @@ module EarlyCareerPayments
         if claim.logged_in_with_tid? && claim.email_address_check
           sequence.delete("email-address")
           sequence.delete("email-verification")
+        end
+
+        if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["phone_number"].nil?
+          sequence.delete("select-mobile")
+        else
+          sequence.delete("provide-mobile-number")
+        end
+        if claim.logged_in_with_tid? && (claim.mobile_check == "use" || claim.mobile_check == "declined")
+          sequence.delete("mobile-number")
+          sequence.delete("mobile-verification")
         end
 
         unless claim.eligibility.employed_as_supply_teacher?

--- a/app/views/claims/select_mobile.html.erb
+++ b/app/views/claims/select_mobile.html.erb
@@ -1,0 +1,51 @@
+<% content_for(:page_title, page_title(t("early_career_payments.questions.select_phone_number.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { phone_number: "phone_number_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form do |form| %>
+      <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
+      <%= form_group_tag current_claim do %>
+
+        <fieldset class="govuk-fieldset" aria-describedby="phone-number-hint">
+
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--<%= shared_view_css_size %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("early_career_payments.questions.select_phone_number.heading") %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="phone-number-hint">
+              <%= t("early_career_payments.questions.select_phone_number.hint") %>
+          </div>
+
+          <%= errors_tag current_claim, :phone_number %>
+
+          <div class="govuk-radios">
+
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:mobile_check, :use, class: "govuk-radios__input", required: true) %>
+              <%= form.label :mobile_check_use, session[:phone_number].to_s, class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+                <%= form.radio_button(:mobile_check, :alternative, class: "govuk-radios__input", required: true) %>
+              <%= form.label :mobile_check_alternative, t("early_career_payments.questions.select_phone_number.alternative"), class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__divider">or</div>
+            <div class="govuk-radios__item">
+                <%= form.radio_button(:mobile_check, :declined, class: "govuk-radios__input", required: true) %>
+              <%= form.label :mobile_check_declined, t("early_career_payments.questions.select_phone_number.decline"), class: "govuk-label govuk-radios__label" %>
+            </div>
+
+          </div>
+
+        </fieldset>
+
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -100,6 +100,7 @@ shared:
     - details_check
     - teacher_id_user_info
     - email_address_check
+    - mobile_check
   :decisions:
     - id
     - result

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -322,6 +322,8 @@ en:
         trainee_teacher_future_eligibility: "You are not eligible this year"
         generic: "Based on the answers you have provided you are not eligible for an early-career payment"
     questions:
+      check_and_confirm_details: "Check and confirm your personal details"
+      details_correct: "Are these details correct?"
       current_school_search: "Which school do you teach at?"
       current_school_results: "Select the school you teach at"
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
@@ -335,6 +337,11 @@ en:
         heading: "Which email address should we use to contact you?"
         hint: "We recommend you use a non-work email address in case your circumstances change while we process your payment."
         different_email: "A different email address"
+      select_phone_number:
+        heading: "Which mobile number should we use to contact you?"
+        hint: "We will only use this number if we are unable to contact you via email. It may slow down your application if we are unable to reach you."
+        alternative: "A different mobile number"
+        decline: "I do not want to be contacted by mobile"
       induction_completed:
         heading: Have you completed your induction as an early-career teacher?
         hint:

--- a/db/migrate/20231031090701_add_mobile_check_to_claims.rb
+++ b/db/migrate/20231031090701_add_mobile_check_to_claims.rb
@@ -1,0 +1,5 @@
+class AddMobileCheckToClaims < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :mobile_check, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_094829) do
     t.boolean "qa_required", default: false
     t.datetime "qa_completed_at"
     t.boolean "email_address_check"
+    t.string "mobile_check"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/features/check_email_spec.rb
+++ b/spec/features/check_email_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Logs in with TID, confirms teacher details and displays email from DfE Identity" do
   include OmniauthMockHelper
+  include ClaimsControllerHelper
 
   # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
@@ -13,7 +14,7 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
   before do
     freeze_time
     set_mock_auth(trn)
-    mock_address_details_address_data
+    mock_claims_controller_address_data
   end
 
   after do
@@ -31,7 +32,7 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     find("#claim_email_address_check_true").click
     click_on "Continue"
 
-    expect(page).to have_text(I18n.t("questions.provide_mobile_number"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.select_phone_number.heading"))
 
     Claim.order(created_at: :desc).limit(2).each do |c|
       expect(c.email_address).to eq("kelsie.oberbrunner@example.com")
@@ -198,40 +199,5 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
 
     choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
     click_on "Continue"
-  end
-
-  private
-
-  def mock_address_details_address_data
-    allow_any_instance_of(ClaimsController).to receive(:address_data) do |controller|
-      controller.instance_variable_set(:@address_data, address_data)
-      address_data
-    end
-  end
-
-  def address_data
-    [
-      {
-        address: "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
-        address_line_1: "FLAT 1, MILLBROOK TOWER",
-        address_line_2: "WINDERMERE AVENUE",
-        address_line_3: "SOUTHAMPTON",
-        postcode: "SO16 9FX"
-      },
-      {
-        address: "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
-        address_line_1: "FLAT 10, MILLBROOK TOWER",
-        address_line_2: "WINDERMERE AVENUE",
-        address_line_3: "SOUTHAMPTON",
-        postcode: "SO16 9FX"
-      },
-      {
-        address: "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
-        address_line_1: "FLAT 11, MILLBROOK TOWER",
-        address_line_2: "WINDERMERE AVENUE",
-        address_line_3: "SOUTHAMPTON",
-        postcode: "SO16 9FX"
-      }
-    ]
   end
 end

--- a/spec/features/check_phone_number_spec.rb
+++ b/spec/features/check_phone_number_spec.rb
@@ -1,0 +1,299 @@
+require "rails_helper"
+
+RSpec.feature "Logs in with TID, confirms teacher details and displays phone number from DfE Identity" do
+  include OmniauthMockHelper
+  include ClaimsControllerHelper
+
+  # create a school eligible for ECP and LUP so can walk the whole journey
+  let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+  let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
+  let(:trn) { "1234567" }
+  let(:phone_number) { "01234567890" }
+
+  before do
+    freeze_time
+    set_mock_auth(trn, phone_number:)
+    mock_claims_controller_address_data
+  end
+
+  after do
+    set_mock_auth(nil)
+    travel_back
+  end
+
+  scenario "Selects suggested phone number" do
+    navigate_to_check_phone_number_page(school:)
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.select_phone_number.heading"))
+    expect(page).to have_text(phone_number)
+
+    # - Select the suggested phone number
+    find("#claim_mobile_check_use").click
+    click_on "Continue"
+
+    # - Choose bank or building society
+    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(phone_number)
+      expect(c.provide_mobile_number).to eq(true)
+      expect(c.mobile_check).to eq("use")
+    end
+  end
+
+  scenario "Select to use an alternative phone number" do
+    navigate_to_check_phone_number_page(school:)
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.select_phone_number.alternative"))
+
+    # - Select A different mobile number
+    find("#claim_mobile_check_alternative").click
+    click_on "Continue"
+
+    # - Enter your phone number
+    expect(page).to have_text("To verify your mobile number we will send you a text message with a 6-digit passcode. You can enter the passcode on the next screen.")
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(nil)
+      expect(c.provide_mobile_number).to eq(nil)
+      expect(c.mobile_check).to eq("alternative")
+    end
+  end
+
+  scenario "Choose not to be contacted by phone" do
+    navigate_to_check_phone_number_page(school:)
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.select_phone_number.decline"))
+
+    # - Choose not to be contacted by mobile
+    find("#claim_mobile_check_declined").click
+    click_on "Continue"
+
+    # - Choose bank or building society
+    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(nil)
+      expect(c.provide_mobile_number).to eq(false)
+      expect(c.mobile_check).to eq("declined")
+    end
+  end
+
+  scenario "Selects suggested phone number and then changes to an alternative phone number" do
+    navigate_to_check_phone_number_page(school:)
+
+    # - Select the suggested phone number
+    find("#claim_mobile_check_use").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    # - Select A different mobile number
+    find("#claim_mobile_check_alternative").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(nil)
+      expect(c.provide_mobile_number).to eq(nil)
+      expect(c.mobile_check).to eq("alternative")
+    end
+  end
+
+  scenario "Selects suggested phone number and then changes to decline to be contacted by phone" do
+    navigate_to_check_phone_number_page(school:)
+
+    # - Select the suggested phone number
+    find("#claim_mobile_check_use").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    # - Choose not to be contacted by mobile
+    find("#claim_mobile_check_declined").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(nil)
+      expect(c.provide_mobile_number).to eq(false)
+      expect(c.mobile_check).to eq("declined")
+    end
+  end
+
+  scenario "Selects an alternative phone number and then changes to use the suggested phone number" do
+    navigate_to_check_phone_number_page(school:)
+
+    # - Select A different mobile number
+    find("#claim_mobile_check_alternative").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    # - Select the suggested phone number
+    find("#claim_mobile_check_use").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(phone_number)
+      expect(c.provide_mobile_number).to eq(true)
+      expect(c.mobile_check).to eq("use")
+    end
+  end
+
+  scenario "Selects an alternative phone number and then changes to decline to be contacted by phone" do
+    navigate_to_check_phone_number_page(school:)
+
+    # - Select A different mobile number
+    find("#claim_mobile_check_alternative").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    # - Choose not to be contacted by mobile
+    find("#claim_mobile_check_declined").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(nil)
+      expect(c.provide_mobile_number).to eq(false)
+      expect(c.mobile_check).to eq("declined")
+    end
+  end
+
+  scenario "Declines to be contacted by phone and then changes to use the suggested phone number" do
+    navigate_to_check_phone_number_page(school:)
+
+    # - Choose not to be contacted by mobile
+    find("#claim_mobile_check_declined").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    # - Select the suggested phone number
+    find("#claim_mobile_check_use").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(phone_number)
+      expect(c.provide_mobile_number).to eq(true)
+      expect(c.mobile_check).to eq("use")
+    end
+  end
+
+  scenario "Declines to be contacted by phone and then changes to an alternative phone number" do
+    navigate_to_check_phone_number_page(school:)
+
+    # - Choose not to be contacted by mobile
+    find("#claim_mobile_check_declined").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    # - Select A different mobile number
+    find("#claim_mobile_check_alternative").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.mobile_number).to eq(nil)
+      expect(c.provide_mobile_number).to eq(nil)
+      expect(c.mobile_check).to eq("alternative")
+    end
+  end
+
+  def navigate_to_check_phone_number_page(school:)
+    visit landing_page_path(EarlyCareerPayments.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
+    click_on "Start now"
+
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
+
+    # - Teacher details page
+    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school school
+    click_on "Continue"
+
+    # - Have you started your first year as a newly qualified teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt.heading"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Have you completed your induction as an early-career teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.induction_completed.heading"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Are you currently employed as a supply teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
+
+    choose "No"
+    click_on "Continue"
+
+    # - Poor performance
+    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
+
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+
+    choose "Undergraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+    choose "2020 to 2021"
+    click_on "Continue"
+
+    # User should be redirected to the next question which was previously answered but wiped by the attribute dependency
+    expect(page).to have_text("Which subject")
+    choose "Mathematics"
+    click_on "Continue"
+
+    # - Do you teach mathematics now?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+    choose "Yes"
+    click_on "Continue"
+
+    # - Check your answers for eligibility
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    click_on("Continue")
+
+    expect(page).to have_text("You’re eligible for an additional payment")
+    choose("£2,000 levelling up premium payment")
+    click_on("Apply now")
+
+    # - How will we use the information you provide
+    expect(page).to have_text("How we will use the information you provide")
+    click_on "Continue"
+
+    # - What is your home address
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
+    expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
+
+    fill_in "Postcode", with: "SO16 9FX"
+    click_on "Search"
+
+    # - Select your home address
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
+
+    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+    click_on "Continue"
+
+    # - Select the suggested email address
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+  end
+end

--- a/spec/features/teacher_detail_page_in_user_jouney_spec.rb
+++ b/spec/features/teacher_detail_page_in_user_jouney_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Teacher Identity Sign in" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "email" => "kelsie.oberbrunner@example.com", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "email" => "kelsie.oberbrunner@example.com", "phone_number" => "01234567890", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True"})
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects no to details confirm" do
@@ -67,6 +67,6 @@ RSpec.feature "Teacher Identity Sign in" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
   end
 end

--- a/spec/features/teacher_detail_page_student_loans_journey_spec.rb
+++ b/spec/features/teacher_detail_page_student_loans_journey_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
 
     # check the user_info details from teacher id are saved to the claim
     expect(claim.first_name).to eq("Kelsie")
@@ -75,7 +75,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
 
     # check the user_info details from teacher id are not saved to the claim
     expect(claim.first_name).to eq("")

--- a/spec/forms/select_mobile_number_form_spec.rb
+++ b/spec/forms/select_mobile_number_form_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe SelectMobileNumberForm do
+  let(:claim) { instance_double("Claim", teacher_id_user_info: {"phone_number" => "123-456-7890"}) }
+
+  describe ".extract_attributes" do
+    context "when mobile_check is 'use'" do
+      let(:form) { SelectMobileNumberForm.new(claim, "use") }
+
+      it "returns the teacher's phone number and sets provide_mobile_number to true" do
+        expect(form.extract_attributes).to eq({
+          mobile_number: "123-456-7890",
+          provide_mobile_number: true,
+          mobile_check: "use"
+        })
+      end
+    end
+
+    context "when mobile_check is 'alternative'" do
+      let(:form) { SelectMobileNumberForm.new(claim, "alternative") }
+
+      it "returns nil for mobile_number and provide_mobile_number, and sets mobile_check to 'alternative'" do
+        expect(form.extract_attributes).to eq({
+          mobile_number: nil,
+          provide_mobile_number: nil,
+          mobile_check: "alternative"
+        })
+      end
+    end
+
+    context "when mobile_check is 'declined'" do
+      let(:form) { SelectMobileNumberForm.new(claim, "declined") }
+
+      it "returns nil for mobile_number and sets provide_mobile_number to false, and sets mobile_check to 'declined'" do
+        expect(form.extract_attributes).to eq({
+          mobile_number: nil,
+          provide_mobile_number: false,
+          mobile_check: "declined"
+        })
+      end
+    end
+  end
+end

--- a/spec/models/claim/permitted_parameters_spec.rb
+++ b/spec/models/claim/permitted_parameters_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Claim::PermittedParameters do
       :logged_in_with_tid,
       :details_check,
       :email_address_check,
+      :mobile_check,
       eligibility_attributes: [
         :qts_award_year,
         :claim_school_id,

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1318,7 +1318,8 @@ RSpec.describe Claim, type: :model do
         :one_time_password,
         :assigned_to_id,
         :details_check,
-        :email_address_check
+        :email_address_check,
+        :mobile_check
       ])
     end
   end

--- a/spec/support/claims_controller_helper.rb
+++ b/spec/support/claims_controller_helper.rb
@@ -1,0 +1,34 @@
+module ClaimsControllerHelper
+  def mock_claims_controller_address_data
+    allow_any_instance_of(ClaimsController).to receive(:address_data) do |controller|
+      controller.instance_variable_set(:@address_data, mocked_address_data)
+      mocked_address_data
+    end
+  end
+
+  def mocked_address_data
+    [
+      {
+        address: "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 1, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      },
+      {
+        address: "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 10, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      },
+      {
+        address: "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 11, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      }
+    ]
+  end
+end

--- a/spec/support/omniauth_mock_helper.rb
+++ b/spec/support/omniauth_mock_helper.rb
@@ -1,5 +1,5 @@
 module OmniauthMockHelper
-  def set_mock_auth(trn, opts = {})
+  def set_mock_auth(trn, opts = {}, phone_number: "01234567890")
     omniauth_data = if trn.nil?
       nil
     else
@@ -12,7 +12,8 @@ module OmniauthMockHelper
             "family_name" => "Oberbrunner",
             "ni_number" => opts.key?(:nino) ? opts[:nino] : "AB123456C",
             "trn_match_ni_number" => "True",
-            "email" => "kelsie.oberbrunner@example.com"
+            "email" => "kelsie.oberbrunner@example.com",
+            "phone_number" => phone_number
           }
         }
       )


### PR DESCRIPTION
[CAPT-1205](https://dfedigital.atlassian.net/browse/CAPT-1205?atlOrigin=eyJpIjoiMDAyMmVhNDk4Mjc2NDIxN2IyNDYwZmEzYTRjMWM4OTkiLCJwIjoiaiJ9) Create new screen - Playback mobile number from Teacher ID

- Check for signed-in with teacher id and phone number from teacher id
  - If either or both are `false` or missing go straight to the old mobile verification flow
  - If both are `true`, show the select mobile page and pre-populate the `phone_number` from teacher id
  - If mobile is confirmed set
    - the `mobile_number` on the claim,
    - `provide_mobile_number` to `true` and
    - `mobile_check` to "use".
    - go to the next question (bank or building society)
  - If mobile is not confirmed set
    - the `mobile_number` on the claim to nil,
    - `provide_mobile_number` to `nil`,
    - `mobile_check` to "alternative" and
     - go to the old mobile verification flow
 - if declined to provide a mobile
    - the `mobile_number` on the claim to nil,
    - `provide_mobile_number` to `false`,
    - `mobile_check` to "declined" and
    - go to the next question (bank or building society)

[CAPT-1205]: https://dfedigital.atlassian.net/browse/CAPT-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ