### PR TITLE
CAPT-1317 - auto-fill qualifications from DQT record

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,8 +5,7 @@ DFE_SIGN_IN_IDENTIFIER=teacherpayments
 DFE_SIGN_IN_API_CLIENT_ID=teacherpayments
 DFE_SIGN_IN_API_ENDPOINT=https://pp-api.signin.education.gov.uk
 
-DQT_API_URL=https://teacher-qualifications-api.education.gov.uk/
-DQT_API_KEY=1a2b3c4d5e6f7g8h9i0
+DQT_API_URL=https://preprod.teacher-qualifications-api.education.gov.uk/v1
 
 ADMIN_ALLOWED_IPS=::1,127.0.0.1
 ENVIRONMENT_NAME=local

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -303,8 +303,8 @@ class ClaimsController < BasePublicController
   end
 
   # NOTE: needs to be done before the slug_sequence is generated.
-  # `logged_in_with_tid: nil` means the user had pressed "Continue without signing in", reset it to `false`.
-  # `logged_in_with_tid: nil` is used to reject "teacher-details" from the slug_sequence.
+  # `logged_in_with_tid: false` means the user had pressed "Continue without signing in", reset it to `true`.
+  # `logged_in_with_tid: false` is used to reject "teacher-details" and "qualification-details" from the slug_sequence.
   # Handles user somehow using Back button to go back and choose "Continue with DfE Identity" option.
   # Or they sign in a second time, `details_check` needs resetting in case details are different.
   def check_and_reset_if_new_tid_user_info

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -367,7 +367,7 @@ class ClaimsController < BasePublicController
 
   def set_dqt_data_as_answers
     current_claim.attributes = claim_params
-    current_claim.claims.each {|claim| claim.eligibility.set_qualifications_from_dqt_record }
+    current_claim.claims.each { |claim| claim.eligibility.set_qualifications_from_dqt_record }
   end
 
   def policy_configuration

--- a/app/helpers/claims/itt_subject_helper.rb
+++ b/app/helpers/claims/itt_subject_helper.rb
@@ -52,7 +52,7 @@ module Claims
     # Often the DQT record will represent subject names in all lowercase
     def dqt_subjects_playback(claim)
       claim.dqt_teacher_record.itt_subjects.map do |subject|
-        subject.downcase == subject ? subject.titleize : subject
+        (subject.downcase == subject) ? subject.titleize : subject
       end.join(", ")
     end
   end

--- a/app/helpers/claims/itt_subject_helper.rb
+++ b/app/helpers/claims/itt_subject_helper.rb
@@ -48,5 +48,12 @@ module Claims
         .to_sentence(last_word_connector: " or ")
         .downcase
     end
+
+    # Often the DQT record will represent subject names in all lowercase
+    def dqt_subjects_playback(claim)
+      claim.dqt_teacher_record.itt_subjects.map do |subject|
+        subject.downcase == subject ? subject.titleize : subject
+      end.join(", ")
+    end
   end
 end

--- a/app/jobs/claim_verifier_job.rb
+++ b/app/jobs/claim_verifier_job.rb
@@ -2,7 +2,7 @@ class ClaimVerifierJob < ApplicationJob
   def perform(claim)
     AutomatedChecks::ClaimVerifier.new(
       claim:,
-      dqt_teacher_status: Dqt::Client.new.teacher.find(
+      dqt_teacher_status: claim.has_dqt_record? ? Dqt::Teacher.new(claim.dqt_teacher_status) : Dqt::Client.new.teacher.find(
         claim.teacher_reference_number,
         birthdate: claim.date_of_birth.to_s,
         nino: claim.national_insurance_number

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -212,7 +212,7 @@ class Claim < ApplicationRecord
     if: -> { surname.present? }
 
   validates :details_check, on: [:"teacher-detail"], inclusion: {in: [true, false], message: "Select an option to whether the details are correct or not"}
-  validates :qualifications_details_check, on: [:"qualification-details"], inclusion: {in: [true, false], message: "Select an option to whether the details are correct or not"}
+  validates :qualifications_details_check, on: [:"qualification-details"], inclusion: {in: [true, false], message: "Select yes if your qualification details are correct"}
   validates :email_address_check, on: [:"select-email"], inclusion: {in: [true, false], message: "Select an option to indicate whether the email is correct or not"}
   validates :mobile_check, on: [:"select-mobile"], inclusion: {in: ["use", "alternative", "declined"], message: "Select an option to indicate whether the mobile number is correct or not"}
   validates :address_line_1, on: [:address], presence: {message: "Enter a house number or name"}, if: :has_ecp_or_lupp_policy?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -112,7 +112,8 @@ class Claim < ApplicationRecord
     mobile_check: true,
     qa_required: false,
     qa_completed_at: false,
-    qualifications_details_check: true
+    qualifications_details_check: true,
+    dqt_teacher_status: false
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks
@@ -622,8 +623,12 @@ class Claim < ApplicationRecord
     logged_in_with_tid? && teacher_reference_number.present? && has_recent_tps_school?
   end
 
-  def has_no_dqt_record?
-    dqt_teacher_status == {}
+  def has_dqt_record?
+    !dqt_teacher_status.blank?
+  end
+
+  def dqt_teacher_record
+    policy::DqtRecord.new(Dqt::Teacher.new(dqt_teacher_status), self) if has_dqt_record?
   end
 
   private

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -40,7 +40,8 @@ class Claim < ApplicationRecord
     :logged_in_with_tid,
     :details_check,
     :email_address_check,
-    :mobile_check
+    :mobile_check,
+    :qualifications_details_check
   ].freeze
   AMENDABLE_ATTRIBUTES = %i[
     teacher_reference_number
@@ -110,7 +111,8 @@ class Claim < ApplicationRecord
     email_address_check: true,
     mobile_check: true,
     qa_required: false,
-    qa_completed_at: false
+    qa_completed_at: false,
+    qualifications_details_check: true
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks
@@ -209,6 +211,7 @@ class Claim < ApplicationRecord
     if: -> { surname.present? }
 
   validates :details_check, on: [:"teacher-detail"], inclusion: {in: [true, false], message: "Select an option to whether the details are correct or not"}
+  validates :qualifications_details_check, on: [:"qualification-details"], inclusion: {in: [true, false], message: "Select an option to whether the details are correct or not"}
   validates :email_address_check, on: [:"select-email"], inclusion: {in: [true, false], message: "Select an option to indicate whether the email is correct or not"}
   validates :mobile_check, on: [:"select-mobile"], inclusion: {in: ["use", "alternative", "declined"], message: "Select an option to indicate whether the mobile number is correct or not"}
   validates :address_line_1, on: [:address], presence: {message: "Enter a house number or name"}, if: :has_ecp_or_lupp_policy?
@@ -617,6 +620,10 @@ class Claim < ApplicationRecord
 
   def logged_in_with_tid_and_has_recent_tps_school?
     logged_in_with_tid? && teacher_reference_number.present? && has_recent_tps_school?
+  end
+
+  def has_no_dqt_record?
+    dqt_teacher_status == {}
   end
 
   private

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -102,6 +102,10 @@ class CurrentClaim
     claims.all? { |c| c.persisted? }
   end
 
+  def has_no_dqt_data_for_claim?
+    claims.all? { |c| !c.has_dqt_record? || c.dqt_teacher_record&.has_no_data_for_claim? }
+  end
+
   # Non-combined journey code like Student Loans should really
   # be using `eligibility_status` instead of this.
   def ineligible?

--- a/app/models/dfe_identity/claim_user_details_reset.rb
+++ b/app/models/dfe_identity/claim_user_details_reset.rb
@@ -27,14 +27,14 @@ module DfeIdentity
           teacher_reference_number: "",
           date_of_birth: nil,
           national_insurance_number: "",
-          logged_in_with_tid: nil,
+          logged_in_with_tid: false,
           details_check: nil,
           teacher_id_user_info: {}
         )
       when :new_user_info
         @claim.update(
           details_check: nil,
-          logged_in_with_tid: false
+          logged_in_with_tid: true
         )
       end
     end

--- a/app/models/dfe_identity/claim_user_details_updater.rb
+++ b/app/models/dfe_identity/claim_user_details_updater.rb
@@ -18,7 +18,8 @@ module DfeIdentity
         teacher_reference_number: user_info["trn"],
         date_of_birth: user_info["birthdate"],
         national_insurance_number: user_info["ni_number"],
-        logged_in_with_tid: true
+        logged_in_with_tid: true,
+        dqt_teacher_status: nil
       )
     end
   end

--- a/app/models/dfe_identity/claim_user_details_updater.rb
+++ b/app/models/dfe_identity/claim_user_details_updater.rb
@@ -10,17 +10,24 @@ module DfeIdentity
 
     def update_with_teacher_id_user_info
       user_info = @claim.teacher_id_user_info
-      return unless UserInfo.validated?(user_info)
 
-      @claim.update(
-        first_name: user_info["given_name"],
-        surname: user_info["family_name"],
-        teacher_reference_number: user_info["trn"],
-        date_of_birth: user_info["birthdate"],
-        national_insurance_number: user_info["ni_number"],
-        logged_in_with_tid: true,
-        dqt_teacher_status: nil
-      )
+      if UserInfo.validated?(user_info)
+        @claim.update(
+          first_name: user_info["given_name"],
+          surname: user_info["family_name"],
+          teacher_reference_number: user_info["trn"],
+          date_of_birth: user_info["birthdate"],
+          national_insurance_number: user_info["ni_number"],
+          logged_in_with_tid: true,
+          dqt_teacher_status: nil
+        )
+      else
+        @claim.update(
+          logged_in_with_tid: true,
+          details_check: false,
+          dqt_teacher_status: nil
+        )
+      end
     end
   end
 end

--- a/app/models/dqt/retrieve_claim_qualifications_data.rb
+++ b/app/models/dqt/retrieve_claim_qualifications_data.rb
@@ -1,0 +1,34 @@
+module Dqt
+  class RetrieveClaimQualificationsData
+    def self.call(claim)
+      new(claim).save_qualifications_result
+    end
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def save_qualifications_result
+      return if @claim.dqt_teacher_status
+
+      begin
+        # {} would indicate nothing was found in DQT but also truthy to prevent further requests
+        @claim.update(dqt_teacher_status: response || {})
+      rescue
+        # Something went wrong with the DQT call, just assume no result returned and continue
+        Rollbar.error(e)
+        @claim.update(dqt_teacher_status: {})
+      end
+    end
+
+    private
+
+    def response
+      Dqt::Client.new.teacher.find_raw(
+        @claim.teacher_reference_number,
+        birthdate: @claim.date_of_birth.to_s,
+        nino: @claim.national_insurance_number
+      )
+    end
+  end
+end

--- a/app/models/early_career_payments/dqt_record.rb
+++ b/app/models/early_career_payments/dqt_record.rb
@@ -40,8 +40,8 @@ module EarlyCareerPayments
       itt_subjects.delete_if do |itt_subject|
         !itt_subject.to_sym.in?(itt_subject_checker.current_and_future_subject_symbols(claim.policy))
       end.first.to_sym
-    rescue StandardError # JourneySubjectEligibilityChecker can also raise an exception if itt_year is out of eligible range
-      return :none_of_the_above
+    rescue # JourneySubjectEligibilityChecker can also raise an exception if itt_year is out of eligible range
+      :none_of_the_above
     end
 
     def itt_academic_year_for_claim

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -152,6 +152,14 @@ module EarlyCareerPayments
         !LevellingUpPremiumPayments::SchoolEligibility.new(claim.eligibility.current_school).eligible?
     end
 
+    def set_qualifications_from_dqt_record
+      self.attributes = {
+        itt_academic_year: claim.qualifications_details_check ? claim.dqt_teacher_record.itt_academic_year_for_claim : nil,
+        eligible_itt_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_itt_subject_for_claim : nil,
+        qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil,
+      }
+    end
+
     private
 
     def calculate_award_amount

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -156,7 +156,7 @@ module EarlyCareerPayments
       self.attributes = {
         itt_academic_year: claim.qualifications_details_check ? claim.dqt_teacher_record.itt_academic_year_for_claim : nil,
         eligible_itt_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_itt_subject_for_claim : nil,
-        qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil,
+        qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil
       }
     end
 

--- a/app/models/early_career_payments/eligibility.rb
+++ b/app/models/early_career_payments/eligibility.rb
@@ -131,7 +131,16 @@ module EarlyCareerPayments
     def reset_dependent_answers(reset_attrs = [])
       attrs = ineligible? ? changed.concat(reset_attrs) : changed
 
-      ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
+      dependencies = ATTRIBUTE_DEPENDENCIES.dup
+
+      # If some data was derived from DQT we do not want to reset these.
+      if claim.qualifications_details_check
+        dependencies.delete("qualification")
+        dependencies.delete("eligible_itt_subject")
+        dependencies.delete("itt_academic_year")
+      end
+
+      dependencies.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
           write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
         end
@@ -154,9 +163,9 @@ module EarlyCareerPayments
 
     def set_qualifications_from_dqt_record
       self.attributes = {
-        itt_academic_year: claim.qualifications_details_check ? claim.dqt_teacher_record.itt_academic_year_for_claim : nil,
-        eligible_itt_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_itt_subject_for_claim : nil,
-        qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil
+        itt_academic_year: claim.qualifications_details_check ? (claim.dqt_teacher_record&.itt_academic_year_for_claim || itt_academic_year) : nil,
+        eligible_itt_subject: claim.qualifications_details_check ? (claim.dqt_teacher_record&.eligible_itt_subject_for_claim || eligible_itt_subject) : nil,
+        qualification: claim.qualifications_details_check ? (claim.dqt_teacher_record&.route_into_teaching || qualification) : nil
       }
     end
 

--- a/app/models/early_career_payments/eligibility_answers_presenter.rb
+++ b/app/models/early_career_payments/eligibility_answers_presenter.rb
@@ -30,12 +30,10 @@ module EarlyCareerPayments
         a << subject_to_formal_performance_action
         a << subject_to_disciplinary_action
 
-        unless eligibility.claim.qualifications_details_check
-          a << qualification
-          a << itt_academic_year
-          a << eligible_itt_subject
-          a << eligible_degree_subject
-        end
+        a << qualification
+        a << itt_academic_year
+        a << eligible_itt_subject
+        a << eligible_degree_subject
 
         a << teaching_subject_now
       end.compact
@@ -108,6 +106,8 @@ module EarlyCareerPayments
     end
 
     def qualification
+      return if eligibility.claim.qualifications_details_check && eligibility.claim.dqt_teacher_record&.route_into_teaching
+
       [
         translate("early_career_payments.questions.qualification.heading"),
         translate("early_career_payments.answers.qualification.#{eligibility.qualification}"),
@@ -116,6 +116,8 @@ module EarlyCareerPayments
     end
 
     def eligible_itt_subject
+      return if eligibility.claim.qualifications_details_check && eligibility.claim.dqt_teacher_record&.eligible_itt_subject_for_claim
+
       [
         eligible_itt_subject_translation(CurrentClaim.new(claims: [eligibility.claim])),
         text_for_subject_answer,
@@ -124,7 +126,7 @@ module EarlyCareerPayments
     end
 
     def eligible_degree_subject
-      return unless (eligibility.respond_to? :eligible_degree_subject) && eligibility.eligible_degree_subject?
+      return if !eligibility.respond_to?(:eligible_degree_subject) || !eligibility.eligible_degree_subject? || (eligibility.claim.qualifications_details_check && eligibility.claim.dqt_teacher_record&.eligible_degree_code?)
 
       [
         translate("early_career_payments.questions.eligible_degree_subject"),
@@ -142,6 +144,8 @@ module EarlyCareerPayments
     end
 
     def itt_academic_year
+      return if eligibility.claim.qualifications_details_check && eligibility.claim.dqt_teacher_record&.itt_academic_year_for_claim
+
       [
         I18n.t("early_career_payments.questions.itt_academic_year.qualification.#{eligibility.qualification}"),
         eligibility.itt_academic_year.to_s.gsub("/", " - "),

--- a/app/models/early_career_payments/eligibility_answers_presenter.rb
+++ b/app/models/early_career_payments/eligibility_answers_presenter.rb
@@ -29,10 +29,14 @@ module EarlyCareerPayments
         a << employed_directly if eligibility.employed_as_supply_teacher?
         a << subject_to_formal_performance_action
         a << subject_to_disciplinary_action
-        a << qualification
-        a << itt_academic_year
-        a << eligible_itt_subject
-        a << eligible_degree_subject
+
+        unless eligibility.claim.qualifications_details_check
+          a << qualification
+          a << itt_academic_year
+          a << eligible_itt_subject
+          a << eligible_degree_subject
+        end
+
         a << teaching_subject_now
       end.compact
     end

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -165,12 +165,16 @@ module EarlyCareerPayments
 
         sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
 
-        if claim.logged_in_with_tid? && claim.qualifications_details_check
-          sequence.delete("qualification") if claim.eligibility.qualification
-          sequence.delete("itt-year") if claim.eligibility.itt_academic_year
-          sequence.delete("eligible-itt-subject") if claim.eligibility.eligible_itt_subject
-          sequence.delete("eligible-degree-subject") if claim.eligibility.respond_to?(:eligible_degree_subject) && claim.eligibility.eligible_degree_subject
-        elsif claim.dqt_teacher_status && claim.dqt_teacher_status.empty?
+        if claim.logged_in_with_tid?
+          if claim.qualifications_details_check
+            sequence.delete("qualification") if claim.eligibility.qualification
+            sequence.delete("itt-year") if claim.eligibility.itt_academic_year
+            sequence.delete("eligible-itt-subject") if claim.eligibility.eligible_itt_subject
+            sequence.delete("eligible-degree-subject") if claim.eligibility.respond_to?(:eligible_degree_subject) && claim.eligibility.eligible_degree_subject
+          elsif claim.dqt_teacher_status && claim.dqt_teacher_status.empty?
+            sequence.delete("qualification-details")
+          end
+        elsif claim.logged_in_with_tid == false
           sequence.delete("qualification-details")
         end
       end

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -106,16 +106,16 @@ module EarlyCareerPayments
           sequence.delete("select-mobile")
         end
 
-        sequence.delete("teacher-detail") if claim.logged_in_with_tid.nil?
-        sequence.delete("reset-claim") if [nil, true].include?(claim.logged_in_with_tid)
+        sequence.delete("teacher-detail") unless claim.logged_in_with_tid?
+        sequence.delete("reset-claim") if (!claim.logged_in_with_tid? && claim.details_check.nil?) || claim.details_check?
 
-        sequence.delete("select-email") if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["email"].nil?
+        sequence.delete("select-email") if (claim.logged_in_with_tid == false) || claim.teacher_id_user_info["email"].nil?
         if claim.logged_in_with_tid? && claim.email_address_check
           sequence.delete("email-address")
           sequence.delete("email-verification")
         end
 
-        if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["phone_number"].nil?
+        if (claim.logged_in_with_tid == false) || claim.teacher_id_user_info["phone_number"].nil?
           sequence.delete("select-mobile")
         else
           sequence.delete("provide-mobile-number")
@@ -175,7 +175,7 @@ module EarlyCareerPayments
           elsif claim.dqt_teacher_status && claim.dqt_teacher_status.empty?
             sequence.delete("qualification-details")
           end
-        elsif claim.logged_in_with_tid == false
+        else
           sequence.delete("qualification-details")
         end
       end

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -22,6 +22,7 @@ module EarlyCareerPayments
       "entire-term-contract",
       "employed-directly",
       "poor-performance",
+      "qualification-details",
       "qualification",
       "itt-year",
       "eligible-itt-subject",
@@ -163,6 +164,11 @@ module EarlyCareerPayments
         end
 
         sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
+
+        sequence.delete("qualification-details") if !claim.logged_in_with_tid? || claim.has_no_dqt_record?
+
+        # TODO: "qualification", "itt-year", "eligible-itt-subject", "eligible-degree-subject" will need deleting if DQT has that information from "qualification-details" step
+        # Not too sure on "eligible-degree-subject" with the trainee option.
       end
     end
 

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -100,6 +100,7 @@ module EarlyCareerPayments
           sequence.delete("sign-in-or-continue")
           sequence.delete("teacher-detail")
           sequence.delete("reset-claim")
+          sequence.delete("qualification-details")
           sequence.delete("correct-school")
           sequence.delete("select-email")
           sequence.delete("select-mobile")

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -166,13 +166,13 @@ module EarlyCareerPayments
 
         sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
 
-        if claim.logged_in_with_tid?
+        if claim.logged_in_with_tid? && claim.details_check?
           if claim.qualifications_details_check
-            sequence.delete("qualification") if claim.eligibility.qualification
-            sequence.delete("itt-year") if claim.eligibility.itt_academic_year
-            sequence.delete("eligible-itt-subject") if claim.eligibility.eligible_itt_subject
-            sequence.delete("eligible-degree-subject") if claim.eligibility.respond_to?(:eligible_degree_subject) && claim.eligibility.eligible_degree_subject
-          elsif claim.dqt_teacher_status && claim.dqt_teacher_status.empty?
+            sequence.delete("qualification") if claim.dqt_teacher_record&.route_into_teaching
+            sequence.delete("itt-year") if claim.dqt_teacher_record&.itt_academic_year_for_claim
+            sequence.delete("eligible-itt-subject") if claim.dqt_teacher_record&.eligible_itt_subject_for_claim
+            sequence.delete("eligible-degree-subject") if claim.for_policy(LevellingUpPremiumPayments)&.dqt_teacher_record&.eligible_degree_code?
+          elsif claim.dqt_teacher_status && (!claim.has_dqt_record? || claim.has_no_dqt_data_for_claim?)
             sequence.delete("qualification-details")
           end
         else

--- a/app/models/early_career_payments/slug_sequence.rb
+++ b/app/models/early_career_payments/slug_sequence.rb
@@ -165,10 +165,14 @@ module EarlyCareerPayments
 
         sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
 
-        sequence.delete("qualification-details") if !claim.logged_in_with_tid? || claim.has_no_dqt_record?
-
-        # TODO: "qualification", "itt-year", "eligible-itt-subject", "eligible-degree-subject" will need deleting if DQT has that information from "qualification-details" step
-        # Not too sure on "eligible-degree-subject" with the trainee option.
+        if claim.logged_in_with_tid? && claim.qualifications_details_check
+          sequence.delete("qualification") if claim.eligibility.qualification
+          sequence.delete("itt-year") if claim.eligibility.itt_academic_year
+          sequence.delete("eligible-itt-subject") if claim.eligibility.eligible_itt_subject
+          sequence.delete("eligible-degree-subject") if claim.eligibility.respond_to?(:eligible_degree_subject) && claim.eligibility.eligible_degree_subject
+        elsif claim.dqt_teacher_status && claim.dqt_teacher_status.empty?
+          sequence.delete("qualification-details")
+        end
       end
     end
 

--- a/app/models/levelling_up_premium_payments/dqt_record.rb
+++ b/app/models/levelling_up_premium_payments/dqt_record.rb
@@ -34,6 +34,19 @@ module LevellingUpPremiumPayments
       eligible_codes? || (eligible_subject? && no_invalid_subject_codes?)
     end
 
+    def eligible_degree_code?
+      eligible_code?(degree_codes)
+    end
+
+    def eligible_itt_subject_for_claim
+      (JourneySubjectEligibilityChecker.fixed_lup_subject_symbols & itt_subjects.map(&:to_sym)).first || :none_of_the_above
+    end
+
+    def itt_academic_year_for_claim
+      year = AcademicYear.for(academic_date)
+      itt_year_within_allowed_range?(year) ? year : AcademicYear.new
+    end
+
     private
 
     attr_reader :record, :claim
@@ -43,7 +56,7 @@ module LevellingUpPremiumPayments
     end
 
     def eligible_codes?
-      eligible_code?(itt_subject_codes) || eligible_code?(degree_codes)
+      eligible_code?(itt_subject_codes) || eligible_degree_code?
     end
 
     def eligible_subject_and_none_of_the_above?
@@ -59,12 +72,6 @@ module LevellingUpPremiumPayments
       itt_year_within_allowed_range?
     end
 
-    def itt_year_within_allowed_range?
-      policy_year = PolicyConfiguration.for(claim.policy).current_academic_year
-      eligible_itt_years = JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_year)
-      eligible_itt_years.include?(itt_year)
-    end
-
     def applicable_eligible_subjects
       return ELIGIBLE_ITT_SUBJECTS.values.flatten if claim.eligibility.itt_subject_none_of_the_above?
 
@@ -77,6 +84,12 @@ module LevellingUpPremiumPayments
 
     def no_invalid_subject_codes?
       (itt_subject_codes - ELIGIBLE_CODES).empty?
+    end
+
+    def itt_year_within_allowed_range?(year = itt_year)
+      policy_year = PolicyConfiguration.for(claim.policy).current_academic_year
+      eligible_itt_years = JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_year)
+      eligible_itt_years.include?(year)
     end
   end
 end

--- a/app/models/levelling_up_premium_payments/dqt_record.rb
+++ b/app/models/levelling_up_premium_payments/dqt_record.rb
@@ -39,12 +39,20 @@ module LevellingUpPremiumPayments
     end
 
     def eligible_itt_subject_for_claim
+      return nil if itt_subjects.empty?
+
       (JourneySubjectEligibilityChecker.fixed_lup_subject_symbols & itt_subjects.map(&:to_sym)).first || :none_of_the_above
     end
 
     def itt_academic_year_for_claim
+      return nil unless academic_date
+
       year = AcademicYear.for(academic_date)
       itt_year_within_allowed_range?(year) ? year : AcademicYear.new
+    end
+
+    def has_no_data_for_claim?
+      !eligible_itt_subject_for_claim && !itt_academic_year_for_claim && !route_into_teaching && !eligible_degree_code?
     end
 
     private

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -115,6 +115,15 @@ module LevellingUpPremiumPayments
       end
     end
 
+    def set_qualifications_from_dqt_record
+      self.attributes = {
+        itt_academic_year: claim.qualifications_details_check ? claim.dqt_teacher_record.itt_academic_year_for_claim : nil,
+        eligible_itt_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_itt_subject_for_claim : nil,
+        qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil,
+        eligible_degree_subject: claim.qualifications_details_check ?  claim.dqt_teacher_record.eligible_degree_code? : nil
+      }
+    end
+
     private
 
     def indicated_ecp_only_itt_subject?

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -89,7 +89,16 @@ module LevellingUpPremiumPayments
     def reset_dependent_answers(reset_attrs = [])
       attrs = ineligible? ? changed.concat(reset_attrs) : changed
 
-      ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
+      dependencies = ATTRIBUTE_DEPENDENCIES.dup
+
+      # If some data was derived from DQT we do not want to reset these.
+      if claim.qualifications_details_check
+        dependencies.delete("qualification")
+        dependencies.delete("eligible_itt_subject")
+        dependencies.delete("itt_academic_year")
+      end
+
+      dependencies.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|
           write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
         end
@@ -117,10 +126,10 @@ module LevellingUpPremiumPayments
 
     def set_qualifications_from_dqt_record
       self.attributes = {
-        itt_academic_year: claim.qualifications_details_check ? claim.dqt_teacher_record.itt_academic_year_for_claim : nil,
-        eligible_itt_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_itt_subject_for_claim : nil,
-        qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil,
-        eligible_degree_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_degree_code? : nil
+        itt_academic_year: claim.qualifications_details_check ? (claim.dqt_teacher_record&.itt_academic_year_for_claim || itt_academic_year) : nil,
+        eligible_itt_subject: claim.qualifications_details_check ? (claim.dqt_teacher_record&.eligible_itt_subject_for_claim || eligible_itt_subject) : nil,
+        qualification: claim.qualifications_details_check ? (claim.dqt_teacher_record&.route_into_teaching || qualification) : nil,
+        eligible_degree_subject: claim.qualifications_details_check ? (claim.dqt_teacher_record&.eligible_degree_code? || eligible_degree_subject) : nil
       }
     end
 

--- a/app/models/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/levelling_up_premium_payments/eligibility.rb
@@ -120,7 +120,7 @@ module LevellingUpPremiumPayments
         itt_academic_year: claim.qualifications_details_check ? claim.dqt_teacher_record.itt_academic_year_for_claim : nil,
         eligible_itt_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_itt_subject_for_claim : nil,
         qualification: claim.qualifications_details_check ? claim.dqt_teacher_record.route_into_teaching : nil,
-        eligible_degree_subject: claim.qualifications_details_check ?  claim.dqt_teacher_record.eligible_degree_code? : nil
+        eligible_degree_subject: claim.qualifications_details_check ? claim.dqt_teacher_record.eligible_degree_code? : nil
       }
     end
 

--- a/app/models/student_loans/dqt_record.rb
+++ b/app/models/student_loans/dqt_record.rb
@@ -11,6 +11,8 @@ module StudentLoans
   #   qts_award_date: The date the teacher achieved qualified
   #                   teacher status.
   class DqtRecord
+    include Dqt::Matchers::General
+
     delegate(
       :qts_award_date,
       :itt_subjects,

--- a/app/models/student_loans/dqt_record.rb
+++ b/app/models/student_loans/dqt_record.rb
@@ -38,6 +38,10 @@ module StudentLoans
       qts_award_date.present? && AcademicYear.for(qts_award_date) >= StudentLoans.first_eligible_qts_award_year
     end
 
+    def has_no_data_for_claim?
+      !qts_award_date
+    end
+
     private
 
     attr_reader :record

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -121,7 +121,7 @@ module StudentLoans
     end
 
     def set_qualifications_from_dqt_record
-      self.qts_award_year = if claim.qualifications_details_check
+      self.qts_award_year = if claim.qualifications_details_check && claim.dqt_teacher_record&.qts_award_date
         claim.dqt_teacher_record.eligible_qts_award_date? ? :on_or_after_cut_off_date : :before_cut_off_date
       end
     end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -123,8 +123,6 @@ module StudentLoans
     def set_qualifications_from_dqt_record
       self.qts_award_year = if claim.qualifications_details_check
         claim.dqt_teacher_record.eligible_qts_award_date? ? :on_or_after_cut_off_date : :before_cut_off_date
-      else
-        nil
       end
     end
 

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -120,6 +120,14 @@ module StudentLoans
       I18n.t("student_loans.questions.claim_school_select_error", financial_year: StudentLoans.current_financial_year)
     end
 
+    def set_qualifications_from_dqt_record
+      self.qts_award_year = if claim.qualifications_details_check
+        claim.dqt_teacher_record.eligible_qts_award_date? ? :on_or_after_cut_off_date : :before_cut_off_date
+      else
+        nil
+      end
+    end
+
     private
 
     def ineligible_claim_school?

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -21,7 +21,7 @@ module StudentLoans
     # [2]: slug for changing the answer.
     def answers
       [].tap do |a|
-        a << qts_award_year
+        a << qts_award_year unless eligibility.claim.qualifications_details_check
         a << claim_school
         a << current_school
         a << subjects_taught

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -85,6 +85,7 @@ module StudentLoans
           sequence.delete("sign-in-or-continue")
           sequence.delete("teacher-detail")
           sequence.delete("reset-claim")
+          sequence.delete("qualification-details")
           sequence.delete("select-email")
           sequence.delete("select-mobile")
         end

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -127,10 +127,10 @@ module StudentLoans
         sequence.delete("claim-school") if claim.eligibility.claim_school_somewhere_else == false
         sequence.delete("teacher-reference-number") if claim.logged_in_with_tid? && claim.teacher_reference_number.present?
 
-        if claim.logged_in_with_tid?
+        if claim.logged_in_with_tid? && claim.details_check?
           if claim.qualifications_details_check
-            sequence.delete("qts-year") if claim.eligibility.qts_award_year
-          elsif claim.dqt_teacher_status && !claim.has_dqt_record?
+            sequence.delete("qts-year") if claim.dqt_teacher_record&.qts_award_date
+          elsif claim.dqt_teacher_status && (!claim.has_dqt_record? || claim.has_no_dqt_data_for_claim?)
             sequence.delete("qualification-details")
           end
         else

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -13,6 +13,7 @@ module StudentLoans
       "sign-in-or-continue",
       "teacher-detail",
       "reset-claim",
+      "qualification-details",
       "qts-year",
       "select-claim-school",
       "claim-school",
@@ -124,6 +125,16 @@ module StudentLoans
         end
         sequence.delete("claim-school") if claim.eligibility.claim_school_somewhere_else == false
         sequence.delete("teacher-reference-number") if claim.logged_in_with_tid? && claim.teacher_reference_number.present?
+
+        if claim.logged_in_with_tid?
+          if claim.qualifications_details_check
+            sequence.delete("qts-year") if claim.eligibility.qts_award_year
+          elsif claim.dqt_teacher_status && !claim.has_dqt_record?
+            sequence.delete("qualification-details")
+          end
+        elsif claim.logged_in_with_tid == false
+          sequence.delete("qualification-details")
+        end
       end
     end
   end

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -90,8 +90,8 @@ module StudentLoans
           sequence.delete("select-mobile")
         end
 
-        sequence.delete("teacher-detail") if claim.logged_in_with_tid.nil?
-        sequence.delete("reset-claim") if [nil, true].include?(claim.logged_in_with_tid)
+        sequence.delete("teacher-detail") unless claim.logged_in_with_tid?
+        sequence.delete("reset-claim") if (!claim.logged_in_with_tid? && claim.details_check.nil?) || claim.details_check?
         sequence.delete("current-school") if claim.eligibility.employed_at_claim_school? || claim.eligibility.employed_at_recent_tps_school?
         sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
         sequence.delete("student-loan-country") if claim.no_student_loan?
@@ -106,13 +106,13 @@ module StudentLoans
         sequence.delete("mobile-verification") if claim.provide_mobile_number == false
         sequence.delete("ineligible") unless claim.eligibility&.ineligible?
         sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
-        sequence.delete("select-email") if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["email"].nil?
+        sequence.delete("select-email") if (claim.logged_in_with_tid == false) || claim.teacher_id_user_info["email"].nil?
         if claim.logged_in_with_tid? && claim.email_address_check?
           sequence.delete("email-address")
           sequence.delete("email-verification")
         end
 
-        if [nil, false].include?(claim.logged_in_with_tid) || claim.teacher_id_user_info["phone_number"].nil?
+        if (claim.logged_in_with_tid == false) || claim.teacher_id_user_info["phone_number"].nil?
           sequence.delete("select-mobile")
         else
           sequence.delete("provide-mobile-number")
@@ -133,7 +133,7 @@ module StudentLoans
           elsif claim.dqt_teacher_status && !claim.has_dqt_record?
             sequence.delete("qualification-details")
           end
-        elsif claim.logged_in_with_tid == false
+        else
           sequence.delete("qualification-details")
         end
       end

--- a/app/views/claims/qualification_details.html.erb
+++ b/app/views/claims/qualification_details.html.erb
@@ -1,0 +1,71 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { details_check: "qualifications_details_check_true" }) if current_claim.errors.any? %>
+  </div>
+</div>
+
+<div class="govuk-body" id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Check and confirm your qualification details</h1>
+
+      <div class="personal-details-section">
+        <h2 class="govuk-heading-m">Qualification details</h2>
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Teacher route taken</dt>
+            <dd class="govuk-summary-list__value">
+              [PLACEHOLDER] Undergraduate initial teacher training (ITT)
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Academic year you completed your undergraduate initial teacher training (ITT)</dt>
+            <dd class="govuk-summary-list__value">
+              [PLACEHOLDER] 2021-2022
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Subject you did your undergraduate initial teacher training (ITT) in</dt>
+            <dd class="govuk-summary-list__value">
+              [PLACEHOLDER] Mathematics
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+  <%= form_for current_claim, url: path_for_form do |form| %>
+    <%= form.hidden_field :qualifications_details_check %>
+    <%= form_group_tag current_claim do %>
+
+    <div class="govuk-radios">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Are these details correct?</legend>
+
+        <%= errors_tag current_claim, :qualifications_details_check %>
+
+        <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:qualifications_details_check, true, class: "govuk-radios__input") %>
+            <%= form.label :qualifications_details_check_true, "Yes", class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+          <%= form.radio_button(:qualifications_details_check, false, class: "govuk-radios__input") %>
+          <%= form.label :qualifications_details_check_false, "No", class: "govuk-label govuk-radios__label" %>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+  <% end %>
+
+  <p class="govuk-body">By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.</p>
+
+  <div class="govuk-form-group">
+    <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+  </div>
+<% end %>

--- a/app/views/claims/reset_claim.erb
+++ b/app/views/claims/reset_claim.erb
@@ -6,7 +6,7 @@
       </h1>
 
       <%# Teacher selected YES however TRN was missing %>
-      <% if current_claim.details_check? && DfeIdentity::UserInfo.trn_missing?(current_claim.teacher_id_user_info) %>
+      <% if !current_claim.details_check? && DfeIdentity::UserInfo.trn_missing?(current_claim.teacher_id_user_info) %>
         <%= render partial: "claims/reset_claim_trn_missing" %>
       <% else %>
         <%= render partial: "claims/reset_claim_default" %>

--- a/app/views/early_career_payments/claims/_ineligibility_dqt_data_ineligible.html.erb
+++ b/app/views/early_career_payments/claims/_ineligibility_dqt_data_ineligible.html.erb
@@ -1,0 +1,10 @@
+<p class="govuk-body">
+  You are not eligible for the
+  <%= link_to("early-career payment", EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %> or the
+  <%= link_to("levelling up premium payment", LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  because of the subject you studied or the year you studied.
+</p>
+
+<p class="govuk-body">
+  For more information, check the eligibility criteria for <%= link_to("early-career payments", EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %> and <%= link_to("levelling up premium payments", LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+</p>

--- a/app/views/early_career_payments/claims/qualification_details.html.erb
+++ b/app/views/early_career_payments/claims/qualification_details.html.erb
@@ -7,27 +7,27 @@
 <div class="govuk-body" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Check and confirm your qualification details</h1>
+      <h1 class="govuk-heading-l"><%= t("questions.check_and_confirm_qualification_details") %></h1>
 
       <div class="personal-details-section">
-        <h2 class="govuk-heading-m">Qualification details</h2>
+        <h2 class="govuk-heading-m"><%= t("questions.qualification_details") %></h2>
         <dl class="govuk-summary-list govuk-!-margin-bottom-9">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Teacher route taken</dt>
+            <dt class="govuk-summary-list__key"><%= t("questions.teacher_route") %></dt>
             <dd class="govuk-summary-list__value">
-              [PLACEHOLDER] Undergraduate initial teacher training (ITT)
+              <%= t("#{current_claim.policy.locale_key}.answers.qualification.#{current_claim.dqt_teacher_record.route_into_teaching}") %>
             </dd>
           </div>
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Academic year you completed your undergraduate initial teacher training (ITT)</dt>
+            <dt class="govuk-summary-list__key"><%= t("questions.academic_year.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
             <dd class="govuk-summary-list__value">
-              [PLACEHOLDER] 2021-2022
+              <%= AcademicYear.for(current_claim.dqt_teacher_record.academic_date) %>
             </dd>
           </div>
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Subject you did your undergraduate initial teacher training (ITT) in</dt>
+            <dt class="govuk-summary-list__key"><%= t("questions.itt_subject.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
             <dd class="govuk-summary-list__value">
-              [PLACEHOLDER] Mathematics
+              <%= dqt_subjects_playback(current_claim) %>
             </dd>
           </div>
         </dl>
@@ -44,18 +44,18 @@
 
     <div class="govuk-radios">
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Are these details correct?</legend>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t("questions.details_correct") %></legend>
 
         <%= errors_tag current_claim, :qualifications_details_check %>
 
         <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
           <div class="govuk-radios__item">
             <%= form.radio_button(:qualifications_details_check, true, class: "govuk-radios__input") %>
-            <%= form.label :qualifications_details_check_true, "Yes", class: "govuk-label govuk-radios__label" %>
+            <%= form.label :qualifications_details_check_true, t("questions.yes"), class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
           <%= form.radio_button(:qualifications_details_check, false, class: "govuk-radios__input") %>
-          <%= form.label :qualifications_details_check_false, "No", class: "govuk-label govuk-radios__label" %>
+          <%= form.label :qualifications_details_check_false, t("questions.no"), class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>
@@ -63,9 +63,9 @@
 
   <% end %>
 
-  <p class="govuk-body">By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.</p>
+  <p class="govuk-body"><%= t("questions.select_yes_confirm") %></p>
 
   <div class="govuk-form-group">
-    <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <%= form.submit t("questions.continue"), class: "govuk-button", data: {module: "govuk-button"} %>
   </div>
 <% end %>

--- a/app/views/early_career_payments/claims/qualification_details.html.erb
+++ b/app/views/early_career_payments/claims/qualification_details.html.erb
@@ -12,24 +12,32 @@
       <div class="personal-details-section">
         <h2 class="govuk-heading-m"><%= t("questions.qualification_details") %></h2>
         <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key"><%= t("questions.teacher_route") %></dt>
-            <dd class="govuk-summary-list__value">
-              <%= t("#{current_claim.policy.locale_key}.answers.qualification.#{current_claim.dqt_teacher_record.route_into_teaching}") %>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key"><%= t("questions.academic_year.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
-            <dd class="govuk-summary-list__value">
-              <%= AcademicYear.for(current_claim.dqt_teacher_record.academic_date) %>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key"><%= t("questions.itt_subject.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
-            <dd class="govuk-summary-list__value">
-              <%= dqt_subjects_playback(current_claim) %>
-            </dd>
-          </div>
+          <% if current_claim.dqt_teacher_record.route_into_teaching %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key"><%= t("questions.teacher_route") %></dt>
+              <dd class="govuk-summary-list__value">
+                <%= t("#{current_claim.policy.locale_key}.answers.qualification.#{current_claim.dqt_teacher_record.route_into_teaching}") %>
+              </dd>
+            </div>
+          <% end %>
+
+          <% if current_claim.dqt_teacher_record.academic_date %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key"><%= t("questions.academic_year.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
+              <dd class="govuk-summary-list__value">
+                <%= AcademicYear.for(current_claim.dqt_teacher_record.academic_date) %>
+              </dd>
+            </div>
+          <% end %>
+
+          <% unless current_claim.dqt_teacher_record.itt_subjects.empty? %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key"><%= t("questions.itt_subject.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
+              <dd class="govuk-summary-list__value">
+                <%= dqt_subjects_playback(current_claim) %>
+              </dd>
+            </div>
+          <% end %>
         </dl>
       </div>
     </div>

--- a/app/views/early_career_payments/claims/qualification_details.html.erb
+++ b/app/views/early_career_payments/claims/qualification_details.html.erb
@@ -51,11 +51,11 @@
         <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
           <div class="govuk-radios__item">
             <%= form.radio_button(:qualifications_details_check, true, class: "govuk-radios__input") %>
-            <%= form.label :qualifications_details_check_true, t("questions.yes"), class: "govuk-label govuk-radios__label" %>
+            <%= form.label :qualifications_details_check_true, t("questions.radio_yes"), class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
           <%= form.radio_button(:qualifications_details_check, false, class: "govuk-radios__input") %>
-          <%= form.label :qualifications_details_check_false, t("questions.no"), class: "govuk-label govuk-radios__label" %>
+          <%= form.label :qualifications_details_check_false, t("questions.radio_no"), class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>

--- a/app/views/student_loans/claims/qualification_details.html.erb
+++ b/app/views/student_loans/claims/qualification_details.html.erb
@@ -13,7 +13,7 @@
         <h2 class="govuk-heading-m"><%= t("questions.qualification_details") %></h2>
         <dl class="govuk-summary-list govuk-!-margin-bottom-9">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key"><%= t("questions.academic_year.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
+            <dt class="govuk-summary-list__key"><%= t("student_loans.questions.academic_year") %></dt>
             <dd class="govuk-summary-list__value">
               <%= AcademicYear.for(current_claim.dqt_teacher_record.qts_award_date) %>
             </dd>

--- a/app/views/student_loans/claims/qualification_details.html.erb
+++ b/app/views/student_loans/claims/qualification_details.html.erb
@@ -1,0 +1,59 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { details_check: "qualifications_details_check_true" }) if current_claim.errors.any? %>
+  </div>
+</div>
+
+<div class="govuk-body" id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t("questions.check_and_confirm_qualification_details") %></h1>
+
+      <div class="personal-details-section">
+        <h2 class="govuk-heading-m"><%= t("questions.qualification_details") %></h2>
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key"><%= t("questions.academic_year.#{current_claim.dqt_teacher_record.route_into_teaching}") %></dt>
+            <dd class="govuk-summary-list__value">
+              <%= AcademicYear.for(current_claim.dqt_teacher_record.qts_award_date) %>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% shared_view_css_size = current_claim.policy == EarlyCareerPayments ? "l" : "xl" %>
+  <%= form_for current_claim, url: path_for_form do |form| %>
+    <%= form.hidden_field :qualifications_details_check %>
+    <%= form_group_tag current_claim do %>
+
+    <div class="govuk-radios">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t("questions.details_correct") %></legend>
+
+        <%= errors_tag current_claim, :qualifications_details_check %>
+
+        <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:qualifications_details_check, true, class: "govuk-radios__input") %>
+            <%= form.label :qualifications_details_check_true, t("questions.radio_yes"), class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+          <%= form.radio_button(:qualifications_details_check, false, class: "govuk-radios__input") %>
+          <%= form.label :qualifications_details_check_false, t("questions.radio_no"), class: "govuk-label govuk-radios__label" %>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+  <% end %>
+
+  <p class="govuk-body"><%= t("questions.select_yes_confirm") %></p>
+
+  <div class="govuk-form-group">
+    <%= form.submit t("questions.continue"), class: "govuk-button", data: {module: "govuk-button"} %>
+  </div>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -102,6 +102,8 @@ shared:
     - teacher_id_user_info
     - email_address_check
     - mobile_check
+    - qualifications_details_check
+    - dqt_teacher_status
   :decisions:
     - id
     - result

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -24,6 +24,7 @@ shared:
   - payroll_gender
   - one_time_password
   - hmrc_bank_validation_responses
+  - dqt_teacher_status
   :reminders:
   - full_name
   - email_address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,23 @@ en:
     account_details: Enter your %{bank_or_building_society} details
     account_hint: "For example: your name as it appears on your %{bank_or_building_society} statement or %{card} card."
     check_your_account_details: Incorrect details will cause a delay to your payment.
+    check_and_confirm_qualification_details: Check and confirm your qualification details
+    qualification_details: Qualification details
+    academic_year:
+      postgraduate_itt: Academic year you started your postgraduate initial teacher training (ITT)
+      undergraduate_itt: Academic year you completed your undergraduate initial teacher training (ITT)
+      assessment_only: Academic year you earned your qualified teacher status (QTS)
+      overseas_recognition: Academic year you earned your qualified teacher status (QTS)
+    teacher_route: Teacher route taken
+    itt_subject:
+      postgraduate_itt: Subject you did your postgraduate initial teacher training (ITT) in
+      undergraduate_itt: Subject you did your undergraduate initial teacher training (ITT) in
+      assessment_only: Subject you did you teaching qualification in
+      overseas_recognition: Subject you did you teaching qualification in
+    select_yes_confirm: By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.
+    continue: Continue
+    yes: Yes
+    no: No
   admin:
     qts_award_year: "Award year"
     current_school: "Current school"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,8 +114,8 @@ en:
       overseas_recognition: Subject you did you teaching qualification in
     select_yes_confirm: By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.
     continue: Continue
-    yes: Yes
-    no: No
+    radio_yes: "Yes"
+    radio_no: "No"
   admin:
     qts_award_year: "Award year"
     current_school: "Current school"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,6 +288,7 @@ en:
     landing_page: "Claim back student loan repayments if you're a teacher"
     questions:
       qts_award_year: "When did you complete your initial teacher training (ITT)?"
+      academic_year: "Academic year you completed your Initial Teacher Training (ITT)"
       claim_school: "Which school were you employed to teach at between %{financial_year}?"
       claim_school_select_error: "Select the school you taught at between %{financial_year}"
       additional_school: "Which additional school were you employed to teach at between %{financial_year}?"

--- a/db/migrate/20231224180838_add_qualifications_details_check_to_claim.rb
+++ b/db/migrate/20231224180838_add_qualifications_details_check_to_claim.rb
@@ -1,0 +1,6 @@
+class AddQualificationsDetailsCheckToClaim < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :dqt_teacher_status, :jsonb, default: nil
+    add_column :claims, :qualifications_details_check, :boolean, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_18_102954) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_24_180838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -93,6 +93,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_102954) do
     t.jsonb "teacher_id_user_info", default: {}
     t.boolean "email_address_check"
     t.string "mobile_check"
+    t.jsonb "dqt_teacher_status"
+    t.boolean "qualifications_details_check"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/lib/dqt/resources/teacher.rb
+++ b/lib/dqt/resources/teacher.rb
@@ -1,12 +1,18 @@
 module Dqt
   class TeacherResource < Resource
     def find(trn, **params)
+      response = find_raw(trn, **params)
+
+      Teacher.new(response)
+    end
+
+    def find_raw(trn, **params)
       response = get_request(
         "teachers/#{trn}", params: params
       )&.body
       return unless response
 
-      Teacher.new(response)
+      response
     end
   end
 end

--- a/lib/dqt/resources/teacher.rb
+++ b/lib/dqt/resources/teacher.rb
@@ -2,17 +2,15 @@ module Dqt
   class TeacherResource < Resource
     def find(trn, **params)
       response = find_raw(trn, **params)
+      return unless response
 
       Teacher.new(response)
     end
 
     def find_raw(trn, **params)
-      response = get_request(
+      get_request(
         "teachers/#{trn}", params: params
       )&.body
-      return unless response
-
-      response
     end
   end
 end

--- a/lib/dqt/resources/teacher.rb
+++ b/lib/dqt/resources/teacher.rb
@@ -1,7 +1,7 @@
 module Dqt
   class TeacherResource < Resource
-    def find(trn, **params)
-      response = find_raw(trn, **params)
+    def find(trn, **)
+      response = find_raw(trn, **)
       return unless response
 
       Teacher.new(response)

--- a/lib/ineligibility_reason_checker.rb
+++ b/lib/ineligibility_reason_checker.rb
@@ -6,6 +6,8 @@ class IneligibilityReasonChecker
   def reason
     if current_school?
       :current_school
+    elsif dqt_data_ineligible?
+      :dqt_data_ineligible
     elsif generic?
       :generic
     elsif trainee_teacher_last_policy_year?
@@ -41,6 +43,17 @@ class IneligibilityReasonChecker
       !EarlyCareerPayments::SchoolEligibility.new(school).eligible?,
       !LevellingUpPremiumPayments::SchoolEligibility.new(school).eligible?
     ].all?
+  end
+
+  def dqt_data_ineligible?
+    @current_claim.logged_in_with_tid? && @current_claim.qualifications_details_check && [
+      @current_claim.eligibility.itt_academic_year == AcademicYear.new,
+      bad_itt_year_for_ecp?,
+      bad_itt_subject_for_ecp?,
+      no_ecp_subjects_that_itt_year?,
+      lack_both_valid_itt_subject_and_degree?,
+      trainee_teaching_lacking_both_valid_itt_subject_and_degree?
+    ].any?
   end
 
   def generic?

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
@@ -7,13 +7,16 @@ RSpec.feature "Combined journey with Teacher ID email check" do
   # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
   let(:email) { "kelsie.oberbrunner@example.com" }
   let(:new_email) { "new.email@example" }
 
   before do
     freeze_time
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
     mock_claims_controller_address_data
   end
 

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -7,12 +7,15 @@ RSpec.feature "Combined journey with Teacher ID mobile check" do
   # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
   let(:phone_number) { "01234567890" }
 
   before do
     freeze_time
-    set_mock_auth(trn, phone_number:)
+    set_mock_auth(trn, {date_of_birth:, nino:, phone_number:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
     mock_claims_controller_address_data
   end
 

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -7,9 +7,19 @@ RSpec.feature "Combined journey with Teacher ID" do
 
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
-  let(:current_academic_year) { policy_configuration.current_academic_year }
-
-  let(:itt_year) { current_academic_year - 3 }
+  let(:eligible_itt_years) { JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_configuration.current_academic_year) }
+  let(:academic_date) { Date.new(eligible_itt_years.first.start_year,12,1) }
+  let(:itt_year) { AcademicYear.for(academic_date) }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
+  let(:eligible_dqt_body) do
+    {
+      qualified_teacher_status: {
+        qts_date: academic_date.to_s
+      }
+    }
+  end
 
   before do
     allow(NotifySmsMessage).to receive(:new).with(
@@ -29,8 +39,9 @@ RSpec.feature "Combined journey with Teacher ID" do
     set_mock_auth(nil)
   end
 
-  scenario "When user is logged in with Teacher ID" do
-    set_mock_auth("1234567")
+  scenario "When user is logged in with Teacher ID and there is a matching DQT record" do
+    set_mock_auth(trn, { date_of_birth:, nino: })
+    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: }, body: eligible_dqt_body)
 
     visit landing_page_path(EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
@@ -105,6 +116,59 @@ RSpec.feature "Combined journey with Teacher ID" do
     expect(claim.eligibility.reload.subject_to_formal_performance_action).to eql false
     expect(claim.eligibility.reload.subject_to_disciplinary_action).to eql false
 
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "Yes"
+    click_on "Continue"
+
+    # Claim eligibility answers are pre-filled from DQT record
+    claim.eligibility.reload
+    expect(claim.eligibility.eligible_itt_subject).to eq("mathematics")
+    expect(claim.eligibility.itt_academic_year).to eq(itt_year)
+    expect(claim.eligibility.qualification).to eq("undergraduate_itt")
+
+    # Qualification pages are skipped
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # - Check your answers for eligibility
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+    ["Identity details", "Payment details", "Student loan details"].each do |section_heading|
+      expect(page).not_to have_text section_heading
+    end
+
+    within(".govuk-summary-list") do
+      expect(page).not_to have_text(I18n.t("questions.postgraduate_masters_loan"))
+      expect(page).not_to have_text(I18n.t("questions.postgraduate_doctoral_loan"))
+    end
+
+    # Check your answers page does not include qualifications questions
+    expect(page).not_to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+    expect(page).not_to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teacher training (ITT)"))
+    expect(page).not_to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+    expect(page).not_to have_text(I18n.t("early_career_payments.questions.eligible_degree_subject"))
+
+    # Go back to the qualification details page
+    click_link "Back"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+    click_link "Back"
+
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "No"
+    click_on "Continue"
+
+    # Claim eligibility answers are wiped
+    claim.eligibility.reload
+    expect(claim.eligibility.eligible_itt_subject).to be nil
+    expect(claim.eligibility.itt_academic_year).to be nil
+    expect(claim.eligibility.qualification).to be nil
+
     # - What route into teaching did you take?
     expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
 
@@ -135,23 +199,17 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # - Check your answers for eligibility
     expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.primary_heading"))
-    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.secondary_heading"))
-    expect(page).to have_text(I18n.t("early_career_payments.check_your_answers.part_one.confirmation_notice"))
+
+    # Check your answers page includes qualifications questions
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject_one_option", qualification: "undergraduate initial teacher training (ITT)", subject: "mathematics"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
     expect(page).not_to have_text(I18n.t("early_career_payments.questions.eligible_degree_subject"))
 
-    ["Identity details", "Payment details", "Student loan details"].each do |section_heading|
-      expect(page).not_to have_text section_heading
-    end
-
-    within(".govuk-summary-list") do
-      expect(page).not_to have_text(I18n.t("questions.postgraduate_masters_loan"))
-      expect(page).not_to have_text(I18n.t("questions.postgraduate_doctoral_loan"))
-    end
     click_on("Continue")
 
     # - You are eligible for an early career payment
     expect(page).to have_text("You’re eligible for an additional payment")
-    expect(page).to have_field("£2,000 early-career payment")
     expect(page).to have_field("£2,000 levelling up premium payment")
     expect(page).to have_selector('input[type="radio"]', count: 2)
 
@@ -168,8 +226,8 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     expect(claim.reload.first_name).to eql("Kelsie")
     expect(claim.reload.surname).to eql("Oberbrunner")
-    expect(claim.reload.date_of_birth).to eq(Date.new(1940, 1, 1))
-    expect(claim.reload.national_insurance_number).to eq("AB123456C")
+    expect(claim.reload.date_of_birth).to eq(Date.parse(date_of_birth))
+    expect(claim.reload.national_insurance_number).to eq(nino)
 
     # - What is your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
@@ -242,8 +300,67 @@ RSpec.feature "Combined journey with Teacher ID" do
     expect(page).to have_text(I18n.t("questions.payroll_gender"))
   end
 
+  scenario "When user is logged in with Teacher ID and there is no matching DQT record" do
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
+
+    visit landing_page_path(EarlyCareerPayments.routing_name)
+    click_on "Start now"
+
+    click_on "Continue with DfE Identity"
+
+    choose "Yes"
+    click_on "Continue"
+
+    choose_school school
+
+    choose "Yes"
+    click_on "Continue"
+
+    choose "Yes"
+    click_on "Continue"
+
+    choose "No"
+    click_on "Continue"
+
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+
+    click_on "Continue"
+
+    # Qualification pages are not skipped
+    expect(page).not_to have_text(I18n.t("early_career_payments.questions.check_and_confirm_qualification_details"))
+
+    # - What route into teaching did you take?
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+
+    choose "Undergraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    # - In which academic year did you start your undergraduate ITT
+    choose "#{itt_year.start_year} to #{itt_year.end_year}"
+    click_on "Continue"
+
+    expect(page).to have_text("Which subject")
+
+    choose "Mathematics"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    # Check your answers page includes qualifications questions
+    expect(page).to have_text(I18n.t("early_career_payments.questions.qualification.heading"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.eligible_itt_subject_one_option", qualification: "undergraduate initial teacher training (ITT)", subject: "mathematics"))
+    expect(page).to have_text(I18n.t("early_career_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
+    expect(page).not_to have_text(I18n.t("early_career_payments.questions.eligible_degree_subject"))
+  end
+
   scenario "When user is logged in with Teacher ID and NINO is not supplied" do
-    set_mock_auth("1234567", {nino: nil})
+    set_mock_auth("1234567", {nino: "", date_of_birth:})
+    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: "" }, body: eligible_dqt_body)
 
     visit landing_page_path(EarlyCareerPayments.routing_name)
     click_on "Start now"
@@ -261,15 +378,19 @@ RSpec.feature "Combined journey with Teacher ID" do
     choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
     choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
     click_on "Continue"
-    choose "Undergraduate initial teacher training (ITT)"
+
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "Yes"
     click_on "Continue"
-    choose "#{itt_year.start_year} to #{itt_year.end_year}"
-    click_on "Continue"
-    choose "Mathematics"
-    click_on "Continue"
+
+    # Qualification pages are skipped
+
+    expect(page).to have_text(I18n.t("early_career_payments.questions.teaching_subject_now"))
+
     choose "Yes"
     click_on "Continue"
     click_on "Continue"
+
     choose "£2,000 levelling up premium payment"
     click_on "Apply now"
     click_on "Continue"
@@ -289,5 +410,33 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     claim = Claim.all.order(created_at: :desc).limit(1).first
     expect(claim.errors).to be_empty
+  end
+
+  scenario "When user is logged in with Teacher ID and the qualifications are not eligible" do
+    set_mock_auth("1234567", {nino:, date_of_birth:})
+    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: })
+
+    visit landing_page_path(EarlyCareerPayments.routing_name)
+    click_on "Start now"
+    click_on "Continue with DfE Identity"
+    choose "Yes"
+    click_on "Continue"
+    choose_school school
+    click_on "Continue"
+    choose "Yes"
+    click_on "Continue"
+    choose "Yes"
+    click_on "Continue"
+    choose "No"
+    click_on "Continue"
+    choose "claim_eligibility_attributes_subject_to_formal_performance_action_false"
+    choose "claim_eligibility_attributes_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text("You are not eligible for the early-career payment or the levelling up premium payment because of the subject you studied or the year you studied.")
   end
 end

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Combined journey with Teacher ID" do
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
   let(:eligible_itt_years) { JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_configuration.current_academic_year) }
-  let(:academic_date) { Date.new(eligible_itt_years.first.start_year,12,1) }
+  let(:academic_date) { Date.new(eligible_itt_years.first.start_year, 12, 1) }
   let(:itt_year) { AcademicYear.for(academic_date) }
   let(:trn) { 1234567 }
   let(:date_of_birth) { "1981-01-01" }
@@ -40,8 +40,8 @@ RSpec.feature "Combined journey with Teacher ID" do
   end
 
   scenario "When user is logged in with Teacher ID and there is a matching DQT record" do
-    set_mock_auth(trn, { date_of_birth:, nino: })
-    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: }, body: eligible_dqt_body)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:}, body: eligible_dqt_body)
 
     visit landing_page_path(EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
@@ -360,7 +360,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
   scenario "When user is logged in with Teacher ID and NINO is not supplied" do
     set_mock_auth("1234567", {nino: "", date_of_birth:})
-    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: "" }, body: eligible_dqt_body)
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino: ""}, body: eligible_dqt_body)
 
     visit landing_page_path(EarlyCareerPayments.routing_name)
     click_on "Start now"
@@ -414,7 +414,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
   scenario "When user is logged in with Teacher ID and the qualifications are not eligible" do
     set_mock_auth("1234567", {nino:, date_of_birth:})
-    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: })
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:})
 
     visit landing_page_path(EarlyCareerPayments.routing_name)
     click_on "Start now"

--- a/spec/features/correct_school_spec.rb
+++ b/spec/features/correct_school_spec.rb
@@ -7,11 +7,14 @@ RSpec.feature "Logs in with TID, confirms teacher details and displays school fr
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:eligible_school) { create(:school, :combined_journey_eligibile_for_all) }
   let!(:ineligible_school) { create(:school, :early_career_payments_ineligible, :levelling_up_premium_payments_ineligible) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   before do
     freeze_time
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
   end
 
   after do

--- a/spec/features/sign_in_or_continue_spec.rb
+++ b/spec/features/sign_in_or_continue_spec.rb
@@ -7,12 +7,19 @@ RSpec.feature "Teacher Identity Sign in" do
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
   let(:current_academic_year) { policy_configuration.current_academic_year }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   let(:itt_year) { current_academic_year - 3 }
 
+  before do
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
+  end
+
   scenario "Teacher makes claim for 'Early-Career Payments' claim and select continue without signing in" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
-    set_mock_auth("1234567")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
 
@@ -31,7 +38,6 @@ RSpec.feature "Teacher Identity Sign in" do
 
   scenario "Teacher makes claim for 'Early-Career Payments' claim and select Continue with DfE Identity" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
-    set_mock_auth("1234567")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
 

--- a/spec/features/teacher_detail_page_in_user_jouney_spec.rb
+++ b/spec/features/teacher_detail_page_in_user_jouney_spec.rb
@@ -7,14 +7,20 @@ RSpec.feature "Teacher Identity Sign in" do
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
   let(:current_academic_year) { policy_configuration.current_academic_year }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
+
+  before do
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
+  end
 
   after do
     set_mock_auth(nil)
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects yes to details confirm" do
-    set_mock_auth("1234567")
-
     visit landing_page_path(EarlyCareerPayments.routing_name)
 
     # - Landing (start)
@@ -36,12 +42,10 @@ RSpec.feature "Teacher Identity Sign in" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "email" => "kelsie.oberbrunner@example.com", "phone_number" => "01234567890", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "trn_match_ni_number" => "True"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1981-01-01", "email" => "kelsie.oberbrunner@example.com", "phone_number" => "01234567890", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123123A", "trn_match_ni_number" => "True"})
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects no to details confirm" do
-    set_mock_auth("1234567")
-
     visit landing_page_path(EarlyCareerPayments.routing_name)
 
     # - Landing (start)
@@ -68,7 +72,7 @@ RSpec.feature "Teacher Identity Sign in" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1981-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123123A", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
   end
 
   scenario "Teacher makes claim for 'Early-Career Payments' by logging in with teacher_id and selects yes to details confirm but trn missing" do

--- a/spec/features/teacher_detail_page_student_loans_journey_spec.rb
+++ b/spec/features/teacher_detail_page_student_loans_journey_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
   end
 
   scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects yes to details confirm" do
-    set_mock_auth(trn, { date_of_birth:, nino: })
+    set_mock_auth(trn, {date_of_birth:, nino:})
     stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
 
     visit landing_page_path(StudentLoans.routing_name)
@@ -88,7 +88,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
   end
 
   scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects no to details confirm" do
-    set_mock_auth(trn, { date_of_birth:, nino: })
+    set_mock_auth(trn, {date_of_birth:, nino:})
 
     visit landing_page_path(StudentLoans.routing_name)
 
@@ -154,7 +154,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
   end
 
   scenario "When user is logged in with Teacher ID and NINO is not supplied" do
-    set_mock_auth(trn, { date_of_birth:, nino: nil })
+    set_mock_auth(trn, {date_of_birth:, nino: nil})
     stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino: ""})
 
     visit landing_page_path(StudentLoans.routing_name)

--- a/spec/features/teacher_detail_page_student_loans_journey_spec.rb
+++ b/spec/features/teacher_detail_page_student_loans_journey_spec.rb
@@ -7,13 +7,17 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
   let(:current_academic_year) { policy_configuration.current_academic_year }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   after do
     set_mock_auth(nil)
   end
 
   scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects yes to details confirm" do
-    set_mock_auth("1234567")
+    set_mock_auth(trn, { date_of_birth:, nino: })
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
 
     visit landing_page_path(StudentLoans.routing_name)
 
@@ -64,13 +68,13 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => date_of_birth, "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => nino, "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
 
     # check the user_info details from teacher id are saved to the claim
     expect(claim.first_name).to eq("Kelsie")
     expect(claim.surname).to eq("Oberbrunner")
-    expect(claim.date_of_birth).to eq(Date.parse("1940-01-01"))
-    expect(claim.national_insurance_number).to eq("AB123456C")
+    expect(claim.date_of_birth).to eq(Date.parse(date_of_birth))
+    expect(claim.national_insurance_number).to eq(nino)
     expect(claim.teacher_reference_number).to eq("1234567")
     expect(claim.logged_in_with_tid?).to eq(true)
     expect(claim.details_check).to eq(true)
@@ -84,7 +88,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
   end
 
   scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects no to details confirm" do
-    set_mock_auth("1234567")
+    set_mock_auth(trn, { date_of_birth:, nino: })
 
     visit landing_page_path(StudentLoans.routing_name)
 
@@ -111,7 +115,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "AB123456C", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => date_of_birth, "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => nino, "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
 
     # check the user_info details from teacher id are not saved to the claim
     expect(claim.first_name).to eq("")
@@ -150,7 +154,8 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
   end
 
   scenario "When user is logged in with Teacher ID and NINO is not supplied" do
-    set_mock_auth("1234567", {nino: nil})
+    set_mock_auth(trn, { date_of_birth:, nino: nil })
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino: ""})
 
     visit landing_page_path(StudentLoans.routing_name)
     click_on "Start now"
@@ -186,12 +191,12 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
 
     # check the teacher_id_user_info details are saved to the claim
     claim = Claim.order(:created_at).last
-    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => "1940-01-01", "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => nil, "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
+    expect(claim.teacher_id_user_info).to eq({"trn" => "1234567", "birthdate" => date_of_birth, "given_name" => "Kelsie", "family_name" => "Oberbrunner", "ni_number" => "", "phone_number" => "01234567890", "trn_match_ni_number" => "True", "email" => "kelsie.oberbrunner@example.com"})
 
     # check the user_info details from teacher id are saved to the claim
     expect(claim.first_name).to eq("Kelsie")
     expect(claim.surname).to eq("Oberbrunner")
-    expect(claim.date_of_birth).to eq(Date.parse("1940-01-01"))
+    expect(claim.date_of_birth).to eq(Date.parse(date_of_birth))
     expect(claim.national_insurance_number).to eq(updated_nino)
     expect(claim.teacher_reference_number).to eq("1234567")
     expect(claim.logged_in_with_tid?).to eq(true)

--- a/spec/features/teacher_identity_sign_in_spec.rb
+++ b/spec/features/teacher_identity_sign_in_spec.rb
@@ -7,12 +7,19 @@ RSpec.feature "Teacher Identity Sign in" do
   let!(:policy_configuration) { create(:policy_configuration, :additional_payments) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
   let(:current_academic_year) { policy_configuration.current_academic_year }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   let(:itt_year) { current_academic_year - 3 }
 
+  before do
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
+  end
+
   scenario "Teacher makes claim without signing in" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
-    set_mock_auth("1234567")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
 
@@ -31,7 +38,6 @@ RSpec.feature "Teacher Identity Sign in" do
 
   scenario "Teacher makes claim after signing in" do
     visit landing_page_path(EarlyCareerPayments.routing_name)
-    set_mock_auth("1234567")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
     expect(page).to have_link(href: "mailto:#{EarlyCareerPayments.feedback_email}")
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
@@ -7,13 +7,16 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
   # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
   let(:email) { "kelsie.oberbrunner@example.com" }
   let(:new_email) { "new.email@example" }
 
   before do
     freeze_time
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
     mock_address_details_address_data
   end
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -7,12 +7,15 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
   # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
   let(:phone_number) { "01234567890" }
 
   before do
     freeze_time
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
     mock_address_details_address_data
   end
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "TSLR journey with Teacher ID email check" do
+RSpec.feature "TSLR journey with Teacher ID mobile check" do
   include OmniauthMockHelper
   include StudentLoansHelper
 
@@ -169,7 +169,11 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
     find("#claim_mobile_check_declined").click
     click_on "Continue"
 
+    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
+
     click_on "Back"
+
+    expect(page).to have_text(I18n.t("questions.select_phone_number.heading"))
 
     # - Select the suggested phone number
     find("#claim_mobile_check_use").click
@@ -189,7 +193,11 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
     find("#claim_mobile_check_declined").click
     click_on "Continue"
 
+    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
+
     click_on "Back"
+
+    expect(page).to have_text(I18n.t("questions.select_phone_number.heading"))
 
     # - Select A different mobile number
     find("#claim_mobile_check_alternative").click

--- a/spec/features/tslr_claim_journey_with_teacher_id_select_claim_school_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_select_claim_school_spec.rb
@@ -7,11 +7,14 @@ RSpec.feature "TSLR journey with Teacher ID school playback" do
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:eligible_school) { create(:school, :student_loans_eligible) }
   let!(:ineligible_school) { create(:school, :student_loans_ineligible) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   before do
     freeze_time
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
   end
 
   after do

--- a/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
@@ -31,6 +31,8 @@ RSpec.feature "TSLR journey with Teacher ID" do
     navigate_past_teacher_details_page
 
     expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    expect(page).to have_text(I18n.t("student_loans.questions.academic_year"))
+    expect(page).to have_text(itt_year.to_s)
     choose "Yes"
     click_on "Continue"
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "TSLR journey with Teacher ID" do
   end
 
   scenario "When user is logged in with Teacher ID and the qualifications are not eligible" do
-    set_mock_auth("1234567", {nino:, date_of_birth:})
+    set_mock_auth(trn, {nino:, date_of_birth:})
     stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:})
 
     navigate_past_teacher_details_page
@@ -82,6 +82,23 @@ RSpec.feature "TSLR journey with Teacher ID" do
 
     # Qualification pages are skipped
     expect(page).to have_text("You’re not eligible for this payment")
+  end
+
+  scenario "When user is logged in with Teacher ID and the qualifications data is incomplete" do
+    set_mock_auth(trn, {nino:, date_of_birth:})
+    missing_qts_date_body = {
+      qualified_teacher_status: {
+        qts_date: nil
+      }
+    }
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:}, body: missing_qts_date_body)
+
+    navigate_past_teacher_details_page
+
+    # Qualification pages are not skipped
+
+    # - Select qts year
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
   end
 
   def navigate_past_teacher_details_page

--- a/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "TSLR journey with Teacher ID" do
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
   let(:eligible_itt_years) { JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_configuration.current_academic_year) }
-  let(:academic_date) { Date.new(eligible_itt_years.first.start_year,12,1) }
+  let(:academic_date) { Date.new(eligible_itt_years.first.start_year, 12, 1) }
   let(:itt_year) { AcademicYear.for(academic_date) }
   let(:trn) { 1234567 }
   let(:date_of_birth) { "1981-01-01" }
@@ -25,8 +25,8 @@ RSpec.feature "TSLR journey with Teacher ID" do
   end
 
   scenario "When user is logged in with Teacher ID and there is a matching DQT record" do
-    set_mock_auth(trn, { date_of_birth:, nino: })
-    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: }, body: eligible_dqt_body)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:}, body: eligible_dqt_body)
 
     navigate_past_teacher_details_page
 
@@ -72,7 +72,7 @@ RSpec.feature "TSLR journey with Teacher ID" do
 
   scenario "When user is logged in with Teacher ID and the qualifications are not eligible" do
     set_mock_auth("1234567", {nino:, date_of_birth:})
-    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: })
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:})
 
     navigate_past_teacher_details_page
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.feature "TSLR journey with Teacher ID" do
+  include OmniauthMockHelper
+  include StudentLoansHelper
+
+  let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
+  let!(:school) { create(:school, :student_loans_eligible) }
+  let(:eligible_itt_years) { JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_configuration.current_academic_year) }
+  let(:academic_date) { Date.new(eligible_itt_years.first.start_year,12,1) }
+  let(:itt_year) { AcademicYear.for(academic_date) }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
+  let(:eligible_dqt_body) do
+    {
+      qualified_teacher_status: {
+        qts_date: academic_date.to_s
+      }
+    }
+  end
+
+  after do
+    set_mock_auth(nil)
+  end
+
+  scenario "When user is logged in with Teacher ID and there is a matching DQT record" do
+    set_mock_auth(trn, { date_of_birth:, nino: })
+    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: }, body: eligible_dqt_body)
+
+    navigate_past_teacher_details_page
+
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "Yes"
+    click_on "Continue"
+
+    # Claim eligibility answers are pre-filled from DQT record
+    claim = Claim.all.order(created_at: :desc).limit(1).first
+    expect(claim.eligibility.qts_award_year).to eq("on_or_after_cut_off_date")
+
+    # Qualification pages are skipped
+
+    # - Which school do you teach at
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year))
+    click_link "Back"
+
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "No"
+    click_on "Continue"
+
+    # Claim eligibility qualification answers are wiped
+    claim.eligibility.reload
+    expect(claim.eligibility.qts_award_year).to be nil
+
+    # Qualification pages are no longer skipped
+
+    # - Select qts year
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+  end
+
+  scenario "When user is logged in with Teacher ID and there is no matching DQT record" do
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
+
+    navigate_past_teacher_details_page
+
+    # Qualification pages are not skipped
+
+    # - Select qts year
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+  end
+
+  scenario "When user is logged in with Teacher ID and the qualifications are not eligible" do
+    set_mock_auth("1234567", {nino:, date_of_birth:})
+    stub_qualified_teaching_statuses_show(trn:, params: { birthdate: date_of_birth, nino: })
+
+    navigate_past_teacher_details_page
+
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
+    choose "Yes"
+    click_on "Continue"
+
+    # Qualification pages are skipped
+    expect(page).to have_text("You’re not eligible for this payment")
+  end
+
+  def navigate_past_teacher_details_page
+    visit landing_page_path(StudentLoans.routing_name)
+
+    # - Landing (start)
+    expect(page).to have_text(I18n.t("student_loans.landing_page"))
+    click_on "Start now"
+
+    expect(page).to have_text("Use DfE Identity to sign in")
+    click_on "Continue with DfE Identity"
+
+    # - Teacher details page
+    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
+    expect(page).to have_text(I18n.t("questions.details_correct"))
+
+    choose "Yes"
+    click_on "Continue"
+  end
+end

--- a/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
@@ -8,7 +8,9 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
   let!(:eligible_claim_school) { create(:school, :student_loans_eligible) }
   let!(:eligible_school) { create(:school, :student_loans_eligible) }
   let!(:ineligible_school) { create(:school, :student_loans_ineligible) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   before do
     freeze_time
@@ -24,7 +26,8 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
     recent_tps_full_months = TeachersPensionsService::RECENT_TPS_FULL_MONTHS
     create(:teachers_pensions_service, teacher_reference_number: trn, end_date: recent_tps_full_months.ago, school_urn: eligible_school.establishment_number, la_urn: eligible_school.local_authority.code)
 
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
   end
 
   after do

--- a/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
@@ -6,11 +6,14 @@ RSpec.feature "TSLR journey with Teacher ID teacher reference number page remova
 
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
-  let(:trn) { "1234567" }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1981-01-01" }
+  let(:nino) { "AB123123A" }
 
   before do
     freeze_time
-    set_mock_auth(trn)
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
     mock_address_details_address_data
   end
 

--- a/spec/helpers/claims/itt_subject_helper_spec.rb
+++ b/spec/helpers/claims/itt_subject_helper_spec.rb
@@ -80,4 +80,14 @@ RSpec.describe Claims::IttSubjectHelper do
       it { is_expected.to eq("chemistry, languages, mathematics or physics") }
     end
   end
+
+  describe "#dqt_subjects_playback" do
+    let(:dbl) { double(dqt_teacher_record: double(itt_subjects:)) }
+
+    let(:itt_subjects) { ["test test", "Test McTest", "TEST"] }
+
+    it "titleizes the subjects which are all lowercase and joins with commas" do
+      expect(helper.dqt_subjects_playback(dbl)).to eq("Test Test, Test McTest, TEST")
+    end
+  end
 end

--- a/spec/jobs/claim_verifier_job_spec.rb
+++ b/spec/jobs/claim_verifier_job_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe ClaimVerifierJob do
+  describe "#perform" do
+    let(:claim) { build(:claim, dqt_teacher_status:) }
+    let(:dbl) { double(find: mock_payload) }
+    let(:verifier) { double(perform: true) }
+    let(:mock_payload) { Dqt::Teacher.new({ "mock" => "mock" }) }
+
+    before do
+      allow(Dqt::TeacherResource).to receive(:new).and_return(dbl)
+      allow(AutomatedChecks::ClaimVerifier).to receive(:new).and_return(verifier)
+    end
+
+    context "when the claim has a DQT record payload" do
+      let(:dqt_teacher_status) { { "test" => "test" } }
+
+      it "does not request a new DQT payload" do
+        expect(dbl).not_to receive(:find)
+        described_class.new.perform(claim)
+      end
+
+      it "performs the verifier job" do
+        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: Dqt::Teacher.new(dqt_teacher_status))
+        described_class.new.perform(claim)
+      end
+    end
+
+    context "when the claim has an empty DQT record payload" do
+      let(:dqt_teacher_status) { {} }
+
+      it "does requests a new DQT payload" do
+        expect(dbl).to receive(:find)
+        described_class.new.perform(claim)
+      end
+
+      it "performs the verifier job" do
+        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: mock_payload)
+        described_class.new.perform(claim)
+      end
+    end
+
+    context "when the claim does not have a DQT record payload" do
+      let(:dqt_teacher_status) { nil }
+
+      it "does requests a new DQT payload" do
+        expect(dbl).to receive(:find)
+        described_class.new.perform(claim)
+      end
+
+      it "performs the verifier job" do
+        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: mock_payload)
+        described_class.new.perform(claim)
+      end
+    end
+  end
+end

--- a/spec/jobs/claim_verifier_job_spec.rb
+++ b/spec/jobs/claim_verifier_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ClaimVerifierJob do
     let(:claim) { build(:claim, dqt_teacher_status:) }
     let(:dbl) { double(find: mock_payload) }
     let(:verifier) { double(perform: true) }
-    let(:mock_payload) { Dqt::Teacher.new({ "mock" => "mock" }) }
+    let(:mock_payload) { Dqt::Teacher.new({"mock" => "mock"}) }
 
     before do
       allow(Dqt::TeacherResource).to receive(:new).and_return(dbl)
@@ -13,7 +13,7 @@ RSpec.describe ClaimVerifierJob do
     end
 
     context "when the claim has a DQT record payload" do
-      let(:dqt_teacher_status) { { "test" => "test" } }
+      let(:dqt_teacher_status) { {"test" => "test"} }
 
       it "does not request a new DQT payload" do
         expect(dbl).not_to receive(:find)

--- a/spec/lib/dqt/resources/teacher_spec.rb
+++ b/spec/lib/dqt/resources/teacher_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Dqt::TeacherResource do
+  let(:client) { Dqt::Client.new }
+
+  describe "#find" do
+    let(:trn) { 1234567 }
+    let(:birthdate) { "1981-01-01" }
+    let(:nino) { "AB123123A" }
+
+    subject(:result) { described_class.new(client).find(trn, birthdate:, nino:) }
+
+    context "when DQT returns a payload" do
+      let(:status) { 200 }
+      let(:body) do
+        {
+          qualified_teacher_status: {
+            qts_date: qts_date.to_s
+          }
+        }
+      end
+      let(:qts_date) { (Date.today - 1.year) }
+
+      before { stub_qualified_teaching_statuses_show(trn:, params: {birthdate:, nino:}, body:, status:) }
+
+      it { is_expected.to be_a(Dqt::Teacher) }
+
+      it "returns the response body" do
+        expect(result.qts_award_date).to eq(qts_date)
+      end
+    end
+
+    context "when DQT does not return a payload" do
+      let(:status) { 404 }
+      let(:body) { nil }
+
+      before { stub_dqt_empty_response(trn:, params: {birthdate:, nino:}) }
+
+      it { is_expected.to be nil }
+    end
+  end
+end

--- a/spec/lib/ineligibility_reason_checker_spec.rb
+++ b/spec/lib/ineligibility_reason_checker_spec.rb
@@ -3,8 +3,10 @@ require "ineligibility_reason_checker"
 
 RSpec.describe IneligibilityReasonChecker do
   let(:academic_year) { AcademicYear.new(2022) }
-  let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, academic_year:, eligibility: ecp_eligibility) }
-  let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, academic_year:, eligibility: lup_eligibility) }
+  let(:ecp_claim) { build(:claim, policy: EarlyCareerPayments, academic_year:, eligibility: ecp_eligibility, logged_in_with_tid:, qualifications_details_check:) }
+  let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, academic_year:, eligibility: lup_eligibility, logged_in_with_tid:, qualifications_details_check:) }
+  let(:logged_in_with_tid) { nil }
+  let(:qualifications_details_check) { nil }
 
   let(:school_eligible_for_ecp_but_not_lup) { build(:school, :early_career_payments_eligible) }
   let(:school_ineligible_for_both_ecp_and_lup) { build(:school, :early_career_payments_ineligible) }
@@ -169,6 +171,16 @@ RSpec.describe IneligibilityReasonChecker do
       let(:lup_claim) { build(:claim, policy: LevellingUpPremiumPayments, academic_year: "2024/2025", eligibility: lup_eligibility) }
 
       it { is_expected.to eq(:trainee_in_last_policy_year) }
+    end
+
+    context "when DQT-derived qualifications data indicates the user is ineligible" do
+      let(:qualifications_details_check) { true }
+      let(:logged_in_with_tid) { true }
+
+      let(:ecp_eligibility) { build(:early_career_payments_eligibility, :eligible, eligible_itt_subject: :none_of_the_above) }
+      let(:lup_eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, :no_relevant_degree, eligible_itt_subject: :none_of_the_above) }
+
+      it { is_expected.to eq(:dqt_data_ineligible) }
     end
   end
 end

--- a/spec/models/claim/permitted_parameters_spec.rb
+++ b/spec/models/claim/permitted_parameters_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Claim::PermittedParameters do
       :details_check,
       :email_address_check,
       :mobile_check,
+      :qualifications_details_check,
       eligibility_attributes: [
         :qts_award_year,
         :claim_school_id,

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1319,7 +1319,8 @@ RSpec.describe Claim, type: :model do
         :assigned_to_id,
         :details_check,
         :email_address_check,
-        :mobile_check
+        :mobile_check,
+        :qualifications_details_check
       ])
     end
   end
@@ -2020,6 +2021,46 @@ RSpec.describe Claim, type: :model do
       it "returns false" do
         expect(claim.has_valid_nino?).to be false
       end
+    end
+  end
+
+  describe "#has_dqt_record?" do
+    let(:claim) { build(:claim, dqt_teacher_status:) }
+    subject(:result) { claim.has_dqt_record? }
+
+    context "when dqt_teacher_status value is nil" do
+      let(:dqt_teacher_status) { nil }
+      it { is_expected.to be false }
+    end
+
+    context "when dqt_teacher_status value is empty" do
+      let(:dqt_teacher_status) { {} }
+      it { is_expected.to be false }
+    end
+
+    context "when dqt_teacher_status value is not empty" do
+      let(:dqt_teacher_status) { { "test" => "test" } }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#dqt_teacher_record" do
+    let(:claim) { build(:claim, dqt_teacher_status:) }
+    subject(:result) { claim.dqt_teacher_record }
+
+    context "when dqt_teacher_status value is nil" do
+      let(:dqt_teacher_status) { nil }
+      it { is_expected.to be nil }
+    end
+
+    context "when dqt_teacher_status value is empty" do
+      let(:dqt_teacher_status) { {} }
+      it { is_expected.to be nil }
+    end
+
+    context "when dqt_teacher_status value is not empty" do
+      let(:dqt_teacher_status) { { "test" => "test" } }
+      it { is_expected.to be_a(claim.policy::DqtRecord) }
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -2039,7 +2039,7 @@ RSpec.describe Claim, type: :model do
     end
 
     context "when dqt_teacher_status value is not empty" do
-      let(:dqt_teacher_status) { { "test" => "test" } }
+      let(:dqt_teacher_status) { {"test" => "test"} }
       it { is_expected.to be true }
     end
   end
@@ -2059,7 +2059,7 @@ RSpec.describe Claim, type: :model do
     end
 
     context "when dqt_teacher_status value is not empty" do
-      let(:dqt_teacher_status) { { "test" => "test" } }
+      let(:dqt_teacher_status) { {"test" => "test"} }
       it { is_expected.to be_a(claim.policy::DqtRecord) }
     end
   end

--- a/spec/models/dfe_identity/claim_user_details_updater_spec.rb
+++ b/spec/models/dfe_identity/claim_user_details_updater_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DfeIdentity::ClaimUserDetailsUpdater do
         "trn" => "123456",
         "birthdate" => "1990-01-01",
         "ni_number" => "AB123456C",
-        "trn_match_ni_number" => "True",
+        "trn_match_ni_number" => "True"
       }
       allow(claim).to receive(:teacher_id_user_info).and_return(teacher_id_user_info)
 

--- a/spec/models/dfe_identity/claim_user_details_updater_spec.rb
+++ b/spec/models/dfe_identity/claim_user_details_updater_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe DfeIdentity::ClaimUserDetailsUpdater do
   describe ".call" do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:claim, dqt_teacher_status: {}) }
 
     it "updates the claim with teacher ID user info" do
       teacher_id_user_info = {
@@ -11,7 +11,7 @@ RSpec.describe DfeIdentity::ClaimUserDetailsUpdater do
         "trn" => "123456",
         "birthdate" => "1990-01-01",
         "ni_number" => "AB123456C",
-        "trn_match_ni_number" => "True"
+        "trn_match_ni_number" => "True",
       }
       allow(claim).to receive(:teacher_id_user_info).and_return(teacher_id_user_info)
 
@@ -23,10 +23,11 @@ RSpec.describe DfeIdentity::ClaimUserDetailsUpdater do
         .and change { claim.date_of_birth }.to(Date.new(1990, 1, 1))
         .and change { claim.national_insurance_number }.to("AB123456C")
         .and change { claim.logged_in_with_tid }.to(true)
+        .and change { claim.dqt_teacher_status }.to(nil)
     end
 
     it "updates the claim with the saved teacher ID user info" do
-      claim = create(:claim, :with_valid_teacher_id_user_info)
+      claim = create(:claim, :with_valid_teacher_id_user_info, dqt_teacher_status: {})
 
       expect {
         described_class.call(claim)
@@ -36,6 +37,7 @@ RSpec.describe DfeIdentity::ClaimUserDetailsUpdater do
         .and change { claim.date_of_birth }.to(Date.new(1990, 1, 1))
         .and change { claim.national_insurance_number }.to("AB123456C")
         .and change { claim.logged_in_with_tid }.to(true)
+        .and change { claim.dqt_teacher_status }.to(nil)
     end
 
     it "does not update the claim if user info is not validated" do

--- a/spec/models/dqt/retrieve_claim_qualifications_data_spec.rb
+++ b/spec/models/dqt/retrieve_claim_qualifications_data_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Dqt::RetrieveClaimQualificationsData do
+  let(:dbl) { double(find_raw: response) }
+  let(:response) { { "mock" => "mock" } }
+  let(:claim) { build(:claim, :submittable, dqt_teacher_status:) }
+
+  before do
+    allow(Dqt::TeacherResource).to receive(:new).and_return(dbl)
+  end
+
+  describe "#save_qualifications_result" do
+    subject(:service) { described_class.new(claim) }
+
+    context "when the claim already has a saved DQT payload" do
+      let(:dqt_teacher_status) { { "test" => "test" } }
+
+      it "does not retrieve a new DQT payload" do
+        expect(dbl).not_to receive(:find_raw)
+        expect { service.save_qualifications_result }.not_to change { claim.dqt_teacher_status }
+      end
+    end
+
+    context "when the claim already has a saved DQT payload that is empty" do
+      let(:dqt_teacher_status) { {} }
+
+      it "does not retrieve a new DQT payload" do
+        expect(dbl).not_to receive(:find_raw)
+        expect { service.save_qualifications_result }.not_to change { claim.dqt_teacher_status }
+      end
+    end
+
+    context "when the claim does not have a saved DQT payload" do
+      let(:dqt_teacher_status) { nil }
+
+      it "retrieves and saves the DQT payload" do
+        expect(dbl).to receive(:find_raw).with(claim.teacher_reference_number, birthdate: claim.date_of_birth.to_s, nino: claim.national_insurance_number)
+        expect { service.save_qualifications_result }.to change { claim.dqt_teacher_status }.from(dqt_teacher_status).to(response)
+      end
+    end
+  end
+end

--- a/spec/models/dqt/retrieve_claim_qualifications_data_spec.rb
+++ b/spec/models/dqt/retrieve_claim_qualifications_data_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Dqt::RetrieveClaimQualificationsData do
   let(:dbl) { double(find_raw: response) }
-  let(:response) { { "mock" => "mock" } }
+  let(:response) { {"mock" => "mock"} }
   let(:claim) { build(:claim, :submittable, dqt_teacher_status:) }
 
   before do
@@ -13,7 +13,7 @@ RSpec.describe Dqt::RetrieveClaimQualificationsData do
     subject(:service) { described_class.new(claim) }
 
     context "when the claim already has a saved DQT payload" do
-      let(:dqt_teacher_status) { { "test" => "test" } }
+      let(:dqt_teacher_status) { {"test" => "test"} }
 
       it "does not retrieve a new DQT payload" do
         expect(dbl).not_to receive(:find_raw)

--- a/spec/models/early_career_payments/dqt_record_spec.rb
+++ b/spec/models/early_career_payments/dqt_record_spec.rb
@@ -2229,7 +2229,7 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
     end
 
     context "with an invalid ITT year" do
-      let(:claim_academic_year) { AcademicYear.for(Date.new(1666,1,1)) }
+      let(:claim_academic_year) { AcademicYear.for(Date.new(1666, 1, 1)) }
       let(:itt_subjects) { ["mathematics"] }
 
       before do
@@ -2252,7 +2252,8 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
     let(:record) do
       OpenStruct.new(
         qualification_name: "BA",
-        qts_award_date:)
+        qts_award_date:
+      )
     end
 
     let(:claim_year) { 2023 }
@@ -2261,7 +2262,7 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
     let(:eligible_years) { (AcademicYear.new(claim_year - 5)...AcademicYear.new(claim_year)).to_a }
 
     context "when the record returns an eligible date" do
-      let(:qts_award_date) { Date.new(claim_year,1,1) }
+      let(:qts_award_date) { Date.new(claim_year, 1, 1) }
 
       it "returns the academic year" do
         expect(dqt_record.itt_academic_year_for_claim).to eq(AcademicYear.for(qts_award_date))
@@ -2269,7 +2270,7 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
     end
 
     context "when the record returns an ineligible date" do
-      let(:qts_award_date) { Date.new(claim_year - 10,12,1) }
+      let(:qts_award_date) { Date.new(claim_year - 10, 12, 1) }
 
       it "returns a blank academic year" do
         expect(dqt_record.itt_academic_year_for_claim).to eq(AcademicYear.new)

--- a/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
+++ b/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter do
           expect(questions(subject)).not_to include(
             "Which route into teaching did you take?",
             "In which academic year did you start your postgraduate initial teacher training (ITT)?",
-            "Did you do your postgraduate initial teacher training (ITT) in mathematics?",
+            "Did you do your postgraduate initial teacher training (ITT) in mathematics?"
           )
         }
       end
@@ -133,7 +133,7 @@ RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter do
             "Which route into teaching did you take?",
             "In which academic year did you start your postgraduate initial teacher training (ITT)?",
             "Which subject did you do your postgraduate initial teacher training (ITT) in?",
-            "Do you have a degree in an eligible subject?",
+            "Do you have a degree in an eligible subject?"
           )
         }
       end

--- a/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
+++ b/spec/models/early_career_payments/eligibility_answers_presenter_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter do
   describe "#answers" do
     let(:policy_year) { AcademicYear.new(2022) }
     let(:policy) { EarlyCareerPayments }
-    let(:claim) { build(:claim, policy: policy, academic_year: policy_year, eligibility: eligibility) }
+    let(:claim) { build(:claim, policy: policy, academic_year: policy_year, eligibility: eligibility, qualifications_details_check:) }
     let!(:policy_configuration) { create(:policy_configuration, :additional_payments, current_academic_year: policy_year) }
+    let(:qualifications_details_check) { false }
 
     subject { described_class.new(claim.eligibility).answers }
 
@@ -80,6 +81,19 @@ RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter do
 
         it { is_expected.to include(["Which subject did you do your postgraduate initial teacher training (ITT) in?", "Mathematics", "eligible-itt-subject"]) }
       end
+
+      context "qualifications retrieved from DQT" do
+        let(:qualifications_details_check) { true }
+        let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
+
+        specify {
+          expect(questions(subject)).not_to include(
+            "Which route into teaching did you take?",
+            "In which academic year did you start your postgraduate initial teacher training (ITT)?",
+            "Did you do your postgraduate initial teacher training (ITT) in mathematics?",
+          )
+        }
+      end
     end
 
     context "LUP" do
@@ -106,6 +120,20 @@ RSpec.describe EarlyCareerPayments::EligibilityAnswersPresenter do
               ["Do you have a degree in an eligible subject?", "Yes", "eligible-degree-subject"],
               ["Do you spend at least half of your contracted hours teaching eligible subjects?", "Yes", "teaching-subject-now"]
             ]
+          )
+        }
+      end
+
+      context "qualifications retrieved from DQT" do
+        let(:qualifications_details_check) { true }
+        let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, :long_term_directly_employed_supply_teacher, :ineligible_itt_subject, :relevant_degree) }
+
+        specify {
+          expect(questions(subject)).not_to include(
+            "Which route into teaching did you take?",
+            "In which academic year did you start your postgraduate initial teacher training (ITT)?",
+            "Which subject did you do your postgraduate initial teacher training (ITT) in?",
+            "Do you have a degree in an eligible subject?",
           )
         }
       end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -488,6 +488,16 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
           .and change { eligibility.eligible_itt_subject }.from(eligible_itt_subject.to_s).to(eligible_itt_subject_for_claim.to_s)
           .and change { eligibility.qualification }.from(qualification.to_s).to(route_into_teaching.to_s)
       end
+
+      context "when the DQT record is missing data" do
+        let(:itt_academic_year_for_claim) { nil }
+        let(:eligible_itt_subject_for_claim) { nil }
+        let(:route_into_teaching) { nil }
+
+        it "does not change the answers" do
+          expect(eligibility.set_qualifications_from_dqt_record).to eq(eligibility.attributes.symbolize_keys.slice(:itt_academic_year, :eligible_itt_subject, :qualification).transform_values(&:to_s))
+        end
+      end
     end
 
     context "when user has not confirmed their qualification details" do

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
     context "when logged_in_with_tid is nil" do
       let(:logged_in_with_tid) { nil }
 
-      it "adds the qualification details page" do
-        expect(slug_sequence.slugs).to include("qualification-details")
+      it "removes the qualification details page" do
+        expect(slug_sequence.slugs).not_to include("qualification-details")
       end
     end
 
@@ -239,7 +239,6 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
           induction-completed
           supply-teacher
           poor-performance
-          qualification-details
           qualification
           itt-year
           eligible-itt-subject
@@ -287,7 +286,6 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
           induction-completed
           supply-teacher
           poor-performance
-          qualification-details
           qualification
           itt-year
           eligible-itt-subject
@@ -330,7 +328,6 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
           induction-completed
           supply-teacher
           poor-performance
-          qualification-details
           qualification
           itt-year
           eligible-itt-subject
@@ -390,7 +387,6 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
           induction-completed
           supply-teacher
           poor-performance
-          qualification-details
           qualification
           itt-year
           eligible-itt-subject

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
       let(:teacher_id_enabled) { false }
 
       it "removes the Teacher ID-dependant slugs" do
-        slugs = %w[sign-in-or-continue teacher-detail reset-claim correct-school select-email select-mobile]
+        slugs = %w[sign-in-or-continue teacher-detail reset-claim qualification-details correct-school select-email select-mobile]
         expect(slug_sequence.slugs).not_to include(*slugs)
       end
     end

--- a/spec/models/early_career_payments/slug_sequence_spec.rb
+++ b/spec/models/early_career_payments/slug_sequence_spec.rb
@@ -123,6 +123,10 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
     context "when logged_in_with_tid is false" do
       let(:logged_in_with_tid) { false }
 
+      it "removes the qualification details page" do
+        expect(slug_sequence.slugs).not_to include("qualification-details")
+      end
+
       it "includes teacher reference number slug if teacher reference number is nil" do
         claim.teacher_reference_number = nil
 
@@ -133,6 +137,14 @@ RSpec.describe EarlyCareerPayments::SlugSequence do
         claim.teacher_reference_number = "1234567"
 
         expect(slug_sequence.slugs).to include("teacher-reference-number")
+      end
+    end
+
+    context "when logged_in_with_tid is nil" do
+      let(:logged_in_with_tid) { nil }
+
+      it "adds the qualification details page" do
+        expect(slug_sequence.slugs).to include("qualification-details")
       end
     end
 

--- a/spec/models/levelling_up_premium_payments/dqt_record_spec.rb
+++ b/spec/models/levelling_up_premium_payments/dqt_record_spec.rb
@@ -354,7 +354,8 @@ RSpec.describe LevellingUpPremiumPayments::DqtRecord do
     let(:record) do
       OpenStruct.new(
         qualification_name: "BA",
-        qts_award_date:)
+        qts_award_date:
+      )
     end
 
     let(:year) { 2023 }
@@ -363,7 +364,7 @@ RSpec.describe LevellingUpPremiumPayments::DqtRecord do
     let(:eligible_years) { (AcademicYear.new(year - 5)...AcademicYear.new(year)).to_a }
 
     context "when the record returns an eligible date" do
-      let(:qts_award_date) { Date.new(year,1,1) }
+      let(:qts_award_date) { Date.new(year, 1, 1) }
 
       it "returns the academic year" do
         expect(dqt_record.itt_academic_year_for_claim).to eq(AcademicYear.for(qts_award_date))
@@ -371,7 +372,7 @@ RSpec.describe LevellingUpPremiumPayments::DqtRecord do
     end
 
     context "when the record returns an ineligible date" do
-      let(:qts_award_date) { Date.new(year - 10,12,1) }
+      let(:qts_award_date) { Date.new(year - 10, 12, 1) }
 
       it "returns a blank academic year" do
         expect(dqt_record.itt_academic_year_for_claim).to eq(AcademicYear.new)

--- a/spec/models/levelling_up_premium_payments/dqt_record_spec.rb
+++ b/spec/models/levelling_up_premium_payments/dqt_record_spec.rb
@@ -274,4 +274,108 @@ RSpec.describe LevellingUpPremiumPayments::DqtRecord do
       end
     end
   end
+
+  describe "#eligible_degree_code?" do
+    subject(:result) { dqt_record.eligible_degree_code? }
+
+    context "with a valid code" do
+      let(:degree_codes) { [described_class::ELIGIBLE_CODES.sample] }
+      it { is_expected.to be true }
+    end
+
+    context "with an invalid code" do
+      let(:degree_codes) { ["invalid"] }
+      it { is_expected.to be false }
+    end
+
+    context "with a valid and invalid code" do
+      let(:degree_codes) { ["invalid", described_class::ELIGIBLE_CODES.sample] }
+      it { is_expected.to be true }
+    end
+
+    context "with no code" do
+      let(:degree_codes) { [] }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#eligible_itt_subject_for_claim" do
+    before do
+      allow(JourneySubjectEligibilityChecker).to receive(:fixed_lup_subject_symbols)
+        .and_return(eligible_subjects)
+    end
+
+    let(:record) { OpenStruct.new(itt_subjects:) }
+    let(:claim_academic_year) { AcademicYear.new(2023) }
+
+    context "when the record returns a valid subject" do
+      let(:itt_subjects) { ["mathematics"] }
+      let(:eligible_subjects) { [:mathematics] }
+
+      it "returns the valid subject" do
+        expect(dqt_record.eligible_itt_subject_for_claim).to eq(:mathematics)
+      end
+    end
+
+    context "when the record returns multiple valid subjects" do
+      let(:itt_subjects) { ["mathematics", "physics"] }
+      let(:eligible_subjects) { [:physics, :mathematics, :computing] }
+
+      it "returns the first valid subject" do
+        expect(dqt_record.eligible_itt_subject_for_claim).to eq(:physics)
+      end
+    end
+
+    context "when the record returns an invalid subject" do
+      let(:itt_subjects) { ["test"] }
+      let(:eligible_subjects) { [:mathematics] }
+
+      it "returns none_of_the_above" do
+        expect(dqt_record.eligible_itt_subject_for_claim).to eq(:none_of_the_above)
+      end
+    end
+
+    context "when the record returns valid and invalid subjects" do
+      let(:itt_subjects) { ["invalid", "mathematics", "test", "physics"] }
+      let(:eligible_subjects) { [:mathematics] }
+
+      it "returns the first valid subject" do
+        expect(dqt_record.eligible_itt_subject_for_claim).to eq(:mathematics)
+      end
+    end
+  end
+
+  describe "#itt_academic_year_for_claim" do
+    before do
+      allow(JourneySubjectEligibilityChecker).to receive(:new)
+        .and_return(double(selectable_itt_years_for_claim_year: eligible_years))
+    end
+
+    let(:record) do
+      OpenStruct.new(
+        qualification_name: "BA",
+        qts_award_date:)
+    end
+
+    let(:year) { 2023 }
+    let(:claim_year) { AcademicYear.new(year) }
+
+    let(:eligible_years) { (AcademicYear.new(year - 5)...AcademicYear.new(year)).to_a }
+
+    context "when the record returns an eligible date" do
+      let(:qts_award_date) { Date.new(year,1,1) }
+
+      it "returns the academic year" do
+        expect(dqt_record.itt_academic_year_for_claim).to eq(AcademicYear.for(qts_award_date))
+      end
+    end
+
+    context "when the record returns an ineligible date" do
+      let(:qts_award_date) { Date.new(year - 10,12,1) }
+
+      it "returns a blank academic year" do
+        expect(dqt_record.itt_academic_year_for_claim).to eq(AcademicYear.new)
+      end
+    end
+  end
 end

--- a/spec/models/levelling_up_premium_payments/eligibility_spec.rb
+++ b/spec/models/levelling_up_premium_payments/eligibility_spec.rb
@@ -163,6 +163,17 @@ RSpec.describe LevellingUpPremiumPayments::Eligibility, type: :model do
           .and change { eligibility.qualification }.from(qualification.to_s).to(route_into_teaching.to_s)
           .and change { eligibility.eligible_degree_subject }.from(eligible_degree_subject).to(eligible_degree_code)
       end
+
+      context "when the DQT record is missing data" do
+        let(:itt_academic_year_for_claim) { nil }
+        let(:eligible_itt_subject_for_claim) { nil }
+        let(:route_into_teaching) { nil }
+        let(:eligible_degree_code) { nil }
+
+        it "does not change the answers" do
+          expect(eligibility.set_qualifications_from_dqt_record).to eq(eligibility.attributes.symbolize_keys.slice(:itt_academic_year, :eligible_itt_subject, :qualification, :eligible_degree_subject).transform_values { |v| (v == false) ? v : v.to_s })
+        end
+      end
     end
 
     context "when user has not confirmed their qualification details" do

--- a/spec/models/student_loans/dqt_record_spec.rb
+++ b/spec/models/student_loans/dqt_record_spec.rb
@@ -50,4 +50,20 @@ RSpec.describe StudentLoans::DqtRecord do
       expect(StudentLoans::DqtRecord.new(OpenStruct.new({qts_award_date: ""})).eligible_qts_award_date?).to eql false
     end
   end
+
+  describe "#has_no_data_for_claim?" do
+    subject(:dqt_record) { described_class.new(nil) }
+
+    context "when one or more required data are present" do
+      before { allow(dqt_record).to receive(:qts_award_date).and_return("test") }
+
+      it { is_expected.not_to be_has_no_data_for_claim }
+    end
+
+    context "when all required data are not present" do
+      before { allow(dqt_record).to receive(:qts_award_date).and_return(nil) }
+
+      it { is_expected.to be_has_no_data_for_claim }
+    end
+  end
 end

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
 
   let(:subject_attributes) { {chemistry_taught: true, physics_taught: true} }
   let(:eligibility) { claim.eligibility }
-  let(:claim) { build(:claim, eligibility: build(:student_loans_eligibility, :eligible, subject_attributes)) }
+  let(:claim) { build(:claim, eligibility: build(:student_loans_eligibility, :eligible, subject_attributes), qualifications_details_check:) }
+  let(:qualifications_details_check) { false }
 
   subject(:presenter) { described_class.new(eligibility) }
 
@@ -45,6 +46,14 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
 
     it "separates the subjects with commas and a final 'and'" do
       expect(presenter.answers[3][1]).to eq("Biology, Chemistry and Physics")
+    end
+  end
+
+  context "qualifications retrieved from DQT" do
+    let(:qualifications_details_check) { true }
+
+    it "removes the QTS question" do
+      expect(presenter.answers).not_to include([I18n.t("student_loans.questions.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year", "qts-year"])
     end
   end
 end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -386,8 +386,9 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
     context "when user has confirmed their qualification details" do
       let(:qualifications_details_check) { true }
+      let(:qts_award_date) { Date.new(1981, 1, 1) }
 
-      before { allow(claim).to receive(:dqt_teacher_record).and_return(double(eligible_qts_award_date?: eligible)) }
+      before { allow(claim).to receive(:dqt_teacher_record).and_return(double(eligible_qts_award_date?: eligible, qts_award_date:)) }
 
       context "when the DQT payload QTS award date is eligible" do
         let(:eligible) { true }
@@ -402,6 +403,15 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
         it "sets the qts_award_year to before_cut_off_date" do
           expect { eligibility.set_qualifications_from_dqt_record }.to change { eligibility.qts_award_year }.from(qts_award_year).to("before_cut_off_date")
+        end
+      end
+
+      context "when the DQT payload QTS award date is nil" do
+        let(:eligible) { nil }
+        let(:qts_award_date) { nil }
+
+        it "does not change the qts_award_year" do
+          expect { eligibility.set_qualifications_from_dqt_record }.not_to change { eligibility.qts_award_year }
         end
       end
     end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -378,4 +378,41 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#set_qualifications_from_dqt_record" do
+    let(:eligibility) { build(:student_loans_eligibility, claim:, qts_award_year:) }
+    let(:claim) { build(:claim, policy: StudentLoans, qualifications_details_check:) }
+    let(:qts_award_year) { nil }
+
+    context "when user has confirmed their qualification details" do
+      let(:qualifications_details_check) { true }
+
+      before { allow(claim).to receive(:dqt_teacher_record).and_return(double(eligible_qts_award_date?: eligible)) }
+
+      context "when the DQT payload QTS award date is eligible" do
+        let(:eligible) { true }
+
+        it "sets the qts_award_year to on_or_after_cut_off_date" do
+          expect { eligibility.set_qualifications_from_dqt_record }.to change { eligibility.qts_award_year }.from(qts_award_year).to("on_or_after_cut_off_date")
+        end
+      end
+
+      context "when the DQT payload QTS award date is not eligible" do
+        let(:eligible) { false }
+
+        it "sets the qts_award_year to before_cut_off_date" do
+          expect { eligibility.set_qualifications_from_dqt_record }.to change { eligibility.qts_award_year }.from(qts_award_year).to("before_cut_off_date")
+        end
+      end
+    end
+
+    context "when user has not confirmed their qualification details" do
+      let(:qualifications_details_check) { false }
+      let(:qts_award_year) { :on_or_after_cut_off_date }
+
+      it "sets the qts_award_year to nil" do
+        expect { eligibility.set_qualifications_from_dqt_record }.to change { eligibility.qts_award_year }.from(qts_award_year.to_s).to(nil)
+      end
+    end
+  end
 end

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe StudentLoans::SlugSequence do
   subject(:slug_sequence) { StudentLoans::SlugSequence.new(current_claim) }
 
   let(:eligibility) { create(:student_loans_eligibility, :eligible) }
-  let(:claim) { build(:claim, eligibility:, logged_in_with_tid:, qualifications_details_check:, dqt_teacher_status:) }
+  let(:claim) { build(:claim, eligibility:, logged_in_with_tid:, details_check:, qualifications_details_check:, dqt_teacher_status:) }
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:logged_in_with_tid) { nil }
+  let(:details_check) { nil }
   let(:qualifications_details_check) { nil }
   let(:dqt_teacher_status) { nil }
 
@@ -123,14 +124,32 @@ RSpec.describe StudentLoans::SlugSequence do
       end
     end
 
-    context "when logged_in_with_tid is true" do
+    context "when logged_in_with_tid and details_check are true" do
       let(:logged_in_with_tid) { true }
+      let(:details_check) { true }
+      let(:qts_award_date) { "test" }
+
+      before do
+        allow(claim).to receive(:dqt_teacher_record).and_return(double(qts_award_date:, has_no_data_for_claim?: false))
+      end
 
       context "when DQT returns some data" do
         let(:dqt_teacher_status) { {test: true} }
 
         it "adds the qualification details page" do
           expect(slug_sequence.slugs).to include("qualification-details")
+        end
+
+        context "when the DQT payload is missing all required data" do
+          before { allow(current_claim).to receive(:has_no_dqt_data_for_claim?).and_return(true) }
+
+          it "removes the qualification details page" do
+            expect(slug_sequence.slugs).not_to include("qualification-details")
+          end
+
+          it "does not remove the relevant pages" do
+            expect(slug_sequence.slugs).to include("qts-year")
+          end
         end
       end
 
@@ -145,8 +164,18 @@ RSpec.describe StudentLoans::SlugSequence do
       context "when the user confirmed DQT data is correct" do
         let(:qualifications_details_check) { true }
 
-        it "removes the qualification questions" do
-          expect(slug_sequence.slugs).not_to include("qts-year")
+        context "when the DQT record contains all required data" do
+          it "removes the qualification questions" do
+            expect(slug_sequence.slugs).not_to include("qts-year")
+          end
+        end
+
+        context "when the DQT payload is missing some data" do
+          let(:qts_award_date) { nil }
+
+          it "does not remove the relevant pages" do
+            expect(slug_sequence.slugs).to include("qts-year")
+          end
         end
       end
 

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe StudentLoans::SlugSequence do
       before { create(:policy_configuration, :student_loans, teacher_id_enabled: false) }
 
       it "removes the Teacher ID-dependant slugs" do
-        slugs = %w[sign-in-or-continue teacher-detail reset-claim select-email select-mobile]
+        slugs = %w[sign-in-or-continue teacher-detail reset-claim qualification-details select-email select-mobile]
         expect(slug_sequence.slugs).not_to include(*slugs)
       end
     end

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -170,8 +170,8 @@ RSpec.describe StudentLoans::SlugSequence do
     context "when logged_in_with_tid is nil" do
       let(:logged_in_with_tid) { nil }
 
-      it "adds the qualification details page" do
-        expect(slug_sequence.slugs).to include("qualification-details")
+      it "does not add the qualification details page" do
+        expect(slug_sequence.slugs).not_to include("qualification-details")
       end
     end
   end

--- a/spec/support/dqt_helpers.rb
+++ b/spec/support/dqt_helpers.rb
@@ -58,6 +58,19 @@ module DqtHelpers
       )
   end
 
+  def stub_dqt_empty_response(
+    trn: 1231234,
+    params: {}
+  )
+    stub_request(:get, "#{ENV["DQT_API_URL"]}teachers/#{trn}")
+      .with(query: WebMock::API.hash_including(params))
+      .to_return(
+        body: {}.to_json,
+        status: 404,
+        headers: {"Content-Type" => "application/json"}
+      )
+  end
+
   private
 
   def merge_recursively(a, b)

--- a/spec/support/omniauth_mock_helper.rb
+++ b/spec/support/omniauth_mock_helper.rb
@@ -6,14 +6,14 @@ module OmniauthMockHelper
       OmniAuth::AuthHash.new(
         "extra" => {
           "raw_info" => {
-            "trn" => opts.key?(:returned_trn) ? opts[:returned_trn] : trn,
-            "birthdate" => "1940-01-01",
+            "trn" => opts.key?(:returned_trn) ? opts[:returned_trn].to_s : trn.to_s,
+            "birthdate" => opts.key?(:date_of_birth) ? opts[:date_of_birth].to_s : "1940-01-01",
             "given_name" => "Kelsie",
             "family_name" => "Oberbrunner",
-            "ni_number" => opts.key?(:nino) ? opts[:nino] : "AB123456C",
+            "ni_number" => opts.key?(:nino) ? opts[:nino].to_s : "AB123456C",
             "trn_match_ni_number" => "True",
             "email" => "kelsie.oberbrunner@example.com",
-            "phone_number" => phone_number
+            "phone_number" => phone_number.to_s
           }
         }
       )


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1317

Presents the teacher's qualifications (as derived from the DQT) to them in the claim journey, and pre-fills the claim with that information if the Teacher confirms they are correct. Otherwise, the Teacher can manually enter their qualifications.