### PR TITLE
Rename front-end helpers to use journey naming instead of policy

### DIFF
--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -3,27 +3,21 @@ class BasePublicController < ApplicationController
   include ClaimSessionTimeout
   include HttpAuthConcern
 
-  helper_method :current_policy, :current_policy_routing_name, :claim_timeout_in_minutes
+  helper_method :current_journey_routing_name, :claim_timeout_in_minutes
   before_action :add_view_paths
   before_action :end_expired_claim_sessions
   after_action :update_last_seen_at
 
   private
 
-  def current_policy
-    JourneyConfiguration.policy_for_routing_name(current_policy_routing_name)
-  end
-  helper_method :current_policy
-
-  def current_policy_routing_name
-    params[:policy]
+  def current_journey_routing_name
+    params[:journey]
   end
 
   def end_expired_claim_sessions
     if claim_session_timed_out?
-      policy_routing_name_for_redirect = current_policy_routing_name
       clear_claim_session
-      redirect_to timeout_claim_path(policy_routing_name_for_redirect)
+      redirect_to timeout_claim_path(current_journey_routing_name)
     end
   end
 
@@ -32,7 +26,7 @@ class BasePublicController < ApplicationController
   end
 
   def add_view_paths
-    path = JourneyConfiguration.view_path(current_policy_routing_name)
+    path = JourneyConfiguration.view_path(current_journey_routing_name)
     prepend_view_path(Rails.root.join("app", "views", path)) if path
   end
 end

--- a/app/controllers/concerns/address_details.rb
+++ b/app/controllers/concerns/address_details.rb
@@ -47,7 +47,7 @@ module AddressDetails
 
   def save_address_to_claim
     session[:no_address_selected] = "Select an address"
-    redirect_to claim_path(current_policy_routing_name, "select-home-address", {"claim[postcode]": params[:postcode]}) and return if params[:address].nil?
+    redirect_to claim_path(current_journey_routing_name, "select-home-address", {"claim[postcode]": params[:postcode]}) and return if params[:address].nil?
 
     address_parts = params[:address].split(":")
     current_claim.attributes = {

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -3,15 +3,15 @@ module PartOfClaimJourney
 
   included do
     before_action :set_cache_headers
-    before_action :check_whether_closed_for_submissions, if: :current_policy_routing_name
+    before_action :check_whether_closed_for_submissions, if: :current_journey_routing_name
     before_action :send_unstarted_claimants_to_the_start, if: :send_to_start?
     helper_method :current_claim, :submitted_claim
   end
 
   private
 
-  def current_policy_routing_name
-    super || current_claim.policy&.routing_name
+  def current_journey_routing_name
+    super || current_claim.policy.routing_name
   end
 
   def check_whether_closed_for_submissions
@@ -22,7 +22,7 @@ module PartOfClaimJourney
   end
 
   def send_unstarted_claimants_to_the_start
-    redirect_to current_policy.start_page_url, allow_other_host: true
+    redirect_to JourneyConfiguration.start_page_url(current_journey_routing_name), allow_other_host: true
   end
 
   def current_claim_persisted?
@@ -71,7 +71,7 @@ module PartOfClaimJourney
   end
 
   def journey_configuration
-    @journey_configuration ||= JourneyConfiguration.for_routing_name(current_policy_routing_name)
+    @journey_configuration ||= JourneyConfiguration.for_routing_name(current_journey_routing_name)
   end
 
   def set_cache_headers

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -8,7 +8,7 @@ class OmniauthCallbacksController < ApplicationController
 
     session[:user_info] = auth.extra.raw_info
 
-    redirect_to claim_path(policy: policy.routing_name, slug: "teacher-detail")
+    redirect_to claim_path(journey: policy.routing_name, slug: "teacher-detail")
   end
 
   def failure
@@ -19,5 +19,9 @@ class OmniauthCallbacksController < ApplicationController
 
   def policy
     @policy ||= current_claim.policy
+  end
+
+  def current_journey_routing_name
+    policy.routing_name
   end
 end

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -7,7 +7,7 @@ class RemindersController < BasePublicController
     # - transfer the email_verified state to the reminder (done in #current_reminder)
     # - jump straight to reminder set
     if current_reminder.email_verified? && current_reminder.save
-      redirect_to reminder_path(current_policy_routing_name, "set")
+      redirect_to reminder_path(current_journey_routing_name, "set")
       return
     end
 
@@ -30,7 +30,7 @@ class RemindersController < BasePublicController
 
     if current_reminder.save(context: current_slug.to_sym)
       session[:reminder_id] = current_reminder.to_param
-      redirect_to reminder_path(current_policy_routing_name, next_slug)
+      redirect_to reminder_path(current_journey_routing_name, next_slug)
     else
       render first_template_in_sequence
     end
@@ -44,7 +44,7 @@ class RemindersController < BasePublicController
     current_reminder.attributes = reminder_params
     one_time_password
     if current_reminder.save(context: current_slug.to_sym)
-      redirect_to reminder_path(current_policy_routing_name, next_slug)
+      redirect_to reminder_path(current_journey_routing_name, next_slug)
     else
       show
     end
@@ -76,12 +76,12 @@ class RemindersController < BasePublicController
     Reminder::SLUGS.index(params[:slug]) || 0
   end
 
-  def current_policy_routing_name
+  def current_journey_routing_name
     "additional-payments"
   end
 
   def journey_configuration
-    @journey_configuration ||= JourneyConfiguration.for_routing_name(current_policy_routing_name)
+    @journey_configuration ||= JourneyConfiguration.for_routing_name(current_journey_routing_name)
   end
 
   def current_reminder

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,9 +15,11 @@ class StaticPagesController < BasePublicController
   end
 
   def landing_page
+    current_policy = JourneyConfiguration.policy_for_routing_name(current_journey_routing_name)
+
     jc = JourneyConfiguration.for(current_policy)
     @academic_year = jc.current_academic_year
 
-    render "#{JourneyConfiguration.view_path(jc.routing_name)}/landing_page"
+    render "#{JourneyConfiguration.view_path(current_journey_routing_name)}/landing_page"
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -19,6 +19,6 @@ class SubmissionsController < BasePublicController
   end
 
   def show
-    redirect_to current_policy.start_page_url, allow_other_host: true unless submitted_claim
+    redirect_to JourneyConfiguration.start_page_url(current_journey_routing_name), allow_other_host: true unless submitted_claim
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
-  def page_title(title, policy: nil, show_error: false)
+  def page_title(title, journey: nil, show_error: false)
     [].tap do |a|
       a << "Error" if show_error
       a << title
-      a << policy_service_name(policy)
+      a << journey_service_name(journey)
       a << "GOV.UK"
     end.join(" — ")
   end
@@ -18,8 +18,6 @@ module ApplicationHelper
     number_to_currency(value, delimiter: "", unit: "")
   end
 
-  # TODO: routing_name is not best way to do this due to the combined journey
-  # This remains for backwards compatibility of the existing mailers without a refactor
   def support_email_address(routing_name = nil)
     return t("support_email_address") unless routing_name
 
@@ -34,28 +32,29 @@ module ApplicationHelper
     t("support_email_address")
   end
 
-  def policy_service_name(routing_name = nil)
+  def journey_service_name(routing_name = nil)
     return t("service_name") unless routing_name
 
     namespace = JourneyConfiguration.i18n_namespace_for_routing_name(routing_name)
     t("#{namespace}.journey_name")
   end
 
-  def policy_description(routing_name)
+  def journey_description(routing_name)
     namespace = JourneyConfiguration.i18n_namespace_for_routing_name(routing_name)
     t("#{namespace}.claim_description")
   end
 
-  def feedback_url
-    current_policy.feedback_url
+  def feedback_email(routing_name)
+    namespace = JourneyConfiguration.i18n_namespace_for_routing_name(routing_name)
+    t("#{namespace}.feedback_email")
   end
 
-  def feedback_email
-    current_policy.feedback_email
+  def start_page_url(routing_name)
+    JourneyConfiguration.start_page_url(routing_name)
   end
 
-  def start_page_url
-    current_policy.start_page_url
+  def eligibility_page_url
+    current_claim.policy.eligibility_page_url
   end
 
   def claim_decision_deadline_in_weeks

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -53,8 +53,7 @@ module ClaimsHelper
   end
 
   def additional_payments_open?
-    policy = JourneyConfiguration.policy_for_routing_name("additional-payments")
-    JourneyConfiguration.for(policy).open_for_submissions?
+    JourneyConfiguration.for_routing_name("additional-payments").open_for_submissions?
   end
 
   def show_name(claim)

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -37,7 +37,7 @@ class ReminderMailer < ApplicationMailer
   def reminder(reminder)
     @reminder = reminder
     support_email_address = translate("additional_payments.support_email_address")
-    service_start_page_url = Policies::EarlyCareerPayments.start_page_url
+    service_start_page_url = JourneyConfiguration.start_page_url("additional-payments")
     personalisation = {
       first_name: extract_first_name(@reminder.full_name),
       support_email_address: support_email_address,

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -13,12 +13,16 @@ module BasePolicy
     I18n.t("#{locale_key}.policy_short_name")
   end
 
-  def locale_key
-    to_s.underscore
+  def support_email_address
+    I18n.t("#{locale_key}.support_email_address")
   end
 
   def routing_name
     JourneyConfiguration.routing_name_for_policy(self)
+  end
+
+  def locale_key
+    to_s.underscore
   end
 
   def configuration

--- a/app/models/journey_configuration.rb
+++ b/app/models/journey_configuration.rb
@@ -15,14 +15,14 @@ class JourneyConfiguration < ApplicationRecord
   SERVICES = [
     {
       routing_name: "student-loans",
-      slugs: StudentLoans::SlugSequence::SLUGS,
+      slug_sequence: StudentLoans::SlugSequence,
       policies: [StudentLoans],
       view_path: "student_loans",
       i18n_namespace: "student_loans"
     },
     {
       routing_name: "additional-payments",
-      slugs: Policies::EarlyCareerPayments::SlugSequence::SLUGS,
+      slug_sequence: Policies::EarlyCareerPayments::SlugSequence,
       policies: [Policies::EarlyCareerPayments, LevellingUpPremiumPayments],
       view_path: "additional_payments",
       i18n_namespace: "additional_payments"
@@ -72,6 +72,10 @@ class JourneyConfiguration < ApplicationRecord
     SERVICES.detect { |j| policy.in? j[:policies] }[:routing_name]
   end
 
+  def self.start_page_url(routing_name)
+    service_for_routing_name(routing_name)[:slug_sequence].start_page_url
+  end
+
   def policies
     policy_types.map(&Policies.method(:constantize))
   end
@@ -81,7 +85,7 @@ class JourneyConfiguration < ApplicationRecord
   end
 
   def slugs
-    SERVICES.detect { |j| policies.first.in? j[:policies] }[:slugs]
+    SERVICES.detect { |j| policies.first.in? j[:policies] }[:slug_sequence]::SLUGS
   end
 
   def additional_payments?

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -23,10 +23,6 @@ module Policies
 
     POLICY_START_YEAR = AcademicYear.new(2021).freeze
 
-    def start_page_url
-      Rails.application.routes.url_helpers.landing_page_path(routing_name)
-    end
-
     def eligibility_page_url
       "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools"
     end
@@ -37,14 +33,6 @@ module Policies
 
     def notify_reply_to_id
       "3f85a1f7-9400-4b48-9a31-eaa643d6b977"
-    end
-
-    def feedback_url
-      "https://docs.google.com/forms/TO-BE-REPLACED-by-response-to-ECP-509/viewform"
-    end
-
-    def feedback_email
-      "earlycareerteacherpayments@digital.education.gov.uk"
     end
 
     def first_eligible_qts_award_year(claim_year = nil)

--- a/app/models/policies/early_career_payments/slug_sequence.rb
+++ b/app/models/policies/early_career_payments/slug_sequence.rb
@@ -182,6 +182,10 @@ module Policies
         end
       end
 
+      def self.start_page_url
+        Rails.application.routes.url_helpers.landing_page_path("additional-payments")
+      end
+
       private
 
       def remove_student_loan_slugs(sequence, slugs = nil)

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -24,14 +24,6 @@ module StudentLoans
   POLICY_END_YEAR = AcademicYear.new(2020).freeze
   ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR = 11
 
-  def start_page_url
-    if Rails.env.production?
-      "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
-    else
-      "/#{routing_name}/claim"
-    end
-  end
-
   def eligibility_page_url
     "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
   end
@@ -42,14 +34,6 @@ module StudentLoans
 
   def notify_reply_to_id
     "962b3044-cdd4-4dbe-b6ea-c461530b3dc6"
-  end
-
-  def feedback_url
-    "https://docs.google.com/forms/d/e/1FAIpQLSdAyOxHme39E8lMnD2qY029mmk4Lpn84soYg2vLrT5BV9IUSg/viewform?usp=sf_link"
-  end
-
-  def feedback_email
-    "studentloanteacherpayment@digital.education.gov.uk"
   end
 
   # Returns the AcademicYear during or after which teachers must have completed

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -138,5 +138,13 @@ module StudentLoans
         end
       end
     end
+
+    def self.start_page_url
+      if Rails.env.production?
+        "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
+      else
+        "/student-loans/claim"
+      end
+    end
   end
 end

--- a/app/views/additional_payments/claims/_eligibility_confirmed_multiple.html.erb
+++ b/app/views/additional_payments/claims/_eligibility_confirmed_multiple.html.erb
@@ -1,6 +1,6 @@
 <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-<%= form_for current_claim, url: claim_path(current_policy_routing_name), method: :patch do |form| %>
+<%= form_for current_claim, url: claim_path(current_journey_routing_name), method: :patch do |form| %>
   <%= form_group_tag current_claim do %>
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/additional_payments/claims/_eligibility_guidance_early_career_payments.html.erb
+++ b/app/views/additional_payments/claims/_eligibility_guidance_early_career_payments.html.erb
@@ -2,7 +2,7 @@
   It is for early career teachers who teach certain subjects to encourage them to stay in the profession.
 </p>
 
-<%= button_to "Apply now", claim_path(current_policy_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"}, params: { claim: { policy: claim.policy } } %>
+<%= button_to "Apply now", claim_path(current_journey_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"}, params: { claim: { policy: claim.policy } } %>
 
 <p class="govuk-body">
   For more information about why you are eligible, read about the <%= link_to "early-career payment (opens in new tab)", Policies::EarlyCareerPayments.eligibility_page_url, class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>.

--- a/app/views/additional_payments/claims/_eligibility_guidance_levelling_up_premium_payments.html.erb
+++ b/app/views/additional_payments/claims/_eligibility_guidance_levelling_up_premium_payments.html.erb
@@ -2,7 +2,7 @@
   It is for early career teachers who teach certain subjects and work in disadvantaged schools in England. There is a high need for teachers in your area.
 </p>
 
-<%= button_to "Apply now", claim_path(current_policy_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"}, params: { claim: { policy: claim.policy } } %>
+<%= button_to "Apply now", claim_path(current_journey_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"}, params: { claim: { policy: claim.policy } } %>
 
 <p class="govuk-body">
   For more information about why you are eligible, read about the <%= link_to "levelling up premium payment (opens in new tab)", LevellingUpPremiumPayments.eligibility_page_url, class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>.

--- a/app/views/additional_payments/claims/_ineligibility_current_school.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_current_school.html.erb
@@ -38,9 +38,9 @@
 
 <div class="govuk-!-padding-bottom-6">
   <% if current_claim.eligibility.school_somewhere_else == false %>
-    <%= button_to "Change school", claim_path(current_policy_routing_name, "correct-school", change_school: true), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
+    <%= button_to "Change school", claim_path(current_journey_routing_name, "correct-school", change_school: true), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
   <% else %>
-    <%= link_to "Change school", claim_path(current_policy_routing_name, "current-school"), class: "govuk-button", role: "button", draggable: false, data: {module: "govuk-button"} %>
+    <%= link_to "Change school", claim_path(current_journey_routing_name, "current-school"), class: "govuk-button", role: "button", draggable: false, data: {module: "govuk-button"} %>
   <% end %>
 </div>
 

--- a/app/views/additional_payments/claims/check_your_answers_part_one.html.erb
+++ b/app/views/additional_payments/claims/check_your_answers_part_one.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.check_your_answers.part_one.primary_heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.check_your_answers.part_one.primary_heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/disciplinary_action.html.erb
+++ b/app/views/additional_payments/claims/disciplinary_action.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.disciplinary_action"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.disciplinary_action"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/eligibility_confirmed.html.erb
+++ b/app/views/additional_payments/claims/eligibility_confirmed.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("You’re eligible for an additional payment", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("You’re eligible for an additional payment", journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/eligible_degree_subject.html.erb
+++ b/app/views/additional_payments/claims/eligible_degree_subject.html.erb
@@ -1,8 +1,8 @@
 <% claim = current_claim.for_policy(LevellingUpPremiumPayments) %>
 
-<% content_for(:page_title, page_title(t("additional_payments.questions.eligible_degree_subject"), policy: current_policy_routing_name, show_error: claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.eligible_degree_subject"), journey: current_journey_routing_name, show_error: claim.errors.any?)) %>
 
-<% path_for_form = claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% path_for_form = claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/eligible_itt_subject.html.erb
+++ b/app/views/additional_payments/claims/eligible_itt_subject.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(eligible_itt_subject_translation(current_claim), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(eligible_itt_subject_translation(current_claim), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% subject_symbols = subject_symbols(current_claim) %>
 
 <% if subject_symbols.present? %>

--- a/app/views/additional_payments/claims/employed_directly.html.erb
+++ b/app/views/additional_payments/claims/employed_directly.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.employed_directly"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.employed_directly"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/entire_term_contract.html.erb
+++ b/app/views/additional_payments/claims/entire_term_contract.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.has_entire_term_contract"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.has_entire_term_contract"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/formal_performance_action.html.erb
+++ b/app/views/additional_payments/claims/formal_performance_action.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.formal_performance_action"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.formal_performance_action"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/future_eligibility.html.erb
+++ b/app/views/additional_payments/claims/future_eligibility.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("additional_payments.ineligible.reason.trainee_teacher_future_eligibility"), policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title(t("additional_payments.ineligible.reason.trainee_teacher_future_eligibility"), journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/induction_completed.html.erb
+++ b/app/views/additional_payments/claims/induction_completed.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.induction_completed.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.induction_completed.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/ineligible.html.erb
+++ b/app/views/additional_payments/claims/ineligible.html.erb
@@ -1,7 +1,7 @@
 <% require "./lib/ineligibility_reason_checker.rb" %>
 <% reason = IneligibilityReasonChecker.new(current_claim).reason %>
 <% title_and_h1_content = reason == :current_school ? I18n.t("additional_payments.ineligible.school_heading") : I18n.t("additional_payments.ineligible.heading") %>
-<% content_for(:page_title, page_title(title_and_h1_content, policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title(title_and_h1_content, journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div id="<%= reason %>" class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/itt_year.html.erb
+++ b/app/views/additional_payments/claims/itt_year.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.itt_academic_year.qualification.#{current_claim.eligibility.qualification}"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.itt_academic_year.qualification.#{current_claim.eligibility.qualification}"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 <% qualification_symbol = current_claim.eligibility.qualification.to_sym %>
 
@@ -33,7 +33,7 @@
             <% end %>
 
             <div class="govuk-radios">
-              <% JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(JourneyConfiguration.for(Policies::EarlyCareerPayments).current_academic_year).each do |year| %>
+              <% JourneySubjectEligibilityChecker.selectable_itt_years_for_claim_year(JourneyConfiguration.for_routing_name(current_journey_routing_name).current_academic_year).each do |year| %>
                 <div class="govuk-radios__item">
                   <%= fields.radio_button(:itt_academic_year, year, class: "govuk-radios__input") %>
                   <%= fields.label "itt_academic_year_#{year.start_year}#{year.end_year}", year.to_s(:long), class: "govuk-label govuk-radios__label" %>

--- a/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
+++ b/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.nqt_in_academic_year_after_itt.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.nqt_in_academic_year_after_itt.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/poor_performance.html.erb
+++ b/app/views/additional_payments/claims/poor_performance.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.poor_performance"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.poor_performance"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/qualification.html.erb
+++ b/app/views/additional_payments/claims/qualification.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.qualification.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.qualification.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/additional_payments/claims/qualification_details.html.erb
+++ b/app/views/additional_payments/claims/qualification_details.html.erb
@@ -53,7 +53,7 @@
   </div>
 </div>
 
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
   <%= form_for current_claim, url: path_for_form do |form| %>
     <%= form.hidden_field :qualifications_details_check %>

--- a/app/views/additional_payments/claims/reminder_email_verification.html.erb
+++ b/app/views/additional_payments/claims/reminder_email_verification.html.erb
@@ -1,7 +1,7 @@
-<% content_for(:page_title, page_title(t("additional_payments.one_time_password"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("additional_payments.one_time_password"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("one_time_password", locals: {current_claim: current_claim, current_policy_routing_name: current_policy_routing_name, next_slug: next_slug, button_text: "Confirm and set reminder"}) %>
+    <%= render("one_time_password", locals: {current_claim: current_claim, current_journey_routing_name: current_journey_routing_name, next_slug: next_slug, button_text: "Confirm and set reminder"}) %>
   </div>
 </div>

--- a/app/views/additional_payments/claims/supply_teacher.html.erb
+++ b/app/views/additional_payments/claims/supply_teacher.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.employed_as_supply_teacher"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.employed_as_supply_teacher"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/teaching_subject_now.html.erb
+++ b/app/views/additional_payments/claims/teaching_subject_now.html.erb
@@ -1,7 +1,7 @@
 <% eligible_itt_subject = current_claim.eligibility.eligible_itt_subject %>
 <% translated_eligible_itt_subject = t("additional_payments.answers.eligible_itt_subject.#{eligible_itt_subject}").downcase %>
-<% content_for(:page_title, page_title(t("additional_payments.questions.teaching_subject_now", eligible_itt_subject: eligible_itt_subject), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.teaching_subject_now", eligible_itt_subject: eligible_itt_subject), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/claims/undergraduate_itt_academic_year.html.erb
+++ b/app/views/additional_payments/claims/undergraduate_itt_academic_year.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.undergraduate_itt_academic_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.undergraduate_itt_academic_year"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/additional_payments/landing_page.html.erb
+++ b/app/views/additional_payments/landing_page.html.erb
@@ -37,7 +37,7 @@
       </p>
 
       <p class="govuk-!-margin-top-8">
-        <a href="<%= claim_path(current_policy.routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("View claim #{@claim.reference} for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("View claim #{@claim.reference} for #{@claim.policy.short_name}") } %>
 
 <%= link_to "Back", admin_claim_tasks_path(@claim), class: "govuk-back-link" %>
 

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title) { page_title("Manage #{policy_service_name(journey_configuration.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Manage #{journey_service_name(journey_configuration.routing_name)}") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl">Manage services</span>
-      <%= policy_service_name(journey_configuration.routing_name) %>
+      <%= journey_service_name(journey_configuration.routing_name) %>
     </h1>
 
     <div class="govuk-panel govuk-panel--informational govuk-panel--small">

--- a/app/views/admin/journey_configurations/index.html.erb
+++ b/app/views/admin/journey_configurations/index.html.erb
@@ -27,12 +27,12 @@
       <tbody class="govuk-table__body">
         <% @journey_configurations.each do |journey_configuration| %>
           <tr class="govuk-table__row" data-policy-configuration-id="<%= journey_configuration.id %>">
-            <th scope="row" class="govuk-table__header"><%= policy_service_name(journey_configuration.routing_name) %></th>
+            <th scope="row" class="govuk-table__header"><%= journey_service_name(journey_configuration.routing_name) %></th>
             <td class="govuk-table__cell"><%= journey_configuration.current_academic_year %></td>
             <td class="govuk-table__cell"><%= journey_configuration.open_for_submissions? ? "Open" : "Closed" %></td>
             <td class="govuk-table__cell">
               <%= link_to edit_admin_journey_configuration_path(journey_configuration), class: "govuk-link" do %>
-                Change <span class="govuk-visually-hidden"><%= policy_service_name(journey_configuration.routing_name) %></span>
+                Change <span class="govuk-visually-hidden"><%= journey_service_name(journey_configuration.routing_name) %></span>
               <% end %>
             </td>
           </tr>

--- a/app/views/admin/tasks/census_subjects_taught.html.erb
+++ b/app/views/admin/tasks/census_subjects_taught.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} school workforce census check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} school workforce census check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} employment check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} employment check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/identity_confirmation.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} checks for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} checks for #{@claim.policy.short_name}") } %>
 
 <%= link_to "Back", claims_backlink_path, class: "govuk-back-link" %>
 

--- a/app/views/admin/tasks/induction_confirmation.erb
+++ b/app/views/admin/tasks/induction_confirmation.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} induction check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} induction check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/matching_details.html.erb
+++ b/app/views/admin/tasks/matching_details.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} matching details check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} matching details check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/payroll_details.html.erb
+++ b/app/views/admin/tasks/payroll_details.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll details check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll details check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/payroll_gender.html.erb
+++ b/app/views/admin/tasks/payroll_gender.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll gender check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll gender check for #{@claim.policy.short_name}") } %>
 
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @claim, errored_field_id_overrides: { "payroll_gender": "claim_payroll_gender_female" } if @claim.errors.any? %>

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} qualification check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} qualification check for #{@claim.policy.short_name}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} student loan amount check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} student loan amount check for #{@claim.policy.short_name}") } %>
 
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 

--- a/app/views/claims/_account_details.html.erb
+++ b/app/views/claims/_account_details.html.erb
@@ -1,7 +1,7 @@
 <% account_hint = bank_or_building_society == "personal bank account" ? "bank" : bank_or_building_society %>
 <% account_card = account_hint == "bank" ? account_hint : "" %>
 
-<%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+<%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
   <fieldset class="govuk-fieldset" aria-describedby="bank_details-hint" role="group">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--<%= shared_view_css_class_size(current_claim) %>">
       <h1 class="govuk-fieldset__heading">

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -16,7 +16,7 @@
       </dd>
 
       <dd class="govuk-summary-list__actions">
-        <%= link_to('Change', claim_path(current_policy_routing_name, slug), class: 'govuk-link', 'aria-label': "Change #{label.downcase}") unless slug.nil? %>
+        <%= link_to('Change', claim_path(current_journey_routing_name, slug), class: 'govuk-link', 'aria-label': "Change #{label.downcase}") unless slug.nil? %>
       </dd>
     </div>
   <% end %>

--- a/app/views/claims/_confirmation_form.html.erb
+++ b/app/views/claims/_confirmation_form.html.erb
@@ -1,4 +1,4 @@
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
   <%= form_for current_claim, url: path_for_form do |form| %>
     <%= form.hidden_field :details_check %>

--- a/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,11 +4,11 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  <%= t("answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)).downcase %>.
+  <%= t("answers.qts_award_years.on_or_after_cut_off_date", year: current_claim.policy.first_eligible_qts_award_year.to_s(:long)).downcase %>.
 </p>
 
 <p class="govuk-body">
   For more information, including eligibility criteria for this payment, visit the
-  <%= link_to "‘#{policy_service_name(current_policy.routing_name)}’", "#{current_policy.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  <%= link_to "‘#{journey_service_name(current_journey_routing_name)}’", "#{eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
   guidance.
 </p>

--- a/app/views/claims/_one_time_password.html.erb
+++ b/app/views/claims/_one_time_password.html.erb
@@ -6,7 +6,7 @@
 
     <span class="govuk-caption-xl"><%= email_or_mobile == "email" ? "Email address" : "Mobile number" %> verification</span>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
           <label class="govuk-label govuk-label--l" for="claim_one_time_password"><%= t("one_time_password.title") %></label>
@@ -27,9 +27,9 @@
 
       <div class="govuk-!-margin-bottom-6">
         <% if email_or_mobile == "email" %>
-          <%= link_to "Resend passcode (you will be sent back to the email address page)", claim_path(current_claim.policy.routing_name, "email-address"), class: "govuk-link govuk-link--no-visited-state" %>
+          <%= link_to "Resend passcode (you will be sent back to the email address page)", claim_path(current_journey_routing_name, "email-address"), class: "govuk-link govuk-link--no-visited-state" %>
         <% else %>
-          <%= link_to "Resend passcode (you will be sent back to the mobile number page)", claim_path(current_claim.policy.routing_name, "mobile-number"), class: "govuk-link govuk-link--no-visited-state" %>
+          <%= link_to "Resend passcode (you will be sent back to the mobile number page)", claim_path(current_journey_routing_name, "mobile-number"), class: "govuk-link govuk-link--no-visited-state" %>
         <% end %>
       </div>
 
@@ -37,9 +37,9 @@
         <%= form.submit "Confirm", class: "govuk-button" %>
 
         <% if email_or_mobile == "email" %>
-          <%= link_to "Change email address", claim_path(current_claim.policy.routing_name, "email-address"), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
+          <%= link_to "Change email address", claim_path(current_journey_routing_name, "email-address"), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
         <% else %>
-          <%= link_to "Change mobile number", claim_path(current_claim.policy.routing_name, "mobile-number"), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
+          <%= link_to "Change mobile number", claim_path(current_journey_routing_name, "mobile-number"), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
         <% end %>
 
       </div>

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -2,12 +2,12 @@
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <%= form_for current_claim,
-             url: claim_path(current_policy_routing_name),
+             url: claim_path(current_journey_routing_name),
              method: :get,
              data: {
                "school-id-param": "claim_eligibility_attributes_#{school_id_param}",
                "exclude-closed": exclude_closed,
-               "current-policy": current_policy_routing_name
+               "current-policy": current_journey_routing_name
              },
              html: { class: "school_search_form" } do |form|
 %>

--- a/app/views/claims/_school_search_results.html.erb
+++ b/app/views/claims/_school_search_results.html.erb
@@ -2,7 +2,7 @@
 %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
-<%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+<%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
   <%= form_group_tag current_claim do %>
     <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
 

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(t("questions.address.generic.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.generic.title"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <fieldset class="govuk-fieldset">
         <% if current_claim.has_ecp_or_lupp_policy? %>
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/claims/bank_or_building_society.html.erb
+++ b/app/views/claims/bank_or_building_society.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:page_title, page_title(t("questions.bank_or_building_society"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.bank_or_building_society"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { bank_or_building_society: "claim_bank_or_building_society_personal_bank_account" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :bank_or_building_society %>
       <%= form_group_tag current_claim do %>
         <fieldset class="govuk-fieldset" role="group" aria-describedby="bank_details-hint">

--- a/app/views/claims/building_society_account.html.erb
+++ b/app/views/claims/building_society_account.html.erb
@@ -1,12 +1,12 @@
 <% bank_or_building_society = current_claim.bank_or_building_society.humanize.downcase %>
-<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <%= render("shared/error_summary", instance: @form ) if @form.errors.any? %>
 
-    <%= render partial: "account_details", locals: { current_claim: current_claim, bank_or_building_society: bank_or_building_society, current_policy_routing_name: current_policy_routing_name} %>
+    <%= render partial: "account_details", locals: { current_claim: current_claim, bank_or_building_society: bank_or_building_society, current_journey_routing_name: current_journey_routing_name} %>
 
   </div>
 </div>

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Check your answers before sending your application", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("Check your answers before sending your application", journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/correct_school.html.erb
+++ b/app/views/claims/correct_school.html.erb
@@ -1,7 +1,7 @@
 <%= render("shared/error_summary", instance: current_claim.eligibility) if current_claim.eligibility.errors.any? %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
-<%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+<%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
   <%= form_group_tag current_claim do %>
     <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
 

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.current_school"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.current_school"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/doctoral_loan.html.erb
+++ b/app/views/claims/doctoral_loan.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("questions.postgraduate_doctoral_loan"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.postgraduate_doctoral_loan"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(t("questions.email_address"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.email_address"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name), html: { novalidate: false } do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name), html: { novalidate: false } do |form| %>
       <%= personal_details_caption(current_claim) %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">

--- a/app/views/claims/email_verification.html.erb
+++ b/app/views/claims/email_verification.html.erb
@@ -1,3 +1,3 @@
-<% content_for(:page_title, page_title(t("one_time_password.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("one_time_password.title"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
-<%= render partial: "one_time_password", locals: {current_claim: current_claim, current_policy_routing_name: current_policy_routing_name, email_or_mobile: "email", email_or_text_message: "an email"} %>
+<%= render partial: "one_time_password", locals: {current_claim: current_claim, current_journey_routing_name: current_journey_routing_name, email_or_mobile: "email", email_or_text_message: "an email"} %>

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -1,17 +1,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-panel govuk-panel--interruption">
-      <%= form_with url: start_new_path(policy: params[:policy]), method: :post do |form| %>
+      <%= form_with url: start_new_path(journey: current_journey_routing_name), method: :post do |form| %>
         <fieldset class="govuk-fieldset" aria-describedby="start_new_claim">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-heading-xl" id="start_new_claim">
-                Are you sure you want to start a claim <%= policy_description(params[:policy]) %>?
+                Are you sure you want to start a claim <%= journey_description(current_journey_routing_name) %>?
               </h1>
             </legend>
 
           <h2 class="govuk-heading-m">
-            You have a claim in progress <%= policy_description(current_claim.policy.routing_name) %>.
+            You have a claim in progress <%= journey_description(current_journey_routing_name) %>.
           </h2>
 
           <h2 class="govuk-heading-m">
@@ -21,7 +21,7 @@
           <div class="govuk-radios govuk-!-margin-bottom-9">
             <div class="govuk-radios__item">
               <%= form.radio_button(:start_new_claim, true, class: "govuk-radios__input") %>
-              <%= form.label :start_new_claim_true, "Yes, start claim #{policy_description(params[:policy])} and lose my progress on my first claim", class: "govuk-label govuk-radios__label" %>
+              <%= form.label :start_new_claim_true, "Yes, start claim #{journey_description(current_journey_routing_name)} and lose my progress on my first claim", class: "govuk-label govuk-radios__label" %>
             </div>
             <div class="govuk-radios__item">
               <%= form.radio_button(:start_new_claim, false, class: "govuk-radios__input") %>

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:page_title, page_title(t("questions.payroll_gender"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.payroll_gender"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { payroll_gender: "claim_payroll_gender_female" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <fieldset class="govuk-fieldset" aria-describedby="payroll_gender-hint" role="group">
 

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("You’re not eligible for this payment", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("You’re not eligible for this payment", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -6,7 +6,7 @@
 
     <p class="govuk-body">
       If you need help with your claim, contact
-      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>.
+      <%= mail_to support_email_address(current_journey_routing_name), support_email_address(current_journey_routing_name), class: "govuk-link" %>.
     </p>
   </div>
 </div>

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("How we will use the information you provide", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("How we will use the information you provide", journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -91,6 +91,6 @@
       </p>
     <% end %>
 
-    <%= button_to "Continue", claim_path(current_policy_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
+    <%= button_to "Continue", claim_path(current_journey_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
   </div>
 </div>

--- a/app/views/claims/masters_doctoral_loan.html.erb
+++ b/app/views/claims/masters_doctoral_loan.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.has_masters_and_or_doctoral_loan"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.has_masters_and_or_doctoral_loan"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { has_masters_doctoral_loan: "claim_has_masters_doctoral_loan_true" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :has_masters_doctoral_loan %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" role="group">

--- a/app/views/claims/masters_loan.html.erb
+++ b/app/views/claims/masters_loan.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("questions.postgraduate_masters_loan"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.postgraduate_masters_loan"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/mobile_number.html.erb
+++ b/app/views/claims/mobile_number.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(t("questions.mobile_number"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.mobile_number"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">

--- a/app/views/claims/mobile_verification.html.erb
+++ b/app/views/claims/mobile_verification.html.erb
@@ -1,3 +1,3 @@
-<% content_for(:page_title, page_title(t("one_time_password.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("one_time_password.title"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
-<%= render partial: "one_time_password", locals: {current_claim: current_claim, current_policy_routing_name: current_policy_routing_name, email_or_mobile: "mobile", email_or_text_message: "a text message"} %>
+<%= render partial: "one_time_password", locals: {current_claim: current_claim, current_journey_routing_name: current_journey_routing_name, email_or_mobile: "mobile", email_or_text_message: "a text message"} %>

--- a/app/views/claims/no_address_found.html.erb
+++ b/app/views/claims/no_address_found.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.address.home.no_address_found"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.home.no_address_found"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name), method: :get do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name), method: :get do |form| %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-heading-l"><%= t("questions.address.home.no_address_found") %></h1>
@@ -18,18 +18,18 @@
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Postcode</h2>
         <p class="govuk-body">
           <%= session[:claim_postcode] %>
-          <%= link_to "Change", claim_path(current_claim.policy.routing_name, "postcode-search"), class: "govuk-link govuk-!-margin-left-3", "aria-label": "Change" %>
+          <%= link_to "Change", claim_path(current_journey_routing_name, "postcode-search"), class: "govuk-link govuk-!-margin-left-3", "aria-label": "Change" %>
         </p>
 
         <% if session[:claim_address_line_1].present? %>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-1">House number or name</h2>
           <p class="govuk-body">
             <%= session[:claim_address_line_1] %>
-            <%= link_to "Change", claim_path(current_claim.policy.routing_name, "postcode-search"), class: "govuk-link govuk-!-margin-left-3", "aria-label": "Change" %>
+            <%= link_to "Change", claim_path(current_journey_routing_name, "postcode-search"), class: "govuk-link govuk-!-margin-left-3", "aria-label": "Change" %>
           </p>
         <% end %>
 
-        <%= link_to "Enter your address manually", claim_path(current_claim.policy.routing_name, "address"), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
+        <%= link_to "Enter your address manually", claim_path(current_journey_routing_name, "address"), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/personal_bank_account.html.erb
+++ b/app/views/claims/personal_bank_account.html.erb
@@ -1,12 +1,12 @@
 <% bank_or_building_society = current_claim.bank_or_building_society.humanize.downcase %>
-<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), policy: current_policy_routing_name, show_error: @form.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { banking_name: :claim_banking_name } ) if @form.errors.any? %>
 
-    <%= render partial: "account_details", locals: { current_claim: current_claim, bank_or_building_society: bank_or_building_society, current_policy_routing_name: current_policy_routing_name} %>
+    <%= render partial: "account_details", locals: { current_claim: current_claim, bank_or_building_society: bank_or_building_society, current_journey_routing_name: current_journey_routing_name} %>
 
   </div>
 </div>

--- a/app/views/claims/personal_details.html.erb
+++ b/app/views/claims/personal_details.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:page_title, page_title(t("questions.personal_details"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.personal_details"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { date_of_birth: "claim_date_of_birth_3i"}) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <h1 class="govuk-heading-xl">
         <%= t("questions.personal_details") %>
       </h1>

--- a/app/views/claims/postcode_search.html.erb
+++ b/app/views/claims/postcode_search.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.address.home.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.home.title"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name), method: :get do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name), method: :get do |form| %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-heading-l"><%= I18n.t("questions.address.home.title") %></h1>
@@ -21,7 +21,7 @@
           %>
         <% end %>
 
-        <%= link_to I18n.t("questions.address.home.link_to_manual_address"), claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.link_to_manual_address") %>
+        <%= link_to I18n.t("questions.address.home.link_to_manual_address"), claim_path(current_journey_routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.link_to_manual_address") %>
       </fieldset>
       <p class="govuk-!-padding-top-6">
         <%= form.submit "Search", class: "govuk-button" %>

--- a/app/views/claims/provide_mobile_number.html.erb
+++ b/app/views/claims/provide_mobile_number.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("questions.provide_mobile_number"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.provide_mobile_number"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.qts_award_year"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -21,14 +21,14 @@
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, :before_cut_off_date, class: "govuk-radios__input") %>
                 <%= fields.label "qts_award_year_before_cut_off_date",
-                      t("answers.qts_award_years.before_cut_off_date", year: current_policy.last_ineligible_qts_award_year.to_s(:long)),
+                      t("answers.qts_award_years.before_cut_off_date", year: current_claim.last_ineligible_qts_award_year.to_s(:long)),
                       class: "govuk-label govuk-radios__label" %>
               </div>
 
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, :on_or_after_cut_off_date, class: "govuk-radios__input") %>
                 <%= fields.label "qts_award_year_on_or_after_cut_off_date",
-                      t("answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)),
+                      t("answers.qts_award_years.on_or_after_cut_off_date", year: current_claim.policy.first_eligible_qts_award_year.to_s(:long)),
                       class: "govuk-label govuk-radios__label" %>
               </div>
             </div>

--- a/app/views/claims/reset_claim.erb
+++ b/app/views/claims/reset_claim.erb
@@ -16,7 +16,7 @@
         You can continue to complete an application to check your eligibility and apply for a payment.
       </p>
 
-      <%= form_with(url: claim_path(current_policy_routing_name, "current-school"), method: :get) do %>
+      <%= form_with(url: claim_path(current_journey_routing_name, "current-school"), method: :get) do %>
         <div class="govuk-form-group">
           <%= hidden_field_tag :skip_landing_page, 'true' %>
           <%= submit_tag 'Continue', class: 'govuk-button', data: { module: 'govuk-button' }, 'data-disable-with' => 'Continue' %>

--- a/app/views/claims/select_email.html.erb
+++ b/app/views/claims/select_email.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("questions.select_email.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.select_email.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -1,16 +1,16 @@
-<% content_for(:page_title, page_title(t("questions.address.home.title"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address.home.title"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "address": "#{@address_data.first[:address].gsub(",", "").gsub(" ", "_").downcase}"}) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <div class="govuk-!-margin-bottom-5">
         <h1 class="govuk-heading-xl"><%= t("questions.address.home.title") %></h1>
         <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Postcode</h2>
         <p class="govuk-body">
           <%= params["claim"]["postcode"] %>
-          <%= link_to "Change", claim_path(current_claim.policy.routing_name, "postcode-search"), class: "govuk-link govuk-!-margin-left-3", "aria-label": "Change" %>
+          <%= link_to "Change", claim_path(current_journey_routing_name, "postcode-search"), class: "govuk-link govuk-!-margin-left-3", "aria-label": "Change" %>
         </p>
         <%= form_group_tag current_claim do %>
           <%= hidden_field_tag :postcode, params["claim"]["postcode"] %>
@@ -36,7 +36,7 @@
             </div>
           </fieldset>
         <% end %>
-        <%= link_to I18n.t("questions.address.home.i_cannot_find"), claim_path(current_claim.policy.routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.i_cannot_find") %>
+        <%= link_to I18n.t("questions.address.home.i_cannot_find"), claim_path(current_journey_routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.i_cannot_find") %>
       </div>
       <p class="govuk-!-padding-top-3">
         <%= form.submit "Continue", class: "govuk-button" %>

--- a/app/views/claims/select_mobile.html.erb
+++ b/app/views/claims/select_mobile.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("questions.select_phone_number.heading"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.select_phone_number.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">

--- a/app/views/claims/sign_in_or_continue.html.erb
+++ b/app/views/claims/sign_in_or_continue.html.erb
@@ -14,7 +14,7 @@
 
       <div class="govuk-button-group">
         <%= button_to "Continue with DfE Identity", "/auth/tid", class: "govuk-button", method: :post %>
-        <%= button_to "Continue without signing in", claim_path(current_policy_routing_name, "sign-in-or-continue"), method: :patch, class: "govuk-button govuk-button--secondary"%>
+        <%= button_to "Continue without signing in", claim_path(current_journey_routing_name, "sign-in-or-continue"), method: :patch, class: "govuk-button govuk-button--secondary"%>
       </div>
     </div>
   </div>

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.has_student_loan"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.has_student_loan"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { has_student_loan: "claim_has_student_loan_true" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :has_student_loan %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" role="group">

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.student_loan_country"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_country"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_country: "claim_student_loan_country_england" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :student_loan_country %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset">

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(t("questions.student_loan_how_many_courses"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_how_many_courses"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_courses: "claim_student_loan_courses_one_course" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :student_loan_courses %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" role="group", aria-describedby="student_loan_courses-hint">

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_start_date: "claim_student_loan_start_date_before_first_september_2012" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :student_loan_start_date %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset">

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(t("questions.teacher_reference_number"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.teacher_reference_number"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
           <%= form.label :teacher_reference_number, t("questions.teacher_reference_number"), class: "govuk-label govuk-label--#{shared_view_css_size}" %>

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Your session has ended due to inactivity", policy: current_policy_routing_name,)) %>
+<% content_for(:page_title, page_title("Your session has ended due to inactivity", journey: current_journey_routing_name,)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -10,6 +10,6 @@
       Your session ended because you haven't done anything for <%= claim_timeout_in_minutes %> minutes
     </h2>
 
-    <%= link_to "Start your application again", start_page_url, class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
+    <%= link_to "Start your application again", start_page_url(current_journey_routing_name), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= content_for(:page_title) || "#{policy_service_name(current_policy_routing_name)} – GOV.UK" %>
+      <%= content_for(:page_title) || "#{journey_service_name(current_journey_routing_name)} – GOV.UK" %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -45,16 +45,16 @@
       </noscript>
     <% end %>
 
-    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes, path_on_timeout: timeout_claim_path(current_policy_routing_name), refresh_session_path: refresh_session_path) if claim_in_progress? %>
+    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes, path_on_timeout: timeout_claim_path(current_journey_routing_name), refresh_session_path: refresh_session_path) if claim_in_progress? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
     <div id="global-cookie-message" class="govuk-cookie-banner" role="region" aria-label="cookie banner">
       <div class="govuk-width-container">
-        <p class="govuk-cookie-banner__message"><%= policy_service_name(current_policy_routing_name) %> uses cookies to make the site simpler.</p>
+        <p class="govuk-cookie-banner__message"><%= journey_service_name(current_journey_routing_name) %> uses cookies to make the site simpler.</p>
         <div class="govuk-cookie-banner__buttons">
           <button id="accept-cookies" class="govuk-button" type="submit" data-module="govuk-button">Accept cookies</button>
-          <%= link_to('Cookie information', cookies_path(current_policy_routing_name), class: "govuk-cookie-banner__link" ) %>
+          <%= link_to('Cookie information', cookies_path(current_journey_routing_name), class: "govuk-cookie-banner__link" ) %>
         </div>
       </div>
     </div>
@@ -78,7 +78,7 @@
           </a>
         </div>
         <div class="govuk-header__content">
-          <%= link_to policy_service_name(current_policy_routing_name), start_page_url, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to journey_service_name(current_journey_routing_name), start_page_url(current_journey_routing_name), class: "govuk-header__link govuk-header__link--service-name" %>
         </div>
       </div>
     </header>
@@ -88,7 +88,7 @@
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag ">beta</strong>
           <span class="govuk-phase-banner__text">
-            This is a new service – your <%= mail_to feedback_email, "feedback", class: "govuk-link" %> will help us to improve it.
+            This is a new service – your <%= mail_to feedback_email(current_journey_routing_name), "feedback", class: "govuk-link" %> will help us to improve it.
           </span>
         </p>
       </div>
@@ -111,19 +111,19 @@
             <h2 class="govuk-visually-hidden">Support links</h2>
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item">
-                <%= link_to "Contact us", contact_us_path(current_policy_routing_name), class: "govuk-footer__link" %>
+                <%= link_to "Contact us", contact_us_path(current_journey_routing_name), class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= link_to "Cookies", cookies_path(current_policy_routing_name), class: "govuk-footer__link" %>
+                <%= link_to "Cookies", cookies_path(current_journey_routing_name), class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= link_to "Terms and conditions", terms_conditions_path(current_policy_routing_name), class: "govuk-footer__link" %>
+                <%= link_to "Terms and conditions", terms_conditions_path(current_journey_routing_name), class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= link_to "Privacy notice", privacy_notice_path(current_policy_routing_name), class: "govuk-footer__link" %>
+                <%= link_to "Privacy notice", privacy_notice_path(current_journey_routing_name), class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= link_to "Accessibility statement", accessibility_statement_path(current_policy_routing_name), class: "govuk-footer__link" %>
+                <%= link_to "Accessibility statement", accessibility_statement_path(current_journey_routing_name), class: "govuk-footer__link" %>
               </li>
             </ul>
 

--- a/app/views/reminders/_one_time_password.html.erb
+++ b/app/views/reminders/_one_time_password.html.erb
@@ -4,7 +4,7 @@
 
     <span class="govuk-caption-xl">Email verification</span>
 
-    <%= form_for current_reminder, url: reminder_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_reminder, url: reminder_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_reminder do %>
         <h1 class="govuk-label-wrapper">
           <label class="govuk-label govuk-label--l" for="claim_one_time_password"><%= t("one_time_password.title") %></label>

--- a/app/views/reminders/email_verification.html.erb
+++ b/app/views/reminders/email_verification.html.erb
@@ -1,3 +1,3 @@
-<% content_for(:page_title, page_title(t("one_time_password.title"), policy: current_policy_routing_name, show_error: current_reminder.errors.any?)) %>
+<% content_for(:page_title, page_title(t("one_time_password.title"), journey: current_journey_routing_name, show_error: current_reminder.errors.any?)) %>
 
-<%= render partial: "one_time_password", locals: {current_reminder: current_reminder, current_policy_routing_name: current_policy_routing_name} %>
+<%= render partial: "one_time_password", locals: {current_reminder: current_reminder, current_journey_routing_name: current_journey_routing_name} %>

--- a/app/views/reminders/personal_details.html.erb
+++ b/app/views/reminders/personal_details.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("questions.personal_details"), policy: current_policy_routing_name, show_error: current_reminder.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.personal_details"), journey: current_journey_routing_name, show_error: current_reminder.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_reminder) if current_reminder.errors.any? %>
 
-    <%= form_for current_reminder, url: reminders_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_reminder, url: reminders_path(current_journey_routing_name) do |form| %>
       <h1 class="govuk-heading-xl">
         <%= t("questions.personal_details") %>
       </h1>

--- a/app/views/reminders/set.html.erb
+++ b/app/views/reminders/set.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("We have set your reminders", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("We have set your reminders", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}",  policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Accessibility statement for #{journey_service_name(current_journey_routing_name)}",  journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
-      Accessibility statement for <%= policy_service_name(current_policy_routing_name) %>
+      Accessibility statement for <%= journey_service_name(current_journey_routing_name) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/static_pages/closed_for_submissions.html.erb
+++ b/app/views/static_pages/closed_for_submissions.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Sorry, the service is unavailable", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Sorry, the service is unavailable", journey: current_journey_routing_name)) %>
 
 <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
 
@@ -20,7 +20,7 @@
     </p>
 
     <p class="govuk-body">
-      Contact <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>
+      Contact <%= mail_to support_email_address(current_journey_routing_name), support_email_address(current_journey_routing_name), class: "govuk-link" %>
       if you need further information.
     </p>
   </div>

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Contact us", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Contact us", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -9,7 +9,7 @@
 
     <p class="govuk-body">
       If you have any problems using this service contact us by emailing
-      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-footer__link" %>.
+      <%= mail_to support_email_address(current_journey_routing_name), support_email_address(current_journey_routing_name), class: "govuk-footer__link" %>.
     </p>
 
   </div>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Cookies", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Cookies", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
 
@@ -23,7 +23,7 @@
     </ul>
 
     <div class="panel panel-border-wide">
-      <p class="govuk-body"><%= policy_service_name(current_policy_routing_name) %>  cookies aren’t used to identify you personally.</p>
+      <p class="govuk-body"><%= journey_service_name(current_journey_routing_name) %>  cookies aren’t used to identify you personally.</p>
     </div>
 
     <p class="govuk-body">
@@ -35,7 +35,7 @@
     </h2>
 
     <p class="govuk-body">
-      We use Google Analytics software to collect information about how you use <%= policy_service_name(current_policy_routing_name) %>.
+      We use Google Analytics software to collect information about how you use <%= journey_service_name(current_journey_routing_name) %>.
       We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
     </p>
 
@@ -44,7 +44,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the pages you visit on <%= policy_service_name(current_policy_routing_name) %></li>
+      <li>the pages you visit on <%= journey_service_name(current_journey_routing_name) %></li>
       <li>how long you spend on each page</li>
       <li>how you got to the site</li>
       <li>what you click on while you’re visiting the site</li>
@@ -75,13 +75,13 @@
       <tbody>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">_ga</td>
-          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(current_policy_routing_name) %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= journey_service_name(current_journey_routing_name) %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 2 years</td>
         </tr>
         <tr>
           <tr class="govuk-table__row">
           <td class="govuk-table__cell">_gid</td>
-          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(current_policy_routing_name) %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= journey_service_name(current_journey_routing_name) %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 24 hours</td>
         </tr>
         <tr>
@@ -102,7 +102,7 @@
     </h2>
 
     <p class="govuk-body">
-      We use Google Forms software to collect information about what you thought of the <%= policy_service_name(current_policy_routing_name) %> service.
+      We use Google Forms software to collect information about what you thought of the <%= journey_service_name(current_journey_routing_name) %> service.
       We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
     </p>
 
@@ -140,7 +140,7 @@
     </h2>
 
     <p class="govuk-body">
-      You will see a pop-up cookie consent message when you visit <%= policy_service_name(current_policy_routing_name) %>.
+      You will see a pop-up cookie consent message when you visit <%= journey_service_name(current_journey_routing_name) %>.
       If you give us consent to, we'll store a cookie so that your computer knows you’ve consented to non-essential cookies and don't ask you again.
     </p>
 

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Privacy Notice", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Privacy Notice", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Terms and Conditions", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Terms and Conditions", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -12,11 +12,11 @@
     </h2>
 
     <h3 class="govuk-heading-m">
-      Using the <%= policy_service_name(current_policy_routing_name) %> service
+      Using the <%= journey_service_name(current_journey_routing_name) %> service
     </h3>
 
     <p class="govuk-body">
-      Please read these Terms of Use (“General Terms”) carefully before using this <%= policy_service_name(current_policy_routing_name) %> service (the “Service”).
+      Please read these Terms of Use (“General Terms”) carefully before using this <%= journey_service_name(current_journey_routing_name) %> service (the “Service”).
     </p>
 
     <p class="govuk-body">
@@ -43,7 +43,7 @@
 
     <p class="govuk-body">
       You can contact us using the following email address:
-      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>
+      <%= mail_to support_email_address(current_journey_routing_name), support_email_address(current_journey_routing_name), class: "govuk-link" %>
     </p>
 
     <h3 class="govuk-heading-m">

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -19,10 +19,10 @@
 
   <div class="govuk-button-group">
     <% if current_claim.eligibility.claim_school_somewhere_else == false %>
-      <%= button_to "Enter another school", claim_path(current_policy_routing_name, "select-claim-school", additional_school: true), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
+      <%= button_to "Enter another school", claim_path(current_journey_routing_name, "select-claim-school", additional_school: true), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
     <% else %>
-      <div><%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %></div>
+      <div><%= link_to "Enter another school", claim_path(current_journey_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %></div>
     <% end %>
-      <div><%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %></div>
+      <div><%= link_to "I've tried all of my schools", claim_path(current_journey_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %></div>
   </div>
 <% end %>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,11 +4,11 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  <%= t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)).downcase %>.
+  <%= t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: StudentLoans.first_eligible_qts_award_year.to_s(:long)).downcase %>.
 </p>
 
 <p class="govuk-body">
   For more information, including eligibility criteria for this payment, visit the
-  <%= link_to "‘#{policy_service_name(current_policy.routing_name)}’", "#{current_policy.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  <%= link_to "‘#{journey_service_name(current_journey_routing_name)}’", "#{eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
   guidance.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -29,6 +29,6 @@
     You only need to have worked at one eligible school to claim.
   </p>
 
-  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
-  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
+  <%= link_to "Enter another school", claim_path(current_journey_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
+  <%= link_to "I've tried all of my schools", claim_path(current_journey_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
 <% end %>

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(claim_school_question(additional_school: params[:additional_school]), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(claim_school_question(additional_school: params[:additional_school]), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/eligibility_confirmed.html.erb
+++ b/app/views/student_loans/claims/eligibility_confirmed.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("You are eligible to claim back student loan repayments", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("You are eligible to claim back student loan repayments", journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -6,6 +6,6 @@
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
     <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between <%= StudentLoans.current_financial_year %>.</p>
 
-    <%= button_to "Continue", claim_path(current_policy_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"} %>
+    <%= button_to "Continue", claim_path(current_journey_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"} %>
   </div>
 </div>

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(leadership_position_question, policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(leadership_position_question, journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.had_leadership_position": "claim_eligibility_attributes_had_leadership_position_true" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
 

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(mostly_performed_leadership_duties_question, policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(mostly_performed_leadership_duties_question, journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.mostly_performed_leadership_duties": "claim_eligibility_attributes_mostly_performed_leadership_duties_true"}) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
           <%= fields.hidden_field :mostly_performed_leadership_duties %>

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -25,7 +25,7 @@
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, :on_or_after_cut_off_date, class: "govuk-radios__input") %>
                 <%= fields.label "qts_award_year_on_or_after_cut_off_date",
-                      t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)),
+                      t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: current_claim.policy.first_eligible_qts_award_year.to_s(:long)),
                       class: "govuk-label govuk-radios__label" %>
               </div>
 

--- a/app/views/student_loans/claims/qualification_details.html.erb
+++ b/app/views/student_loans/claims/qualification_details.html.erb
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 <% shared_view_css_size = current_claim.policy == Policies::EarlyCareerPayments ? "l" : "xl" %>
   <%= form_for current_claim, url: path_for_form do |form| %>
     <%= form.hidden_field :qualifications_details_check %>

--- a/app/views/student_loans/claims/select_claim_school.html.erb
+++ b/app/views/student_loans/claims/select_claim_school.html.erb
@@ -1,6 +1,6 @@
 <%= render("shared/error_summary", instance: current_claim.eligibility) if current_claim.eligibility.errors.any? %>
 
-<%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+<%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
   <%= form_group_tag current_claim do %>
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/student_loans/claims/still_teaching.html.erb
+++ b/app/views/student_loans/claims/still_teaching.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.employment_status"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.employment_status"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.employment_status": "claim_eligibility_attributes_employment_status_claim_school" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
           <fieldset class="govuk-fieldset">

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(student_loan_amount_question, policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(student_loan_amount_question, journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
           <fieldset class="govuk-fieldset" role="group">

--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, page_title(subjects_taught_question(school_name: current_claim.eligibility.claim_school_name), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(subjects_taught_question(school_name: current_claim.eligibility.claim_school_name), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.subjects_taught": "eligible_subjects_biology_taught" }) if current_claim.errors.any? %>
 
-    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
 
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>

--- a/app/views/student_loans/landing_page.html.erb
+++ b/app/views/student_loans/landing_page.html.erb
@@ -30,7 +30,7 @@
     </p>
 
     <p class="govuk-!-margin-top-8">
-        <a href="<%= claim_path(current_policy.routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Claim submitted", policy: current_policy_routing_name)) %>
+<% content_for(:page_title, page_title("Claim submitted", journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -137,8 +137,54 @@
         89
       ],
       "note": "The concetenated attributes in the CONCAT operation are not user-generated, so this can be safely ignored"
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "b838db1b7beff28cdeff71a154a46d7c57062fb11aebf82f0487a9991445bea5",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/concerns/part_of_claim_journey.rb",
+      "line": 25,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(JourneyConfiguration.start_page_url(current_journey_routing_name), :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "PartOfClaimJourney",
+        "method": "send_unstarted_claimants_to_the_start"
+      },
+      "user_input": "JourneyConfiguration.start_page_url(current_journey_routing_name)",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "d7efbb65a649f824e34aa86f2d844a9d5ffac945eea04198f59418ac1998721c",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/submissions_controller.rb",
+      "line": 22,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(JourneyConfiguration.start_page_url(current_journey_routing_name), :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SubmissionsController",
+        "method": "show"
+      },
+      "user_input": "JourneyConfiguration.start_page_url(current_journey_routing_name)",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
     }
   ],
-  "updated": "2023-11-23 09:43:08 +0000",
-  "brakeman_version": "6.0.1"
+  "updated": "2024-03-07 12:34:07 +0000",
+  "brakeman_version": "6.1.2"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,6 +227,7 @@ en:
     claim_action: "claim back student loan repayments"
     award_description: "claim payment"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
+    feedback_email: "studentloanteacherpayment@digital.education.gov.uk"
     landing_page: "Claim back student loan repayments if you're a teacher"
     questions:
       qts_award_year: "When did you complete your initial teacher training (ITT)?"
@@ -287,6 +288,7 @@ en:
     claim_description: "for an additional payment for teaching"
     landing_page: "Find out if you are eligible for any additional payments"
     support_email_address: "additionalteachingpayment@digital.education.gov.uk"
+    feedback_email: "additionalteachingpayment@digital.education.gov.uk"
     ineligible:
       heading: "You are not eligible"
       school_heading: "The school you have selected is not eligible"

--- a/lib/journey_subject_eligibility_checker.rb
+++ b/lib/journey_subject_eligibility_checker.rb
@@ -1,3 +1,5 @@
+# TODO: Move this into an additional-payments journey specific namespace
+#
 class JourneySubjectEligibilityChecker
   def initialize(claim_year:, itt_year:)
     raise "Claim year #{claim_year} is after ECP and LUP both ended" if claim_year > EligibilityCheckable::FINAL_COMBINED_ECP_AND_LUP_POLICY_YEAR

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
   scenario "Teacher makes claim for 'Early-Career Payments' claim" do
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))
@@ -343,7 +343,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
 
   scenario "Supply Teacher makes claim for 'Early Career Payments' with a contract to teach for entire term & employed directly by school" do
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))
@@ -501,7 +501,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
 
   scenario "Teacher makes claim for 'Early Career Payments' without uplift school" do
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))

--- a/spec/features/early_career_payments_landing_page_spec.rb
+++ b/spec/features/early_career_payments_landing_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Landing page - Early Career Payments - journey" do
 
   scenario "navigate to first page in ECP journey" do
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))

--- a/spec/features/early_career_payments_trainee_teacher_spec.rb
+++ b/spec/features/early_career_payments_trainee_teacher_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Trainee Teacher - Early Career Payments - journey" do
 
     scenario "ECP-only school with trainee teacher" do
       visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
-      expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+      expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
       # - Landing (start)
       expect(page).to have_text(I18n.t("additional_payments.landing_page"))

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           fill_in "Email address", with: "david.tau1988@hotmail.co.uk"
           click_on "Continue"
 
-          expect(page).to have_link("Resend passcode (you will be sent back to the email address page)", href: new_reminder_path(policy: claim.policy.routing_name))
+          expect(page).to have_link("Resend passcode (you will be sent back to the email address page)", href: new_reminder_path(journey: claim.policy.routing_name))
 
           click_link "Resend passcode"
           expect(page).to have_text("Personal details")

--- a/spec/features/sign_in_or_continue_spec.rb
+++ b/spec/features/sign_in_or_continue_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Teacher Identity Sign in" do
   scenario "Teacher makes claim for 'Early-Career Payments' claim and select continue without signing in" do
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))
@@ -39,7 +39,7 @@ RSpec.feature "Teacher Identity Sign in" do
   scenario "Teacher makes claim for 'Early-Career Payments' claim and select Continue with DfE Identity" do
     visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(page).to have_current_path("/#{StudentLoans.routing_name}/qts-year")
 
       expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
-      expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
+      expect(page).to have_link(href: "mailto:#{I18n.t("student_loans.feedback_email")}")
 
       choose_qts_year
       claim = Claim.by_policy(StudentLoans).order(:created_at).last
@@ -250,7 +250,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
         visit new_claim_path(StudentLoans.routing_name)
         skip_tid
         expect(page).to have_text(I18n.t("questions.qts_award_year"))
-        expect(page).to have_link(href: "mailto:#{StudentLoans.feedback_email}")
+        expect(page).to have_link(href: "mailto:#{I18n.t("student_loans.feedback_email")}")
 
         choose_qts_year
         claim = Claim.by_policy(StudentLoans).order(:created_at).last

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Switching policies" do
     create(:journey_configuration, :early_career_payments)
 
     start_student_loans_claim
-    visit new_claim_path(Policies::EarlyCareerPayments.routing_name)
+    visit new_claim_path("additional-payments")
   end
 
   scenario "a user can switch to a different policy after starting a claim on another" do

--- a/spec/features/teacher_identity_sign_in_spec.rb
+++ b/spec/features/teacher_identity_sign_in_spec.rb
@@ -20,9 +20,9 @@ RSpec.feature "Teacher Identity Sign in" do
 
   scenario "Teacher makes claim" do
     # - Teacher makes claim without signing in
-    visit landing_page_path(Policies::EarlyCareerPayments.routing_name)
+    visit landing_page_path("additional-payments")
     expect(page).to have_link("Claim additional payments for teaching", href: "/additional-payments/landing-page")
-    expect(page).to have_link(href: "mailto:#{Policies::EarlyCareerPayments.feedback_email}")
+    expect(page).to have_link(href: "mailto:#{I18n.t("additional_payments.feedback_email")}")
 
     # - Landing (start)
     expect(page).to have_text(I18n.t("additional_payments.landing_page"))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,16 +19,16 @@ describe ApplicationHelper do
 
   describe "page_title" do
     it "returns a title for the page that follows the guidance of the design system" do
-      expected_title = page_title("Title", policy: "student-loans")
+      expected_title = page_title("Title", journey: "student-loans")
       expect(expected_title).to eq("Title — Teachers: claim back your student loan repayments — GOV.UK")
     end
 
     it "uses the generic service name if a specific policy isn't available" do
-      expect(page_title("Some Title", policy: nil)).to eq("Some Title — Claim additional payments for teaching — GOV.UK")
+      expect(page_title("Some Title", journey: nil)).to eq("Some Title — Claim additional payments for teaching — GOV.UK")
     end
 
     it "includes an optional error prefix" do
-      expected_title = page_title("Some Title", show_error: true, policy: "student-loans")
+      expected_title = page_title("Some Title", show_error: true, journey: "student-loans")
       expect(expected_title).to eq("Error — Some Title — Teachers: claim back your student loan repayments — GOV.UK")
     end
   end
@@ -56,27 +56,27 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#policy_service_name" do
+  describe "#journey_service_name" do
     it "defaults to the generic service name" do
-      expect(policy_service_name).to eq t("service_name")
+      expect(journey_service_name).to eq t("service_name")
     end
 
     it "returns a policy-specific service name for student loans" do
-      expect(policy_service_name("student-loans")).to eq t("student_loans.journey_name")
+      expect(journey_service_name("student-loans")).to eq t("student_loans.journey_name")
     end
 
     it "returns a policy-specific service name for additional payments" do
-      expect(policy_service_name("additional-payments")).to eq t("additional_payments.journey_name")
+      expect(journey_service_name("additional-payments")).to eq t("additional_payments.journey_name")
     end
   end
 
-  describe "#policy_description" do
+  describe "#journey_description" do
     it "returns description for student loans" do
-      expect(policy_description("student-loans")).to eq t("student_loans.claim_description")
+      expect(journey_description("student-loans")).to eq t("student_loans.claim_description")
     end
 
     it "returns description for early career payments" do
-      expect(policy_description("additional-payments")).to eq t("additional_payments.claim_description")
+      expect(journey_description("additional-payments")).to eq t("additional_payments.claim_description")
     end
   end
 end

--- a/spec/models/early_career_payments_spec.rb
+++ b/spec/models/early_career_payments_spec.rb
@@ -21,19 +21,6 @@ RSpec.describe Policies::EarlyCareerPayments, type: :model do
       eligibility_criteria_url: "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools#eligibility-criteria")
   }
 
-  describe ".start_page_url" do
-    it "returns a url containing '/additional-payments/landing-page'" do
-      expect(subject.start_page_url).to include("/additional-payments/landing-page")
-    end
-  end
-
-  describe ".feedback_url" do
-    it "returns a 'docs.google.com/forms/<slug>/viewform' url" do
-      # TODO: get proper feedback URL - ECP-509
-      expect(subject.feedback_url).to include("https://docs.google.com/forms/TO-BE-REPLACED-by-response-to-ECP-509/viewform")
-    end
-  end
-
   describe ".notify_reply_to_id" do
     let(:ecp_notify_reply_to_id) { "3f85a1f7-9400-4b48-9a31-eaa643d6b977" }
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "Claims", type: :request do
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page indicated by the routing" do
         get claim_path(StudentLoans.routing_name, "qts-year")
-        expect(response).to redirect_to(StudentLoans.start_page_url)
+        expect(response).to redirect_to(JourneyConfiguration.start_page_url("student-loans"))
       end
     end
   end
@@ -155,7 +155,7 @@ RSpec.describe "Claims", type: :request do
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page indicated by the routing" do
         get claim_path(StudentLoans.routing_name, "ineligible")
-        expect(response).to redirect_to(StudentLoans.start_page_url)
+        expect(response).to redirect_to(JourneyConfiguration.start_page_url("student-loans"))
       end
     end
   end
@@ -250,7 +250,7 @@ RSpec.describe "Claims", type: :request do
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page indicated by the routing" do
         put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
-        expect(response).to redirect_to(StudentLoans.start_page_url)
+        expect(response).to redirect_to(JourneyConfiguration.start_page_url("student-loans"))
       end
     end
   end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
         get claim_auth_tid_callback_path
 
         expect(response).to redirect_to(
-          claim_path(policy: "additional-payments", slug: "teacher-detail")
+          claim_path(journey: "additional-payments", slug: "teacher-detail")
         )
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
         get claim_auth_tid_callback_path
 
         expect(response).to redirect_to(
-          claim_path(policy: "student-loans", slug: "teacher-detail")
+          claim_path(journey: "student-loans", slug: "teacher-detail")
         )
       end
     end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Sessions", type: :request do
         expect(session[:claim_id]).to be_nil
 
         get claim_path(StudentLoans.routing_name, "qts-year")
-        expect(response).to redirect_to(new_claim_path(StudentLoans.routing_name))
+        expect(response).to redirect_to(JourneyConfiguration.start_page_url("student-loans"))
       end
     end
   end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Submissions", type: :request do
 
     it "redirects to the start page if there is no claim actually in progress" do
       post claim_submission_path(StudentLoans.routing_name)
-      expect(response).to redirect_to(StudentLoans.start_page_url)
+      expect(response).to redirect_to(JourneyConfiguration.start_page_url("student-loans"))
     end
   end
 
@@ -102,7 +102,7 @@ RSpec.describe "Submissions", type: :request do
     context "when the user has not followed the slug sequence" do
       it "redirect to the start page" do
         get claim_confirmation_path(StudentLoans.routing_name)
-        expect(response).to redirect_to(StudentLoans.start_page_url)
+        expect(response).to redirect_to(JourneyConfiguration.start_page_url("student-loans"))
       end
     end
   end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -3,21 +3,21 @@ require "rails_helper"
 describe "Routes", type: :routing do
   describe "Claims routing" do
     it "routes GET requests to pages in the policies’ page sequences" do
-      expect(get: "student-loans/qts-year").to route_to "claims#show", slug: "qts-year", policy: "student-loans"
+      expect(get: "student-loans/qts-year").to route_to "claims#show", slug: "qts-year", journey: "student-loans"
     end
 
     it "routes GET /:policy/claim to the new action" do
-      expect(get: "student-loans/claim").to route_to "claims#new", policy: "student-loans"
+      expect(get: "student-loans/claim").to route_to "claims#new", journey: "student-loans"
     end
 
     it "routes POST /:policy/claim to the create action" do
-      expect(post: "student-loans/claim").to route_to "claims#create", policy: "student-loans"
-      expect(post: "additional-payments/claim").to route_to "claims#create", policy: "additional-payments"
+      expect(post: "student-loans/claim").to route_to "claims#create", journey: "student-loans"
+      expect(post: "additional-payments/claim").to route_to "claims#create", journey: "additional-payments"
     end
 
     it "routes policy page sequence slugs to the update action" do
-      expect(put: "student-loans/claim-school").to route_to "claims#update", slug: "claim-school", policy: "student-loans"
-      expect(put: "additional-payments/employed-directly").to route_to "claims#update", slug: "employed-directly", policy: "additional-payments"
+      expect(put: "student-loans/claim-school").to route_to "claims#update", slug: "claim-school", journey: "student-loans"
+      expect(put: "additional-payments/employed-directly").to route_to "claims#update", slug: "employed-directly", journey: "additional-payments"
     end
 
     it "does not route for unrecognised policies" do


### PR DESCRIPTION
Continuation from https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2606

This change removes or renames a number of helpers used to support the front end journey from 'policy' to 'journey' for consistency with the new concept, and removes some concerns from the `Policy` model which are not strictly related to the policy.

Also fixes the ```
super: no superclass method `current_policy_routing_name' for #<OmniauthCallbacksController:0x0000000035aa48>` ``` error.

Note: `feedback_url` was redundant and not used anywhere, and the ECP URL was still marked `TODO`, so was removed.

The next step is to refactor `JourneyConfiguration` to create a new namespace and class for each journey where journey-specific configuration (such as slug sequence, eligibility presenter) can be placed, and potentially other things like form objects.