### PR TITLE
CAPT-1407 - fix change school link

### DIFF
--- a/app/models/early_career_payments/eligibility_answers_presenter.rb
+++ b/app/models/early_career_payments/eligibility_answers_presenter.rb
@@ -51,7 +51,7 @@ module EarlyCareerPayments
       [
         translate("early_career_payments.questions.current_school_search"),
         eligibility.current_school_name,
-        "current-school"
+        (eligibility.school_somewhere_else == false) ? "correct-school" : "current-school"
       ]
     end
 


### PR DESCRIPTION
If the school playback (from TPS) was suggested and the user clicked on the suggested school the change school link goes back to the playback, all other scenarios it goes to the current-school where the user types in the school name.
