### PR TITLE
Update dfe-analytics gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,4 +121,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.3"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: e6443cbf0efd46c1d46772efab3bdb1c0d1da5eb
-  tag: v1.11.3
+  revision: fdfd7f0bdbe5c6b6677d7502afb8691ae08bedeb
+  tag: v1.11.5
   specs:
-    dfe-analytics (1.11.3)
+    dfe-analytics (1.11.5)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -302,3 +302,5 @@ shared:
   - subject_description_sfr
   - general_subject_code
   - hours_taught
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -28,8 +28,6 @@
   - subject_7
   - subject_8
   - subject_9
-  - created_at
-  - updated_at
   - subject_10
   - subject_11
   - subject_12


### PR DESCRIPTION
Updating to the latest version of dfe-analytics (v1.11.5) prior to enabling the entity_table_check_job
