### PR TITLE
Rollbar: scrub session keys

### DIFF
--- a/app/controllers/concerns/claim_session_timeout.rb
+++ b/app/controllers/concerns/claim_session_timeout.rb
@@ -14,6 +14,7 @@ module ClaimSessionTimeout
     session.delete(:tps_school_id)
     session.delete(:tps_school_name)
     session.delete(:tps_school_address)
+    session.delete(:phone_number)
     @current_claim = nil
   end
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,7 +3,9 @@
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [:password]
 
-# Personal data in a claim
 Rails.application.config.after_initialize do
-  Rails.application.config.filter_parameters += Claim.filtered_params
+  # Personal data in a claim
+  Rails.application.config.filter_parameters |= Claim.filtered_params
+  # Personal data in a session
+  Rails.application.config.filter_parameters |= %i[user_info phone_number claim_postcode claim_address_line_1]
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -10,7 +10,10 @@ Rollbar.configure do |config|
   # removing personal data
   config.collect_user_ip = false
   config.scrub_headers |= ["X-Client-Ip", "Client-Ip"]
-  config.scrub_fields |= Rails.application.config.filter_parameters
+
+  Rails.application.config.after_initialize do
+    config.scrub_fields |= Rails.application.config.filter_parameters
+  end
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object"s `id`


### PR DESCRIPTION
According to Rollbar docs
> The fields in scrub_fields will be used to scrub the values for the matching keys in the GET, POST, raw body and route params and also in cookies and session

At the moment the `Rails.application.config.filter_parameters` are added to `Rollbar.configuration.scrub_fields` after initialisation, but `filter_parameters` contains `Claim.filtered_params`, which consumes a constant on the model, supposedly tight to the model attributes. After some more recent changes to the existing journeys, it looks like some PII are being stored in the session during the journey, and these could be accidentally sent to Rollbar unless explicitly added to `scrub_fields`