### PR TITLE
CAPT-1466 - Add rack-mini-profiler gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,8 @@ group :development do
   gem "foreman"
 
   gem "lefthook"
+  # Provides a detailed speed badge for every HTML page to aid performance optimisation.
+  gem "rack-mini-profiler"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,8 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.8.1)
+    rack-mini-profiler (3.3.1)
+      rack (>= 1.2.0)
     rack-oauth2 (1.21.3)
       activesupport
       attr_required
@@ -557,6 +559,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 6.4)
+  rack-mini-profiler
   rack_session_access
   rails (~> 7.0.8)
   rails_semantic_logger


### PR DESCRIPTION
[JIRA Issue: CAPT-1466](https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1466)

This PR adds the Rack-Mini-Profiler gem to the development group so that while working on the application we can get performance metrics back for each page so that we can detect performance issues early in development to prevent significant impact on user experience further down the line.

 - Speed Badge: Visual display of each page's load time in our application.
 - Detailed Metrics: Upon clicking the speed badge, reveals a breakdown of the total load time.
 - SQL Queries Insight: Shows the exact part of the code running each query and its duration.

Small badge displayed in the top-left corner showing each page's load time.
<img width="76" alt="Screenshot 2024-02-27 at 15 03 39" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/24491613/88d5cf48-a2b2-45a6-ab82-e7a14802943f">

Performance Breakdown View (On Badge Click)
<img width="617" alt="Screenshot 2024-02-27 at 15 01 52" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/24491613/dba8ecc8-4b0e-44a9-b18d-32181bfdc4cc">


