### PR TITLE
CAPT-1343 no trn return from teacher id

### DIFF
--- a/app/models/dfe_identity/user_info.rb
+++ b/app/models/dfe_identity/user_info.rb
@@ -25,5 +25,10 @@ module DfeIdentity
     def self.from_params(params)
       (params || {}).slice(*attributes)
     end
+
+    def self.trn_missing?(user_info)
+      new(from_params(user_info))
+        .trn.blank?
+    end
   end
 end

--- a/app/views/claims/_reset_claim_default.html.erb
+++ b/app/views/claims/_reset_claim_default.html.erb
@@ -1,0 +1,3 @@
+<p>
+  As you have told us that the information we’ve received using your DfE Identity account is not correct, you cannot use your DfE Identity account with this service.
+</p>

--- a/app/views/claims/_reset_claim_trn_missing.html.erb
+++ b/app/views/claims/_reset_claim_trn_missing.html.erb
@@ -1,0 +1,3 @@
+<p>
+  You don’t currently have a teacher reference number (TRN) assigned to your DfE Identity account.
+</p>

--- a/app/views/claims/reset_claim.erb
+++ b/app/views/claims/reset_claim.erb
@@ -2,14 +2,20 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
-        You cannot use your DfE Identify account with this service
+        You cannot use your DfE Identity account with this service
       </h1>
-      <p>
-        As you have told us that the information we’ve received using your DfE Identity account is not correct, you cannot use your DfE Identity account with this service.
-      </p>
+
+      <%# Teacher selected YES however TRN was missing %>
+      <% if current_claim.details_check? && DfeIdentity::UserInfo.trn_missing?(current_claim.teacher_id_user_info) %>
+        <%= render partial: "claims/reset_claim_trn_missing" %>
+      <% else %>
+        <%= render partial: "claims/reset_claim_default" %>
+      <% end %>
+
       <p>
         You can continue to complete an application to check your eligibility and apply for a payment.
       </p>
+
       <%= form_with(url: claim_path(current_policy_routing_name, "current-school"), method: :get) do %>
         <div class="govuk-form-group">
           <%= hidden_field_tag :skip_landing_page, 'true' %>

--- a/app/views/claims/teacher_detail.html.erb
+++ b/app/views/claims/teacher_detail.html.erb
@@ -7,7 +7,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l"><%=t "questions.check_and_confirm_details" %></h1>
-          <p>We have used your DfE Identify account to retrieve your personal details.</p>
+          <p>We have used your DfE Identity account to retrieve your personal details.</p>
           <p>You must check that all details are correct and confirm they are correct to continue.</p>
 
           <%= render 'personal_details' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,8 +114,8 @@ en:
     decision_overdue: "Overdue"
     decision_overdue_not_applicable: "N/A"
     claim_route: "Claim route"
-    claim_route_not_tid: "Not signed in with DfE Identify"
-    claim_route_with_tid: "Signed in with DfE Identify"
+    claim_route_not_tid: "Not signed in with DfE Identity"
+    claim_route_with_tid: "Signed in with DfE Identity"
     decision:
       created_at: "Created at"
       result: "Result"

--- a/spec/features/teacher_detail_page_in_user_jouney_spec.rb
+++ b/spec/features/teacher_detail_page_in_user_jouney_spec.rb
@@ -8,15 +8,13 @@ RSpec.feature "Teacher Identity Sign in" do
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
   let(:current_academic_year) { policy_configuration.current_academic_year }
 
-  before do
-    set_mock_auth("1234567")
-  end
-
   after do
     set_mock_auth(nil)
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects yes to details confirm" do
+    set_mock_auth("1234567")
+
     visit landing_page_path(EarlyCareerPayments.routing_name)
 
     # - Landing (start)
@@ -42,6 +40,8 @@ RSpec.feature "Teacher Identity Sign in" do
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects no to details confirm" do
+    set_mock_auth("1234567")
+
     visit landing_page_path(EarlyCareerPayments.routing_name)
 
     # - Landing (start)
@@ -58,7 +58,8 @@ RSpec.feature "Teacher Identity Sign in" do
     choose "No"
     click_on "Continue"
 
-    expect(page).to have_text("You cannot use your DfE Identify account with this service")
+    expect(page).to have_text("You cannot use your DfE Identity account with this service")
+    expect(page).to have_text("As you have told us that the information we’ve received using your DfE Identity account is not correct, you cannot use your DfE Identity account with this service.")
     expect(page).to have_text("You can continue to complete an application to check your eligibility and apply for a payment.")
 
     click_on "Continue"
@@ -68,5 +69,18 @@ RSpec.feature "Teacher Identity Sign in" do
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
     expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+  end
+
+  scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects yes to details confirm but trn missing" do
+    set_mock_auth("1234567", {returned_trn: nil})
+
+    visit landing_page_path(EarlyCareerPayments.routing_name)
+    click_on "Start now"
+    click_on "Continue with DfE Identity"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text("You cannot use your DfE Identity account with this service")
+    expect(page).to have_text("You don’t currently have a teacher reference number (TRN) assigned to your DfE Identity account.")
   end
 end

--- a/spec/features/teacher_detail_page_student_loans_journey_spec.rb
+++ b/spec/features/teacher_detail_page_student_loans_journey_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     choose "No"
     click_on "Continue"
 
-    expect(page).to have_text("You cannot use your DfE Identify account with this service")
+    expect(page).to have_text("You cannot use your DfE Identity account with this service")
     expect(page).to have_text("You can continue to complete an application to check your eligibility and apply for a payment.")
 
     click_on "Continue"

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -100,7 +100,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
 
       expect(page).to have_content("– Approved")
       expect(page).to have_content("Approved awaiting payroll")
-      expect(page).to have_content("Not signed in with DfE Identify")
+      expect(page).to have_content("Not signed in with DfE Identity")
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       find("a[href='#{admin_claim_tasks_path(claim_logged_in_with_tid)}']").click
 
       expect(page).to have_content("Claim route")
-      expect(page).to have_content("Signed in with DfE Identify")
+      expect(page).to have_content("Signed in with DfE Identity")
     end
   end
 

--- a/spec/support/omniauth_mock_helper.rb
+++ b/spec/support/omniauth_mock_helper.rb
@@ -6,7 +6,7 @@ module OmniauthMockHelper
       OmniAuth::AuthHash.new(
         "extra" => {
           "raw_info" => {
-            "trn" => trn,
+            "trn" => opts.key?(:returned_trn) ? opts[:returned_trn] : trn,
             "birthdate" => "1940-01-01",
             "given_name" => "Kelsie",
             "family_name" => "Oberbrunner",


### PR DESCRIPTION
If the teacher says the details aren't correct "No" we land on `reset-claim`.

If the teacher selects "Yes" but the TRN is missing from Teacher ID we still land on `reset-claim` but the message is specifically giving the reason the TRN is missing from DfE Identity and to continue with the non Teacher ID route.