### PR TITLE
Fix CSRF error

### DIFF
--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class BaseAdminController < ApplicationController
     include AdminSessionTimeout
+    include HttpAuthConcern
 
     layout "admin"
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  include HttpAuthConcern
-
   TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
 
   helper_method :timeout_warning_in_minutes

--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -1,6 +1,7 @@
 class BasePublicController < ApplicationController
   include DfE::Analytics::Requests
   include ClaimSessionTimeout
+  include HttpAuthConcern
 
   helper_method :current_policy, :current_policy_routing_name, :claim_timeout_in_minutes
   before_action :add_view_paths

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -1,4 +1,4 @@
-class SchoolSearchController < ApplicationController
+class SchoolSearchController < BasePublicController
   def create
     search_schools
     render status: errors.blank? ? :ok : :bad_request

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -53,7 +53,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
   provider :openid_connect, {
     name: :tid,
-    allow_authorize_params: %i[session_id trn_token],
     callback_path: "/claim/auth/tid/callback",
     client_options: {
       host: tid_sign_in_endpoint_uri&.host,
@@ -66,7 +65,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     discovery: true,
     issuer: ENV["TID_SIGN_IN_ISSUER"],
     pkce: true,
-    response_type: :code,
     scope: ["email", "openid", "profile", "dqt:read"],
     send_scope_to_token_endpoint: false
   }

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -53,7 +53,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
   provider :openid_connect, {
     name: :tid,
-    provider_ignores_state: true,
     allow_authorize_params: %i[session_id trn_token],
     callback_path: "/claim/auth/tid/callback",
     client_options: {

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,7 @@
+domain = if ENV["ENVIRONMENT_NAME"] == "review"
+  ENV["CANONICAL_HOSTNAME"]
+elsif !ENV["TID_BASE_URL"].nil?
+  URI.parse(ENV["TID_BASE_URL"]).host
+end
+
+Rails.application.config.session_store :cookie_store, key: "_claim_session", domain:


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1414

On review apps we were seeing some HTTP auth errors on the Omniauth callback controller, so I have removed it from that controller only.

I have also configured the cookie domain to match the callback URL which was suggested by various people when researching the problem. On its own it did not seem to fix the problem, but I think it is better to have it than not.

I've also removed some old/redundant Omniauth configuration which are either deprecated or the same as default..

