### PR TITLE
Update dfe-analytics to v1.11.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,4 +121,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: efcd939fecbc64574a3e1d5d5efef7e14b65f39f
-  tag: v1.11.0
+  revision: e6443cbf0efd46c1d46772efab3bdb1c0d1da5eb
+  tag: v1.11.3
   specs:
-    dfe-analytics (1.11.0)
+    dfe-analytics (1.11.3)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -84,7 +84,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
     ast (2.4.2)
@@ -173,9 +173,9 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-bigquery_v2 (0.59.0)
+    google-apis-bigquery_v2 (0.61.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-core (0.11.1)
+    google-apis-core (0.11.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -190,14 +190,15 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    google-cloud-core (1.6.0)
-      google-cloud-env (~> 1.0)
+    google-cloud-core (1.6.1)
+      google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (1.6.0)
-      faraday (>= 0.17.3, < 3.0)
+    google-cloud-env (2.1.0)
+      faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.3.1)
-    googleauth (1.8.1)
-      faraday (>= 0.17.3, < 3.a)
+    googleauth (1.9.1)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
       jwt (>= 1.4, < 3.0)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
@@ -304,7 +305,7 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     puma (6.4.0)
       nio4r (~> 2.0)
     raabro (1.4.0)


### PR DESCRIPTION
Update to latest version of dfe-analytics (v1.11.3) prior to enabling the entity table check job
