### PR TITLE
CAPT-1341 TSLR question change: When did you complete your initial teacher training?

### DIFF
--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -81,10 +81,6 @@ module StudentLoans
     ].max
   end
 
-  def last_ineligible_qts_award_year
-    first_eligible_qts_award_year - 1
-  end
-
   # Returns human-friendly String for the financial year that Student Loans
   # claims are being made against based on the currently-configured academic
   # year for the StudentLoans policy. For example:

--- a/app/models/student_loans/admin_tasks_presenter.rb
+++ b/app/models/student_loans/admin_tasks_presenter.rb
@@ -14,7 +14,7 @@ module StudentLoans
 
     def qualifications
       [
-        ["Award year", eligibility.qts_award_year_answer]
+        ["Award year", qts_award_year_answer(eligibility)]
       ]
     end
 
@@ -47,9 +47,7 @@ module StudentLoans
 
     private
 
-    def eligibility
-      claim.eligibility
-    end
+    delegate :eligibility, to: :claim
 
     def financial_year_for_academic_year(academic_year)
       end_year = academic_year.start_year

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -104,23 +104,14 @@ module StudentLoans
       self.current_school = inferred_current_school if employment_status_changed?
     end
 
-    # Returns a String that is the human-readable answer given for the QTS
-    # question when the claim was made.
-    def qts_award_year_answer
-      year_for_answer = StudentLoans.first_eligible_qts_award_year(claim.academic_year)
-      year_for_answer -= 1 if awarded_qualified_status_before_cut_off_date?
-
-      I18n.t("answers.qts_award_years.#{qts_award_year}", year: year_for_answer.to_s(:long))
-    end
-
     def submit!
     end
 
-    private
-
     def ineligible_qts_award_year?
-      awarded_qualified_status_before_cut_off_date?
+      awarded_qualified_status_before_2013_or_after_2020?
     end
+
+    private
 
     def ineligible_claim_school?
       claim_school.present? && !claim_school.eligible_for_student_loans_as_claim_school?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -29,8 +29,8 @@ module StudentLoans
     self.table_name = "student_loans_eligibilities"
 
     enum qts_award_year: {
-      before_cut_off_date: 0,
-      on_or_after_cut_off_date: 1
+      before_2013_or_after_2020: 0,
+      between_2013_and_2020: 1
     }, _prefix: :awarded_qualified_status
 
     enum employment_status: {

--- a/app/models/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_admin_answers_presenter.rb
@@ -33,7 +33,7 @@ module StudentLoans
     def qts_award_year
       [
         translate("admin.qts_award_year"),
-        eligibility.qts_award_year_answer
+        qts_award_year_answer(eligibility)
       ]
     end
 

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -34,8 +34,8 @@ module StudentLoans
 
     def qts_award_year
       [
-        translate("questions.qts_award_year"),
-        eligibility.qts_award_year_answer,
+        translate("student_loans.questions.qts_award_year"),
+        qts_award_year_answer(eligibility),
         "qts-year"
       ]
     end

--- a/app/models/student_loans/presenter_methods.rb
+++ b/app/models/student_loans/presenter_methods.rb
@@ -1,5 +1,14 @@
 module StudentLoans
   module PresenterMethods
+    def qts_award_year_answer(eligibility)
+      if eligibility.ineligible_qts_award_year?
+        I18n.t("student_loans.answers.qts_award_years.before_2013_or_after_2020")
+      else
+        first_eligible_year = StudentLoans.first_eligible_qts_award_year(eligibility.claim.academic_year).to_s(:long)
+        I18n.t("student_loans.answers.qts_award_years.#{eligibility.qts_award_year}", year: first_eligible_year)
+      end
+    end
+
     def subject_list(subjects)
       connector = " and "
       translated_subjects = subjects.map { |subject| I18n.t("student_loans.questions.eligible_subjects.#{subject}") }

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -1,0 +1,14 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you completed your initial teacher training
+  <%= t("student_loans.answers.qts_award_years.between_2013_and_2020", year: current_policy.first_eligible_qts_award_year.to_s(:long)).downcase %>.
+</p>
+
+<p class="govuk-body">
+  For more information, including eligibility criteria for this payment, visit the
+  <%= link_to "‘#{policy_service_name(current_policy.routing_name)}’", "#{current_policy.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.qts_award_year": "claim_eligibility_attributes_qts_award_year_#{current_claim.eligibility.class.qts_award_years.keys.first}" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form  do |form| %>
+      <%= form_group_tag current_claim do %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("student_loans.questions.qts_award_year") %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="qts_year-hint">
+            The academic year runs from 1 September to 31 August.
+          </div>
+
+          <%= form.fields_for :eligibility, include_id: false do |fields| %>
+            <%= errors_tag current_claim.eligibility, :qts_award_year %>
+
+            <div class="govuk-radios">
+              <%= fields.hidden_field :qts_award_year %>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, :between_2013_and_2020, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_between_2013_and_2020",
+                      t("student_loans.answers.qts_award_years.between_2013_and_2020", year: current_policy.first_eligible_qts_award_year.to_s(:long)),
+                      class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, :before_2013_or_after_2020, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_before_2013_or_after_2020",
+                      t("student_loans.answers.qts_award_years.before_2013_or_after_2020"),
+                      class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+          <% end %>
+
+        </fieldset>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,7 @@ en:
     award_description: "claim payment"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
+      qts_award_year: "When did you complete your initial teacher training (ITT)?"
       claim_school: "Which school were you employed to teach at between %{financial_year}?"
       additional_school: "Which additional school were you employed to teach at between %{financial_year}?"
       employment_status: "Are you still employed to teach at a school in England?"
@@ -269,6 +270,11 @@ en:
         languages_taught: "Languages"
         none_taught: "I did not teach any of these subjects"
       student_loan_amount: "Exactly how much student loan did you repay in the %{financial_year} financial year?"
+    answers:
+      qts_award_years:
+        before_2013_or_after_2020: A different academic year
+        between_2013_and_2020: Between the start of the %{year} academic year and the end of the 2020 to 2021 academic year
+        on_date: "In the academic year %{year}"
     admin:
       claim_school: "Claim school"
       subjects_taught: "Subjects taught"

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :student_loans_eligibility, class: "StudentLoans::Eligibility" do
     trait :eligible do
       association :current_school, factory: [:school, :student_loans_eligible]
-      qts_award_year { :on_or_after_cut_off_date }
+      qts_award_year { :between_2013_and_2020 }
       employment_status { :claim_school }
       claim_school { current_school }
       physics_taught { true }

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Backlinking during a claim" do
     click_on "Back"
     expect(page).to have_current_path("/student-loans/claim-school", ignore_query: true)
     click_on "Back"
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
     expect(page).to have_no_link("Back")
   end
 

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -40,15 +40,15 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     find("a[href='#{claim_path(StudentLoans.routing_name, "qts-year")}']").click
 
-    expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_cut_off_date").checked?).to eq(true)
+    expect(find("#claim_eligibility_attributes_qts_award_year_between_2013_and_2020").checked?).to eq(true)
 
-    choose_qts_year :before_cut_off_date
+    choose_qts_year :before_2013_or_after_2020
     click_on "Continue"
 
-    expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")
+    expect(claim.eligibility.reload.qts_award_year).to eq("before_2013_or_after_2020")
 
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year #{StudentLoans.first_eligible_qts_award_year.to_s(:long)}.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training between the start of the #{StudentLoans.first_eligible_qts_award_year.to_s(:long)} academic year and the end of the 2020 to 2021 academic year.")
   end
 
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they've given, remaining eligible" do

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -20,6 +20,6 @@ RSpec.feature "Claim journey does not get cached", js: true do
     page.evaluate_script("window.history.back()")
 
     expect(page).to_not have_text(claim.first_name)
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
   end
 end

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -11,12 +11,12 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     policy_configuration.update!(current_academic_year: "2025/2026")
 
     visit new_claim_path(StudentLoans.routing_name)
-    choose_qts_year(:before_cut_off_date)
+    choose_qts_year(:before_2013_or_after_2020)
     claim = Claim.by_policy(StudentLoans).order(:created_at).last
 
-    expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
+    expect(claim.eligibility.reload.qts_award_year).to eql("before_2013_or_after_2020")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2014 to 2015.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training between the start of the 2014 to 2015 academic year and the end of the 2020 to 2021 academic year.")
 
     # Check we can go back and change the answer
     visit claim_path(StudentLoans.routing_name, "qts-year")
@@ -102,7 +102,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(page).to_not have_content("You have a claim in progress")
 
-    expect(page).to have_content("When did you complete your initial teacher training?")
+    expect(page).to have_content("When did you complete your initial teacher training (ITT)?")
     expect(page).not_to have_css("input[checked]")
     choose_qts_year
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -22,13 +22,13 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       visit claim_path(StudentLoans.routing_name, "leadership-position")
       expect(page).to have_current_path("/#{StudentLoans.routing_name}/qts-year")
 
-      expect(page).to have_text(I18n.t("questions.qts_award_year"))
+      expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
       expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
 
       choose_qts_year
       claim = Claim.by_policy(StudentLoans).order(:created_at).last
 
-      expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
+      expect(claim.eligibility.reload.qts_award_year).to eql("between_2013_and_2020")
 
       expect(page).to have_text(claim_school_question)
 
@@ -245,13 +245,13 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       scenario "Teacher claims back student loan repayments" do
         visit new_claim_path(StudentLoans.routing_name)
-        expect(page).to have_text(I18n.t("questions.qts_award_year"))
+        expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
         expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
 
         choose_qts_year
         claim = Claim.by_policy(StudentLoans).order(:created_at).last
 
-        expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
+        expect(claim.eligibility.reload.qts_award_year).to eql("between_2013_and_2020")
 
         expect(page).to have_text(claim_school_question)
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -7,7 +7,7 @@ describe ClaimsHelper do
       build(
         :student_loans_eligibility,
         :eligible,
-        qts_award_year: "on_or_after_cut_off_date"
+        qts_award_year: "between_2013_and_2020"
       )
     end
     let(:claim) do
@@ -18,7 +18,7 @@ describe ClaimsHelper do
 
     it "returns the correct answers for the eligibility's policy" do
       answers = helper.eligibility_answers(current_claim)
-      expect(answers.first).to eq [I18n.t("questions.qts_award_year"), "In or after the academic year 2013 to 2014", "qts-year"]
+      expect(answers.first).to eq [I18n.t("student_loans.questions.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year", "qts-year"]
     end
   end
 

--- a/spec/models/student_loans/admin_tasks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_tasks_presenter_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
 
   describe "#qualifications" do
     it "returns an array of label and values for displaying information for qualification checks" do
-      expect(presenter.qualifications).to eq [["Award year", "In or after the academic year 2013 to 2014"]]
+      expect(presenter.qualifications).to eq [["Award year", "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year"]]
     end
 
     it "sets the “Award year” value based on the academic year the claim was made in" do
       claim.academic_year = "2030/2031"
 
       expected_qts_answer = presenter.qualifications[0][1]
-      expect(expected_qts_answer).to eq "In or after the academic year 2019 to 2020"
+      expect(expected_qts_answer).to eq "Between the start of the 2019 to 2020 academic year and the end of the 2020 to 2021 academic year"
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
         eligibility: build(
           :student_loans_eligibility,
           :eligible,
-          qts_award_year: "on_or_after_cut_off_date"
+          qts_award_year: "between_2013_and_2020"
         ))
       presenter_2025 = described_class.new(claim_2025)
       expect(presenter_2025.employment[0][0]).to eq "6 April 2024 to 5 April 2025"

--- a/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
   describe "#answers" do
     it "returns an array of questions and answers for displaying to approver" do
       expected_answers = [
-        [I18n.t("admin.qts_award_year"), "In or after the academic year 2013 to 2014"],
+        [I18n.t("admin.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year"],
         [I18n.t("student_loans.admin.claim_school"), presenter.display_school(eligibility.current_school)],
         [I18n.t("admin.current_school"), presenter.display_school(eligibility.current_school)],
         [I18n.t("student_loans.admin.subjects_taught"), "Chemistry and Physics"],
@@ -33,7 +33,7 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
       claim.academic_year = "2029/2030"
 
       expected_qts_answer = presenter.answers[0][1]
-      expect(expected_qts_answer).to eq("In or after the academic year 2018 to 2019")
+      expect(expected_qts_answer).to eq("Between the start of the 2018 to 2019 academic year and the end of the 2020 to 2021 academic year")
     end
 
     it "excludes questions skipped from the flow" do

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
   it "returns an array of questions, answers, and slugs for displaying to the user for review" do
     create(:policy_configuration, :student_loans)
     expected_answers = [
-      [I18n.t("questions.qts_award_year"), "In or after the academic year 2013 to 2014", "qts-year"],
+      [I18n.t("student_loans.questions.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year", "qts-year"],
       [claim_school_question, eligibility.claim_school.name, "claim-school"],
       [I18n.t("questions.current_school"), eligibility.current_school.name, "still-teaching"],
       [subjects_taught_question(school_name: eligibility.current_school.name), "Chemistry and Physics", "subjects-taught"],
@@ -27,11 +27,11 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
     claim.academic_year = "2027/2028"
 
     qts_answer = presenter.answers[0][1]
-    expect(qts_answer).to eq("In or after the academic year 2016 to 2017")
+    expect(qts_answer).to eq("Between the start of the 2016 to 2017 academic year and the end of the 2020 to 2021 academic year")
 
-    eligibility.qts_award_year = :before_cut_off_date
+    eligibility.qts_award_year = :before_2013_or_after_2020
     qts_answer = presenter.answers[0][1]
-    expect(qts_answer).to eq("In or before the academic year 2015 to 2016")
+    expect(qts_answer).to eq("A different academic year")
   end
 
   it "excludes questions skipped from the flow" do

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -8,24 +8,24 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
   describe "qts_award_year attribute" do
     it "rejects invalid values" do
-      expect { StudentLoans::Eligibility.new(qts_award_year: "non-existence") }.to raise_error(ArgumentError)
+      expect { described_class.new(qts_award_year: "non-existence") }.to raise_error(ArgumentError)
     end
 
     it "has handily named boolean methods for the possible values" do
-      eligibility = StudentLoans::Eligibility.new(qts_award_year: "on_or_after_cut_off_date")
+      eligibility = described_class.new(qts_award_year: "between_2013_and_2020")
 
-      expect(eligibility.awarded_qualified_status_on_or_after_cut_off_date?).to eq true
-      expect(eligibility.awarded_qualified_status_before_cut_off_date?).to eq false
+      expect(eligibility.awarded_qualified_status_between_2013_and_2020?).to eq true
+      expect(eligibility.awarded_qualified_status_before_2013_or_after_2020?).to eq false
     end
   end
 
   describe "employment_status attribute" do
     it "rejects invalid values" do
-      expect { StudentLoans::Eligibility.new(employment_status: "non-existence") }.to raise_error(ArgumentError)
+      expect { described_class.new(employment_status: "non-existence") }.to raise_error(ArgumentError)
     end
 
     it "has handily named boolean methods for the possible values" do
-      eligibility = StudentLoans::Eligibility.new(employment_status: :claim_school)
+      eligibility = described_class.new(employment_status: :claim_school)
 
       expect(eligibility.employed_at_claim_school?).to eq true
       expect(eligibility.employed_at_different_school?).to eq false
@@ -34,71 +34,71 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
   describe "student_loan_repayment_amount attribute" do
     it "validates that the loan repayment amount is numerical" do
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "£1,234.56")).not_to be_valid
+      expect(described_class.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
+      expect(described_class.new(student_loan_repayment_amount: "£1,234.56")).not_to be_valid
     end
 
     it "validates that the loan repayment is under £99,999" do
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: 100_000)).not_to be_valid
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: 99_999)).to be_valid
+      expect(described_class.new(student_loan_repayment_amount: 100_000)).not_to be_valid
+      expect(described_class.new(student_loan_repayment_amount: 99_999)).to be_valid
     end
 
     it "validates that the loan repayment a positive number" do
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "-99")).not_to be_valid
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "150")).to be_valid
+      expect(described_class.new(student_loan_repayment_amount: "-99")).not_to be_valid
+      expect(described_class.new(student_loan_repayment_amount: "150")).to be_valid
     end
 
     it "validates that the loan repayment is not zero" do
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "0")).not_to be_valid
+      expect(described_class.new(student_loan_repayment_amount: "0")).not_to be_valid
     end
 
     it "validates that the loan repayment less than £5000 when amending a claim" do
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "5001")).not_to be_valid(:amendment)
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "1200")).to be_valid(:amendment)
+      expect(described_class.new(student_loan_repayment_amount: "5001")).not_to be_valid(:amendment)
+      expect(described_class.new(student_loan_repayment_amount: "1200")).to be_valid(:amendment)
     end
   end
 
   describe "#claim_school_name" do
     it "returns the name of the claim school" do
-      eligibility = StudentLoans::Eligibility.new(claim_school: eligible_school)
+      eligibility = described_class.new(claim_school: eligible_school)
       expect(eligibility.claim_school_name).to eq eligible_school.name
     end
 
     it "does not error if the claim school is not set" do
-      expect(StudentLoans::Eligibility.new.claim_school_name).to be_nil
+      expect(described_class.new.claim_school_name).to be_nil
     end
   end
 
   describe "#current_school_name" do
     it "returns the name of the current school" do
-      claim = StudentLoans::Eligibility.new(current_school: eligible_school)
+      claim = described_class.new(current_school: eligible_school)
       expect(claim.current_school_name).to eq eligible_school.name
     end
 
     it "does not error if the current school is not set" do
-      expect(StudentLoans::Eligibility.new.current_school_name).to be_nil
+      expect(described_class.new.current_school_name).to be_nil
     end
   end
 
   describe "#subjects_taught" do
     it "returns an array of the subject attributes that are true" do
-      expect(StudentLoans::Eligibility.new.subjects_taught).to eq []
-      expect(StudentLoans::Eligibility.new(biology_taught: true, physics_taught: true, chemistry_taught: false).subjects_taught).to eq [:biology_taught, :physics_taught]
+      expect(described_class.new.subjects_taught).to eq []
+      expect(described_class.new(biology_taught: true, physics_taught: true, chemistry_taught: false).subjects_taught).to eq [:biology_taught, :physics_taught]
     end
   end
 
   describe "#ineligible?" do
     it "returns false when the eligibility cannot be determined" do
-      expect(StudentLoans::Eligibility.new.ineligible?).to eql false
+      expect(described_class.new.ineligible?).to eql false
     end
 
     it "returns true when the qts_award_year is before the qualifying cut-off" do
-      expect(StudentLoans::Eligibility.new(qts_award_year: "before_cut_off_date").ineligible?).to eql true
-      expect(StudentLoans::Eligibility.new(qts_award_year: "on_or_after_cut_off_date").ineligible?).to eql false
+      expect(described_class.new(qts_award_year: "before_2013_or_after_2020").ineligible?).to eql true
+      expect(described_class.new(qts_award_year: "between_2013_and_2020").ineligible?).to eql false
     end
 
     describe "claim_school eligibility" do
-      subject(:eligibility) { StudentLoans::Eligibility.new(claim_school: school) }
+      subject(:eligibility) { described_class.new(claim_school: school) }
 
       context "when the claim_school is not eligible" do
         let(:school) { ineligible_school }
@@ -114,7 +114,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
 
     describe "current_school eligibility" do
-      subject(:eligibility) { StudentLoans::Eligibility.new(current_school: school) }
+      subject(:eligibility) { described_class.new(current_school: school) }
 
       context "when the current_school is not eligible" do
         let(:school) { ineligible_school }
@@ -130,39 +130,39 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
 
     it "returns true when no longer teaching" do
-      expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligible?).to eql true
-      expect(StudentLoans::Eligibility.new(employment_status: :claim_school).ineligible?).to eql false
+      expect(described_class.new(employment_status: :no_school).ineligible?).to eql true
+      expect(described_class.new(employment_status: :claim_school).ineligible?).to eql false
     end
 
     it "returns true when not teaching an eligible subject" do
-      expect(StudentLoans::Eligibility.new(taught_eligible_subjects: false).ineligible?).to eql true
-      expect(StudentLoans::Eligibility.new(biology_taught: true).ineligible?).to eql false
+      expect(described_class.new(taught_eligible_subjects: false).ineligible?).to eql true
+      expect(described_class.new(biology_taught: true).ineligible?).to eql false
     end
 
     it "returns true when more than half time is spent performing leadership duties" do
-      expect(StudentLoans::Eligibility.new(mostly_performed_leadership_duties: true).ineligible?).to eql true
-      expect(StudentLoans::Eligibility.new(mostly_performed_leadership_duties: false).ineligible?).to eql false
+      expect(described_class.new(mostly_performed_leadership_duties: true).ineligible?).to eql true
+      expect(described_class.new(mostly_performed_leadership_duties: false).ineligible?).to eql false
     end
   end
 
   describe "#ineligibility_reason" do
     it "returns nil when the reason for ineligibility cannot be determined" do
-      expect(StudentLoans::Eligibility.new.ineligibility_reason).to be_nil
+      expect(described_class.new.ineligibility_reason).to be_nil
     end
 
     it "returns a symbol indicating the reason for ineligibility" do
-      expect(StudentLoans::Eligibility.new(qts_award_year: "before_cut_off_date").ineligibility_reason).to eq :ineligible_qts_award_year
-      expect(StudentLoans::Eligibility.new(claim_school: ineligible_school).ineligibility_reason).to eq :ineligible_claim_school
-      expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligibility_reason).to eq :employed_at_no_school
-      expect(StudentLoans::Eligibility.new(current_school: ineligible_school).ineligibility_reason).to eq :ineligible_current_school
-      expect(StudentLoans::Eligibility.new(taught_eligible_subjects: false).ineligibility_reason).to eq :not_taught_eligible_subjects
-      expect(StudentLoans::Eligibility.new(mostly_performed_leadership_duties: true).ineligibility_reason).to eq :not_taught_enough
+      expect(described_class.new(qts_award_year: "before_2013_or_after_2020").ineligibility_reason).to eq :ineligible_qts_award_year
+      expect(described_class.new(claim_school: ineligible_school).ineligibility_reason).to eq :ineligible_claim_school
+      expect(described_class.new(employment_status: :no_school).ineligibility_reason).to eq :employed_at_no_school
+      expect(described_class.new(current_school: ineligible_school).ineligibility_reason).to eq :ineligible_current_school
+      expect(described_class.new(taught_eligible_subjects: false).ineligibility_reason).to eq :not_taught_eligible_subjects
+      expect(described_class.new(mostly_performed_leadership_duties: true).ineligibility_reason).to eq :not_taught_enough
     end
   end
 
   describe "#award_amount" do
     it "returns the student loan repayment amount" do
-      eligibility = StudentLoans::Eligibility.new(student_loan_repayment_amount: 1000)
+      eligibility = described_class.new(student_loan_repayment_amount: 1000)
       expect(eligibility.award_amount).to eq(1000)
     end
   end
@@ -245,59 +245,28 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
   end
 
-  describe "#qts_award_year_answer" do
-    [
-      {
-        academic_year: "2019/2020",
-        qts_award_year_answer_before: "In or before the academic year 2012 to 2013",
-        qts_award_year_answer_after: "In or after the academic year 2013 to 2014"
-      },
-      {
-        academic_year: "2025/2026",
-        qts_award_year_answer_before: "In or before the academic year 2013 to 2014",
-        qts_award_year_answer_after: "In or after the academic year 2014 to 2015"
-      },
-      {
-        academic_year: "2031/2032",
-        qts_award_year_answer_before: "In or before the academic year 2019 to 2020",
-        qts_award_year_answer_after: "In or after the academic year 2020 to 2021"
-      }
-    ].each do |args|
-      it "returns a String representing the answer of the QTS question based on qts_award_year and the academic year (#{args[:academic_year]}) the claim was made in" do
-        claim = Claim.new(academic_year: args[:academic_year])
-        eligibility = StudentLoans::Eligibility.new(claim: claim)
-
-        eligibility.qts_award_year = :before_cut_off_date
-        expect(eligibility.qts_award_year_answer).to eq args[:qts_award_year_answer_before]
-
-        eligibility.qts_award_year = :on_or_after_cut_off_date
-        expect(eligibility.qts_award_year_answer).to eq args[:qts_award_year_answer_after]
-      end
-    end
-  end
-
   # Validation contexts
   context "when saving in the “qts-year” context" do
     it "is not valid without a value for qts_award_year" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"qts-year")
+      expect(described_class.new).not_to be_valid(:"qts-year")
 
-      StudentLoans::Eligibility.qts_award_years.each_key do |academic_year|
-        expect(StudentLoans::Eligibility.new(qts_award_year: academic_year)).to be_valid(:"qts-year")
+      described_class.qts_award_years.each_key do |academic_year|
+        expect(described_class.new(qts_award_year: academic_year)).to be_valid(:"qts-year")
       end
     end
   end
 
   context "when saving in the “claim-school” context" do
     it "validates the presence of the claim_school" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"claim-school")
-      expect(StudentLoans::Eligibility.new(claim_school: eligible_school)).to be_valid(:"claim-school")
+      expect(described_class.new).not_to be_valid(:"claim-school")
+      expect(described_class.new(claim_school: eligible_school)).to be_valid(:"claim-school")
     end
   end
 
   context "when saving in the “still-teaching” context" do
     it "validates the presence of employment_status" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"still-teaching")
-      expect(StudentLoans::Eligibility.new(employment_status: :claim_school)).to be_valid(:"still-teaching")
+      expect(described_class.new).not_to be_valid(:"still-teaching")
+      expect(described_class.new(employment_status: :claim_school)).to be_valid(:"still-teaching")
     end
 
     it "includes the claim school name in the error message" do
@@ -310,54 +279,54 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
   context "when saving in the “current-school” context" do
     it "validates the presence of the current_school" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"current-school")
-      expect(StudentLoans::Eligibility.new(current_school: eligible_school)).to be_valid(:"current-school")
+      expect(described_class.new).not_to be_valid(:"current-school")
+      expect(described_class.new(current_school: eligible_school)).to be_valid(:"current-school")
     end
   end
 
   context "when saving in the “subjects-taught” context" do
     it "is not valid if none of the subjects-taught attributes are true" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"subjects-taught")
-      expect(StudentLoans::Eligibility.new(biology_taught: false)).not_to be_valid(:"subjects-taught")
-      expect(StudentLoans::Eligibility.new(biology_taught: false, physics_taught: false)).not_to be_valid(:"subjects-taught")
+      expect(described_class.new).not_to be_valid(:"subjects-taught")
+      expect(described_class.new(biology_taught: false)).not_to be_valid(:"subjects-taught")
+      expect(described_class.new(biology_taught: false, physics_taught: false)).not_to be_valid(:"subjects-taught")
     end
 
     it "is valid when one or more of the subjects-taught attributes are true" do
-      expect(StudentLoans::Eligibility.new(biology_taught: true)).to be_valid(:"subjects-taught")
-      expect(StudentLoans::Eligibility.new(biology_taught: true, computing_taught: false)).to be_valid(:"subjects-taught")
-      expect(StudentLoans::Eligibility.new(chemistry_taught: true, languages_taught: true)).to be_valid(:"subjects-taught")
+      expect(described_class.new(biology_taught: true)).to be_valid(:"subjects-taught")
+      expect(described_class.new(biology_taught: true, computing_taught: false)).to be_valid(:"subjects-taught")
+      expect(described_class.new(chemistry_taught: true, languages_taught: true)).to be_valid(:"subjects-taught")
     end
 
     it "is valid with no subjects present if taught_eligible_subjects is false" do
-      expect(StudentLoans::Eligibility.new(taught_eligible_subjects: false)).to be_valid(:"subjects-taught")
-      expect(StudentLoans::Eligibility.new(taught_eligible_subjects: true)).not_to be_valid(:"subjects-taught")
+      expect(described_class.new(taught_eligible_subjects: false)).to be_valid(:"subjects-taught")
+      expect(described_class.new(taught_eligible_subjects: true)).not_to be_valid(:"subjects-taught")
     end
   end
 
   context "when saving in the “leadership-position” context" do
     it "is not valid without a value for had_leadership_position" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"leadership-position")
-      expect(StudentLoans::Eligibility.new(had_leadership_position: true)).to be_valid(:"leadership-position")
-      expect(StudentLoans::Eligibility.new(had_leadership_position: false)).to be_valid(:"leadership-position")
+      expect(described_class.new).not_to be_valid(:"leadership-position")
+      expect(described_class.new(had_leadership_position: true)).to be_valid(:"leadership-position")
+      expect(described_class.new(had_leadership_position: false)).to be_valid(:"leadership-position")
     end
   end
 
   context "when saving in the “mostly-performed-leadership-duties” context" do
     it "is valid when mostly_performed_leadership_duties is present as a boolean value and had_leadership_position is true" do
-      expect(StudentLoans::Eligibility.new(had_leadership_position: true)).not_to be_valid(:"mostly-performed-leadership-duties")
-      expect(StudentLoans::Eligibility.new(had_leadership_position: true, mostly_performed_leadership_duties: true)).to be_valid(:"mostly-performed-leadership-duties")
-      expect(StudentLoans::Eligibility.new(had_leadership_position: true, mostly_performed_leadership_duties: false)).to be_valid(:"mostly-performed-leadership-duties")
+      expect(described_class.new(had_leadership_position: true)).not_to be_valid(:"mostly-performed-leadership-duties")
+      expect(described_class.new(had_leadership_position: true, mostly_performed_leadership_duties: true)).to be_valid(:"mostly-performed-leadership-duties")
+      expect(described_class.new(had_leadership_position: true, mostly_performed_leadership_duties: false)).to be_valid(:"mostly-performed-leadership-duties")
     end
 
     it "is valid when missing if had_leadership_position is false" do
-      expect(StudentLoans::Eligibility.new(had_leadership_position: false)).to be_valid(:"mostly-performed-leadership-duties")
+      expect(described_class.new(had_leadership_position: false)).to be_valid(:"mostly-performed-leadership-duties")
     end
   end
 
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
-      expect(StudentLoans::Eligibility.new).not_to be_valid(:"student-loan-amount")
-      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: 1_100)).to be_valid(:"student-loan-amount")
+      expect(described_class.new).not_to be_valid(:"student-loan-amount")
+      expect(described_class.new(student_loan_repayment_amount: 1_100)).to be_valid(:"student-loan-amount")
     end
   end
 
@@ -369,7 +338,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     it "is not valid without a value for qts_award_year" do
       expect(build(:student_loans_eligibility, :eligible, qts_award_year: nil)).not_to be_valid(:submit)
 
-      StudentLoans::Eligibility.qts_award_years.each_key do |academic_year|
+      described_class.qts_award_years.each_key do |academic_year|
         expect(build(:student_loans_eligibility, :eligible, qts_award_year: academic_year)).to be_valid(:submit)
       end
     end
@@ -408,7 +377,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
   describe "#eligible_itt_subject" do
     it "returns nil" do
-      expect(StudentLoans::Eligibility.new.eligible_itt_subject).to be(nil)
+      expect(described_class.new.eligible_itt_subject).to be(nil)
     end
   end
 end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -380,4 +380,20 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(described_class.new.eligible_itt_subject).to be(nil)
     end
   end
+
+  describe "#ineligible_qts_award_year?" do
+    subject { described_class.new(qts_award_year:).ineligible_qts_award_year? }
+
+    context "when the qts award year is between 2013 and 2020" do
+      let(:qts_award_year) { "between_2013_and_2020" }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when the qts award year is before 2013 or after 2020" do
+      let(:qts_award_year) { "before_2013_or_after_2020" }
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe StudentLoans::SlugSequence do
       expect(claim.eligibility).not_to be_ineligible
       expect(slug_sequence.slugs).not_to include("ineligible")
 
-      claim.eligibility.qts_award_year = "before_cut_off_date"
+      claim.eligibility.qts_award_year = "before_2013_or_after_2020"
       expect(claim.eligibility).to be_ineligible
       expect(slug_sequence.slugs).to include("ineligible")
     end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Claims", type: :request do
       it "renders the first page in the sequence" do
         get new_claim_path(StudentLoans.routing_name)
         follow_redirect!
-        expect(response.body).to include(I18n.t("questions.qts_award_year"))
+        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe "Claims", type: :request do
       context "when the user has not completed the journey in the correct slug sequence" do
         it "redirects to the correct page in the sequence" do
           get claim_path(StudentLoans.routing_name, "qts-year")
-          expect(response.body).to include(I18n.t("questions.qts_award_year"))
+          expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
 
           get claim_path(StudentLoans.routing_name, "claim-school")
           expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "qts-year"))
@@ -186,9 +186,9 @@ RSpec.describe "Claims", type: :request do
       before { start_student_loans_claim }
 
       it "updates the claim with the submitted form data" do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "between_2013_and_2020"}}}
 
-        expect(in_progress_claim.eligibility.qts_award_year).to eq "on_or_after_cut_off_date"
+        expect(in_progress_claim.eligibility.qts_award_year).to eq "between_2013_and_2020"
       end
 
       it "makes sure validations appropriate to the context are run" do
@@ -254,7 +254,7 @@ RSpec.describe "Claims", type: :request do
 
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page indicated by the routing" do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "between_2013_and_2020"}}}
         expect(response).to redirect_to(StudentLoans.start_page_url)
       end
     end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
     it "does not timeout the session" do
       travel before_expiry do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "between_2013_and_2020"}}}
 
         expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "claim-school"))
       end

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -169,7 +169,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
 
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications.title"))
     expect(page).to have_content("Award year")
-    expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+    expect(page).to have_content(I18n.t("student_loans.answers.qts_award_years.#{claim.eligibility.qts_award_year}", year: StudentLoans.first_eligible_qts_award_year(claim.academic_year).to_s(:long)))
     expect(page).to have_link("Next: Census subjects taught")
     expect(page).to have_link("Previous: Identity confirmation")
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -31,7 +31,7 @@ module FeatureHelpers
     Claim.by_policy(StudentLoans).order(:created_at).last
   end
 
-  def choose_qts_year(option = :on_or_after_cut_off_date)
+  def choose_qts_year(option = :between_2013_and_2020)
     choose "claim_eligibility_attributes_qts_award_year_#{option}"
     click_on "Continue"
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1341

My understanding is that TSLR was added after Maths and Physics. The two policies share things like translation entries, views, and similar model patterns. One fundamental difference for TSLR seems to be that the QTS must be awarded between 2013 and 2020. When TSLR was introduced, one could not have received their QTS award in the year following 2020, so for the `StudentLoans::Eligibility` `qts_award_year` enum, they had reused values that had been used for Maths and Physics (`before_cut_over_date` and `on_or_after_cut_over_date`). These values are not representative of what the applicant can actually choose at the moment, as the two options are really _"between 2013 and 2020"_ and _"before 2013 or after 2020"._ This PR addressed the code and content changes required, including isolating the related translation entries and views.

Further info https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments#the-years-you-can-claim-for 