### PR TITLE
CAPT-1354 & CAPT-1355 - Implement TSLR Teacher ID sign-in and related features

### DIFF
--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -12,6 +12,7 @@ class BasePublicController < ApplicationController
   def current_policy
     PolicyConfiguration.policy_for_routing_name(current_policy_routing_name)
   end
+  helper_method :current_policy
 
   def current_policy_routing_name
     params[:policy]

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -4,6 +4,20 @@ class OmniauthCallbacksController < ApplicationController
 
     session[:user_info] = auth.extra.raw_info
 
-    redirect_to claim_path(policy: "additional-payments", slug: "teacher-detail")
+    redirect_to claim_path(policy: policy.routing_name, slug: "teacher-detail")
+  end
+
+  private
+
+  def claim_id
+    @claim_id = session["claim_id"]
+  end
+
+  def current_claim
+    @current_claim ||= Claim.find_by(id: claim_id)
+  end
+
+  def policy
+    @policy ||= current_claim.policy
   end
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,4 +1,8 @@
 class OmniauthCallbacksController < ApplicationController
+  include PartOfClaimJourney
+  skip_before_action :check_whether_closed_for_submissions
+  skip_before_action :send_unstarted_claimants_to_the_start
+
   def callback
     auth = request.env["omniauth.auth"]
 
@@ -8,14 +12,6 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   private
-
-  def claim_id
-    @claim_id = session["claim_id"]
-  end
-
-  def current_claim
-    @current_claim ||= Claim.find_by(id: claim_id)
-  end
 
   def policy
     @policy ||= current_claim.policy

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,6 +15,6 @@ class StaticPagesController < BasePublicController
   end
 
   def landing_page
-    @academic_year = PolicyConfiguration.for(EarlyCareerPayments).current_academic_year
+    @academic_year = PolicyConfiguration.for(current_policy).current_academic_year
   end
 end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -51,7 +51,8 @@ module ClaimsHelper
     claim.date_of_birth && l(claim.date_of_birth)
   end
 
-  def additional_payments_open?(current_policy)
-    PolicyConfiguration.for(current_policy).open_for_submissions?
+  def additional_payments_open?
+    policy = PolicyConfiguration.policy_for_routing_name("additional-payments")
+    PolicyConfiguration.for(policy).open_for_submissions?
   end
 end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -51,8 +51,7 @@ module ClaimsHelper
     claim.date_of_birth && l(claim.date_of_birth)
   end
 
-  def additional_payments_open?
-    policy = PolicyConfiguration.policy_for_routing_name("additional-payments")
-    PolicyConfiguration.for(policy).open_for_submissions?
+  def additional_payments_open?(current_policy)
+    PolicyConfiguration.for(current_policy).open_for_submissions?
   end
 end

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -10,6 +10,9 @@ module StudentLoans
   # reflects the sequence based on the claim's current state.
   class SlugSequence
     ELIGIBILITY_SLUGS = [
+      "sign-in-or-continue",
+      "teacher-detail",
+      "reset-claim",
       "qts-year",
       "claim-school",
       "subjects-taught",
@@ -74,6 +77,8 @@ module StudentLoans
 
     def slugs
       SLUGS.dup.tap do |sequence|
+        sequence.delete("teacher-detail") if claim.logged_in_with_tid.nil?
+        sequence.delete("reset-claim") if [nil, true].include?(claim.logged_in_with_tid)
         sequence.delete("current-school") if claim.eligibility.employed_at_claim_school?
         sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
         sequence.delete("student-loan-country") if claim.no_student_loan?
@@ -86,7 +91,7 @@ module StudentLoans
         sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
         sequence.delete("mobile-number") if claim.provide_mobile_number == false
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
-        sequence.delete("ineligible") unless claim.ineligible?
+        sequence.delete("ineligible") unless claim.eligibility&.ineligible?
       end
     end
   end

--- a/app/views/claims/_personal_details.html.erb
+++ b/app/views/claims/_personal_details.html.erb
@@ -8,12 +8,14 @@
           <%= @teacher_id_user_info["family_name"] %>
       </dd>
     </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Date of birth</dt>
-      <dd class="govuk-summary-list__value">
-        <%= l(Date.parse(@teacher_id_user_info["birthdate"])) %>
-      </dd>
-    </div>
+    <% if @teacher_id_user_info["birthdate"] %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Date of birth</dt>
+        <dd class="govuk-summary-list__value">
+          <%= l(Date.parse(@teacher_id_user_info["birthdate"])) %>
+        </dd>
+      </div>
+    <% end %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Teacher reference number (TRN)</dt>
       <dd class="govuk-summary-list__value">

--- a/app/views/claims/teacher_detail.html.erb
+++ b/app/views/claims/teacher_detail.html.erb
@@ -1,12 +1,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { details_check: "details_check_true" }) if current_claim.errors.any? %>  
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { details_check: "details_check_true" }) if current_claim.errors.any? %>
   </div>
 </div>
     <div class="govuk-body" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l"><%=t "early_career_payments.questions.check_and_confirm_details" %></h1>
+          <h1 class="govuk-heading-l"><%=t "questions.check_and_confirm_details" %></h1>
           <p>We have used your DfE Identify account to retrieve your personal details.</p>
           <p>You must check that all details are correct and confirm they are correct to continue.</p>
 

--- a/app/views/static_pages/landing_page.html.erb
+++ b/app/views/static_pages/landing_page.html.erb
@@ -27,7 +27,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">How to apply</h2>
 
-    <% if additional_payments_open? %>
+    <% if additional_payments_open?(current_policy) %>
       <p class="govuk-body">
         The application checks your eligibility before you apply. Once you start the application you cannot save your progress.
       </p>
@@ -37,7 +37,7 @@
       </p>
 
       <p class="govuk-!-margin-top-8">
-        <a href="<%= claim_path(EarlyCareerPayments.routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="<%= claim_path(current_policy.routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
@@ -53,7 +53,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-4">Further information</h2>
 
-    <% if additional_payments_open? %>
+    <% if additional_payments_open?(current_policy) %>
       <p class="govuk-body">
         You must apply between September <%= @academic_year.start_year.to_s %> and March <%= @academic_year.end_year.to_s %>.
       </p>

--- a/app/views/static_pages/landing_page.html.erb
+++ b/app/views/static_pages/landing_page.html.erb
@@ -27,7 +27,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">How to apply</h2>
 
-    <% if additional_payments_open?(current_policy) %>
+    <% if additional_payments_open? %>
       <p class="govuk-body">
         The application checks your eligibility before you apply. Once you start the application you cannot save your progress.
       </p>
@@ -53,7 +53,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-4">Further information</h2>
 
-    <% if additional_payments_open?(current_policy) %>
+    <% if additional_payments_open? %>
       <p class="govuk-body">
         You must apply between September <%= @academic_year.start_year.to_s %> and March <%= @academic_year.end_year.to_s %>.
       </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,8 @@ en:
     hint1_html: "We have sent %{email_or_mobile_message} to <b><strong>%{email_or_mobile_value}</strong></b> with a 6-digit passcode."
     validity_duration: "The passcode will expire %{duration_valid} after you receive it."
   questions:
+    check_and_confirm_details: "Check and confirm your personal details"
+    details_correct: "Are these details correct?"
     current_school: "Which school are you currently employed to teach at?"
     qts_award_year: "When did you complete your initial teacher training?"
     name: "What is your full name?"
@@ -320,8 +322,6 @@ en:
         trainee_teacher_future_eligibility: "You are not eligible this year"
         generic: "Based on the answers you have provided you are not eligible for an early-career payment"
     questions:
-      check_and_confirm_details: "Check and confirm your personal details"
-      details_correct: "Are these details correct?" 
       current_school_search: "Which school do you teach at?"
       current_school_results: "Select the school you teach at"
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       resources :reminders, only: [:show, :update], param: :slug, constraints: {slug: %r{#{Reminder::SLUGS.join("|")}}}
     end
 
-    scope path: "/", constraints: {policy: "additional-payments"} do
+    scope path: "/", constraints: {policy: /student-loans|additional-payments/} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end
   end

--- a/db/migrate/20231114094829_default_logged_in_with_tid_to_nil.rb
+++ b/db/migrate/20231114094829_default_logged_in_with_tid_to_nil.rb
@@ -1,0 +1,5 @@
+class DefaultLoggedInWithTidToNil < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :claims, :logged_in_with_tid, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_20_160015) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_14_094829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -86,7 +86,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_20_160015) do
     t.boolean "held", default: false
     t.boolean "hmrc_bank_validation_succeeded", default: false
     t.json "hmrc_bank_validation_responses", default: []
-    t.boolean "logged_in_with_tid", default: false
+    t.boolean "logged_in_with_tid"
     t.boolean "details_check"
     t.jsonb "teacher_id_user_info", default: {}
     t.boolean "qa_required", default: false

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -4,9 +4,9 @@ RSpec.feature "Backlinking during a claim" do
   scenario "Student Loans journey" do
     create(:policy_configuration, :student_loans)
     school = create(:school, :student_loans_eligible)
-
     visit new_claim_path(StudentLoans.routing_name)
-    expect(page).to have_no_link("Back")
+    skip_tid
+    expect(page).to have_link("Back")
     choose_qts_year
     expect(page).to have_link("Back")
     choose_school school
@@ -14,7 +14,10 @@ RSpec.feature "Backlinking during a claim" do
     expect(page).to have_current_path("/student-loans/claim-school", ignore_query: true)
     click_on "Back"
     expect(page).to have_text(I18n.t("questions.qts_award_year"))
-    expect(page).to have_no_link("Back")
+    click_on "Back"
+    expect(page).to have_text("Use DfE Identity to sign in")
+    expect(page).to have_link("Back")
+    # TODO: CAPT-1353 loading the landing-page won't work until we have a landing page for student loans
   end
 
   scenario "ECP/LUP journey" do

--- a/spec/features/check_email_spec.rb
+++ b/spec/features/check_email_spec.rb
@@ -114,8 +114,8 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -20,6 +20,6 @@ RSpec.feature "Claim journey does not get cached", js: true do
     page.evaluate_script("window.history.back()")
 
     expect(page).to_not have_text(claim.first_name)
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    expect(page).to have_text("Use DfE Identity to sign in")
   end
 end

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -55,8 +55,8 @@ RSpec.feature "Combined journey with Teacher ID" do
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/correct_school_spec.rb
+++ b/spec/features/correct_school_spec.rb
@@ -109,8 +109,8 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays school fr
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     policy_configuration.update!(current_academic_year: "2025/2026")
 
     visit new_claim_path(StudentLoans.routing_name)
+    skip_tid
     choose_qts_year(:before_cut_off_date)
     claim = Claim.by_policy(StudentLoans).order(:created_at).last
 
@@ -101,6 +102,8 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     visit new_claim_path(StudentLoans.routing_name)
 
     expect(page).to_not have_content("You have a claim in progress")
+
+    skip_tid
 
     expect(page).to have_content("When did you complete your initial teacher training?")
     expect(page).not_to have_css("input[checked]")

--- a/spec/features/sign_in_or_continue_spec.rb
+++ b/spec/features/sign_in_or_continue_spec.rb
@@ -44,8 +44,8 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     scenario "Teacher claims back student loan repayments with javascript #{js_status}", js: javascript_enabled do
       visit new_claim_path(StudentLoans.routing_name)
 
+      skip_tid
+
       # Check we can't skip ahead pages in the journey
       visit claim_completion_path(StudentLoans.routing_name)
       expect(page).to have_current_path("/#{StudentLoans.routing_name}/existing-session")
@@ -232,7 +234,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       # Check we can't skip to pages in middle of page sequence after claim is submitted
       visit claim_path(StudentLoans.routing_name, "still-teaching")
-      expect(page).to have_current_path("/#{StudentLoans.routing_name}/qts-year")
+      expect(page).to have_current_path("/#{StudentLoans.routing_name}/sign-in-or-continue")
     end
   end
 
@@ -246,6 +248,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       scenario "Teacher claims back student loan repayments" do
         visit new_claim_path(StudentLoans.routing_name)
+        skip_tid
         expect(page).to have_text(I18n.t("questions.qts_award_year"))
         expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
 

--- a/spec/features/teacher_detail_page_in_user_jouney_spec.rb
+++ b/spec/features/teacher_detail_page_in_user_jouney_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
 
     choose "Yes"
     click_on "Continue"
@@ -52,8 +52,8 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("early_career_payments.questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.details_correct"))
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
 
     choose "No"
     click_on "Continue"
@@ -64,5 +64,9 @@ RSpec.feature "Teacher Identity Sign in" do
     click_on "Continue"
 
     expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+
+    # check the teacher_id_user_info details are saved to the claim
+    claim = Claim.order(:created_at).last
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
   end
 end

--- a/spec/features/teacher_detail_page_student_loans_journey_spec.rb
+++ b/spec/features/teacher_detail_page_student_loans_journey_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.feature "Teacher Identity Sign in for TSLR" do
+  include OmniauthMockHelper
+
+  let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
+  let!(:school) { create(:school, :student_loans_eligible) }
+  let(:current_academic_year) { policy_configuration.current_academic_year }
+
+  before do
+    set_mock_auth("1234567")
+  end
+
+  after do
+    set_mock_auth(nil)
+  end
+
+  scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects yes to details confirm" do
+    visit landing_page_path(StudentLoans.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page")) # TODO: CAPT-1353 change with new landing page
+    click_on "Start now"
+
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
+
+    # - Teacher details page
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+
+    # check the teacher_id_user_info details are saved to the claim
+    claim = Claim.order(:created_at).last
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+
+    # check the user_info details from teacher id are saved to the claim
+    expect(claim.first_name).to eq("Kelsie")
+    expect(claim.surname).to eq("Oberbrunner")
+    expect(claim.date_of_birth).to eq(Date.parse("1940-01-01"))
+    expect(claim.national_insurance_number).to eq("AB123456C")
+    expect(claim.teacher_reference_number).to eq("1234567")
+    expect(claim.logged_in_with_tid?).to eq(true)
+    expect(claim.details_check).to eq(true)
+  end
+
+  scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects no to details confirm" do
+    visit landing_page_path(StudentLoans.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page")) # TODO: CAPT-1353 change with new landing page
+    click_on "Start now"
+
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
+
+    # - Teacher details page
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
+
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text("You cannot use your DfE Identify account with this service")
+    expect(page).to have_text("You can continue to complete an application to check your eligibility and apply for a payment.")
+
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+
+    # check the teacher_id_user_info details are saved to the claim
+    claim = Claim.order(:created_at).last
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+
+    # check the user_info details from teacher id are not saved to the claim
+    expect(claim.first_name).to eq("")
+    expect(claim.surname).to eq("")
+    expect(claim.date_of_birth).to eq(nil)
+    expect(claim.national_insurance_number).to eq("")
+    expect(claim.teacher_reference_number).to eq("")
+    expect(claim.logged_in_with_tid?).to eq(false)
+    expect(claim.details_check).to eq(false)
+  end
+
+  scenario "Teacher makes claim for 'Student Loans' selects not to log in with teacher_id" do
+    visit landing_page_path(StudentLoans.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page")) # TODO: CAPT-1353 change with new landing page
+    click_on "Start now"
+
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue without signing in"
+
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+
+    # check the teacher_id_user_info details are not saved to the claim
+    claim = Claim.order(:created_at).last
+    expect(claim.teacher_id_user_info).to eq({})
+
+    # check the user_info details from teacher id are not saved to the claim
+    expect(claim.first_name).to eq("")
+    expect(claim.surname).to eq("")
+    # expect(claim.date_of_birth).to eq(nil)
+    # expect(claim.national_insurance_number).to eq("")
+    # expect(claim.teacher_reference_number).to eq("")
+    # expect(claim.logged_in_with_tid?).to eq(nil)
+    # expect(claim.details_check).to eq(nil)
+  end
+end

--- a/spec/features/teacher_detail_page_student_loans_journey_spec.rb
+++ b/spec/features/teacher_detail_page_student_loans_journey_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
 
   before do
     set_mock_auth("1234567")
+    create(:policy_configuration, :additional_payments) # TODO: CAPT-1353 remove with new landing page
   end
 
   after do

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
     context "when trn is not nil" do
       before do
         set_mock_auth("1234567")
+        claim = create(:claim, policy: EarlyCareerPayments)
+        OmniauthCallbacksController.any_instance.stub(:claim_id).and_return(claim.id)
       end
 
       it "redirects to the claim path with correct parameters" do
@@ -30,13 +32,15 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
     context "when trn is nil" do
       before do
         set_mock_auth(nil)
+        claim = create(:claim)
+        OmniauthCallbacksController.any_instance.stub(:claim_id).and_return(claim.id)
       end
 
       it "redirects to the claim path with correct parameters" do
         get claim_auth_tid_callback_path
 
         expect(response).to redirect_to(
-          claim_path(policy: "additional-payments", slug: "teacher-detail")
+          claim_path(policy: "student-loans", slug: "teacher-detail")
         )
       end
     end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
     context "when trn is not nil" do
       before do
         set_mock_auth("1234567")
-        claim = create(:claim, policy: EarlyCareerPayments)
-        OmniauthCallbacksController.any_instance.stub(:claim_id).and_return(claim.id)
+
+        allow_any_instance_of(OmniauthCallbacksController).to receive(:policy).and_return(EarlyCareerPayments)
       end
 
       it "redirects to the claim path with correct parameters" do
@@ -32,8 +32,8 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
     context "when trn is nil" do
       before do
         set_mock_auth(nil)
-        claim = create(:claim)
-        OmniauthCallbacksController.any_instance.stub(:claim_id).and_return(claim.id)
+
+        allow_any_instance_of(OmniauthCallbacksController).to receive(:policy).and_return(StudentLoans)
       end
 
       it "redirects to the claim path with correct parameters" do

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Claim session timing out", type: :request do
   let(:timeout_length_in_minutes) { BasePublicController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES }
+  let(:current_claim) { CurrentClaim.new(claims: [Claim.by_policy(StudentLoans).order(:created_at).last]) }
   before { create(:policy_configuration, :student_loans) }
 
   context "no actions performed for more than the timeout period" do
@@ -9,7 +10,6 @@ RSpec.describe "Claim session timing out", type: :request do
       start_student_loans_claim
     end
 
-    let(:current_claim) { CurrentClaim.new(claims: [Claim.by_policy(StudentLoans).order(:created_at).last]) }
     let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
 
     it "clears the session and redirects to the timeout page" do
@@ -27,6 +27,7 @@ RSpec.describe "Claim session timing out", type: :request do
   context "no action performed just within the timeout period" do
     before do
       start_student_loans_claim
+      set_slug_sequence_in_session(current_claim, "qts-year")
     end
 
     let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -27,6 +27,7 @@ module FeatureHelpers
 
   def start_student_loans_claim
     visit new_claim_path(StudentLoans.routing_name)
+    skip_tid
     choose_qts_year
     Claim.by_policy(StudentLoans).order(:created_at).last
   end


### PR DESCRIPTION
This pull request adds the ability for TSLR users to sign in using Teacher ID. It also includes the addition of specs and feature specs for sign-in with Teacher ID, as well as the removal of the TRN question from the user journey if the user has logged in to Teacher ID. Additionally, this PR implements the check and confirm your details page, adds the details check to the claim model, and persists teacher details from Teacher ID. Finally, it fixes failing specs and updates copy on the DfE Identity sign-in prompt page.

- [CAPT-1354](https://dfedigital.atlassian.net/browse/CAPT-1354?atlOrigin=eyJpIjoiZjc2NTk3OTY3NDQ0NGYzYjk1YjljNWY4N2VjMDgyM2MiLCJwIjoiaiJ9) Dev - TSLR ID - Use DfE Identity to sign in
- [CAPT-1355](https://dfedigital.atlassian.net/browse/CAPT-1355?atlOrigin=eyJpIjoiMDRkYjhiY2IwMTVkNDE3ZTgwZmU5OGJiNjliOTBjNWUiLCJwIjoiaiJ9) - Dev - TSLR ID - Check and confirm your personal details playback


[CAPT-1354]: https://dfedigital.atlassian.net/browse/CAPT-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAPT-1355]: https://dfedigital.atlassian.net/browse/CAPT-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ