### PR TITLE
CAPT-1385 - Personal details page with TID

### DIFF
--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -141,6 +141,8 @@ module EarlyCareerPayments
         if ecp_claim.eligibility.induction_not_completed? && ecp_claim.eligibility.ecp_only_school?
           replace_ecp_only_induction_not_completed_slugs(sequence)
         end
+
+        sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
       end
     end
 

--- a/app/views/claims/personal_details.html.erb
+++ b/app/views/claims/personal_details.html.erb
@@ -8,6 +8,7 @@
         <%= t("questions.personal_details") %>
       </h1>
 
+      <% unless current_claim.logged_in_with_tid? && current_claim.has_valid_name? && current_claim.name_same_as_tid? %>
       <div class="govuk-form-group govuk-!-padding-bottom-6">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="full-name-hint" id="full-name-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -33,7 +34,9 @@
           <% end %>
         </fieldset>
       </div>
+      <% end %>
 
+      <% unless current_claim.logged_in_with_tid? && current_claim.has_valid_date_of_birth? && current_claim.dob_same_as_tid? %>
       <div class="govuk-!-padding-bottom-6">
         <%= form_group_tag current_claim, :date_of_birth do %>
           <fieldset class="govuk-fieldset" role="group" aria-describedby="date-of-birth-hint" id="date-of-birth-fieldset">
@@ -74,7 +77,9 @@
           </fieldset>
         <% end %>
       </div>
+      <% end %>
 
+      <% unless current_claim.logged_in_with_tid? && current_claim.has_valid_nino? && current_claim.nino_same_as_tid? %>
       <div class="govuk-!-padding-bottom-6">
         <%= form_group_tag current_claim, :national_insurance_number do %>
           <h2 class="govuk-label-wrapper">
@@ -94,6 +99,7 @@
                 "aria-describedby" => "national_insurance_number-hint" %>
           <% end %>
       </div>
+      <% end %>
 
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/spec/features/check_email_spec.rb
+++ b/spec/features/check_email_spec.rb
@@ -183,23 +183,8 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     expect(page).to have_text("How we will use the information you provide")
     click_on "Continue"
 
-    # - Personal details
-    expect(page).to have_text(I18n.t("questions.personal_details"))
-    expect(page).to have_text(I18n.t("questions.name"))
-
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
-
-    expect(page).to have_text(I18n.t("questions.date_of_birth"))
-
-    fill_in "Day", with: "28"
-    fill_in "Month", with: "2"
-    fill_in "Year", with: "1988"
-
-    expect(page).to have_text(I18n.t("questions.national_insurance_number"))
-
-    fill_in "National Insurance number", with: "PX321499A"
-    click_on "Continue"
+    # - Personal details - skipped as all details from TID are valid
+    expect(page).not_to have_text(I18n.t("questions.personal_details"))
 
     # - What is your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -43,6 +43,52 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
 
         expect(slug_sequence.slugs).not_to include("teacher-reference-number")
       end
+
+      it "skips personal-details page if all details were provided and valid from TID" do
+        dob = 30.years.ago.to_date
+        claim.logged_in_with_tid = true
+        claim.teacher_id_user_info = {"given_name" => "John", "family_name" => "Doe", "birthdate" => dob.to_s, "ni_number" => "JH001234D"}
+
+        claim.first_name = "John"
+        claim.surname = "Doe"
+        claim.date_of_birth = dob
+        claim.national_insurance_number = "JH001234D"
+
+        expect(slug_sequence.slugs).not_to include("personal-details")
+      end
+
+      it "includes personal-details page if nino is missing" do
+        claim.logged_in_with_tid = true
+
+        claim.first_name = "John"
+        claim.surname = "Doe"
+        claim.date_of_birth = 30.years.ago.to_date
+        claim.national_insurance_number = nil
+
+        expect(slug_sequence.slugs).to include("personal-details")
+      end
+
+      it "includes personal-details page if name is missing" do
+        claim.logged_in_with_tid = true
+
+        claim.first_name = nil
+        claim.surname = nil
+        claim.date_of_birth = 30.years.ago.to_date
+        claim.national_insurance_number = "JH001234D"
+
+        expect(slug_sequence.slugs).to include("personal-details")
+      end
+
+      it "includes personal-details page if dob is missing" do
+        claim.logged_in_with_tid = true
+
+        claim.first_name = "John"
+        claim.surname = "Doe"
+        claim.date_of_birth = nil
+        claim.national_insurance_number = "JH001234D"
+
+        expect(slug_sequence.slugs).to include("personal-details")
+      end
     end
 
     context "when logged_in_with_tid is false " do

--- a/spec/support/omniauth_mock_helper.rb
+++ b/spec/support/omniauth_mock_helper.rb
@@ -1,18 +1,22 @@
 module OmniauthMockHelper
-  def set_mock_auth(trn)
-    omniauth_data = trn.nil? ? nil : OmniAuth::AuthHash.new(
-      "extra" => {
-        "raw_info" => {
-          "trn" => trn,
-          "birthdate" => "1940-01-01",
-          "given_name" => "Kelsie",
-          "family_name" => "Oberbrunner",
-          "ni_number" => "AB123456C",
-          "trn_match_ni_number" => "True",
-          "email" => "kelsie.oberbrunner@example.com"
+  def set_mock_auth(trn, opts = {})
+    omniauth_data = if trn.nil?
+      nil
+    else
+      OmniAuth::AuthHash.new(
+        "extra" => {
+          "raw_info" => {
+            "trn" => trn,
+            "birthdate" => "1940-01-01",
+            "given_name" => "Kelsie",
+            "family_name" => "Oberbrunner",
+            "ni_number" => opts.key?(:nino) ? opts[:nino] : "AB123456C",
+            "trn_match_ni_number" => "True",
+            "email" => "kelsie.oberbrunner@example.com"
+          }
         }
-      }
-    )
+      )
+    end
     OmniAuth.config.mock_auth[:tid] = omniauth_data
     Rails.application.env_config["omniauth.auth"] = omniauth_data
   end


### PR DESCRIPTION
* Skip page if all details are valid from TID
* Conditionally show personal details page with specific questions if anything is missing from TID
* Change first/surname valid lengh to 1..100 inline with TID validation
