### PR TITLE
Determine the answer to the induction question using DQT (TID route)

### DIFF
--- a/app/models/policies/early_career_payments/slug_sequence.rb
+++ b/app/models/policies/early_career_payments/slug_sequence.rb
@@ -161,6 +161,8 @@ module Policies
             sequence.delete("eligible-degree-subject") unless ecp_claim&.eligibility&.status == :ineligible && lup_claim&.eligibility&.indicated_ineligible_itt_subject?
           end
 
+          sequence.delete("induction-completed") if claim.logged_in_with_tid? && ecp_claim.dqt_teacher_record&.eligible_induction?
+
           if ecp_claim.eligibility.induction_not_completed? && ecp_claim.eligibility.ecp_only_school?
             replace_ecp_only_induction_not_completed_slugs(sequence)
           end

--- a/app/models/policies/early_career_payments/slug_sequence.rb
+++ b/app/models/policies/early_career_payments/slug_sequence.rb
@@ -161,7 +161,7 @@ module Policies
             sequence.delete("eligible-degree-subject") unless ecp_claim&.eligibility&.status == :ineligible && lup_claim&.eligibility&.indicated_ineligible_itt_subject?
           end
 
-          sequence.delete("induction-completed") if claim.logged_in_with_tid? && ecp_claim.dqt_teacher_record&.eligible_induction?
+          sequence.delete("induction-completed") unless induction_question_required?
 
           if ecp_claim.eligibility.induction_not_completed? && ecp_claim.eligibility.ecp_only_school?
             replace_ecp_only_induction_not_completed_slugs(sequence)
@@ -247,6 +247,26 @@ module Policies
         ]
 
         [sequence.dup - trainee_slugs].flatten.each { |slug| sequence.delete(slug) }
+      end
+
+      def induction_question_required?
+        # Induction question is not required if an ECP-eligible school is not selected.
+        return false unless ecp_school_selected?
+
+        # If the claimant is logged in with their Teacher ID, check the DQT record directly.
+        if claim.logged_in_with_tid?
+          # If the DQT record confirms induction eligibility, the question is not required.
+          return false if claim.for_policy(Policies::EarlyCareerPayments).dqt_teacher_record&.eligible_induction?
+        end
+
+        # In all other cases, the induction question is required.
+        true
+      end
+
+      def ecp_school_selected?
+        return false unless claim.eligibility.current_school
+
+        Policies::EarlyCareerPayments::SchoolEligibility.new(claim.eligibility.current_school).eligible?
       end
     end
   end

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -85,10 +85,6 @@ RSpec.feature "Combined journey with Teacher ID mobile check" do
     choose "Yes"
     click_on "Continue"
 
-    # - Have you completed your induction as an early-career teacher?
-    choose "Yes"
-    click_on "Continue"
-
     # - Are you currently employed as a supply teacher
     choose "No"
     click_on "Continue"

--- a/spec/features/ineligible_levelling_up_premium_payments_spec.rb
+++ b/spec/features/ineligible_levelling_up_premium_payments_spec.rb
@@ -61,12 +61,6 @@ RSpec.feature "Ineligible Levelling up premium payments claims" do
     choose "Yes"
     click_on "Continue"
 
-    # - Have you completed your induction as an early-career teacher?
-    expect(page).to have_text(I18n.t("additional_payments.questions.induction_completed.heading"))
-
-    choose "No"
-    click_on "Continue"
-
     # - Are you currently employed as a supply teacher
     expect(page).to have_text(I18n.t("additional_payments.questions.employed_as_supply_teacher"))
 

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -53,12 +53,6 @@ RSpec.feature "Levelling up premium payments claims" do
     choose "Yes"
     click_on "Continue"
 
-    # - Have you completed your induction as an early-career teacher?
-    expect(page).to have_text(I18n.t("additional_payments.questions.induction_completed.heading"))
-
-    choose "No"
-    click_on "Continue"
-
     # - Are you currently employed as a supply teacher
     expect(page).to have_text(I18n.t("additional_payments.questions.employed_as_supply_teacher"))
 

--- a/spec/features/subject_teaching_question_spec.rb
+++ b/spec/features/subject_teaching_question_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
 
   before do
     claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible, :eligible_school_ecp_and_lup))
   end
 
   context "when ECP and LUP eligible" do
@@ -33,16 +33,7 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
   end
 
   context "when eligible only for ECP" do
-    let!(:school) { create(:school, :early_career_payments_eligible) }
-
-    before do
-      claim.eligibility.update!(itt_academic_year: AcademicYear.new(2020))
-    end
-
     it "has the correct subjects" do
-      jump_to_claim_journey_page(claim, "current-school")
-      choose_school school
-
       jump_to_claim_journey_page(claim, "nqt-in-academic-year-after-itt")
       choose "Yes"
       click_on "Continue"
@@ -52,7 +43,7 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(claim, "eligible-itt-subject")
-      choose "Mathematics"
+      choose "Languages" # ECP-only subject
       click_on "Continue"
 
       jump_to_claim_journey_page(claim, "teaching-subject-now")

--- a/spec/support/stubbing_helpers.rb
+++ b/spec/support/stubbing_helpers.rb
@@ -3,7 +3,7 @@ module StubbingHelpers
     stub_const("Claim::MIN_QA_THRESHOLD", 0)
   end
 
-  def stub_otp_verification(otp_code:, valid: true)
+  def stub_otp_verification(otp_code: "123456", valid: true)
     allow_any_instance_of(NotifySmsMessage).to receive(:deliver!)
     allow_any_instance_of(OneTimePassword::Generator).to receive(:code).and_return(otp_code)
     allow_any_instance_of(OneTimePassword::Validator).to receive(:valid?).and_return(valid)


### PR DESCRIPTION
The way the TID route works, we retrieve the DQT record for a claim at the beginning of the journey when the applicant confirms their personal details (`teacher-detail` slug). Upon confirmation, we have access to the induction data retrieved from DQT. Before using it to determine if the claimant has induction data that does _not_ make them ineligible, we need to wait until they confirm that they are qualified teachers (`nqt-in-academic-year-after-itt` slug): we can then determine the answer to the `induction_completed` question and skip it (it's the next slug in the sequence) if we have determined a positive value for it; otherwise, the question is presented as it's currently done: if they confirmed the question with a "No", then they'd be presented an exit screen (unless the chosen school is LUPP eligible as well, see below).

This is for ECP/LUPP only.

Things to remember:

- In terms of eligibility criteria, induction is relevant to ECP only
- We ask about induction very early in the combined journey, shortly after asking the school the applicant is teaching at with two possible eligible scenarios:
  - They teach at an ECP-only school
  - They teach at an ECP and LUPP eligible school
  
  This ⬆️ is why we always need to ask the induction question in the combined journey, even if relevant to ECP only, and store the value on both the ECP and LUPP eligibility model



https://dfedigital.atlassian.net/browse/CAPT-1260