### PR TITLE
Feature/capt 1499 namespace early career payments eligibility

### DIFF
--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -64,7 +64,7 @@ module PartOfClaimJourney
   def build_new_claims
     journey_configuration.policies.map do |policy|
       Claim.new(
-        eligibility: "#{policy}::Eligibility".constantize.new,
+        eligibility: policy::Eligibility.new,
         academic_year: journey_configuration.current_academic_year
       )
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -297,7 +297,7 @@ class Claim < ApplicationRecord
   scope :rejected, -> { joins(:decisions).merge(Decision.active.rejected) }
   scope :approaching_decision_deadline, -> { awaiting_decision.where("submitted_at < ? AND submitted_at > ?", DECISION_DEADLINE.ago + DECISION_DEADLINE_WARNING_POINT, DECISION_DEADLINE.ago) }
   scope :passed_decision_deadline, -> { awaiting_decision.where("submitted_at < ?", DECISION_DEADLINE.ago) }
-  scope :by_policy, ->(policy) { where(eligibility_type: "#{policy}::Eligibility") }
+  scope :by_policy, ->(policy) { where(eligibility_type: ["#{policy}::Eligibility", policy::Eligibility.to_s]) }
   scope :by_policies, ->(policies) { where(eligibility_type: policies.map { |p| p::Eligibility.to_s }) }
   scope :by_academic_year, ->(academic_year) { where(academic_year: academic_year) }
   scope :assigned_to_team_member, ->(service_operator_id) { where(assigned_to_id: service_operator_id) }

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -165,6 +165,8 @@ class CurrentClaim
   end
 
   def eligible_eligibility
+    # TODO: Remove the gsub after all Policies are namespaced
+    #
     claims.sort_by { |c| c.eligibility_type.gsub("Policies::", "") }.each do |claim|
       return claim.eligibility unless claim.eligibility.ineligible?
     end

--- a/app/models/current_claim.rb
+++ b/app/models/current_claim.rb
@@ -23,7 +23,12 @@ class CurrentClaim
   end
 
   def for_policy(policy)
-    claims.find { |c| c.eligibility_type == "#{policy}::Eligibility" }
+    claims.find do |c|
+      [
+        Policies.constantize(policy.to_s)::Eligibility.to_s,
+        "#{policy}::Eligibility"
+      ].include?(c.eligibility_type)
+    end
   end
 
   def policies
@@ -160,7 +165,7 @@ class CurrentClaim
   end
 
   def eligible_eligibility
-    claims.sort_by(&:eligibility_type).each do |claim|
+    claims.sort_by { |c| c.eligibility_type.gsub("Policies::", "") }.each do |claim|
       return claim.eligibility unless claim.eligibility.ineligible?
     end
 

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -73,7 +73,7 @@ class PayrollRun < ApplicationRecord
 
     payments.includes(claims: [:eligibility]).includes(:topups).map do |payment|
       payment.claims.each do |claim|
-        if policy == :all || claim.eligibility_type == "#{policy}::Eligibility"
+        if policy == :all || [policy::Eligibility.to_s, "#{policy}::Eligibility"].include?(claim.eligibility_type)
           topup_claim_ids = payment.topups.pluck(:claim_id)
           line_item = topup_claim_ids.include?(claim.id) ? payment.topups.find { |t| t.claim_id == claim.id } : claim
           case filter

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -6,7 +6,7 @@ module Policies
   ].freeze
 
   AMENDABLE_ELIGIBILITY_ATTRIBUTES = POLICIES.map do |policy|
-    "#{policy}::Eligibility::AMENDABLE_ATTRIBUTES".constantize
+    policy::Eligibility::AMENDABLE_ATTRIBUTES
   end.flatten.freeze
 
   def self.all

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -1,0 +1,255 @@
+module Policies
+  module EarlyCareerPayments
+    class Eligibility < ApplicationRecord
+      include EligibilityCheckable
+
+      EDITABLE_ATTRIBUTES = [
+        :nqt_in_academic_year_after_itt,
+        :current_school_id,
+        :induction_completed,
+        :school_somewhere_else,
+        :employed_as_supply_teacher,
+        :has_entire_term_contract,
+        :employed_directly,
+        :subject_to_formal_performance_action,
+        :subject_to_disciplinary_action,
+        :qualification,
+        :eligible_itt_subject,
+        :teaching_subject_now,
+        :itt_academic_year
+      ].freeze
+      AMENDABLE_ATTRIBUTES = [:award_amount].freeze
+      ATTRIBUTE_DEPENDENCIES = {
+        "employed_as_supply_teacher" => ["has_entire_term_contract", "employed_directly"],
+        "qualification" => ["eligible_itt_subject", "teaching_subject_now"],
+        "eligible_itt_subject" => ["teaching_subject_now"],
+        "itt_academic_year" => ["eligible_itt_subject"]
+      }.freeze
+
+      IGNORED_ATTRIBUTES = [
+        "eligible_degree_subject"
+      ]
+
+      self.table_name = "early_career_payments_eligibilities"
+
+      FIRST_ITT_AY = "2016/2017"
+      LAST_POLICY_YEAR = "2024/2025"
+
+      # Generates an object similar to
+      # {
+      #   <AcademicYear:0x00007f7d87429238 @start_year=2020, @end_year=2021> => "2020/2021",
+      #   <AcademicYear:0x00007f7d87429210 @start_year=2021, @end_year=2022> => "2021/2022",
+      #   <AcademicYear:0x00007f7d87428c98 @start_year=nil, @end_year=nil> => "None"
+      # }
+      # Note: ECP policy began in academic year 2021/22 so the persisted options
+      # should include 2016/17 onward.
+      # In test environment the policy configuration record may not exist.
+      # This can't be dynamic on PolicyConfiguration current_academic_year because changing the year means the 5 year window changes
+      # and the enums would be stale until after a server restart.
+      # Make all valid ITT values based on the last known policy year.
+      ITT_ACADEMIC_YEARS =
+        (AcademicYear.new(FIRST_ITT_AY)...AcademicYear.new(LAST_POLICY_YEAR)).each_with_object({}) do |year, hsh|
+          hsh[year] = AcademicYear::Type.new.serialize(year)
+        end.merge({AcademicYear.new => AcademicYear::Type.new.serialize(AcademicYear.new)})
+
+      enum itt_academic_year: ITT_ACADEMIC_YEARS
+
+      enum qualification: {
+        postgraduate_itt: 0,
+        undergraduate_itt: 1,
+        assessment_only: 2,
+        overseas_recognition: 3
+      }
+
+      enum eligible_itt_subject: {
+        chemistry: 0,
+        foreign_languages: 1,
+        mathematics: 2,
+        physics: 3,
+        none_of_the_above: 4,
+        computing: 5
+      }, _prefix: :itt_subject
+
+      def self.max_award_amount_in_pounds
+        Policies::EarlyCareerPayments::AwardAmountCalculator.max_award_amount_in_pounds
+      end
+
+      has_one :claim, as: :eligibility, inverse_of: :eligibility
+      belongs_to :current_school, optional: true, class_name: "School"
+
+      validates :nqt_in_academic_year_after_itt, on: [:"nqt-in-academic-year-after-itt", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently teaching as a qualified teacher"}
+      validates :current_school, on: [:"current-school", :submit], presence: {message: "Select the school you teach at"}
+      validates :current_school, on: [:"correct-school"], presence: {message: "Select the school you teach at or choose somewhere else"}, unless: :school_somewhere_else?
+      validates :induction_completed, on: [:"induction-completed", :submit], inclusion: {in: [true, false], message: "Select yes if you have completed your induction"}
+      validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select yes if you are a supply teacher"}
+      validates :has_entire_term_contract, on: [:"entire-term-contract", :submit], inclusion: {in: [true, false], message: "Select yes if you have a contract to teach at the same school for an entire term or longer"}, if: :employed_as_supply_teacher?
+      validates :employed_directly, on: [:"employed-directly", :submit], inclusion: {in: [true, false], message: "Select yes if you are directly employed by your school"}, if: :employed_as_supply_teacher?
+      validates :subject_to_formal_performance_action, on: [:"poor-performance", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to formal action for poor performance at work"}
+      validates :subject_to_disciplinary_action, on: [:"poor-performance", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to disciplinary action"}
+      validates :qualification, on: [:qualification, :submit], presence: {message: "Select the route you took into teaching"}
+      validates :eligible_itt_subject, on: [:"eligible-itt-subject", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.eligible_itt_subject.blank.qualification") }}
+      validates :teaching_subject_now, on: [:"teaching-subject-now", :submit], inclusion: {in: [true, false], message: "Select yes if you spend at least half of your contracted hours teaching eligible subjects"}
+      validates :itt_academic_year, on: [:"itt-year", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.itt_academic_year.blank.qualification.#{object.qualification}") }}
+      validates :award_amount, on: [:submit], presence: {message: "Enter an award amount"}
+      validates_numericality_of :award_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7500
+      validates :award_amount, on: :amendment, award_range: {max: max_award_amount_in_pounds}
+
+      before_save :set_qualification_if_trainee_teacher, if: :nqt_in_academic_year_after_itt_changed?
+
+      delegate :name, to: :current_school, prefix: true, allow_nil: true
+
+      def policy
+        Policies::EarlyCareerPayments
+      end
+
+      # Rescues from errors for assignments coming from LUP-only fields
+      # eg. `claim.eligibility.eligible_degree_subject = true` will get ignored
+      def assign_attributes(*args, **kwargs)
+        super
+      rescue ActiveRecord::UnknownAttributeError
+        all_attributes_ignored = (args.first.keys - IGNORED_ATTRIBUTES).empty?
+        raise unless all_attributes_ignored
+      end
+
+      def eligible_later_year
+        # This covers the case for *the other policy* (LUP) which has *no* ITT academic year set for a trainee teacher
+        # but this method will still be called and needs to run without error
+        if itt_academic_year.blank?
+          nil
+        else
+          JourneySubjectEligibilityChecker.new(claim_year: claim_year, itt_year: itt_academic_year).next_eligible_claim_year_after_current_claim_year(CurrentClaim.new(claims: [claim]))
+        end
+      end
+
+      def award_amount
+        super || BigDecimal(calculate_award_amount || 0)
+      end
+
+      def first_eligible_itt_academic_year
+        JourneySubjectEligibilityChecker.first_eligible_itt_year_for_subject(policy: policy, claim_year: claim_year, subject_symbol: eligible_itt_subject.to_sym)
+      end
+
+      def reset_dependent_answers(reset_attrs = [])
+        attrs = ineligible? ? changed.concat(reset_attrs) : changed
+
+        dependencies = ATTRIBUTE_DEPENDENCIES.dup
+
+        # If some data was derived from DQT we do not want to reset these.
+        if claim.qualifications_details_check
+          dependencies.delete("qualification")
+          dependencies.delete("eligible_itt_subject")
+          dependencies.delete("itt_academic_year")
+        end
+
+        dependencies.each do |attribute_name, dependent_attribute_names|
+          dependent_attribute_names.each do |dependent_attribute_name|
+            write_attribute(dependent_attribute_name, nil) if attrs.include?(attribute_name)
+          end
+        end
+      end
+
+      def submit!
+        self.award_amount = award_amount
+        save!
+      end
+
+      def induction_not_completed?
+        !induction_completed.nil? && !induction_completed?
+      end
+
+      def ecp_only_school?
+        Policies::EarlyCareerPayments::SchoolEligibility.new(claim.eligibility.current_school).eligible? &&
+          !LevellingUpPremiumPayments::SchoolEligibility.new(claim.eligibility.current_school).eligible?
+      end
+
+      def set_qualifications_from_dqt_record
+        self.attributes = {
+          itt_academic_year: claim.qualifications_details_check ? (claim.dqt_teacher_record&.itt_academic_year_for_claim || itt_academic_year) : nil,
+          eligible_itt_subject: claim.qualifications_details_check ? (claim.dqt_teacher_record&.eligible_itt_subject_for_claim || eligible_itt_subject) : nil,
+          qualification: claim.qualifications_details_check ? (claim.dqt_teacher_record&.route_into_teaching || qualification) : nil
+        }
+      end
+
+      private
+
+      def calculate_award_amount
+        return 0 if eligible_itt_subject.blank?
+
+        args = {policy_year: claim_year, itt_year: itt_academic_year, subject_symbol: eligible_itt_subject.to_sym, school: current_school}
+
+        if args.values.any?(&:blank?)
+          0
+        else
+          Policies::EarlyCareerPayments::AwardAmountCalculator.new(**args).amount_in_pounds
+        end
+      end
+
+      def specific_eligible_now_attributes?
+        induction_completed? && itt_subject_eligible_now?
+      end
+
+      def itt_subject_eligible_now?
+        itt_subject = eligible_itt_subject # attribute name implies eligibility which isn't always the case
+        return false if itt_subject.blank?
+        return false if itt_subject_none_of_the_above?
+
+        itt_subject_checker = JourneySubjectEligibilityChecker.new(claim_year: claim_year, itt_year: itt_academic_year)
+        itt_subject.to_sym.in?(itt_subject_checker.current_subject_symbols(policy))
+      end
+
+      def specific_ineligible_attributes?
+        trainee_teacher? || (induction_not_completed? && !ecp_only_school?) || itt_subject_ineligible_now_and_in_the_future?
+      end
+
+      def itt_subject_ineligible_now_and_in_the_future?
+        itt_subject = eligible_itt_subject # attribute name implies eligibility which isn't always the case
+        return false if itt_subject.blank?
+        return true if itt_subject_none_of_the_above?
+
+        itt_subject_checker = JourneySubjectEligibilityChecker.new(claim_year: claim_year, itt_year: itt_academic_year)
+        !itt_subject.to_sym.in?(itt_subject_checker.current_and_future_subject_symbols(policy))
+      end
+
+      def specific_eligible_later_attributes?
+        newly_qualified_teacher? && ((induction_not_completed? && ecp_only_school?) || (!itt_subject_eligible_now? && itt_subject_eligible_later?))
+      end
+
+      def itt_subject_eligible_later?
+        itt_subject = eligible_itt_subject # attribute name implies eligibility which isn't always the case
+        return false if itt_subject.blank?
+        return false if itt_subject_none_of_the_above?
+
+        itt_subject_checker = JourneySubjectEligibilityChecker.new(claim_year: claim_year, itt_year: itt_academic_year)
+        itt_subject.to_sym.in?(itt_subject_checker.future_subject_symbols(policy))
+      end
+
+      def itt_subject_ineligible?
+        return false if claim_year.blank?
+
+        itt_subject_other_than_those_eligible_now_or_in_the_future?
+      end
+
+      def itt_subject_other_than_those_eligible_now_or_in_the_future?
+        itt_subject = eligible_itt_subject # attribute name implies eligibility which isn't always the case
+        return false if itt_subject.blank?
+
+        args = {claim_year: claim_year, itt_year: itt_academic_year}
+
+        if args.any?(&:blank?)
+          # can still rule some out
+          itt_subject_none_of_the_above?
+        else
+          itt_subject_checker = JourneySubjectEligibilityChecker.new(**args)
+          itt_subject_symbol = itt_subject.to_sym
+          !itt_subject_symbol.in?(itt_subject_checker.current_and_future_subject_symbols(policy))
+        end
+      end
+
+      def set_qualification_if_trainee_teacher
+        return unless trainee_teacher?
+
+        self.qualification = :postgraduate_itt
+      end
+    end
+  end
+end

--- a/lib/ineligibility_reason_checker.rb
+++ b/lib/ineligibility_reason_checker.rb
@@ -168,7 +168,7 @@ class IneligibilityReasonChecker
     [
       @current_claim.eligibility.nqt_in_academic_year_after_itt == false,
       @current_claim.academic_year >= AcademicYear.new(LevellingUpPremiumPayments::Eligibility::LAST_POLICY_YEAR),
-      @current_claim.academic_year >= AcademicYear.new(EarlyCareerPayments::Eligibility::LAST_POLICY_YEAR)
+      @current_claim.academic_year >= AcademicYear.new(Policies::EarlyCareerPayments::Eligibility::LAST_POLICY_YEAR)
     ].all?
   end
 end

--- a/spec/factories/early_career_payments/eligibilities.rb
+++ b/spec/factories/early_career_payments/eligibilities.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :early_career_payments_eligibility, class: "EarlyCareerPayments::Eligibility" do
+  factory :early_career_payments_eligibility, class: "Policies::EarlyCareerPayments::Eligibility" do
     trait :eligible do
       eligible_now
     end

--- a/spec/features/claim_with_mobile_sms_otp_spec.rb
+++ b/spec/features/claim_with_mobile_sms_otp_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "GOVUK Nofity SMS sends OTP" do
       scenario "when making a #{scenario[:policy]} claim" do
         claim = send(:"start_#{scenario[:policy].to_s.underscore}_claim")
         if scenario[:policy] == Policies::EarlyCareerPayments
-          claim.eligibility = EarlyCareerPayments::Eligibility.new
+          claim.eligibility = Policies::EarlyCareerPayments::Eligibility.new
           claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
           claim.update!(early_career_payments_personal_details_attributes)
         elsif scenario[:policy] == StudentLoans

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1637,7 +1637,7 @@ RSpec.describe Claim, type: :model do
 
     it "destroys associated records" do
       claim.reload.destroy!
-      expect(EarlyCareerPayments::Eligibility.count).to be_zero
+      expect(Policies::EarlyCareerPayments::Eligibility.count).to be_zero
       expect(Note.count).to be_zero
       expect(Task.count).to be_zero
       expect(Amendment.count).to be_zero

--- a/spec/models/current_claim_spec.rb
+++ b/spec/models/current_claim_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe CurrentClaim, type: :model do
       let(:policy) { "not_found" }
 
       it "raises an Exception" do
-        expect { submit! }.to raise_error(NoMethodError)
+        expect { submit! }.to raise_error(NameError)
       end
     end
   end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
+RSpec.describe Policies::EarlyCareerPayments::Eligibility, type: :model do
   describe "#policy" do
     let(:early_career_payments_eligibility) { build(:early_career_payments_eligibility) }
 
@@ -16,7 +16,7 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
 
     context "current_school not set and school_somewhere_else is not set return one is required error" do
       it "returns an error" do
-        eligibility = EarlyCareerPayments::Eligibility.new(current_school: nil, school_somewhere_else: nil)
+        eligibility = Policies::EarlyCareerPayments::Eligibility.new(current_school: nil, school_somewhere_else: nil)
 
         expect(eligibility).not_to be_valid(:"correct-school")
         expect(eligibility.errors.messages[:current_school]).to eq(["Select the school you teach at or choose somewhere else"])
@@ -25,7 +25,7 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
 
     context "selects a school suggested from TPS" do
       it "sets current_school and sets school_somewhere_else to false" do
-        eligibility = EarlyCareerPayments::Eligibility.new(current_school: school, school_somewhere_else: false)
+        eligibility = Policies::EarlyCareerPayments::Eligibility.new(current_school: school, school_somewhere_else: false)
 
         expect(eligibility).to be_valid(:"correct-school")
       end
@@ -33,14 +33,14 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
 
     context "selects somewhere else and not the suggested school" do
       it "sets school_somewhere_else to true and current_school stays nil" do
-        eligibility = EarlyCareerPayments::Eligibility.new(current_school: nil, school_somewhere_else: true)
+        eligibility = Policies::EarlyCareerPayments::Eligibility.new(current_school: nil, school_somewhere_else: true)
 
         expect(eligibility).to be_valid(:"correct-school")
       end
 
       # e.g. the teacher presses the backlink a school is already set
       it "sets school_somewhere_else to true and current_school stays remains if already set" do
-        eligibility = EarlyCareerPayments::Eligibility.new(current_school: school, school_somewhere_else: true)
+        eligibility = Policies::EarlyCareerPayments::Eligibility.new(current_school: school, school_somewhere_else: true)
 
         expect(eligibility).to be_valid(:"correct-school")
       end
@@ -52,13 +52,13 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
 
     context "school_somewhere_else is already true and set a school" do
       it "is valid" do
-        eligibility = EarlyCareerPayments::Eligibility.new(current_school: school, school_somewhere_else: true)
+        eligibility = Policies::EarlyCareerPayments::Eligibility.new(current_school: school, school_somewhere_else: true)
 
         expect(eligibility).to be_valid(:"current-school")
       end
 
       it "returns an error if current_school is not set" do
-        eligibility = EarlyCareerPayments::Eligibility.new(current_school: nil, school_somewhere_else: true)
+        eligibility = Policies::EarlyCareerPayments::Eligibility.new(current_school: nil, school_somewhere_else: true)
 
         expect(eligibility).not_to be_valid(:"current-school")
         expect(eligibility.errors.messages[:current_school]).to eq(["Select the school you teach at"])
@@ -68,11 +68,11 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
 
   describe "qualification attribute" do
     it "rejects invalid values" do
-      expect { EarlyCareerPayments::Eligibility.new(qualification: "non-existance") }.to raise_error(ArgumentError)
+      expect { Policies::EarlyCareerPayments::Eligibility.new(qualification: "non-existance") }.to raise_error(ArgumentError)
     end
 
     it "has handily named boolean methods for the possible values" do
-      eligibility = EarlyCareerPayments::Eligibility.new(qualification: "postgraduate_itt")
+      eligibility = Policies::EarlyCareerPayments::Eligibility.new(qualification: "postgraduate_itt")
 
       expect(eligibility.postgraduate_itt?).to eq true
       expect(eligibility.undergraduate_itt?).to eq false
@@ -83,11 +83,11 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
 
   describe "eligible_itt_subject attribute" do
     it "rejects invalid values" do
-      expect { EarlyCareerPayments::Eligibility.new(eligible_itt_subject: "not-in-list-of-options") }.to raise_error(ArgumentError)
+      expect { Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: "not-in-list-of-options") }.to raise_error(ArgumentError)
     end
 
     it "has handily named boolean methods for the possible values" do
-      eligibility = EarlyCareerPayments::Eligibility.new(eligible_itt_subject: "foreign_languages")
+      eligibility = Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: "foreign_languages")
 
       expect(eligibility.itt_subject_foreign_languages?).to eq true
       expect(eligibility.itt_subject_chemistry?).to eq false
@@ -299,76 +299,76 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
   describe "validation contexts" do
     context "award_amount attribute" do
       it "validates the award_amount is numerical" do
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: "don't know")).not_to be_valid
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: "£2,000.00")).not_to be_valid
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: "don't know")).not_to be_valid
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: "£2,000.00")).not_to be_valid
       end
 
       it "validates that award_amount is a positive number" do
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: -1_000)).not_to be_valid
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: 2_500)).to be_valid
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: -1_000)).not_to be_valid
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: 2_500)).to be_valid
       end
 
       it "validates that award_amount can be zero" do
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: 0)).to be_valid
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: 0)).to be_valid
       end
 
       it "validates that the award_amount is less than £7,500 when amending a claim" do
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: 7_501)).not_to be_valid(:amendment)
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: 7_500)).to be_valid(:amendment)
-        expect(EarlyCareerPayments::Eligibility.new(award_amount: 7_499)).to be_valid(:amendment)
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: 7_501)).not_to be_valid(:amendment)
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: 7_500)).to be_valid(:amendment)
+        expect(Policies::EarlyCareerPayments::Eligibility.new(award_amount: 7_499)).to be_valid(:amendment)
       end
     end
 
     context "when saving in the 'nqt_in_academic_year_after_itt' context" do
       it "is not valid without a value for 'nqt_in_academic_year_after_itt'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"nqt-in-academic-year-after-itt")
-        expect(EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: true)).to be_valid(:"nqt-in-academic-year-after-itt")
-        expect(EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: false)).to be_valid(:"nqt-in-academic-year-after-itt")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"nqt-in-academic-year-after-itt")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: true)).to be_valid(:"nqt-in-academic-year-after-itt")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: false)).to be_valid(:"nqt-in-academic-year-after-itt")
       end
     end
 
     context "when saving in the 'employed_as_supply_teacher' context" do
       it "is not valid without a value for 'employed_as_supply_teacher'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"supply-teacher")
-        expect(EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true)).to be_valid(:"supply-teacher")
-        expect(EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: false)).to be_valid(:"supply-teacher")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"supply-teacher")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true)).to be_valid(:"supply-teacher")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: false)).to be_valid(:"supply-teacher")
       end
     end
 
     context "when saving in the 'has_entire_term_contract' context" do
       it "is not valid without a value for 'has_entire_term_contract'" do
-        expect(EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true)).not_to be_valid(:"entire-term-contract")
-        expect(EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: false)).to be_valid(:"entire-term-contract")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true)).not_to be_valid(:"entire-term-contract")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: false)).to be_valid(:"entire-term-contract")
       end
     end
 
     context "when saving in the 'employed_directly' context" do
       it "is not valid without a value for 'employed_directly'" do
-        expect(EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true)).not_to be_valid(:"employed-directly")
-        expect(EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true, employed_directly: false)).to be_valid(:"employed-directly")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true)).not_to be_valid(:"employed-directly")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(employed_as_supply_teacher: true, employed_directly: false)).to be_valid(:"employed-directly")
       end
     end
 
     context "when saving in the 'poor-peformance' context" do
       it "is not valid without a value for 'subject_to_disciplinary_action" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"poor-performance")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"poor-performance")
       end
 
       it "is not valid without a value for 'subject_to_formal_performance_action'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"poor-performance")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"poor-performance")
       end
 
       it "is valid when the values are not nil" do
-        expect(EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: true, subject_to_formal_performance_action: false)).to be_valid(:"poor-performance")
-        expect(EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: false, subject_to_formal_performance_action: false)).to be_valid(:"poor-performance")
-        expect(EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: true, subject_to_formal_performance_action: true)).to be_valid(:"poor-performance")
-        expect(EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: true, subject_to_formal_performance_action: true)).to be_valid(:"poor-performance")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: true, subject_to_formal_performance_action: false)).to be_valid(:"poor-performance")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: false, subject_to_formal_performance_action: false)).to be_valid(:"poor-performance")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: true, subject_to_formal_performance_action: true)).to be_valid(:"poor-performance")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(subject_to_disciplinary_action: true, subject_to_formal_performance_action: true)).to be_valid(:"poor-performance")
       end
     end
 
     context "when saving in the 'qualification' context" do
       it "is not valid without a value for 'qualification'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:qualification)
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:qualification)
       end
     end
 
@@ -376,33 +376,33 @@ RSpec.describe EarlyCareerPayments::Eligibility, type: :model do
       before { create(:journey_configuration, :additional_payments) }
 
       it "is not valid without a value for 'eligible_itt_subject'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"eligible-itt-subject")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"eligible-itt-subject")
       end
 
       it "is not valid when the value for 'eligible_itt_subject' is 'none of the above'" do
-        expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :none_of_the_above)).to be_valid(:"eligible-itt-subject")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :none_of_the_above)).to be_valid(:"eligible-itt-subject")
       end
 
       it "is valid when the value for 'eligible_itt_subject' is one of 'chemistry, foreign_languages, mathematics or physics'" do
-        expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :chemistry)).to be_valid(:"eligible-itt-subject")
-        expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :physics)).to be_valid(:"eligible-itt-subject")
-        expect(EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :foreign_languages)).to be_valid(:"eligible-itt-subject")
-        expect { EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :languages) }.to raise_error(ArgumentError)
+        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :chemistry)).to be_valid(:"eligible-itt-subject")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :physics)).to be_valid(:"eligible-itt-subject")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :foreign_languages)).to be_valid(:"eligible-itt-subject")
+        expect { Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :languages) }.to raise_error(ArgumentError)
       end
     end
 
     context "when saving in the 'teaching_subject_now' context" do
       it "is not valid without a value for 'teaching_subject_now'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"teaching-subject-now")
-        expect(EarlyCareerPayments::Eligibility.new(teaching_subject_now: true)).to be_valid(:"teaching-subject-now")
-        expect(EarlyCareerPayments::Eligibility.new(teaching_subject_now: false)).to be_valid(:"teaching-subject-now")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"teaching-subject-now")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(teaching_subject_now: true)).to be_valid(:"teaching-subject-now")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(teaching_subject_now: false)).to be_valid(:"teaching-subject-now")
       end
     end
 
     context "when saving in the 'itt_academic_year' context" do
       it "is not valid without a value for 'itt_academic_year'" do
-        expect(EarlyCareerPayments::Eligibility.new).not_to be_valid(:"itt-year")
-        expect(EarlyCareerPayments::Eligibility.new(itt_academic_year: AcademicYear.new(2020))).to be_valid(:"itt-year")
+        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"itt-year")
+        expect(Policies::EarlyCareerPayments::Eligibility.new(itt_academic_year: AcademicYear.new(2020))).to be_valid(:"itt-year")
       end
     end
   end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Claims", type: :request do
       current_claim = CurrentClaim.new(claims: claims)
 
       current_claim.claims.each_with_index do |claim, i|
-        expect(claim.eligibility).to be_kind_of("#{@journey_configuration.policies[i]}::Eligibility".constantize)
+        expect(claim.eligibility).to be_kind_of(@journey_configuration.policies[i]::Eligibility)
         expect(claim.academic_year).to eq(@journey_configuration.current_academic_year)
       end
     end


### PR DESCRIPTION
[CAPT-1499](https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1499?McasTsid=20596&McasCtx=4)

Namespace `Policies::EarlyCareerPayments::Eligibility` 

1. Add `Policies::EarlyCareerPayments::Eligibility` in combination with `EarlyCareerPayments::Eligibility` to maintain compatibility with existing claims
2. Adjust any existing methods to comply with either policies from step 1

[CAPT-1499]: https://dfedigital.atlassian.net/browse/CAPT-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ