### PR TITLE
CAPT-1119 Amend exit screen for LUP school trainees

### DIFF
--- a/app/views/additional_payments/claims/_ineligibility_trainee_teaching_lacking_both_valid_itt_subject_and_degree.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_trainee_teaching_lacking_both_valid_itt_subject_and_degree.html.erb
@@ -1,24 +1,19 @@
 <p class="govuk-body">
-  The subject you are studying or have studied means you are not eligible for additional payment.
-</p>
-<p class="govuk-body">
-  You will not be able to claim an additional payment when you begin teaching.
-</p>
-<p class="govuk-body">
-  Eligible subjects for
-  <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
-  are:
+  You will not be eligible for the
+  <%= link_to("early-career payment", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
+  once you start work as a qualified teacher. This is because of the year and subject you studied.
+  To be eligible for early-career payments, your initial teacher training (ITT) course must have started (postgraduate) or
+  finished (undergraduate) in:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>chemistry</li>
-  <li>mathematics</li>
-  <li>languages</li>
-  <li>physics</li>
+  <li>mathematics in the 2018 to 2019, 2019 to 2020 or 2020 to 2021 academic year</li>
+  <li>chemistry, languages and physics in the 2020 to 2021 academic year</li>
 </ul>
 <p class="govuk-body">
-  Eligible subjects for
-  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
-  are:
+  You will not be eligible for a
+  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  once you start work as a qualified teacher. This is because of the subject you studied.
+  Eligible subjects for levelling up premium payments are:
 </p>
 <ul class="govuk-list govuk-list--bullet">
   <li>chemistry</li>


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1119

This is just a content change; if you want to understand under which conditions this partial is rendered, look [here](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/lib/ineligibility_reason_checker.rb#L17-L18) and [here](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/lib/ineligibility_reason_checker.rb#L76C1-L82C6): only LUP trainees without an ECP-eligible subject and degree should be presented this exit screen.

