### PR TITLE
CAPT-1365 TSLR Teacher ID playback email

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -16,7 +16,7 @@ module ClaimsHelper
 
       a << [translate("questions.national_insurance_number"), claim.national_insurance_number, "personal-details"]
 
-      a << [translate("questions.email_address"), claim.email_address, "email-address"]
+      a << [translate("questions.email_address"), claim.email_address, claim.email_address_check? ? "select-email" : "email-address"]
 
       a << [translate("questions.provide_mobile_number"), (claim.provide_mobile_number ? "Yes" : "No"), "provide-mobile-number"] if claim.has_ecp_or_lupp_policy?
       a << [translate("questions.mobile_number"), claim.mobile_number, "mobile-number"] if claim.has_ecp_or_lupp_policy? && claim.provide_mobile_number?

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -30,6 +30,7 @@ module StudentLoans
       "no-address-found",
       "select-home-address",
       "address",
+      "select-email",
       "email-address",
       "email-verification",
       "provide-mobile-number",
@@ -93,6 +94,11 @@ module StudentLoans
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
         sequence.delete("ineligible") unless claim.eligibility&.ineligible?
         sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
+        sequence.delete("select-email") if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["email"].nil?
+        if claim.logged_in_with_tid? && claim.email_address_check?
+          sequence.delete("email-address")
+          sequence.delete("email-verification")
+        end
       end
     end
   end

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
@@ -1,0 +1,203 @@
+require "rails_helper"
+
+RSpec.feature "Combined journey with Teacher ID email check" do
+  include OmniauthMockHelper
+  include ClaimsControllerHelper
+
+  # create a school eligible for ECP and LUP so can walk the whole journey
+  let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
+  let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
+  let(:trn) { "1234567" }
+  let(:email) { "kelsie.oberbrunner@example.com" }
+  let(:new_email) { "new.email@example" }
+
+  before do
+    freeze_time
+    set_mock_auth(trn)
+    mock_claims_controller_address_data
+  end
+
+  after do
+    set_mock_auth(nil)
+    travel_back
+  end
+
+  scenario "Selects suggested email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text(email)
+
+    # - Select the suggested email address
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.select_phone_number.heading"))
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq("kelsie.oberbrunner@example.com")
+      expect(c.email_address_check).to eq(true)
+      expect(c.email_verified).to eq(true)
+    end
+  end
+
+  scenario "Select a different email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text("A different email address")
+
+    # - Select A different email address
+    find("#claim_email_address_check_false").click
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("questions.email_address_hint1"))
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq(nil)
+      expect(c.email_address_check).to eq(false)
+      expect(c.email_verified).to eq(nil)
+    end
+  end
+
+  scenario "Selects suggested email address and then changes to a different email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text(email)
+
+    # - Select the suggested email address
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    find("#claim_email_address_check_false").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq(nil)
+      expect(c.email_address_check).to eq(false)
+      expect(c.email_verified).to eq(nil)
+    end
+  end
+
+  scenario "Selects a different email address and then changes to the suggested email address" do
+    navigate_to_check_email_page(school:)
+
+    # - select-email page
+    expect(page).to have_text(email)
+
+    # - Select A different email address
+    find("#claim_email_address_check_false").click
+    click_on "Continue"
+
+    click_on "Back"
+
+    find("#claim_email_address_check_true").click
+    click_on "Continue"
+
+    Claim.order(created_at: :desc).limit(2).each do |c|
+      expect(c.email_address).to eq(email)
+      expect(c.email_address_check).to eq(true)
+      expect(c.email_verified).to eq(true)
+    end
+  end
+
+  def navigate_to_check_email_page(school:)
+    visit landing_page_path(EarlyCareerPayments.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
+    click_on "Start now"
+
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
+
+    # - Teacher details page
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    choose_school school
+    click_on "Continue"
+
+    # - Have you started your first year as a newly qualified teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt.heading"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Have you completed your induction as an early-career teacher?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.induction_completed.heading"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Are you currently employed as a supply teacher
+    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
+
+    choose "No"
+    click_on "Continue"
+
+    # - Poor performance
+    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
+
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+
+    choose "Undergraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+    choose "2020 to 2021"
+    click_on "Continue"
+
+    # User should be redirected to the next question which was previously answered but wiped by the attribute dependency
+    expect(page).to have_text("Which subject")
+    choose "Mathematics"
+    click_on "Continue"
+
+    # - Do you teach mathematics now?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+    choose "Yes"
+    click_on "Continue"
+
+    # - Check your answers for eligibility
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    click_on("Continue")
+
+    expect(page).to have_text("You’re eligible for an additional payment")
+    choose("£2,000 levelling up premium payment")
+    click_on("Apply now")
+
+    # - How will we use the information you provide
+    expect(page).to have_text("How we will use the information you provide")
+    click_on "Continue"
+
+    # - Personal details - skipped as all details from TID are valid
+    expect(page).not_to have_text(I18n.t("questions.personal_details"))
+
+    # - What is your home address
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
+    expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
+
+    fill_in "Postcode", with: "SO16 9FX"
+    click_on "Search"
+
+    # - Select your home address
+    expect(page).to have_text(I18n.t("questions.address.home.title"))
+
+    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+    click_on "Continue"
+  end
+end

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-RSpec.feature "Logs in with TID, confirms teacher details and displays email from DfE Identity" do
+RSpec.feature "TSLR journey with Teacher ID email check" do
   include OmniauthMockHelper
-  include ClaimsControllerHelper
+  include StudentLoansHelper
 
   # create a school eligible for ECP and LUP so can walk the whole journey
-  let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
-  let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
+  let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
+  let!(:school) { create(:school, :student_loans_eligible) }
   let(:trn) { "1234567" }
   let(:email) { "kelsie.oberbrunner@example.com" }
   let(:new_email) { "new.email@example" }
@@ -14,7 +14,7 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
   before do
     freeze_time
     set_mock_auth(trn)
-    mock_claims_controller_address_data
+    mock_address_details_address_data
   end
 
   after do
@@ -32,7 +32,7 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     find("#claim_email_address_check_true").click
     click_on "Continue"
 
-    expect(page).to have_text(I18n.t("early_career_payments.questions.select_phone_number.heading"))
+    expect(page).to have_text(I18n.t("questions.provide_mobile_number"))
 
     Claim.order(created_at: :desc).limit(2).each do |c|
       expect(c.email_address).to eq("kelsie.oberbrunner@example.com")
@@ -105,10 +105,10 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
   end
 
   def navigate_to_check_email_page(school:)
-    visit landing_page_path(EarlyCareerPayments.routing_name)
+    visit landing_page_path(StudentLoans.routing_name)
 
     # - Landing (start)
-    expect(page).to have_text(I18n.t("early_career_payments.landing_page"))
+    expect(page).to have_text(I18n.t("student_loans.landing_page"))
     click_on "Start now"
 
     expect(page).to have_text("Use DfE Identity to sign in")
@@ -121,75 +121,46 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
     choose "Yes"
     click_on "Continue"
 
+    # - Select qts year
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    choose_qts_year
+    click_on "Continue"
+
     # - Which school do you teach at
-    expect(page).to have_text(I18n.t("early_career_payments.questions.current_school_search"))
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year))
     choose_school school
+
+    # - Which subject do you teach
+    check "Physics"
     click_on "Continue"
 
-    # - Have you started your first year as a newly qualified teacher?
-    expect(page).to have_text(I18n.t("early_career_payments.questions.nqt_in_academic_year_after_itt.heading"))
+    #  - Are you still employed to teach at
+    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
+    choose_still_teaching("Yes, at #{school.name}")
 
+    #  - leadership-position question
+    expect(page).to have_text(leadership_position_question)
     choose "Yes"
     click_on "Continue"
 
-    # - Have you completed your induction as an early-career teacher?
-    expect(page).to have_text(I18n.t("early_career_payments.questions.induction_completed.heading"))
-
-    choose "Yes"
-    click_on "Continue"
-
-    # - Are you currently employed as a supply teacher
-    expect(page).to have_text(I18n.t("early_career_payments.questions.employed_as_supply_teacher"))
-
+    #  - mostly-performed-leadership-duties question
+    expect(page).to have_text(mostly_performed_leadership_duties_question)
     choose "No"
     click_on "Continue"
 
-    # - Poor performance
-    expect(page).to have_text(I18n.t("early_career_payments.questions.formal_performance_action"))
-    expect(page).to have_text(I18n.t("early_career_payments.questions.disciplinary_action"))
-
-    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
-    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    # - student-loan-amount page
+    expect(page).to have_text("you can claim back the student loan repayments you made between #{StudentLoans.current_financial_year}.")
     click_on "Continue"
 
-    # - What route into teaching did you take?
-    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
-
-    choose "Undergraduate initial teacher training (ITT)"
-    click_on "Continue"
-
-    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
-    choose "2020 to 2021"
-    click_on "Continue"
-
-    # User should be redirected to the next question which was previously answered but wiped by the attribute dependency
-    expect(page).to have_text("Which subject")
-    choose "Mathematics"
-    click_on "Continue"
-
-    # - Do you teach mathematics now?
-    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
-    choose "Yes"
-    click_on "Continue"
-
-    # - Check your answers for eligibility
-    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
-    click_on("Continue")
-
-    expect(page).to have_text("You’re eligible for an additional payment")
-    choose("£2,000 levelling up premium payment")
-    click_on("Apply now")
-
-    # - How will we use the information you provide
+    # - How we will use the information you provide
     expect(page).to have_text("How we will use the information you provide")
     click_on "Continue"
 
-    # - Personal details - skipped as all details from TID are valid
-    expect(page).not_to have_text(I18n.t("questions.personal_details"))
+    # - Personal details - skipped
 
     # - What is your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
-    expect(page).to have_link(href: claim_path(EarlyCareerPayments.routing_name, "address"))
+    expect(page).to have_link(href: claim_path(StudentLoans.routing_name, "address"))
 
     fill_in "Postcode", with: "SO16 9FX"
     click_on "Search"
@@ -199,5 +170,40 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays email fro
 
     choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
     click_on "Continue"
+  end
+
+  private
+
+  def mock_address_details_address_data
+    allow_any_instance_of(ClaimsController).to receive(:address_data) do |controller|
+      controller.instance_variable_set(:@address_data, address_data)
+      address_data
+    end
+  end
+
+  def address_data
+    [
+      {
+        address: "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 1, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      },
+      {
+        address: "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 10, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      },
+      {
+        address: "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
+        address_line_1: "FLAT 11, MILLBROOK TOWER",
+        address_line_2: "WINDERMERE AVENUE",
+        address_line_3: "SOUTHAMPTON",
+        postcode: "SO16 9FX"
+      }
+    ]
   end
 end


### PR DESCRIPTION
[CAPT-1365](https://dfedigital.atlassian.net/browse/CAPT-1365?atlOrigin=eyJpIjoiM2I1MDgwYWIxYmI4NDcwZTg1M2IwMjQ4YjI2NDk0MzAiLCJwIjoiaiJ9) Dev - TSLR ID - Email playback

Added logic to playback the email address from Teacher ID during the TSLR claim journey.


[CAPT-1365]: https://dfedigital.atlassian.net/browse/CAPT-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ