### PR TITLE
Extract NqtInAcademicYearAfterIttForm

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -15,6 +15,10 @@ class Form
     super
   end
 
+  def persisted?
+    true
+  end
+
   def update!(attrs)
     claim.update!(attrs)
   end
@@ -39,5 +43,14 @@ class Form
 
   def i18n_form_namespace
     raise "Form#i18n_form_namespace requires all sub-classes to override"
+  end
+
+  def page_sequence
+    @page_sequence ||= Journeys::PageSequence.new(
+      claim,
+      journey.slug_sequence.new(claim),
+      nil,
+      params[:slug]
+    )
   end
 end

--- a/app/forms/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/nqt_in_academic_year_after_itt_form.rb
@@ -1,0 +1,83 @@
+class NqtInAcademicYearAfterIttForm < Form
+  attribute :nqt_in_academic_year_after_itt, :boolean
+
+  validates :nqt_in_academic_year_after_itt,
+    inclusion: {
+      in: [true, false],
+      message: "Select yes if you are currently teaching as a qualified teacher"
+    }
+
+  def initialize(journey:, claim:, params:)
+    super
+
+    self.nqt_in_academic_year_after_itt = permitted_params.fetch(
+      :nqt_in_academic_year_after_itt,
+      claim.eligibility.nqt_in_academic_year_after_itt
+    )
+  end
+
+  def persisted?
+    true
+  end
+
+  def save
+    return false unless valid?
+
+    update!(
+      {
+        eligibility_attributes: {
+          nqt_in_academic_year_after_itt: nqt_in_academic_year_after_itt,
+          induction_completed: determine_induction_answer_from_dqt_record
+        }
+      }
+    )
+  end
+
+  def backlink_path
+    return unless page_sequence.in_sequence?("correct-school")
+
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .claim_path(params[:journey], "correct-school")
+  end
+
+  private
+
+  def permitted_params
+    @permitted_params ||= params.fetch(:claim, {}).permit(
+      :nqt_in_academic_year_after_itt
+    )
+  end
+
+  def page_sequence
+    @page_sequence ||= Journeys::PageSequence.new(
+      claim,
+      journey.slug_sequence.new(claim),
+      nil,
+      nil
+    )
+  end
+
+  def determine_induction_answer_from_dqt_record
+    return unless additional_payments_journey?
+    return unless passed_details_check_with_teacher_id?
+    # We can derive the induction_completed value for current_claim using the
+    # ECP DQT record Remember: even if it's only relevant to ECP, the induction
+    # question is asked at the beginning of the combined journey, and the
+    # applicant may end up applying for ECP or LUPP only at a later stage in
+    # the journey, hence we need to store the answer on both eligibilities.
+    claim_for_policy = claim.for_policy(Policies::EarlyCareerPayments)
+    dqt_teacher_record = claim_for_policy.dqt_teacher_record
+    dqt_teacher_record&.eligible_induction?
+  end
+
+  def additional_payments_journey?
+    journey::ROUTING_NAME == "additional-payments"
+  end
+
+  def passed_details_check_with_teacher_id?
+    claim.logged_in_with_tid? && claim.details_check?
+  end
+end

--- a/app/forms/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/nqt_in_academic_year_after_itt_form.rb
@@ -16,10 +16,6 @@ class NqtInAcademicYearAfterIttForm < Form
     )
   end
 
-  def persisted?
-    true
-  end
-
   def save
     return false unless valid?
 
@@ -51,17 +47,7 @@ class NqtInAcademicYearAfterIttForm < Form
     )
   end
 
-  def page_sequence
-    @page_sequence ||= Journeys::PageSequence.new(
-      claim,
-      journey.slug_sequence.new(claim),
-      nil,
-      nil
-    )
-  end
-
   def determine_induction_answer_from_dqt_record
-    return unless additional_payments_journey?
     return unless passed_details_check_with_teacher_id?
     # We can derive the induction_completed value for current_claim using the
     # ECP DQT record Remember: even if it's only relevant to ECP, the induction
@@ -71,10 +57,6 @@ class NqtInAcademicYearAfterIttForm < Form
     claim_for_policy = claim.for_policy(Policies::EarlyCareerPayments)
     dqt_teacher_record = claim_for_policy.dqt_teacher_record
     dqt_teacher_record&.eligible_induction?
-  end
-
-  def additional_payments_journey?
-    journey::ROUTING_NAME == "additional-payments"
   end
 
   def passed_details_check_with_teacher_id?

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -9,5 +9,11 @@ module Journeys
     VIEW_PATH = "additional_payments"
     I18N_NAMESPACE = "additional_payments"
     POLICIES = [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments]
+
+    def forms
+      {
+        "nqt-in-academic-year-after-itt" => NqtInAcademicYearAfterIttForm
+      }
+    end
   end
 end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -18,12 +18,16 @@ module Journeys
       self::SlugSequence
     end
 
-    # TODO: make this work for journey specific forms
-    # that list of forms should be defined in the specific journey
     def form(claim:, params:)
-      form = SHARED_FORMS[params[:slug]]
+      avaliable_forms = SHARED_FORMS.merge(forms)
+
+      form = avaliable_forms[params[:slug]]
 
       form&.new(journey: self, claim: claim, params: params)
+    end
+
+    def forms
+      {}
     end
 
     def page_sequence_for_claim(claim, completed_slugs, current_slug)

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -77,7 +77,6 @@ module Policies
       has_one :claim, as: :eligibility, inverse_of: :eligibility
       belongs_to :current_school, optional: true, class_name: "School"
 
-      validates :nqt_in_academic_year_after_itt, on: [:"nqt-in-academic-year-after-itt", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently teaching as a qualified teacher"}
       validates :current_school, on: [:"correct-school"], presence: {message: "Select the school you teach at or choose somewhere else"}, unless: :school_somewhere_else?
       validates :induction_completed, on: [:"induction-completed", :submit], inclusion: {in: [true, false], message: "Select yes if you have completed your induction"}
       validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select yes if you are a supply teacher"}

--- a/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
+++ b/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
@@ -1,49 +1,56 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.nqt_in_academic_year_after_itt.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.nqt_in_academic_year_after_itt.heading"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.nqt_in_academic_year_after_itt": "claim_eligibility_attributes_nqt_in_academic_year_after_itt_true" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form  do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
-
-          <%= fields.hidden_field :nqt_in_academic_year_after_itt %>
-
-          <fieldset class="govuk-fieldset" aria-describedby="nqt_in_academic_year_after_itt-hint" role="group">
-
-            <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
-              <h1 class="govuk-fieldset__heading">
-                <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.heading") %>
-              </h1>
-            </legend>
-
-            <div class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
-              <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.hint") %>
-            </div>
-
-            <%= errors_tag current_claim.eligibility, :nqt_in_academic_year_after_itt %>
-
-            <div class="govuk-radios govuk-radios">
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:nqt_in_academic_year_after_itt, true, class: "govuk-radios__input") %>
-                <%= fields.label :nqt_in_academic_year_after_itt_true, "Yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:nqt_in_academic_year_after_itt, false, class: "govuk-radios__input") %>
-                <%= fields.label :nqt_in_academic_year_after_itt_false, "No, I’m a trainee teacher", class: "govuk-label govuk-radios__label" %>
-              </div>
-
-            </div>
-
-          </fieldset>
-
-        <% end %>
+    <%= form_for @form, url: path_for_form do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render(
+          "shared/error_summary",
+          instance: f.object,
+          errored_field_id_overrides: {
+            "nqt_in_academic_year_after_itt": "claim_nqt_in_academic_year_after_itt_true"
+          }
+        ) %>
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= form_group_tag f.object.claim do %>
+
+        <%= f.hidden_field :nqt_in_academic_year_after_itt %>
+
+        <fieldset class="govuk-fieldset" aria-describedby="nqt_in_academic_year_after_itt-hint" role="group">
+
+          <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(f.object.journey) %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.heading") %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
+            <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.hint") %>
+          </div>
+
+          <%= errors_tag f.object, :nqt_in_academic_year_after_itt %>
+
+          <div class="govuk-radios govuk-radios">
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:nqt_in_academic_year_after_itt, true, class: "govuk-radios__input") %>
+              <%= f.label :nqt_in_academic_year_after_itt_true, "Yes", class: "govuk-label govuk-radios__label" %>
+            </div>
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:nqt_in_academic_year_after_itt, false, class: "govuk-radios__input") %>
+              <%= f.label :nqt_in_academic_year_after_itt_false, "No, I’m a trainee teacher", class: "govuk-label govuk-radios__label" %>
+            </div>
+
+          </div>
+
+        </fieldset>
+
+      <% end %>
+
+      <%= f.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
     <% end %>
 
   </div>

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -283,5 +283,47 @@ FactoryBot.define do
         create(:support_ticket, claim:)
       end
     end
+
+    trait :with_dqt_teacher_status do
+      dqt_teacher_status do
+        {
+          trn: 123456,
+          ni_number: "AB123123A",
+          name: "Rick Sanchez",
+          dob: "66-06-06T00:00:00",
+          active_alert: false,
+          state: 0,
+          state_name: "Active",
+          qualified_teacher_status: {
+            name: "Qualified teacher (trained)",
+            qts_date: "2018-12-01",
+            state: 0,
+            state_name: "Active"
+          },
+          induction: {
+            start_date: "2021-07-01T00:00:00Z",
+            completion_date: "2021-07-05T00:00:00Z",
+            status: "Pass",
+            state: 0,
+            state_name: "Active"
+          },
+          initial_teacher_training: {
+            programme_start_date: "666-06-06T00:00:00",
+            programme_end_date: "2021-07-04T00:00:00Z",
+            programme_type: "Overseas Trained Teacher Programme",
+            result: "Pass",
+            subject1: "mathematics",
+            subject1_code: "G100",
+            subject2: nil,
+            subject2_code: nil,
+            subject3: nil,
+            subject3_code: nil,
+            qualification: "BA (Hons)",
+            state: 0,
+            state_name: "Active"
+          }
+        }
+      end
+    end
   end
 end

--- a/spec/forms/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/nqt_in_academic_year_after_itt_form_spec.rb
@@ -1,0 +1,281 @@
+require "rails_helper"
+
+RSpec.describe NqtInAcademicYearAfterIttForm, type: :model do
+  before { create(:journey_configuration, :additional_payments) }
+
+  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  describe "validations" do
+    let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+    describe "#nqt_in_academic_year_after_itt" do
+      subject(:form) do
+        described_class.new(
+          journey: additional_payments_journey,
+          claim: current_claim,
+          params: params
+        )
+      end
+
+      context "when `true`" do
+        let(:params) do
+          ActionController::Parameters.new(
+            claim: {
+              nqt_in_academic_year_after_itt: true
+            }
+          )
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `false`" do
+        let(:params) do
+          ActionController::Parameters.new(
+            claim: {
+              nqt_in_academic_year_after_itt: false
+            }
+          )
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `nil`" do
+        let(:params) do
+          ActionController::Parameters.new(
+            claim: {
+              nqt_in_academic_year_after_itt: nil
+            }
+          )
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:form) do
+      described_class.new(
+        journey: journey,
+        claim: current_claim,
+        params: params
+      )
+    end
+
+    before { form.save }
+
+    context "when invalid" do
+      let(:journey) { additional_payments_journey }
+
+      let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            nqt_in_academic_year_after_itt: nil
+          }
+        )
+      end
+
+      it "returns false" do
+        expect { expect(form.save).to be false }.not_to(
+          change { claim.eligibility.reload.nqt_in_academic_year_after_itt }
+        )
+      end
+    end
+
+    context "when valid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            nqt_in_academic_year_after_itt: true
+          }
+        )
+      end
+
+      context "when the current journey is not `additional-payments`" do
+        let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+
+        let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+        it "sets the nqt_in_academic_year_after_itt attribute" do
+          expect(claim.eligibility.nqt_in_academic_year_after_itt).to be true
+        end
+
+        it "does not set the induction as complete" do
+          expect(claim.eligibility.induction_completed).to be nil
+        end
+      end
+
+      context "when the current journey is `additional-payments`" do
+        let(:journey) { additional_payments_journey }
+
+        context "when the teacher has not passed the tid details check" do
+          let(:claim) do
+            create(
+              :claim,
+              :logged_in_with_tid,
+              details_check: false,
+              policy: Policies::EarlyCareerPayments
+            )
+          end
+
+          it "sets the nqt_in_academic_year_after_itt attribute" do
+            expect(claim.eligibility.nqt_in_academic_year_after_itt).to be true
+          end
+
+          it "does not set the induction as complete" do
+            expect(claim.eligibility.induction_completed).to be nil
+          end
+        end
+
+        context "when the teacher has passed the tid details check" do
+          context "when there is not an eligible induction" do
+            let(:claim) do
+              create(
+                :claim,
+                :logged_in_with_tid,
+                policy: Policies::EarlyCareerPayments,
+                details_check: true,
+                dqt_teacher_status: nil
+              )
+            end
+
+            it "sets the nqt_in_academic_year_after_itt attribute" do
+              expect(
+                claim.eligibility.nqt_in_academic_year_after_itt
+              ).to be true
+            end
+
+            it "does not set the induction as complete" do
+              expect(claim.eligibility.induction_completed).to be nil
+            end
+          end
+
+          context "when there is an eligible induction" do
+            let(:claim) do
+              create(
+                :claim,
+                :logged_in_with_tid,
+                policy: Policies::EarlyCareerPayments,
+                details_check: true,
+                dqt_teacher_status: {
+                  trn: 1234567,
+                  ni_number: "AB123123A",
+                  name: "Rick Sanchez",
+                  dob: "66-06-06T00:00:00",
+                  active_alert: false,
+                  state: 0,
+                  state_name: "Active",
+                  qualified_teacher_status: {
+                    name: "Qualified teacher (trained)",
+                    qts_date: "2018-12-01",
+                    state: 0,
+                    state_name: "Active"
+                  },
+                  induction: {
+                    start_date: "2021-07-01T00:00:00Z",
+                    completion_date: "2021-07-05T00:00:00Z",
+                    status: "Pass",
+                    state: 0,
+                    state_name: "Active"
+                  },
+                  initial_teacher_training: {
+                    programme_start_date: "666-06-06T00:00:00",
+                    programme_end_date: "2021-07-04T00:00:00Z",
+                    programme_type: "Overseas Trained Teacher Programme",
+                    result: "Pass",
+                    subject1: "mathematics",
+                    subject1_code: "G100",
+                    subject2: nil,
+                    subject2_code: nil,
+                    subject3: nil,
+                    subject3_code: nil,
+                    qualification: "BA (Hons)",
+                    state: 0,
+                    state_name: "Active"
+                  }
+                }
+              )
+            end
+
+            it "sets the nqt_in_academic_year_after_itt attribute" do
+              expect(
+                claim.eligibility.nqt_in_academic_year_after_itt
+              ).to be true
+            end
+
+            it "sets the induction as complete" do
+              expect(claim.eligibility.induction_completed).to be true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#backlink_path" do
+    context "when the page sequence does not include 'correct-school'" do
+      let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+      let(:form) do
+        described_class.new(
+          journey: additional_payments_journey,
+          claim: current_claim,
+          params: ActionController::Parameters.new({})
+        )
+      end
+
+      subject(:backlink_path) { form.backlink_path }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the page sequence includes 'correct-school'" do
+      before do
+        tps_record = create(
+          :teachers_pensions_service,
+          :early_career_payments_matched_first,
+          teacher_reference_number: "1234567",
+          end_date: 1.year.from_now
+        )
+
+        local_authority = create(:local_authority, code: tps_record.la_urn)
+
+        create(
+          :school,
+          :open,
+          local_authority: local_authority,
+          establishment_number: tps_record.school_urn
+        )
+      end
+
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::EarlyCareerPayments,
+          logged_in_with_tid: true,
+          teacher_reference_number: "1234567"
+        )
+      end
+
+      let(:form) do
+        described_class.new(
+          journey: additional_payments_journey,
+          claim: current_claim,
+          params: ActionController::Parameters.new({
+            journey: "additional-payments"
+          })
+        )
+      end
+
+      subject(:backlink_path) { form.backlink_path }
+
+      it { is_expected.to eq("/additional-payments/correct-school") }
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe Claim, type: :model do
 
     # Tests a single attribute, possibly should test multiple attributes
     it "validates eligibility" do
-      expect(claim).not_to be_valid(:"nqt-in-academic-year-after-itt")
-      expect(claim.errors.first.message).to eq("Select yes if you are currently teaching as a qualified teacher")
+      expect(claim).not_to be_valid(:"teaching-subject-now")
+      expect(claim.errors.first.message).to eq("Select yes if you spend at least half of your contracted hours teaching eligible subjects")
     end
   end
 

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -300,14 +300,6 @@ RSpec.describe Policies::EarlyCareerPayments::Eligibility, type: :model do
       end
     end
 
-    context "when saving in the 'nqt_in_academic_year_after_itt' context" do
-      it "is not valid without a value for 'nqt_in_academic_year_after_itt'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"nqt-in-academic-year-after-itt")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: true)).to be_valid(:"nqt-in-academic-year-after-itt")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: false)).to be_valid(:"nqt-in-academic-year-after-itt")
-      end
-    end
-
     context "when saving in the 'employed_as_supply_teacher' context" do
       it "is not valid without a value for 'employed_as_supply_teacher'" do
         expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"supply-teacher")


### PR DESCRIPTION
Please feel free to nit pick as much as possible!

I changed the `Journeys::Base` class to allow sub classes to define what forms are available.
I'm pretty sure there's a nicer DSLy way of doing this but I didn't want to change the base class too much while others are working on it.
It didn't seem like the `nqt-in-academic-year-after-itt` step is shared so I put the form for that in the additional payments for teaching journey - I could be wrong about this.

I'm unsure about the backlink path piece, I've kept the logic for rendering that the same as it was in the claim controller. I think it could be simplified and we could remove `return unless page_sequence.in_sequence?("correct-school")` if we can assume that `nqt-in-academic-year-after-itt` always follows the `correct-school` step - I'm not sure on that assumption though.

I hope the specs are ok! For the past year or so I've been writing specs avoiding using `let` and `before` entirely and just repeating the test setup in each `it` block, which I've found works really well, so I'm a bit rusty on `let` best practices.

![walk-through](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/e46bf135-902b-43d5-a2c0-c7aee0cb7657)


---
Extracts a new form object and moves the logic associated with the
`nqt_in_academic_year_after_itt` step out of claims controller into the
form.
The view no longer needs to worry about the `eligibility` attributes
being nested, so it has been updated to remove the eligibility
namespacing on fields.

I'm not stoked about having to call url helpers in the form model for
the backlink path but was unsure how else to do this. Maybe we want to
consider introducing a new object `BacklinkPath` and pass the form
object to that? Something like
```
BacklinkPath.new(form).to_s #=> "/the-path/we/want"
```

Also I think if we're going to keep the permitting params logic in the
form object, we'll probably want to make it a bit more ergonomic to
define what params are permitted. We could add a class attribute to the
base form and then child forms could do something like
```
class SomeForm < Form
  permitted_params %i[some_param]
```
or we could just read off the attributes defined on the form and assume
any defined attribute is safe to permit as a paramerter.

We could also now remove the validation for
`:nqt_in_academic_year_after_itt` from
`Policies::EarlyCareerPayments::Eligibility` as it's no longer needed,
though I've left this in place for the time being, something for a
future commit.
