### PR TITLE
Skip deleting and re-running NO DATA student loan amount tasks for older TSLR claims

### DIFF
--- a/app/jobs/student_loan_amount_check_job.rb
+++ b/app/jobs/student_loan_amount_check_job.rb
@@ -26,7 +26,7 @@ class StudentLoanAmountCheckJob < ApplicationJob
   def current_year_tslr_claims_awaiting_decision
     Claim.by_academic_year(current_academic_year).by_policy(Policies::StudentLoans).awaiting_decision
       .where.not(submitted_using_slc_data: nil) # exclude older claims submitted using the student loan questions
-    # This last condition won't be needed once we have processed all the existing TSLR claims submitted using
+    # TODO: This last condition won't be needed once we have processed all the existing TSLR claims submitted using
     # the student loan questions in the journey
   end
 

--- a/app/jobs/student_loan_amount_check_job.rb
+++ b/app/jobs/student_loan_amount_check_job.rb
@@ -25,6 +25,9 @@ class StudentLoanAmountCheckJob < ApplicationJob
 
   def current_year_tslr_claims_awaiting_decision
     Claim.by_academic_year(current_academic_year).by_policy(Policies::StudentLoans).awaiting_decision
+      .where.not(submitted_using_slc_data: nil) # exclude older claims submitted using the student loan questions
+    # This last condition won't be needed once we have processed all the existing TSLR claims submitted using
+    # the student loan questions in the journey
   end
 
   def current_academic_year

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -175,11 +175,8 @@ RSpec.feature "Combined journey with Teacher ID" do
     choose "Male"
     click_on "Continue"
 
-    expect(claim.reload.payroll_gender).to eq("male")
-
-    click_link "Back"
-
-    expect(page).to have_text(I18n.t("questions.payroll_gender"))
+    # - teacher-reference-number removed from user journey
+    expect(page).not_to have_text(I18n.t("questions.teacher_reference_number"))
   end
 
   scenario "When user is logged in with Teacher ID and there is no matching DQT record" do

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -175,8 +175,11 @@ RSpec.feature "Combined journey with Teacher ID" do
     choose "Male"
     click_on "Continue"
 
-    # - teacher-reference-number removed from user journey
-    expect(page).not_to have_text(I18n.t("questions.teacher_reference_number"))
+    # - Check your answers instead of teacher-reference-number (removed slug)
+    expect(page).to have_text(I18n.t("additional_payments.check_your_answers.part_one.primary_heading"))
+
+    click_link "Back"
+    expect(page).to have_text(I18n.t("questions.payroll_gender"))
   end
 
   scenario "When user is logged in with Teacher ID and there is no matching DQT record" do

--- a/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "TSLR journey with Teacher ID teacher reference number page remova
     choose "No"
     click_on "Continue"
 
-    # - student-loan-amount page
+    # - Information provided
     expect(page).to have_text("you can claim back the student loan repayments you made between #{Policies::StudentLoans.current_financial_year}.")
     click_on "Continue"
 


### PR DESCRIPTION
We have a similar mechanism for the student loan _plan_ [task](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2556/commits/6d46f5bf42984a2030e46eb4cfe9079829577194#diff-2c18657c671befd11628bb5625912cbca80a2cbed533959e495ef14492db720dR27)

As a summary, after deploying #2556 we'll have three potential buckets of claims:

1. Claims submitted using the student loan questions in the journey (`submitted_using_slc_data = null`)
2. Claims submitted without the student loan questions, but the student loan details were found in our SLC extract (`submitted_using_slc_data = true`)
2. Claims submitted without the student loan questions, but the student loan details were NOT found in our SLC extract (`submitted_using_slc_data = false`)

The value of `submitted_using_slc_data` drives behaviour in the following places:

A. TSLR claims: Student loan _amount_ task checks (NO DATA) re-triggered by a new SLC extract upload (this PR)
B. ECP/LUPP claims: Student loan _plan_ task applicable only if `submitted_using_slc_data == false` (feature branch)
C. ECP/LUPP claims: Student loan _plan_ NO task checks (NO DATA) re-triggered by a new SLC extract upload (feature branch)

With this PR, we want to protect claims in bucket 1. from having the student loan details overridden due to A.
