### PR TITLE
CAPT-1417 Change the slug sequence of the student loan playback (TSLR)

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -381,9 +381,15 @@ class ClaimsController < BasePublicController
   def retrieve_student_loan_details
     # student loan details are currently retrieved for TSLR and ECP/LUPP journeys only
     return unless ["student-loans", "additional-payments"].include?(current_policy_routing_name)
-    # student loan details are retrieved every time the user confirms their details
-    return unless page_sequence.updating_personal_details?
 
-    ClaimStudentLoanDetailsUpdater.call(current_claim)
+    # Applicants' student loan details must be retrieved any time their personal details are
+    # updated using the `personal-details` page. This is normally the case when using the non-TID
+    # route, or when using the TID-route but not all personal details came through/are valid.
+    # For claims being submitted using the TID-route and where all personal details came through/are
+    # valid, the student loan details must be retrieved after the `information-provided` page instead.
+    if params[:slug] == "personal-details" || (params[:slug] == "information-provided" &&
+        current_claim.logged_in_with_tid? && current_claim.has_all_valid_personal_details?)
+      ClaimStudentLoanDetailsUpdater.call(current_claim)
+    end
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -250,9 +250,9 @@ class Claim < ApplicationRecord
   validates :student_loan_plan, inclusion: {in: STUDENT_LOAN_PLAN_OPTIONS}, allow_nil: true
   validates :student_loan_plan, on: [:"student-loan", :amendment], presence: {message: "Enter a valid student loan plan"}
 
-  validates :has_masters_doctoral_loan, on: [:"masters-doctoral-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a postgraduate masters and/or doctoral loan"}, if: :no_student_loan?
-  validates :postgraduate_masters_loan, on: [:"masters-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a Postgraduate Master’s Loan"}, unless: -> { no_masters_doctoral_loan? }
-  validates :postgraduate_doctoral_loan, on: [:"doctoral-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a Postgraduate Doctoral Loan"}, unless: -> { no_masters_doctoral_loan? }
+  validates :has_masters_doctoral_loan, on: [:"masters-doctoral-loan"], inclusion: {in: [true, false], message: "Select yes if you have a postgraduate masters and/or doctoral loan"}, if: :no_student_loan?
+  validates :postgraduate_masters_loan, on: [:"masters-loan"], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a Postgraduate Master’s Loan"}, unless: -> { no_masters_doctoral_loan? }
+  validates :postgraduate_doctoral_loan, on: [:"doctoral-loan"], inclusion: {in: [true, false], message: "Select yes if you are currently repaying a Postgraduate Doctoral Loan"}, unless: -> { no_masters_doctoral_loan? }
 
   validates :email_address, on: [:"email-address", :submit], presence: {message: "Enter an email address"}
   validates :email_address, format: {with: Rails.application.config.email_regexp, message: "Enter an email address in the correct format, like name@example.com"},

--- a/app/models/claim_student_loan_details_updater.rb
+++ b/app/models/claim_student_loan_details_updater.rb
@@ -30,7 +30,7 @@ class ClaimStudentLoanDetailsUpdater
 
   delegate :eligibility, to: :claim
   delegate :national_insurance_number, :date_of_birth, to: :claim
-  delegate :repaying_plan_types, :total_repayment_amount, to: :student_loans_data
+  delegate :repaying_plan_types, :total_repayment_amount, to: :student_loans_data, prefix: :slc
 
   alias_method :nino, :national_insurance_number
 
@@ -43,18 +43,13 @@ class ClaimStudentLoanDetailsUpdater
   end
 
   def eligibility_student_loan_attributes
-    {student_loan_repayment_amount: total_repayment_amount}
+    {student_loan_repayment_amount: slc_total_repayment_amount}
   end
 
   def claim_student_loan_attributes
     {
       has_student_loan: found_data?,
-      student_loan_plan: repaying_plan_types || Claim::NO_STUDENT_LOAN,
-      # The following flags are irrelevant now, as it was used only to determine the plan type
-      # TODO: remove the update when all the student loan questions and validations are removed from all journeys
-      has_masters_doctoral_loan: false,
-      postgraduate_masters_loan: false,
-      postgraduate_doctoral_loan: false
+      student_loan_plan: slc_repaying_plan_types || Claim::NO_STUDENT_LOAN
     }
   end
 end

--- a/app/models/dqt/retrieve_claim_qualifications_data.rb
+++ b/app/models/dqt/retrieve_claim_qualifications_data.rb
@@ -14,7 +14,7 @@ module Dqt
       begin
         # {} would indicate nothing was found in DQT but also truthy to prevent further requests
         @claim.update(dqt_teacher_status: response || {})
-      rescue
+      rescue => e
         # Something went wrong with the DQT call, just assume no result returned and continue
         Rollbar.error(e)
         @claim.update(dqt_teacher_status: {})

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -6,7 +6,6 @@ class PageSequence
 
   DEAD_END_SLUGS = %w[complete existing-session eligible-later future-eligibility ineligible]
   OPTIONAL_SLUGS = %w[postcode-search no-address-found select-home-address reset-claim]
-  PERSONAL_DETAILS_SLUGS = %w[personal-details teacher-detail]
 
   def initialize(claim, slug_sequence, completed_slugs, current_slug)
     @claim = claim
@@ -56,11 +55,11 @@ class PageSequence
     (slugs - completed_slugs - OPTIONAL_SLUGS).first
   end
 
-  def updating_personal_details?
-    PERSONAL_DETAILS_SLUGS.include?(current_slug)
-  end
-
   private
+
+  def updating_personal_details?
+    current_slug == "personal-details"
+  end
 
   def incomplete_slugs
     (slugs.slice(0, current_slug_index) - OPTIONAL_SLUGS - completed_slugs)

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -28,6 +28,7 @@ module StudentLoans
     PERSONAL_DETAILS_SLUGS = [
       "information-provided",
       "personal-details",
+      "student-loan-amount",
       "postcode-search",
       "no-address-found",
       "select-home-address",
@@ -40,10 +41,6 @@ module StudentLoans
       "mobile-number",
       "mobile-verification"
     ].freeze
-
-    STUDENT_LOANS_SLUGS = [
-      "student-loan-amount"
-    ]
 
     PAYMENT_DETAILS_SLUGS = [
       "bank-or-building-society",
@@ -61,7 +58,6 @@ module StudentLoans
     SLUGS = (
       ELIGIBILITY_SLUGS +
       PERSONAL_DETAILS_SLUGS +
-      STUDENT_LOANS_SLUGS +
       PAYMENT_DETAILS_SLUGS +
       RESULTS_SLUGS
     ).freeze

--- a/spec/features/claim_with_mobile_sms_otp_spec.rb
+++ b/spec/features/claim_with_mobile_sms_otp_spec.rb
@@ -40,17 +40,6 @@ RSpec.feature "GOVUK Nofity SMS sends OTP" do
     }
   end
 
-  def post_otp_screen_title(policy)
-    case policy
-    when EarlyCareerPayments, MathsAndPhysics
-      # Payment to Bank or Building Society
-      I18n.t("questions.bank_or_building_society")
-    when StudentLoans
-      # Student loan amount details
-      I18n.t("student_loans.questions.student_loan_amount")
-    end
-  end
-
   [
     {policy: EarlyCareerPayments, mobile_number: "07123456789", otp_code: "097543"},
     {policy: StudentLoans, mobile_number: "07723190022", otp_code: "123347"},
@@ -106,7 +95,7 @@ RSpec.feature "GOVUK Nofity SMS sends OTP" do
         fill_in "claim_one_time_password", with: scenario[:otp_code]
         click_on "Confirm"
 
-        expect(page).to have_title(post_otp_screen_title(scenario[:policy]))
+        expect(page).to have_title(I18n.t("questions.bank_or_building_society"))
       end
     end
   end

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -1,12 +1,30 @@
 require "rails_helper"
 
 RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
+  include OmniauthMockHelper
   include StudentLoansHelper
 
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
   let!(:ineligible_school) { create(:school, :student_loans_ineligible) }
-  let(:imported_slc_data) { create(:student_loans_data, nino: "PX321499A", date_of_birth: "28/2/1988", plan_type_of_deduction: 1, amount: 0) }
+  let(:imported_slc_data) { create(:student_loans_data, nino:, date_of_birth:, plan_type_of_deduction: 1, amount: 0) }
+  let(:eligible_itt_years) { JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(policy_configuration.current_academic_year) }
+  let(:academic_date) { Date.new(eligible_itt_years.first.start_year, 12, 1) }
+  let(:itt_year) { AcademicYear.for(academic_date) }
+  let(:trn) { 1234567 }
+  let(:date_of_birth) { "1999-01-01" }
+  let(:nino) { "AB123123A" }
+  let(:eligible_dqt_body) do
+    {
+      qualified_teacher_status: {
+        qts_date: academic_date.to_s
+      }
+    }
+  end
+
+  after do
+    set_mock_auth(nil)
+  end
 
   scenario "qualified before the first eligible QTS year" do
     policy_configuration.update!(current_academic_year: "2025/2026")
@@ -95,13 +113,11 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between #{StudentLoans.current_financial_year}.")
   end
 
-  scenario "claimant made zero student loan repayments" do
+  scenario "claimant made zero student loan repayments (Non-TID journey)" do
     imported_slc_data
 
-    claim = start_student_loans_claim
+    start_student_loans_claim
     choose_school school
-    expect(claim.eligibility.reload.claim_school).to eql school
-    expect(page).to have_text(subjects_taught_question(school_name: school.name))
 
     check "Physics"
     click_on "Continue"
@@ -122,11 +138,58 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     fill_in "claim_first_name", with: "Russell"
     fill_in "claim_surname", with: "Wong"
 
-    fill_in "Day", with: "28"
-    fill_in "Month", with: "2"
-    fill_in "Year", with: "1988"
+    fill_in "Day", with: Date.parse(date_of_birth).day
+    fill_in "Month", with: Date.parse(date_of_birth).month
+    fill_in "Year", with: Date.parse(date_of_birth).year
 
-    fill_in "National Insurance number", with: "PX321499A"
+    fill_in "National Insurance number", with: nino
+    click_on "Continue"
+
+    expect(page).to have_text("Your student loan repayment amount is £0.00")
+    expect(page).to have_text("you are not eligible to claim back any repayments")
+  end
+
+  scenario "claimant made zero student loan repayments (TID journey)" do
+    set_mock_auth(trn, {date_of_birth:, nino:})
+    stub_qualified_teaching_statuses_show(trn:, params: {birthdate: date_of_birth, nino:}, body: eligible_dqt_body)
+
+    imported_slc_data
+
+    visit landing_page_path(StudentLoans.routing_name)
+
+    # - Landing (start)
+    click_on "Start now"
+    click_on "Continue with DfE Identity"
+
+    # - Teacher details page
+    choose "Yes"
+    click_on "Continue"
+
+    # - Qualification details
+    choose "Yes"
+    click_on "Continue"
+
+    # - Which school do you teach at
+    choose_school school
+    click_on "Continue"
+
+    # - Select subject
+    check "Physics"
+    click_on "Continue"
+    choose_still_teaching("Yes, at #{school.name}")
+
+    #  - Are you still employed to teach at
+    choose "Yes"
+    click_on "Continue"
+
+    #  - leadership-position question
+    choose "No"
+    click_on "Continue"
+
+    #  - Eligibility confirmed
+    click_on "Continue"
+
+    # - information-provided page
     click_on "Continue"
 
     expect(page).to have_text("Your student loan repayment amount is £0.00")

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -85,6 +85,10 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.reload.surname).to eql("Wong")
     expect(claim.reload.date_of_birth).to eq(Date.new(1988, 2, 28))
     expect(claim.reload.national_insurance_number).to eq("PX321499A")
+  end
+
+  def fill_in_remaining_personal_details_and_submit
+    claim = Claim.by_policy(StudentLoans).order(:created_at).last
 
     expect(page).to have_text(I18n.t("questions.address.home.title"))
 
@@ -134,10 +138,6 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     # - Mobile number
     expect(page).not_to have_text(I18n.t("questions.mobile_number"))
-  end
-
-  def fill_in_payment_information_and_submit
-    claim = Claim.by_policy(StudentLoans).order(:created_at).last
 
     expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
 
@@ -224,7 +224,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.has_masters_doctoral_loan).to eq(false)
       expect(claim.postgraduate_masters_loan).to eq(false)
 
-      fill_in_payment_information_and_submit
+      fill_in_remaining_personal_details_and_submit
     end
 
     scenario "Teacher claims back student loan repayments with javascript #{js_status} (no SLC data present)", js: javascript_enabled do
@@ -243,7 +243,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.has_masters_doctoral_loan).to eq(false)
       expect(claim.postgraduate_masters_loan).to eq(false)
 
-      fill_in_payment_information_and_submit
+      fill_in_remaining_personal_details_and_submit
     end
   end
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -221,8 +221,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.eligibility.reload.student_loan_repayment_amount).to eql(1_100)
       expect(claim.student_loan_plan).to eq(StudentLoan::PLAN_1)
 
-      expect(claim.has_masters_doctoral_loan).to eq(false)
-      expect(claim.postgraduate_masters_loan).to eq(false)
+      expect(claim.has_masters_doctoral_loan).to be_nil
+      expect(claim.postgraduate_masters_loan).to be_nil
 
       fill_in_remaining_personal_details_and_submit
     end
@@ -240,8 +240,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.eligibility.reload.student_loan_repayment_amount).to eql(0)
       expect(claim.student_loan_plan).to eql(Claim::NO_STUDENT_LOAN)
 
-      expect(claim.has_masters_doctoral_loan).to eq(false)
-      expect(claim.postgraduate_masters_loan).to eq(false)
+      expect(claim.has_masters_doctoral_loan).to be_nil
+      expect(claim.postgraduate_masters_loan).to be_nil
 
       fill_in_remaining_personal_details_and_submit
     end

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
@@ -161,6 +161,10 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
 
     # - Personal details - skipped
 
+    # - Student loan amount details
+    expect(page).to have_title(I18n.t("student_loans.questions.student_loan_amount"))
+    click_on "Continue"
+
     # - What is your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
     expect(page).to have_link(href: claim_path(StudentLoans.routing_name, "address"))

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -36,8 +36,8 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
 
     click_on "Continue"
 
-    # -  Student loan amount details
-    expect(page).to have_title(I18n.t("student_loans.questions.student_loan_amount"))
+    # - Choose bank or building society
+    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
 
     claims = Claim.order(created_at: :desc).limit(2)
 
@@ -72,8 +72,8 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
     choose(I18n.t("questions.select_phone_number.decline"))
     click_on "Continue"
 
-    # - Student loan amount details
-    expect(page).to have_title(I18n.t("student_loans.questions.student_loan_amount"))
+    # - Choose bank or building society
+    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
 
     claims.reload.each do |c|
       expect(c.mobile_number).to eq(nil)
@@ -126,7 +126,7 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
     choose "No"
     click_on "Continue"
 
-    # - student-loan-amount page
+    # - Eligibility confirmed
     expect(page).to have_text("you can claim back the student loan repayments you made between #{StudentLoans.current_financial_year}.")
     click_on "Continue"
 
@@ -135,6 +135,10 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
     click_on "Continue"
 
     # - Personal details - skipped
+
+    # - Student loan amount details
+    expect(page).to have_title(I18n.t("student_loans.questions.student_loan_amount"))
+    click_on "Continue"
 
     # - What is your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))

--- a/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
@@ -81,6 +81,9 @@ RSpec.feature "TSLR journey with Teacher ID teacher reference number page remova
 
     # - Personal details - skipped
 
+    # - Student loan amount details
+    click_on "Continue"
+
     # - What is your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
     expect(page).to have_link(href: claim_path(StudentLoans.routing_name, "address"))
@@ -105,9 +108,6 @@ RSpec.feature "TSLR journey with Teacher ID teacher reference number page remova
 
     # - Select the suggested phone number
     find("#claim_mobile_check_use").click
-    click_on "Continue"
-
-    # - Student loan amount details
     click_on "Continue"
 
     # - Choose bank or building society

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe PageSequence do
       let(:completed_slugs) { ["first-slug", "second-slug", "third-slug"] }
 
       it { is_expected.to eq("check-your-answers") }
+
+      context "when student-loan-amount is in the sequence and the current slug is personal-details" do
+        let(:claim) { build(:claim, :submittable) }
+        let(:slug_sequence) { OpenStruct.new(slugs: ["personal-details", "student-loan-amount"]) }
+        let(:current_slug) { "personal-details" }
+        let(:completed_slugs) { ["personal-details", "student-loan-amount"] }
+
+        it { is_expected.to eq("student-loan-amount") }
+      end
     end
 
     context "when address is populated from 'select-home-address'" do
@@ -171,22 +180,6 @@ RSpec.describe PageSequence do
 
     it "returns the next required and incomplete slug" do
       expect(page_sequence.next_required_slug).to eq("second-slug")
-    end
-  end
-
-  describe "#updating_personal_details?" do
-    ["personal-details", "teacher-detail"].each do |slug|
-      context "when the current slug is #{slug}" do
-        let(:current_slug) { slug }
-
-        it { is_expected.to be_updating_personal_details }
-      end
-    end
-
-    context "when the current slug is something else" do
-      let(:current_slug) { "something-else" }
-
-      it { is_expected.not_to be_updating_personal_details }
     end
   end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -202,6 +202,95 @@ RSpec.describe "Claims", type: :request do
         expect(response.body).to include("Select when you completed your initial teacher training")
       end
 
+      context "when initiating the request from personal-details" do
+        let(:params) do
+          {
+            claim: {
+              first_name: "John",
+              surname: "Doe",
+              "date_of_birth(3i)": "1", "date_of_birth(2i)": "1", "date_of_birth(1i)": "1990",
+              national_insurance_number: "QQ123456C"
+            }
+          }
+        end
+        let(:request) { put claim_path(StudentLoans.routing_name, "personal-details"), params: }
+
+        before do
+          set_slug_sequence_in_session(in_progress_claim, "personal-details")
+        end
+
+        it "updates the student loan details" do
+          expect { request }.to change { in_progress_claim.reload.has_student_loan }
+            .and change { in_progress_claim.student_loan_plan }
+        end
+      end
+
+      context "when initiating the request from information-provided" do
+        let(:request) { put claim_path(StudentLoans.routing_name, "information-provided"), params: {} }
+
+        before do
+          in_progress_claim.update!(logged_in_with_tid: true) if tid_journey?
+          set_slug_sequence_in_session(in_progress_claim, "information-provided")
+        end
+
+        context "within the non-TID journey" do
+          let(:tid_journey?) { false }
+
+          it "does not update the student loan details" do
+            expect { request }.to not_change { in_progress_claim.reload.has_student_loan }
+              .and not_change { in_progress_claim.student_loan_plan }
+          end
+        end
+
+        context "within the TID journey" do
+          let(:tid_journey?) { true }
+
+          context "when the claim has all valid personal details" do
+            before do
+              in_progress_claim.update!(
+                first_name: "John",
+                surname: "Doe",
+                date_of_birth: "1/1/1990",
+                national_insurance_number: "QQ123456C",
+                teacher_id_user_info: {
+                  "given_name" => "John",
+                  "family_name" => "Doe",
+                  "birthdate" => "1990-01-01",
+                  "ni_number" => "QQ123456C"
+                }
+              )
+            end
+
+            it "updates the student loan details" do
+              expect { request }.to change { in_progress_claim.reload.has_student_loan }
+                .and change { in_progress_claim.student_loan_plan }
+            end
+          end
+
+          context "when the claim does not have all valid personal details" do
+            before do
+              in_progress_claim.update!(
+                first_name: "John",
+                surname: "Doe",
+                date_of_birth: "1/1/1990",
+                national_insurance_number: "QQ123456C",
+                teacher_id_user_info: {
+                  "given_name" => "Not John",
+                  "family_name" => "Doe",
+                  "birthdate" => "1990-01-01",
+                  "ni_number" => "QQ123456C"
+                }
+              )
+            end
+
+            it "does not update the student loan details" do
+              expect { request }.to not_change { in_progress_claim.reload.has_student_loan }
+                .and not_change { in_progress_claim.student_loan_plan }
+            end
+          end
+        end
+      end
+
       context "when the user has not completed the journey in the correct slug sequence" do
         it "redirects to the start of the journey" do
           put claim_path(StudentLoans.routing_name, "student-loan-amount"), params: {claim: {has_student_loan: true}}


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1417

The only code change should have been in the slug sequence, but I had to make another change in the controller, and it's still quite small. This additional change was necessary because when using the TID route we start retrieving and storing personal details _before_ checking for eligibility criteria (in the non-TID route we first calculate the eligibility, then we ask and store **any** personal details).

In this particular context, retrieving and storing the Student loan details as soon as the user confirms their personal details could cause a premature exit screen when the applicant made zero repayments: in this scenario we'd still want the user to know if their qualifications etc would make them eligible. See ticket comments for more info.

Most changes/additions in this PR are testing-related