### PR TITLE
Fix ECP subject matching against DQT record

### DIFF
--- a/app/models/early_career_payments/dqt_record.rb
+++ b/app/models/early_career_payments/dqt_record.rb
@@ -36,16 +36,16 @@ module EarlyCareerPayments
 
     # TODO: May need to prioritise subject chosen by highest award amount?
     def eligible_itt_subject_for_claim
-      return nil if !itt_subjects || itt_subjects.empty?
+      raise if !itt_subject_groups || itt_subject_groups.empty?
 
       year = itt_year || claim.eligibility.itt_academic_year # The user may have supplied this manually if it was missing from the DQT record
 
-      return nil unless year
+      raise unless year
 
       itt_subject_checker = JourneySubjectEligibilityChecker.new(claim_year: claim.policy.configuration.current_academic_year, itt_year: year)
 
-      itt_subjects.delete_if do |itt_subject|
-        !itt_subject.to_sym.in?(itt_subject_checker.current_and_future_subject_symbols(claim.policy))
+      itt_subject_groups.delete_if do |itt_subject_group|
+        !itt_subject_group.in?(itt_subject_checker.current_and_future_subject_symbols(claim.policy))
       end.first.to_sym
     rescue # JourneySubjectEligibilityChecker can also raise an exception if itt_year is out of eligible range
       :none_of_the_above
@@ -68,7 +68,7 @@ module EarlyCareerPayments
     attr_reader :claim, :record
 
     def award_due?
-      award_args = {policy_year: claim.academic_year, itt_year: itt_year, subject_symbol: itt_subject_group}
+      award_args = {policy_year: claim.academic_year, itt_year: itt_year, subject_symbol: eligible_itt_subject_group}
 
       if award_args.values.any?(&:blank?)
         false
@@ -77,15 +77,17 @@ module EarlyCareerPayments
       end
     end
 
-    def itt_subject_group
+    def itt_subject_groups
       [*itt_subject_codes, *degree_codes, *itt_subjects].map do |subject_code|
         ELIGIBLE_JAC_CODES.find { |key, values| subject_code.start_with?(*values) }&.first ||
           ELIGIBLE_HECOS_CODES.find { |key, values| values.include?(subject_code) }&.first ||
           ELIGIBLE_JAC_NAMES.find { |key, values| values.include?(subject_code) }&.first ||
           ELIGIBLE_HECOS_NAMES.find { |key, values| values.include?(subject_code) }&.first
-      end.compact.uniq.find do |group|
-        group == claim.eligibility.eligible_itt_subject.to_sym
-      end
+      end.compact.uniq
+    end
+
+    def eligible_itt_subject_group
+      itt_subject_groups.find { |group| group == claim.eligibility.eligible_itt_subject.to_sym }
     end
 
     def eligible_subject?

--- a/app/models/early_career_payments/dqt_record.rb
+++ b/app/models/early_career_payments/dqt_record.rb
@@ -36,11 +36,9 @@ module EarlyCareerPayments
 
     # TODO: May need to prioritise subject chosen by highest award amount?
     def eligible_itt_subject_for_claim
-      raise if !itt_subject_groups || itt_subject_groups.empty?
-
       year = itt_year || claim.eligibility.itt_academic_year # The user may have supplied this manually if it was missing from the DQT record
 
-      raise unless year
+      return :none_of_the_above if itt_subject_groups.empty? || !year
 
       itt_subject_checker = JourneySubjectEligibilityChecker.new(claim_year: claim.policy.configuration.current_academic_year, itt_year: year)
 

--- a/spec/models/early_career_payments/dqt_record_spec.rb
+++ b/spec/models/early_career_payments/dqt_record_spec.rb
@@ -2193,7 +2193,7 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
       let(:eligible_subjects) { [:mathematics] }
 
       context "when the record returns a valid subject" do
-        let(:itt_subjects) { ["mathematics"] }
+        let(:itt_subjects) { ["Applied Mathematics"] }
 
         it "returns the valid subject" do
           expect(dqt_record.eligible_itt_subject_for_claim).to eq(:mathematics)
@@ -2201,7 +2201,7 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
       end
 
       context "when the record returns multiple valid subjects" do
-        let(:itt_subjects) { ["mathematics", "physics"] }
+        let(:itt_subjects) { ["Applied Mathematics", "Applied Physics"] }
         let(:eligible_subjects) { [:physics, :mathematics, :computing] }
 
         it "returns the first valid subject" do
@@ -2218,7 +2218,7 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
       end
 
       context "when the record returns valid and invalid subjects" do
-        let(:itt_subjects) { ["invalid", "mathematics", "test", "physics"] }
+        let(:itt_subjects) { ["invalid", "Applied Mathematics", "test", "Applied Physics"] }
 
         it "returns the first valid subject" do
           expect(dqt_record.eligible_itt_subject_for_claim).to eq(:mathematics)
@@ -2229,19 +2229,19 @@ RSpec.describe EarlyCareerPayments::DqtRecord do
         let(:itt_subjects) { nil }
 
         it "returns nil" do
-          expect(dqt_record.eligible_itt_subject_for_claim).to be_nil
+          expect(dqt_record.eligible_itt_subject_for_claim).to eq(:none_of_the_above)
         end
       end
 
       context "when the record has no ITT year" do
         let(:record_qts_date) { nil }
-        let(:itt_subjects) { ["mathematics"] }
+        let(:itt_subjects) { ["Applied Mathematics"] }
 
         context "when the Claim has no ITT year" do
           let(:itt_academic_year) { nil }
 
           it "returns nil" do
-            expect(dqt_record.eligible_itt_subject_for_claim).to be_nil
+            expect(dqt_record.eligible_itt_subject_for_claim).to eq(:none_of_the_above)
           end
         end
 


### PR DESCRIPTION
Similar to https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2573

Fixes a bug in the ECP DQT record matching where the ITT subject was not matched against the list of all possible strings listed in https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/lib/dqt/matchers/early_career_payments.rb. It would only match if it was an exact match for the key, e.g. `computing`.

This would incorrectly determine a user as ineligible in the teacher ID journey.