### PR TITLE
Fix: Unable to submit when selecting mobile number (TID)

### DIFF
--- a/app/forms/select_mobile_number_form.rb
+++ b/app/forms/select_mobile_number_form.rb
@@ -19,7 +19,7 @@ class SelectMobileNumberForm
     when "alternative"
       {
         mobile_number: nil,
-        provide_mobile_number: nil,
+        provide_mobile_number: true,
         mobile_check: @mobile_check
       }
     when "declined"

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -772,8 +772,13 @@ class Claim < ApplicationRecord
     errors[:date_of_birth].empty?
   end
 
+  def using_mobile_number_from_tid?
+    logged_in_with_tid? && mobile_check == "use" && provide_mobile_number && mobile_number.present?
+  end
+
   def submittable_mobile_details?
     return true unless has_ecp_or_lupp_policy?
+    return true if using_mobile_number_from_tid?
     return true if provide_mobile_number && mobile_number.present? && mobile_verified == true
     return true if provide_mobile_number == false && mobile_number.nil? && mobile_verified == false
     return true if provide_mobile_number == false && mobile_verified.nil?

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
       eligibility_trait { nil }
       eligibility_attributes { nil }
       decision_creator { nil }
+      using_mobile_number_from_tid { false }
     end
 
     after(:build) do |claim, evaluator|
@@ -50,11 +51,16 @@ FactoryBot.define do
 
       eligibility_trait { :eligible }
 
-      after(:build) do |claim|
+      after(:build) do |claim, evaluator|
         if claim.has_ecp_or_lupp_policy?
           claim.provide_mobile_number = true
           claim.mobile_number = "07474000123"
           claim.mobile_verified = true
+          if evaluator.using_mobile_number_from_tid
+            claim.mobile_check = "use"
+            claim.mobile_verified = false
+            claim.logged_in_with_tid = true
+          end
         end
       end
     end

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -4,108 +4,74 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
   include OmniauthMockHelper
   include StudentLoansHelper
 
-  # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:policy_configuration) { create(:policy_configuration, :student_loans) }
   let!(:school) { create(:school, :student_loans_eligible) }
   let(:trn) { 1234567 }
   let(:date_of_birth) { "1981-01-01" }
   let(:nino) { "AB123123A" }
-  let(:phone_number) { "01234567890" }
+  let(:alt_phone_number) { "01234567891" }
+  let(:otp_code) { "010101" }
 
   before do
-    freeze_time
     set_mock_auth(trn, {date_of_birth:, nino:})
     stub_dqt_empty_response(trn:, params: {birthdate: date_of_birth, nino:})
-    mock_address_details_address_data
+    stub_otp_verification(otp_code:)
   end
 
   after do
     set_mock_auth(nil)
-    travel_back
   end
 
-  scenario "Select mobile number to be contacted" do
-    # - Selects suggested phone number
+  scenario "User chooses the mobile number from Teacher ID" do
+    navigate_to_check_mobile_page
 
-    navigate_to_check_mobile_page(school:)
-
-    expect(page).to have_text(I18n.t("questions.select_phone_number.heading"))
-
-    # - Select the suggested phone number
-    choose(phone_number)
-
+    find("#claim_mobile_check_use").click
     click_on "Continue"
 
-    # - Choose bank or building society
-    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
-
-    claims = Claim.order(created_at: :desc).limit(2)
-
-    claims.each do |c|
-      expect(c.mobile_number).to eq(phone_number)
-      expect(c.provide_mobile_number).to eq(true)
-      expect(c.mobile_check).to eq("use")
-    end
-
-    # - Select to use an alternative phone number
-
-    click_on "Back"
-
-    # - Select A different mobile number
-    choose(I18n.t("questions.select_phone_number.alternative"))
-    click_on "Continue"
-
-    # - Enter your phone number
-    expect(page).to have_text("To verify your mobile number we will send you a text message with a 6-digit passcode. You can enter the passcode on the next screen.")
-
-    claims.reload.each do |c|
-      expect(c.mobile_number).to eq(nil)
-      expect(c.provide_mobile_number).to eq(nil)
-      expect(c.mobile_check).to eq("alternative")
-    end
-
-    # - Choose not to be contacted by phone
-
-    click_on "Back"
-
-    # - Choose not to be contacted by mobile
-    choose(I18n.t("questions.select_phone_number.decline"))
-    click_on "Continue"
-
-    # - Choose bank or building society
-    expect(page).to have_text(I18n.t("questions.bank_or_building_society"))
-
-    claims.reload.each do |c|
-      expect(c.mobile_number).to eq(nil)
-      expect(c.provide_mobile_number).to eq(false)
-      expect(c.mobile_check).to eq("declined")
-    end
+    fill_in_remaining_details_and_submit_claim
   end
 
-  def navigate_to_check_mobile_page(school:)
+  scenario "User chooses an alternative mobile number" do
+    navigate_to_check_mobile_page
+
+    find("#claim_mobile_check_alternative").click
+    click_on "Continue"
+
+    fill_in "claim_mobile_number", with: alt_phone_number
+    click_on "Continue"
+
+    fill_in "claim_one_time_password", with: otp_code
+    click_on "Confirm"
+
+    fill_in_remaining_details_and_submit_claim
+  end
+
+  scenario "User chooses not to be contacted by mobile" do
+    navigate_to_check_mobile_page
+
+    find("#claim_mobile_check_declined").click
+    click_on "Continue"
+
+    fill_in_remaining_details_and_submit_claim
+  end
+
+  def navigate_to_check_mobile_page
     visit landing_page_path(StudentLoans.routing_name)
 
     # - Landing (start)
-    expect(page).to have_text(I18n.t("student_loans.landing_page"))
     click_on "Start now"
 
-    expect(page).to have_text("Use DfE Identity to sign in")
     click_on "Continue with DfE Identity"
 
     # - Teacher details page
-    expect(page).to have_text(I18n.t("questions.check_and_confirm_details"))
-    expect(page).to have_text(I18n.t("questions.details_correct"))
-
     choose "Yes"
     click_on "Continue"
 
     # - Select qts year
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
     choose_qts_year
     click_on "Continue"
 
     # - Which school do you teach at
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year))
     choose_school school
 
     # - Which subject do you teach
@@ -113,84 +79,61 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
     click_on "Continue"
 
     #  - Are you still employed to teach at
-    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
     choose_still_teaching("Yes, at #{school.name}")
 
     #  - leadership-position question
-    expect(page).to have_text(leadership_position_question)
     choose "Yes"
     click_on "Continue"
 
     #  - mostly-performed-leadership-duties question
-    expect(page).to have_text(mostly_performed_leadership_duties_question)
     choose "No"
     click_on "Continue"
 
     # - student-loan-amount page
-    expect(page).to have_text("you can claim back the student loan repayments you made between #{StudentLoans.current_financial_year}.")
     click_on "Continue"
 
     # - How we will use the information you provide
-    expect(page).to have_text("How we will use the information you provide")
     click_on "Continue"
 
     # - Personal details - skipped
 
     # - What is your home address
-    expect(page).to have_text(I18n.t("questions.address.home.title"))
-    expect(page).to have_link(href: claim_path(StudentLoans.routing_name, "address"))
-
-    fill_in "Postcode", with: "SO16 9FX"
-    click_on "Search"
-
-    # - Select your home address
-    expect(page).to have_text(I18n.t("questions.address.home.title"))
-
-    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
-    click_on "Continue"
-
-    # - select-email page
-    expect(page).to have_text(I18n.t("questions.select_email.heading"))
+    click_link(I18n.t("questions.address.home.link_to_manual_address"))
+    fill_in_address
 
     # - Select the suggested email address
     find("#claim_email_address_check_true").click
     click_on "Continue"
-
-    expect(page).to have_text(I18n.t("questions.select_phone_number.heading"))
   end
 
-  private
+  def fill_in_remaining_details_and_submit_claim
+    choose "Building society"
+    click_on "Continue"
 
-  def mock_address_details_address_data
-    allow_any_instance_of(ClaimsController).to receive(:address_data) do |controller|
-      controller.instance_variable_set(:@address_data, address_data)
-      address_data
-    end
-  end
+    fill_in "Name on your account", with: "Jo Bloggs"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    fill_in "Building society roll number", with: "1234/123456789"
+    click_on "Continue"
 
-  def address_data
-    [
-      {
-        address: "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
-        address_line_1: "FLAT 1, MILLBROOK TOWER",
-        address_line_2: "WINDERMERE AVENUE",
-        address_line_3: "SOUTHAMPTON",
-        postcode: "SO16 9FX"
-      },
-      {
-        address: "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
-        address_line_1: "FLAT 10, MILLBROOK TOWER",
-        address_line_2: "WINDERMERE AVENUE",
-        address_line_3: "SOUTHAMPTON",
-        postcode: "SO16 9FX"
-      },
-      {
-        address: "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX",
-        address_line_1: "FLAT 11, MILLBROOK TOWER",
-        address_line_2: "WINDERMERE AVENUE",
-        address_line_3: "SOUTHAMPTON",
-        postcode: "SO16 9FX"
-      }
-    ]
+    # - What gender does your school's payroll system associate with you
+    choose "Male"
+    click_on "Continue"
+
+    # - Are you currently repaying a student loan?
+    choose "No"
+    click_on "Continue"
+
+    # - Did you take out a Postgraduate Masters or a Postgraduate Doctoral loan?
+    choose "No"
+    click_on "Continue"
+
+    # - Student loan amount
+    fill_in student_loan_amount_question, with: "1100"
+    click_on "Continue"
+
+    click_on "Confirm and send"
+
+    expect(page).to have_text("Claim submitted")
   end
 end

--- a/spec/forms/select_mobile_number_form_spec.rb
+++ b/spec/forms/select_mobile_number_form_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe SelectMobileNumberForm do
     context "when mobile_check is 'alternative'" do
       let(:form) { SelectMobileNumberForm.new(claim, "alternative") }
 
-      it "returns nil for mobile_number and provide_mobile_number, and sets mobile_check to 'alternative'" do
+      it "returns nil for mobile_number and sets provide_mobile_number to true, and sets mobile_check to 'alternative'" do
         expect(form.extract_attributes).to eq({
           mobile_number: nil,
-          provide_mobile_number: nil,
+          provide_mobile_number: true,
           mobile_check: "alternative"
         })
       end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -827,65 +827,41 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "#submittable?" do
-    let(:claim) { build(:claim, trait, academic_year: AcademicYear.new(2021), first_name: first_name, policy: policy) }
-
     context "with student loans policy eligibility" do
       let(:policy) { StudentLoans }
-      let(:first_name) { "Jo" }
 
       context "when submittable" do
-        let(:trait) { :submittable }
+        subject(:claim) { build(:claim, :submittable, policy:) }
 
-        it "returns true" do
-          expect(claim.submittable?).to eq true
-        end
+        it { is_expected.to be_submittable }
       end
 
       context "when submitted" do
-        let(:trait) { :submitted }
+        subject(:claim) { build(:claim, :submitted, policy:) }
 
-        it "returns false" do
-          expect(claim.submittable?).to eq false
-        end
+        it { is_expected.not_to be_submittable }
       end
     end
 
     context "with early-career payments policy eligibility" do
       let(:policy) { EarlyCareerPayments }
-      let(:first_name) { "Tania" }
 
       context "when submittable" do
-        let(:trait) { :submittable }
+        subject(:claim) { build(:claim, :submittable, policy:) }
 
-        it "returns true" do
-          expect(claim.submittable?).to eq true
-        end
+        it { is_expected.to be_submittable }
+      end
+
+      context "when using the mobile number from Teacher ID" do
+        subject(:claim) { build(:claim, :submittable, using_mobile_number_from_tid: true, policy:) }
+
+        it { is_expected.to be_submittable }
       end
 
       context "when submitted" do
-        let(:trait) { :submitted }
+        subject(:claim) { build(:claim, :submitted, policy:) }
 
-        it "returns false" do
-          expect(claim.submittable?).to eq false
-        end
-      end
-    end
-
-    context "Early-Career Payments claim" do
-      let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
-
-      before { create(:policy_configuration, :additional_payments) }
-
-      it "returns true when the claim is valid and has not been submitted" do
-        claim = build(:claim, :submittable, policy: EarlyCareerPayments, academic_year: AcademicYear.new(2021), first_name: "Dee", govuk_verify_fields: [], eligibility: eligibility)
-
-        expect(claim.submittable?).to eq true
-      end
-
-      it "returns false when it has already been submitted" do
-        claim = build(:claim, :unverified, policy: EarlyCareerPayments, eligibility: eligibility)
-
-        expect(claim.submittable?).to eq false
+        it { is_expected.not_to be_submittable }
       end
     end
   end

--- a/spec/support/stubbing_helpers.rb
+++ b/spec/support/stubbing_helpers.rb
@@ -2,4 +2,10 @@ module StubbingHelpers
   def disable_claim_qa_flagging
     stub_const("Claim::MIN_QA_THRESHOLD", 0)
   end
+
+  def stub_otp_verification(otp_code:, valid: true)
+    allow_any_instance_of(NotifySmsMessage).to receive(:deliver!)
+    allow_any_instance_of(OneTimePassword::Generator).to receive(:code).and_return(otp_code)
+    allow_any_instance_of(OneTimePassword::Validator).to receive(:valid?).and_return(valid)
+  end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1483

The best place to start is by looking at the feature specs before/after; they didn't cover the journeys end-to-end, and when rewritten, they highlighted the presence of two scenarios where the submission was being prevented, when choosing an "alternative" number or using the one that came through TID. **Requires manual testing as well**