### PR TITLE
Add specs for removal of TRN page

### DIFF
--- a/app/views/claims/select_email.html.erb
+++ b/app/views/claims/select_email.html.erb
@@ -27,12 +27,12 @@
 
             <div class="govuk-radios__item">
               <%= form.radio_button(:email_address_check, true, class: "govuk-radios__input", required: true) %>
-              <%= form.label :email_address_true, session[:email_address], class: "govuk-label govuk-radios__label" %>
+              <%= form.label :email_address_check_true, session[:email_address], class: "govuk-label govuk-radios__label" %>
             </div>
             <div class="govuk-radios__divider">or</div>
             <div class="govuk-radios__item">
                 <%= form.radio_button(:email_address_check, false, class: "govuk-radios__input", required: true) %>
-              <%= form.label :email_address_false, "A different email address", class: "govuk-label govuk-radios__label" %>
+              <%= form.label :email_address_check_false, "A different email address", class: "govuk-label govuk-radios__label" %>
             </div>
 
           </div>

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
+RSpec.feature "Combined journey with Teacher ID" do
   include OmniauthMockHelper
 
   subject(:slug_sequence) { EarlyCareerPayments::SlugSequence.new(current_claim) }
@@ -40,8 +40,7 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
     set_mock_auth(nil)
   end
 
-  # Rename this file to a tid specific spec later
-  scenario "When user is logged in with teacher_id" do
+  scenario "When user is logged in with Teacher ID" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
@@ -262,5 +261,9 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
 
     # - teacher-reference-number slug removed from user journey
     expect(page).to have_text(I18n.t("questions.has_student_loan"))
+
+    click_link "Back"
+
+    expect(page).to have_text(I18n.t("questions.payroll_gender"))
   end
 end

--- a/spec/features/early_career_payments_claim_sequence_slug_spec.rb
+++ b/spec/features/early_career_payments_claim_sequence_slug_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
   end
 
   # Rename this file to a tid specific spec later
-  xscenario "When user is logged in with teacher_id" do
+  scenario "When user is logged in with teacher_id" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
@@ -78,6 +78,12 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
     eligibility = claim.eligibility
 
     expect(eligibility.nqt_in_academic_year_after_itt).to eql true
+
+    # - Have you completed your induction as an early-career teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.induction_completed.heading"))
+
+    choose "Yes"
+    click_on "Continue"
 
     # - Are you currently employed as a supply teacher
     expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
@@ -210,17 +216,9 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
     expect(claim.postcode).to eql("DE22 4BS")
 
     # - Email address
-    expect(page).to have_text(I18n.t("questions.email_address"))
-
-    fill_in "Email address", with: "david.tau1988@hotmail.co.uk"
+    expect(page).to have_text(I18n.t("early_career_payments.questions.select_email.heading"))
+    choose current_claim.teacher_id_user_info["email"]
     click_on "Continue"
-
-    expect(claim.reload.email_address).to eql("david.tau1988@hotmail.co.uk")
-
-    expect(page).to have_text("Email address verification")
-    expect(page).to have_text("Enter the 6-digit passcode")
-    fill_in "claim_one_time_password", with: "097543"
-    click_on "Confirm"
 
     expect(page).to have_text(I18n.t("questions.provide_mobile_number"))
 
@@ -262,7 +260,7 @@ RSpec.feature "Teacher Early-Career Payments claims sequence slug" do
 
     expect(claim.reload.payroll_gender).to eq("male")
 
-    # - What it removes teacher-reference-number from user journey and displays student loan page
+    # - teacher-reference-number slug removed from user journey
     expect(page).to have_text(I18n.t("questions.has_student_loan"))
   end
 end

--- a/spec/features/teacher_identity_sign_in_spec.rb
+++ b/spec/features/teacher_identity_sign_in_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Teacher Identity Sign in" do
 
   let(:itt_year) { current_academic_year - 3 }
 
-  scenario "Teacher makes claim for 'Early-Career Payments' claim with trn present" do
+  scenario "Teacher makes claim without signing in" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
     set_mock_auth("1234567")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
@@ -29,7 +29,7 @@ RSpec.feature "Teacher Identity Sign in" do
     expect(page.title).to have_text(I18n.t("questions.current_school"))
   end
 
-  scenario "Teacher makes claim for 'Early-Career Payments' claim with no trn" do
+  scenario "Teacher makes claim after signing in" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
     set_mock_auth("1234567")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1387

While the functionality had been implemented, the existing spec was not enabled and also broken.