### PR TITLE
CAPT-1341, CAPT-1396: TSLR QTS award year question content changes

### DIFF
--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -81,10 +81,6 @@ module StudentLoans
     ].max
   end
 
-  def last_ineligible_qts_award_year
-    first_eligible_qts_award_year - 1
-  end
-
   # Returns human-friendly String for the financial year that Student Loans
   # claims are being made against based on the currently-configured academic
   # year for the StudentLoans policy. For example:

--- a/app/models/student_loans/admin_tasks_presenter.rb
+++ b/app/models/student_loans/admin_tasks_presenter.rb
@@ -14,7 +14,7 @@ module StudentLoans
 
     def qualifications
       [
-        ["Award year", eligibility.qts_award_year_answer]
+        ["Award year", qts_award_year_answer(eligibility)]
       ]
     end
 

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -108,23 +108,14 @@ module StudentLoans
       self.current_school = inferred_current_school if employment_status_changed?
     end
 
-    # Returns a String that is the human-readable answer given for the QTS
-    # question when the claim was made.
-    def qts_award_year_answer
-      year_for_answer = StudentLoans.first_eligible_qts_award_year(claim.academic_year)
-      year_for_answer -= 1 if awarded_qualified_status_before_cut_off_date?
-
-      I18n.t("answers.qts_award_years.#{qts_award_year}", year: year_for_answer.to_s(:long))
-    end
-
     def submit!
     end
-
-    private
 
     def ineligible_qts_award_year?
       awarded_qualified_status_before_cut_off_date?
     end
+
+    private
 
     def ineligible_claim_school?
       claim_school.present? && !claim_school.eligible_for_student_loans_as_claim_school?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -28,6 +28,10 @@ module StudentLoans
 
     self.table_name = "student_loans_eligibilities"
 
+    # Note: these mapped values for the `qts_award_year` integer values are symbolic and not to be taken literally,
+    # in particular the "cut off date" is to be considered dynamic and based on the current financial/claim year.
+    # You should simply consider 0 as the ineligible value and 1 as the eligible one.
+    # We don't store claims with a `qts_award_year = 0` as the journey would have ended after the first question.
     enum qts_award_year: {
       before_cut_off_date: 0,
       on_or_after_cut_off_date: 1

--- a/app/models/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_admin_answers_presenter.rb
@@ -33,7 +33,7 @@ module StudentLoans
     def qts_award_year
       [
         translate("admin.qts_award_year"),
-        eligibility.qts_award_year_answer
+        qts_award_year_answer(eligibility)
       ]
     end
 

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -34,8 +34,8 @@ module StudentLoans
 
     def qts_award_year
       [
-        translate("questions.qts_award_year"),
-        eligibility.qts_award_year_answer,
+        translate("student_loans.questions.qts_award_year"),
+        qts_award_year_answer(eligibility),
         "qts-year"
       ]
     end

--- a/app/models/student_loans/presenter_methods.rb
+++ b/app/models/student_loans/presenter_methods.rb
@@ -1,5 +1,14 @@
 module StudentLoans
   module PresenterMethods
+    def qts_award_year_answer(eligibility)
+      if eligibility.ineligible_qts_award_year?
+        I18n.t("student_loans.answers.qts_award_years.before_cut_off_date")
+      else
+        first_eligible_year = StudentLoans.first_eligible_qts_award_year(eligibility.claim.academic_year).to_s(:long)
+        I18n.t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: first_eligible_year)
+      end
+    end
+
     def subject_list(subjects)
       connector = " and "
       translated_subjects = subjects.map { |subject| I18n.t("student_loans.questions.eligible_subjects.#{subject}") }

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -1,0 +1,14 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you completed your initial teacher training
+  <%= t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)).downcase %>.
+</p>
+
+<p class="govuk-body">
+  For more information, including eligibility criteria for this payment, visit the
+  <%= link_to "‘#{policy_service_name(current_policy.routing_name)}’", "#{current_policy.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.qts_award_year": "claim_eligibility_attributes_qts_award_year_#{current_claim.eligibility.class.qts_award_years.keys.first}" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form  do |form| %>
+      <%= form_group_tag current_claim do %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("student_loans.questions.qts_award_year") %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="qts_year-hint">
+            The academic year runs from 1 September to 31 August.
+          </div>
+
+          <%= form.fields_for :eligibility, include_id: false do |fields| %>
+            <%= errors_tag current_claim.eligibility, :qts_award_year %>
+
+            <div class="govuk-radios">
+              <%= fields.hidden_field :qts_award_year %>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, :on_or_after_cut_off_date, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_on_or_after_cut_off_date",
+                      t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)),
+                      class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, :before_cut_off_date, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_before_cut_off_date",
+                      t("student_loans.answers.qts_award_years.before_cut_off_date"),
+                      class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+          <% end %>
+
+        </fieldset>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,7 @@ en:
     award_description: "claim payment"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
+      qts_award_year: "When did you complete your initial teacher training (ITT)?"
       claim_school: "Which school were you employed to teach at between %{financial_year}?"
       additional_school: "Which additional school were you employed to teach at between %{financial_year}?"
       employment_status: "Are you still employed to teach at a school in England?"
@@ -269,6 +270,10 @@ en:
         languages_taught: "Languages"
         none_taught: "I did not teach any of these subjects"
       student_loan_amount: "Exactly how much student loan did you repay in the %{financial_year} financial year?"
+    answers:
+      qts_award_years:
+        before_cut_off_date: A different academic year
+        on_or_after_cut_off_date: Between the start of the %{year} academic year and the end of the 2020 to 2021 academic year
     admin:
       claim_school: "Claim school"
       subjects_taught: "Subjects taught"

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Backlinking during a claim" do
     click_on "Back"
     expect(page).to have_current_path("/student-loans/claim-school", ignore_query: true)
     click_on "Back"
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
     expect(page).to have_no_link("Back")
   end
 

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")
 
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year #{StudentLoans.first_eligible_qts_award_year.to_s(:long)}.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training between the start of the #{StudentLoans.first_eligible_qts_award_year.to_s(:long)} academic year and the end of the 2020 to 2021 academic year.")
   end
 
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they've given, remaining eligible" do

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -20,6 +20,6 @@ RSpec.feature "Claim journey does not get cached", js: true do
     page.evaluate_script("window.history.back()")
 
     expect(page).to_not have_text(claim.first_name)
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
   end
 end

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2014 to 2015.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training between the start of the 2014 to 2015 academic year and the end of the 2020 to 2021 academic year.")
 
     # Check we can go back and change the answer
     visit claim_path(StudentLoans.routing_name, "qts-year")
@@ -102,7 +102,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(page).to_not have_content("You have a claim in progress")
 
-    expect(page).to have_content("When did you complete your initial teacher training?")
+    expect(page).to have_content("When did you complete your initial teacher training (ITT)?")
     expect(page).not_to have_css("input[checked]")
     choose_qts_year
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       visit claim_path(StudentLoans.routing_name, "leadership-position")
       expect(page).to have_current_path("/#{StudentLoans.routing_name}/qts-year")
 
-      expect(page).to have_text(I18n.t("questions.qts_award_year"))
+      expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
       expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
 
       choose_qts_year
@@ -245,7 +245,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       scenario "Teacher claims back student loan repayments" do
         visit new_claim_path(StudentLoans.routing_name)
-        expect(page).to have_text(I18n.t("questions.qts_award_year"))
+        expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
         expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
 
         choose_qts_year

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -18,7 +18,7 @@ describe ClaimsHelper do
 
     it "returns the correct answers for the eligibility's policy" do
       answers = helper.eligibility_answers(current_claim)
-      expect(answers.first).to eq [I18n.t("questions.qts_award_year"), "In or after the academic year 2013 to 2014", "qts-year"]
+      expect(answers.first).to eq [I18n.t("student_loans.questions.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year", "qts-year"]
     end
   end
 

--- a/spec/models/student_loans/admin_tasks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_tasks_presenter_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
 
   describe "#qualifications" do
     it "returns an array of label and values for displaying information for qualification checks" do
-      expect(presenter.qualifications).to eq [["Award year", "In or after the academic year 2013 to 2014"]]
+      expect(presenter.qualifications).to eq [["Award year", "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year"]]
     end
 
     it "sets the “Award year” value based on the academic year the claim was made in" do
       claim.academic_year = "2030/2031"
 
       expected_qts_answer = presenter.qualifications[0][1]
-      expect(expected_qts_answer).to eq "In or after the academic year 2019 to 2020"
+      expect(expected_qts_answer).to eq "Between the start of the 2019 to 2020 academic year and the end of the 2020 to 2021 academic year"
     end
   end
 

--- a/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
   describe "#answers" do
     it "returns an array of questions and answers for displaying to approver" do
       expected_answers = [
-        [I18n.t("admin.qts_award_year"), "In or after the academic year 2013 to 2014"],
+        [I18n.t("admin.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year"],
         [I18n.t("student_loans.admin.claim_school"), presenter.display_school(eligibility.current_school)],
         [I18n.t("admin.current_school"), presenter.display_school(eligibility.current_school)],
         [I18n.t("student_loans.admin.subjects_taught"), "Chemistry and Physics"],
@@ -33,7 +33,7 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
       claim.academic_year = "2029/2030"
 
       expected_qts_answer = presenter.answers[0][1]
-      expect(expected_qts_answer).to eq("In or after the academic year 2018 to 2019")
+      expect(expected_qts_answer).to eq("Between the start of the 2018 to 2019 academic year and the end of the 2020 to 2021 academic year")
     end
 
     it "excludes questions skipped from the flow" do

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
   it "returns an array of questions, answers, and slugs for displaying to the user for review" do
     create(:policy_configuration, :student_loans)
     expected_answers = [
-      [I18n.t("questions.qts_award_year"), "In or after the academic year 2013 to 2014", "qts-year"],
+      [I18n.t("student_loans.questions.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year", "qts-year"],
       [claim_school_question, eligibility.claim_school.name, "claim-school"],
       [I18n.t("questions.current_school"), eligibility.current_school.name, "still-teaching"],
       [subjects_taught_question(school_name: eligibility.current_school.name), "Chemistry and Physics", "subjects-taught"],
@@ -27,11 +27,11 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
     claim.academic_year = "2027/2028"
 
     qts_answer = presenter.answers[0][1]
-    expect(qts_answer).to eq("In or after the academic year 2016 to 2017")
+    expect(qts_answer).to eq("Between the start of the 2016 to 2017 academic year and the end of the 2020 to 2021 academic year")
 
     eligibility.qts_award_year = :before_cut_off_date
     qts_answer = presenter.answers[0][1]
-    expect(qts_answer).to eq("In or before the academic year 2015 to 2016")
+    expect(qts_answer).to eq("A different academic year")
   end
 
   it "excludes questions skipped from the flow" do

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -245,37 +245,6 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
   end
 
-  describe "#qts_award_year_answer" do
-    [
-      {
-        academic_year: "2019/2020",
-        qts_award_year_answer_before: "In or before the academic year 2012 to 2013",
-        qts_award_year_answer_after: "In or after the academic year 2013 to 2014"
-      },
-      {
-        academic_year: "2025/2026",
-        qts_award_year_answer_before: "In or before the academic year 2013 to 2014",
-        qts_award_year_answer_after: "In or after the academic year 2014 to 2015"
-      },
-      {
-        academic_year: "2031/2032",
-        qts_award_year_answer_before: "In or before the academic year 2019 to 2020",
-        qts_award_year_answer_after: "In or after the academic year 2020 to 2021"
-      }
-    ].each do |args|
-      it "returns a String representing the answer of the QTS question based on qts_award_year and the academic year (#{args[:academic_year]}) the claim was made in" do
-        claim = Claim.new(academic_year: args[:academic_year])
-        eligibility = StudentLoans::Eligibility.new(claim: claim)
-
-        eligibility.qts_award_year = :before_cut_off_date
-        expect(eligibility.qts_award_year_answer).to eq args[:qts_award_year_answer_before]
-
-        eligibility.qts_award_year = :on_or_after_cut_off_date
-        expect(eligibility.qts_award_year_answer).to eq args[:qts_award_year_answer_after]
-      end
-    end
-  end
-
   # Validation contexts
   context "when saving in the “qts-year” context" do
     it "is not valid without a value for qts_award_year" do
@@ -409,6 +378,22 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
   describe "#eligible_itt_subject" do
     it "returns nil" do
       expect(StudentLoans::Eligibility.new.eligible_itt_subject).to be(nil)
+    end
+  end
+
+  describe "#ineligible_qts_award_year?" do
+    subject { described_class.new(qts_award_year:).ineligible_qts_award_year? }
+
+    context "when the qts award year is eligibile" do
+      let(:qts_award_year) { "on_or_after_cut_off_date" }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when the qts award year is not eligible" do
+      let(:qts_award_year) { "before_cut_off_date" }
+
+      it { is_expected.to eq(true) }
     end
   end
 end

--- a/spec/models/student_loans/presenter_methods_spec.rb
+++ b/spec/models/student_loans/presenter_methods_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe StudentLoans::PresenterMethods, type: :helper do
+  describe ".qts_award_year_answer" do
+    [
+      {
+        academic_year: "2023/2024",
+        qts_award_year_answer_ineligible: "A different academic year",
+        qts_award_year_answer_eligible: "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year"
+      },
+      {
+        academic_year: "2025/2026",
+        qts_award_year_answer_ineligible: "A different academic year",
+        qts_award_year_answer_eligible: "Between the start of the 2014 to 2015 academic year and the end of the 2020 to 2021 academic year"
+      },
+      {
+        academic_year: "2031/2032",
+        qts_award_year_answer_ineligible: "A different academic year",
+        qts_award_year_answer_eligible: "Between the start of the 2020 to 2021 academic year and the end of the 2020 to 2021 academic year"
+      }
+    ].each do |args|
+      it "returns a String representing the answer of the QTS question based on qts_award_year and the academic year (#{args[:academic_year]}) the claim was made in" do
+        claim = build(:claim, academic_year: args[:academic_year])
+        eligibility = build(:student_loans_eligibility, claim: claim)
+
+        eligibility.qts_award_year = :before_cut_off_date
+        expect(helper.qts_award_year_answer(eligibility)).to eq args[:qts_award_year_answer_ineligible]
+
+        eligibility.qts_award_year = :on_or_after_cut_off_date
+        expect(helper.qts_award_year_answer(eligibility)).to eq args[:qts_award_year_answer_eligible]
+      end
+    end
+  end
+end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Claims", type: :request do
       it "renders the first page in the sequence" do
         get new_claim_path(StudentLoans.routing_name)
         follow_redirect!
-        expect(response.body).to include(I18n.t("questions.qts_award_year"))
+        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe "Claims", type: :request do
       context "when the user has not completed the journey in the correct slug sequence" do
         it "redirects to the correct page in the sequence" do
           get claim_path(StudentLoans.routing_name, "qts-year")
-          expect(response.body).to include(I18n.t("questions.qts_award_year"))
+          expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
 
           get claim_path(StudentLoans.routing_name, "claim-school")
           expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "qts-year"))

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -169,7 +169,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
 
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications.title"))
     expect(page).to have_content("Award year")
-    expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+    expect(page).to have_content(I18n.t("student_loans.answers.qts_award_years.#{claim.eligibility.qts_award_year}", year: StudentLoans.first_eligible_qts_award_year(claim.academic_year).to_s(:long)))
     expect(page).to have_link("Next: Census subjects taught")
     expect(page).to have_link("Previous: Identity confirmation")
 


### PR DESCRIPTION
Content changes as per [CAPT-1341](https://dfedigital.atlassian.net/browse/CAPT-1341) and [CAPT-1396](https://dfedigital.atlassian.net/browse/CAPT-1396)

In a nutshell, the changes are in 4 parts (commits):

1. Segregation of the TSLR QTS award question view + requested content changes
2. Segregation of the TSLR QTS award ineligibility partial + requested content changes (CAPT-1396)
3. Reflecting content changes in the "check your answers page"
4. Reflecting content changes in the admin task presenter
 
We are still calculating the first eligible QTS award year based on the claim year for all of the above points. Still, there is no need to look at the upper limit as the last eligible QTS award year is 2020 to 2021 until the claim year 2031 to 2032 when the TSLR window will open for one last time.

Superseds #2501


[CAPT-1341]: https://dfedigital.atlassian.net/browse/CAPT-1341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAPT-1396]: https://dfedigital.atlassian.net/browse/CAPT-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="665" alt="s1" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9043263/84c60838-5275-4464-9aae-1708a397bebf">
<img width="666" alt="s2" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9043263/db524657-eed5-4a85-84cc-e8626f6f0cd9">
<img width="685" alt="s3" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9043263/ed5d4a1a-652e-40f0-ae57-0a1627936914">
<img width="667" alt="s4" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9043263/14bf3014-adaa-44c1-8802-03dce7768923">

