### PR TITLE
capt 1571/extract form object for qualification

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -15,6 +15,10 @@ class Form
     super
   end
 
+  def persisted?
+    true
+  end
+
   def update!(attrs)
     claim.update!(attrs)
   end
@@ -39,5 +43,14 @@ class Form
 
   def i18n_form_namespace
     raise "Form#i18n_form_namespace requires all sub-classes to override"
+  end
+
+  def page_sequence
+    @page_sequence ||= Journeys::PageSequence.new(
+      claim,
+      journey.slug_sequence.new(claim),
+      nil,
+      params[:slug]
+    )
   end
 end

--- a/app/forms/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/nqt_in_academic_year_after_itt_form.rb
@@ -1,0 +1,83 @@
+class NqtInAcademicYearAfterIttForm < Form
+  attribute :nqt_in_academic_year_after_itt, :boolean
+
+  validates :nqt_in_academic_year_after_itt,
+    inclusion: {
+      in: [true, false],
+      message: "Select yes if you are currently teaching as a qualified teacher"
+    }
+
+  def initialize(journey:, claim:, params:)
+    super
+
+    self.nqt_in_academic_year_after_itt = permitted_params.fetch(
+      :nqt_in_academic_year_after_itt,
+      claim.eligibility.nqt_in_academic_year_after_itt
+    )
+  end
+
+  def persisted?
+    true
+  end
+
+  def save
+    return false unless valid?
+
+    update!(
+      {
+        eligibility_attributes: {
+          nqt_in_academic_year_after_itt: nqt_in_academic_year_after_itt,
+          induction_completed: determine_induction_answer_from_dqt_record
+        }
+      }
+    )
+  end
+
+  def backlink_path
+    return unless page_sequence.in_sequence?("correct-school")
+
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .claim_path(params[:journey], "correct-school")
+  end
+
+  private
+
+  def permitted_params
+    @permitted_params ||= params.fetch(:claim, {}).permit(
+      :nqt_in_academic_year_after_itt
+    )
+  end
+
+  def page_sequence
+    @page_sequence ||= Journeys::PageSequence.new(
+      claim,
+      journey.slug_sequence.new(claim),
+      nil,
+      nil
+    )
+  end
+
+  def determine_induction_answer_from_dqt_record
+    return unless additional_payments_journey?
+    return unless passed_details_check_with_teacher_id?
+    # We can derive the induction_completed value for current_claim using the
+    # ECP DQT record Remember: even if it's only relevant to ECP, the induction
+    # question is asked at the beginning of the combined journey, and the
+    # applicant may end up applying for ECP or LUPP only at a later stage in
+    # the journey, hence we need to store the answer on both eligibilities.
+    claim_for_policy = claim.for_policy(Policies::EarlyCareerPayments)
+    dqt_teacher_record = claim_for_policy.dqt_teacher_record
+    dqt_teacher_record&.eligible_induction?
+  end
+
+  def additional_payments_journey?
+    journey::ROUTING_NAME == "additional-payments"
+  end
+
+  def passed_details_check_with_teacher_id?
+    claim.logged_in_with_tid? && claim.details_check?
+  end
+end

--- a/app/forms/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/nqt_in_academic_year_after_itt_form.rb
@@ -16,10 +16,6 @@ class NqtInAcademicYearAfterIttForm < Form
     )
   end
 
-  def persisted?
-    true
-  end
-
   def save
     return false unless valid?
 
@@ -51,17 +47,7 @@ class NqtInAcademicYearAfterIttForm < Form
     )
   end
 
-  def page_sequence
-    @page_sequence ||= Journeys::PageSequence.new(
-      claim,
-      journey.slug_sequence.new(claim),
-      nil,
-      nil
-    )
-  end
-
   def determine_induction_answer_from_dqt_record
-    return unless additional_payments_journey?
     return unless passed_details_check_with_teacher_id?
     # We can derive the induction_completed value for current_claim using the
     # ECP DQT record Remember: even if it's only relevant to ECP, the induction
@@ -71,10 +57,6 @@ class NqtInAcademicYearAfterIttForm < Form
     claim_for_policy = claim.for_policy(Policies::EarlyCareerPayments)
     dqt_teacher_record = claim_for_policy.dqt_teacher_record
     dqt_teacher_record&.eligible_induction?
-  end
-
-  def additional_payments_journey?
-    journey::ROUTING_NAME == "additional-payments"
   end
 
   def passed_details_check_with_teacher_id?

--- a/app/forms/qualification_form.rb
+++ b/app/forms/qualification_form.rb
@@ -38,6 +38,10 @@ class QualificationForm < Form
     true
   end
 
+  def save!
+    raise ActiveRecord::RecordInvalid.new unless save
+  end
+
   def backlink_path
     Rails
       .application

--- a/app/forms/qualification_form.rb
+++ b/app/forms/qualification_form.rb
@@ -1,0 +1,54 @@
+class QualificationForm < Form
+  QUALIFICATION_OPTIONS = %w[
+    postgraduate_itt
+    undergraduate_itt
+    assessment_only
+    overseas_recognition
+  ].freeze
+
+  attribute :qualification, :string
+
+  validates :qualification,
+    inclusion: {
+      in: QUALIFICATION_OPTIONS,
+      message: "Select the route you took into teaching"
+    }
+
+  def initialize(journey:, claim:, params:)
+    super
+
+    self.qualification = permitted_params.fetch(
+      :qualification,
+      claim.eligibility.qualification
+    )
+  end
+
+  def save
+    return false unless valid?
+
+    # We set the attribute like this, rather than using `update!` from the
+    # superclass, as we need "qualification" to be in the `Eligibility#changed`
+    # list of attributes for the `reset_dependent_answers` method to work
+    claim.assign_attributes(
+      eligibility_attributes: {qualification: qualification}
+    )
+    claim.reset_eligibility_dependent_answers(["qualification"])
+    claim.save!
+
+    true
+  end
+
+  def backlink_path
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .claim_path(params[:journey], page_sequence.previous_slug)
+  end
+
+  private
+
+  def permitted_params
+    @permitted_params ||= params.fetch(:claim, {}).permit(:qualification)
+  end
+end

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -9,5 +9,11 @@ module Journeys
     VIEW_PATH = "additional_payments"
     I18N_NAMESPACE = "additional_payments"
     POLICIES = [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments]
+
+    def forms
+      {
+        "nqt-in-academic-year-after-itt" => NqtInAcademicYearAfterIttForm
+      }
+    end
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -12,7 +12,8 @@ module Journeys
 
     def forms
       {
-        "nqt-in-academic-year-after-itt" => NqtInAcademicYearAfterIttForm
+        "nqt-in-academic-year-after-itt" => NqtInAcademicYearAfterIttForm,
+        "qualification" => QualificationForm
       }
     end
   end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -18,12 +18,16 @@ module Journeys
       self::SlugSequence
     end
 
-    # TODO: make this work for journey specific forms
-    # that list of forms should be defined in the specific journey
     def form(claim:, params:)
-      form = SHARED_FORMS[params[:slug]]
+      avaliable_forms = SHARED_FORMS.merge(forms)
+
+      form = avaliable_forms[params[:slug]]
 
       form&.new(journey: self, claim: claim, params: params)
+    end
+
+    def forms
+      {}
     end
 
     def page_sequence_for_claim(claim, completed_slugs, current_slug)

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -77,7 +77,6 @@ module Policies
       has_one :claim, as: :eligibility, inverse_of: :eligibility
       belongs_to :current_school, optional: true, class_name: "School"
 
-      validates :nqt_in_academic_year_after_itt, on: [:"nqt-in-academic-year-after-itt", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently teaching as a qualified teacher"}
       validates :current_school, on: [:"correct-school"], presence: {message: "Select the school you teach at or choose somewhere else"}, unless: :school_somewhere_else?
       validates :induction_completed, on: [:"induction-completed", :submit], inclusion: {in: [true, false], message: "Select yes if you have completed your induction"}
       validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select yes if you are a supply teacher"}

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -84,7 +84,6 @@ module Policies
       validates :employed_directly, on: [:"employed-directly", :submit], inclusion: {in: [true, false], message: "Select yes if you are directly employed by your school"}, if: :employed_as_supply_teacher?
       validates :subject_to_formal_performance_action, on: [:"poor-performance", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to formal action for poor performance at work"}
       validates :subject_to_disciplinary_action, on: [:"poor-performance", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to disciplinary action"}
-      validates :qualification, on: [:qualification, :submit], presence: {message: "Select the route you took into teaching"}
       validates :eligible_itt_subject, on: [:"eligible-itt-subject", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.eligible_itt_subject.blank.qualification") }}
       validates :teaching_subject_now, on: [:"teaching-subject-now", :submit], inclusion: {in: [true, false], message: "Select yes if you spend at least half of your contracted hours teaching eligible subjects"}
       validates :itt_academic_year, on: [:"itt-year", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.itt_academic_year.blank.qualification.#{object.qualification}") }}

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -91,8 +91,6 @@ module Policies
       validates_numericality_of :award_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7500
       validates :award_amount, on: :amendment, award_range: {max: max_award_amount_in_pounds}
 
-      before_save :set_qualification_if_trainee_teacher, if: :nqt_in_academic_year_after_itt_changed?
-
       delegate :name, to: :current_school, prefix: true, allow_nil: true
 
       def policy
@@ -240,12 +238,6 @@ module Policies
           itt_subject_symbol = itt_subject.to_sym
           !itt_subject_symbol.in?(itt_subject_checker.current_and_future_subject_symbols(policy))
         end
-      end
-
-      def set_qualification_if_trainee_teacher
-        return unless trainee_teacher?
-
-        self.qualification = :postgraduate_itt
       end
     end
   end

--- a/app/models/policies/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/policies/levelling_up_premium_payments/eligibility.rb
@@ -77,8 +77,6 @@ module Policies
         computing: 5
       }, _prefix: :itt_subject
 
-      before_save :set_qualification_if_trainee_teacher, if: :nqt_in_academic_year_after_itt_changed?
-
       def policy
         Policies::LevellingUpPremiumPayments
       end
@@ -188,12 +186,6 @@ module Policies
 
       def calculate_award_amount
         current_school.levelling_up_premium_payments_awards.find_by(academic_year: claim_year.to_s).award_amount if current_school.present?
-      end
-
-      def set_qualification_if_trainee_teacher
-        return unless trainee_teacher?
-
-        self.qualification = :postgraduate_itt
       end
 
       def award_amount_must_be_in_range

--- a/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
+++ b/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
@@ -1,49 +1,56 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.nqt_in_academic_year_after_itt.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.nqt_in_academic_year_after_itt.heading"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.nqt_in_academic_year_after_itt": "claim_eligibility_attributes_nqt_in_academic_year_after_itt_true" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form  do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
-
-          <%= fields.hidden_field :nqt_in_academic_year_after_itt %>
-
-          <fieldset class="govuk-fieldset" aria-describedby="nqt_in_academic_year_after_itt-hint" role="group">
-
-            <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
-              <h1 class="govuk-fieldset__heading">
-                <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.heading") %>
-              </h1>
-            </legend>
-
-            <div class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
-              <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.hint") %>
-            </div>
-
-            <%= errors_tag current_claim.eligibility, :nqt_in_academic_year_after_itt %>
-
-            <div class="govuk-radios govuk-radios">
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:nqt_in_academic_year_after_itt, true, class: "govuk-radios__input") %>
-                <%= fields.label :nqt_in_academic_year_after_itt_true, "Yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:nqt_in_academic_year_after_itt, false, class: "govuk-radios__input") %>
-                <%= fields.label :nqt_in_academic_year_after_itt_false, "No, I’m a trainee teacher", class: "govuk-label govuk-radios__label" %>
-              </div>
-
-            </div>
-
-          </fieldset>
-
-        <% end %>
+    <%= form_for @form, url: path_for_form do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render(
+          "shared/error_summary",
+          instance: f.object,
+          errored_field_id_overrides: {
+            "nqt_in_academic_year_after_itt": "claim_nqt_in_academic_year_after_itt_true"
+          }
+        ) %>
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= form_group_tag f.object.claim do %>
+
+        <%= f.hidden_field :nqt_in_academic_year_after_itt %>
+
+        <fieldset class="govuk-fieldset" aria-describedby="nqt_in_academic_year_after_itt-hint" role="group">
+
+          <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(f.object.journey) %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.heading") %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="nqt_in_academic_year_after_itt-hint">
+            <%= t("additional_payments.questions.nqt_in_academic_year_after_itt.hint") %>
+          </div>
+
+          <%= errors_tag f.object, :nqt_in_academic_year_after_itt %>
+
+          <div class="govuk-radios govuk-radios">
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:nqt_in_academic_year_after_itt, true, class: "govuk-radios__input") %>
+              <%= f.label :nqt_in_academic_year_after_itt_true, "Yes", class: "govuk-label govuk-radios__label" %>
+            </div>
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:nqt_in_academic_year_after_itt, false, class: "govuk-radios__input") %>
+              <%= f.label :nqt_in_academic_year_after_itt_false, "No, I’m a trainee teacher", class: "govuk-label govuk-radios__label" %>
+            </div>
+
+          </div>
+
+        </fieldset>
+
+      <% end %>
+
+      <%= f.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
     <% end %>
 
   </div>

--- a/app/views/additional_payments/claims/qualification.html.erb
+++ b/app/views/additional_payments/claims/qualification.html.erb
@@ -1,58 +1,64 @@
-<% content_for(:page_title, page_title(t("additional_payments.questions.qualification.heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("additional_payments.questions.qualification.heading"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.qualification": "claim_eligibility_attributes_qualification_undergraduate_itt" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+    <%= form_for @form, url: path_for_form do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render(
+          "shared/error_summary",
+          instance: f.object,
+          errored_field_id_overrides: {
+            "qualification": "claim_qualification_undergraduate_itt"
+          }
+        ) %>
+      <% end %>
+      <%= form_group_tag f.object do %>
 
-          <%= fields.hidden_field :qualification %>
+        <%= f.hidden_field :qualification %>
 
-          <fieldset class="govuk-fieldset">
+        <fieldset class="govuk-fieldset">
 
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h1 class="govuk-fieldset__heading">
-                <%= t("additional_payments.questions.qualification.heading") %>
-              </h1>
-            </legend>
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("additional_payments.questions.qualification.heading") %>
+            </h1>
+          </legend>
 
-            <%= errors_tag current_claim.eligibility, :qualification %>
+          <%= errors_tag f.object, :qualification %>
 
-            <div class="govuk-radios">
+          <div class="govuk-radios">
 
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:qualification, :postgraduate_itt, class: "govuk-radios__input") %>
-                <%= fields.label :qualification_postgraduate_itt, t("additional_payments.answers.qualification.postgraduate_itt"), class: "govuk-label govuk-radios__label" %>
-                <div class="govuk-hint govuk-radios__hint"><%= t("additional_payments.questions.qualification.hint.postgraduate_itt") %></div>
-              </div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:qualification, :undergraduate_itt, class: "govuk-radios__input") %>
-                <%= fields.label :qualification_undergraduate_itt, t("additional_payments.answers.qualification.undergraduate_itt"), class: "govuk-label govuk-radios__label" %>
-                <div class="govuk-hint govuk-radios__hint"><%= t("additional_payments.questions.qualification.hint.undergraduate_itt") %></div>
-              </div>
-
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:qualification, :assessment_only, class: "govuk-radios__input") %>
-                <%= fields.label :qualification_assessment_only, t("additional_payments.answers.qualification.assessment_only"), class: "govuk-label govuk-radios__label" %>
-              </div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:qualification, :overseas_recognition, class: "govuk-radios__input") %>
-                <%= fields.label :qualification_overseas_recognition, t("additional_payments.answers.qualification.overseas_recognition"), class: "govuk-label govuk-radios__label" %>
-              </div>
-
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:qualification, :postgraduate_itt, class: "govuk-radios__input") %>
+              <%= f.label :qualification_postgraduate_itt, t("additional_payments.answers.qualification.postgraduate_itt"), class: "govuk-label govuk-radios__label" %>
+              <div class="govuk-hint govuk-radios__hint"><%= t("additional_payments.questions.qualification.hint.postgraduate_itt") %></div>
             </div>
 
-          </fieldset>
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:qualification, :undergraduate_itt, class: "govuk-radios__input") %>
+              <%= f.label :qualification_undergraduate_itt, t("additional_payments.answers.qualification.undergraduate_itt"), class: "govuk-label govuk-radios__label" %>
+              <div class="govuk-hint govuk-radios__hint"><%= t("additional_payments.questions.qualification.hint.undergraduate_itt") %></div>
+            </div>
 
-        <% end %>
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:qualification, :assessment_only, class: "govuk-radios__input") %>
+              <%= f.label :qualification_assessment_only, t("additional_payments.answers.qualification.assessment_only"), class: "govuk-label govuk-radios__label" %>
+            </div>
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:qualification, :overseas_recognition, class: "govuk-radios__input") %>
+              <%= f.label :qualification_overseas_recognition, t("additional_payments.answers.qualification.overseas_recognition"), class: "govuk-label govuk-radios__label" %>
+            </div>
+
+          </div>
+
+        </fieldset>
+
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= f.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
     <% end %>
   </div>
 </div>

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -283,5 +283,47 @@ FactoryBot.define do
         create(:support_ticket, claim:)
       end
     end
+
+    trait :with_dqt_teacher_status do
+      dqt_teacher_status do
+        {
+          trn: 123456,
+          ni_number: "AB123123A",
+          name: "Rick Sanchez",
+          dob: "66-06-06T00:00:00",
+          active_alert: false,
+          state: 0,
+          state_name: "Active",
+          qualified_teacher_status: {
+            name: "Qualified teacher (trained)",
+            qts_date: "2018-12-01",
+            state: 0,
+            state_name: "Active"
+          },
+          induction: {
+            start_date: "2021-07-01T00:00:00Z",
+            completion_date: "2021-07-05T00:00:00Z",
+            status: "Pass",
+            state: 0,
+            state_name: "Active"
+          },
+          initial_teacher_training: {
+            programme_start_date: "666-06-06T00:00:00",
+            programme_end_date: "2021-07-04T00:00:00Z",
+            programme_type: "Overseas Trained Teacher Programme",
+            result: "Pass",
+            subject1: "mathematics",
+            subject1_code: "G100",
+            subject2: nil,
+            subject2_code: nil,
+            subject3: nil,
+            subject3_code: nil,
+            qualification: "BA (Hons)",
+            state: 0,
+            state_name: "Active"
+          }
+        }
+      end
+    end
   end
 end

--- a/spec/forms/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/nqt_in_academic_year_after_itt_form_spec.rb
@@ -1,0 +1,281 @@
+require "rails_helper"
+
+RSpec.describe NqtInAcademicYearAfterIttForm, type: :model do
+  before { create(:journey_configuration, :additional_payments) }
+
+  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  describe "validations" do
+    let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+    describe "#nqt_in_academic_year_after_itt" do
+      subject(:form) do
+        described_class.new(
+          journey: additional_payments_journey,
+          claim: current_claim,
+          params: params
+        )
+      end
+
+      context "when `true`" do
+        let(:params) do
+          ActionController::Parameters.new(
+            claim: {
+              nqt_in_academic_year_after_itt: true
+            }
+          )
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `false`" do
+        let(:params) do
+          ActionController::Parameters.new(
+            claim: {
+              nqt_in_academic_year_after_itt: false
+            }
+          )
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `nil`" do
+        let(:params) do
+          ActionController::Parameters.new(
+            claim: {
+              nqt_in_academic_year_after_itt: nil
+            }
+          )
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:form) do
+      described_class.new(
+        journey: journey,
+        claim: current_claim,
+        params: params
+      )
+    end
+
+    before { form.save }
+
+    context "when invalid" do
+      let(:journey) { additional_payments_journey }
+
+      let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            nqt_in_academic_year_after_itt: nil
+          }
+        )
+      end
+
+      it "returns false" do
+        expect { expect(form.save).to be false }.not_to(
+          change { claim.eligibility.reload.nqt_in_academic_year_after_itt }
+        )
+      end
+    end
+
+    context "when valid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            nqt_in_academic_year_after_itt: true
+          }
+        )
+      end
+
+      context "when the current journey is not `additional-payments`" do
+        let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+
+        let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+        it "sets the nqt_in_academic_year_after_itt attribute" do
+          expect(claim.eligibility.nqt_in_academic_year_after_itt).to be true
+        end
+
+        it "does not set the induction as complete" do
+          expect(claim.eligibility.induction_completed).to be nil
+        end
+      end
+
+      context "when the current journey is `additional-payments`" do
+        let(:journey) { additional_payments_journey }
+
+        context "when the teacher has not passed the tid details check" do
+          let(:claim) do
+            create(
+              :claim,
+              :logged_in_with_tid,
+              details_check: false,
+              policy: Policies::EarlyCareerPayments
+            )
+          end
+
+          it "sets the nqt_in_academic_year_after_itt attribute" do
+            expect(claim.eligibility.nqt_in_academic_year_after_itt).to be true
+          end
+
+          it "does not set the induction as complete" do
+            expect(claim.eligibility.induction_completed).to be nil
+          end
+        end
+
+        context "when the teacher has passed the tid details check" do
+          context "when there is not an eligible induction" do
+            let(:claim) do
+              create(
+                :claim,
+                :logged_in_with_tid,
+                policy: Policies::EarlyCareerPayments,
+                details_check: true,
+                dqt_teacher_status: nil
+              )
+            end
+
+            it "sets the nqt_in_academic_year_after_itt attribute" do
+              expect(
+                claim.eligibility.nqt_in_academic_year_after_itt
+              ).to be true
+            end
+
+            it "does not set the induction as complete" do
+              expect(claim.eligibility.induction_completed).to be nil
+            end
+          end
+
+          context "when there is an eligible induction" do
+            let(:claim) do
+              create(
+                :claim,
+                :logged_in_with_tid,
+                policy: Policies::EarlyCareerPayments,
+                details_check: true,
+                dqt_teacher_status: {
+                  trn: 1234567,
+                  ni_number: "AB123123A",
+                  name: "Rick Sanchez",
+                  dob: "66-06-06T00:00:00",
+                  active_alert: false,
+                  state: 0,
+                  state_name: "Active",
+                  qualified_teacher_status: {
+                    name: "Qualified teacher (trained)",
+                    qts_date: "2018-12-01",
+                    state: 0,
+                    state_name: "Active"
+                  },
+                  induction: {
+                    start_date: "2021-07-01T00:00:00Z",
+                    completion_date: "2021-07-05T00:00:00Z",
+                    status: "Pass",
+                    state: 0,
+                    state_name: "Active"
+                  },
+                  initial_teacher_training: {
+                    programme_start_date: "666-06-06T00:00:00",
+                    programme_end_date: "2021-07-04T00:00:00Z",
+                    programme_type: "Overseas Trained Teacher Programme",
+                    result: "Pass",
+                    subject1: "mathematics",
+                    subject1_code: "G100",
+                    subject2: nil,
+                    subject2_code: nil,
+                    subject3: nil,
+                    subject3_code: nil,
+                    qualification: "BA (Hons)",
+                    state: 0,
+                    state_name: "Active"
+                  }
+                }
+              )
+            end
+
+            it "sets the nqt_in_academic_year_after_itt attribute" do
+              expect(
+                claim.eligibility.nqt_in_academic_year_after_itt
+              ).to be true
+            end
+
+            it "sets the induction as complete" do
+              expect(claim.eligibility.induction_completed).to be true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#backlink_path" do
+    context "when the page sequence does not include 'correct-school'" do
+      let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+      let(:form) do
+        described_class.new(
+          journey: additional_payments_journey,
+          claim: current_claim,
+          params: ActionController::Parameters.new({})
+        )
+      end
+
+      subject(:backlink_path) { form.backlink_path }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the page sequence includes 'correct-school'" do
+      before do
+        tps_record = create(
+          :teachers_pensions_service,
+          :early_career_payments_matched_first,
+          teacher_reference_number: "1234567",
+          end_date: 1.year.from_now
+        )
+
+        local_authority = create(:local_authority, code: tps_record.la_urn)
+
+        create(
+          :school,
+          :open,
+          local_authority: local_authority,
+          establishment_number: tps_record.school_urn
+        )
+      end
+
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::EarlyCareerPayments,
+          logged_in_with_tid: true,
+          teacher_reference_number: "1234567"
+        )
+      end
+
+      let(:form) do
+        described_class.new(
+          journey: additional_payments_journey,
+          claim: current_claim,
+          params: ActionController::Parameters.new({
+            journey: "additional-payments"
+          })
+        )
+      end
+
+      subject(:backlink_path) { form.backlink_path }
+
+      it { is_expected.to eq("/additional-payments/correct-school") }
+    end
+  end
+end

--- a/spec/forms/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/nqt_in_academic_year_after_itt_form_spec.rb
@@ -95,41 +95,23 @@ RSpec.describe NqtInAcademicYearAfterIttForm, type: :model do
         )
       end
 
-      context "when the teacher has not passed the tid details check" do
-        let(:claim) do
-          create(
-            :claim,
-            :logged_in_with_tid,
-            details_check: false,
-            policy: Policies::EarlyCareerPayments
-          )
-        end
+      describe "nqt_in_academic_year_after_itt" do
+        let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
 
-        it "sets the nqt_in_academic_year_after_itt attribute" do
+        it "sets the value on the claim's eligibility" do
           expect(claim.eligibility.nqt_in_academic_year_after_itt).to be true
-        end
-
-        it "does not set the induction as complete" do
-          expect(claim.eligibility.induction_completed).to be nil
         end
       end
 
-      context "when the teacher has passed the tid details check" do
-        context "when there is not an eligible induction" do
+      describe "induction_completed" do
+        context "when the teacher has not passed the tid details check" do
           let(:claim) do
             create(
               :claim,
               :logged_in_with_tid,
-              policy: Policies::EarlyCareerPayments,
-              details_check: true,
-              dqt_teacher_status: nil
+              details_check: false,
+              policy: Policies::EarlyCareerPayments
             )
-          end
-
-          it "sets the nqt_in_academic_year_after_itt attribute" do
-            expect(
-              claim.eligibility.nqt_in_academic_year_after_itt
-            ).to be true
           end
 
           it "does not set the induction as complete" do
@@ -137,25 +119,69 @@ RSpec.describe NqtInAcademicYearAfterIttForm, type: :model do
           end
         end
 
-        context "when there is an eligible induction" do
-          let(:claim) do
-            create(
-              :claim,
-              :logged_in_with_tid,
-              :with_dqt_teacher_status,
-              policy: Policies::EarlyCareerPayments,
-              details_check: true
+        context "when the teacher has passed the tid details check" do
+          context "when there is not an eligible induction" do
+            let(:claim) do
+              create(
+                :claim,
+                :logged_in_with_tid,
+                policy: Policies::EarlyCareerPayments,
+                details_check: true,
+                dqt_teacher_status: nil
+              )
+            end
+
+            it "does not set the induction as complete" do
+              expect(claim.eligibility.induction_completed).to be nil
+            end
+          end
+
+          context "when there is an eligible induction" do
+            let(:claim) do
+              create(
+                :claim,
+                :logged_in_with_tid,
+                :with_dqt_teacher_status,
+                policy: Policies::EarlyCareerPayments,
+                details_check: true
+              )
+            end
+
+            it "sets the induction as complete" do
+              expect(claim.eligibility.induction_completed).to be true
+            end
+          end
+        end
+      end
+
+      describe "qualification" do
+        let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+        context "when the claim is not from a trainee teacher" do
+          let(:params) do
+            ActionController::Parameters.new(
+              claim: {
+                nqt_in_academic_year_after_itt: true
+              }
             )
           end
 
-          it "sets the nqt_in_academic_year_after_itt attribute" do
-            expect(
-              claim.eligibility.nqt_in_academic_year_after_itt
-            ).to be true
+          it "does not set the qualification" do
+            expect(claim.eligibility.qualification).to be nil
+          end
+        end
+
+        context "when the clian is from a trainee teacher" do
+          let(:params) do
+            ActionController::Parameters.new(
+              claim: {
+                nqt_in_academic_year_after_itt: false
+              }
+            )
           end
 
-          it "sets the induction as complete" do
-            expect(claim.eligibility.induction_completed).to be true
+          it "sets the qualification and resets dependent answers" do
+            expect(claim.eligibility.qualification).to eq "postgraduate_itt"
           end
         end
       end

--- a/spec/forms/qualification_form_spec.rb
+++ b/spec/forms/qualification_form_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe QualificationForm, type: :model do
+  before { create(:journey_configuration, :additional_payments) }
+
+  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  describe "validations" do
+    subject(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: ActionController::Parameters.new
+      )
+    end
+
+    it do
+      is_expected.to(
+        validate_inclusion_of(:qualification)
+        .in_array(described_class::QUALIFICATION_OPTIONS)
+        .with_message("Select the route you took into teaching")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: params
+      )
+    end
+
+    context "when invalid" do
+      let(:params) do
+        ActionController::Parameters.new(claim: {qualification: "invalid"})
+      end
+
+      it "returns false" do
+        expect { expect(form.save).to be false }.not_to(
+          change { claim.eligibility.reload.qualification }
+        )
+      end
+    end
+
+    context "when valid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {qualification: "postgraduate_itt"}
+        )
+      end
+
+      it "updates the claim's eligibility" do
+        expect { expect(form.save).to be true }.to(
+          change { claim.eligibility.reload.qualification }
+          .from(nil).to("postgraduate_itt")
+        )
+      end
+
+      it "resets depended answers" do
+        claim.eligibility.update!(eligible_itt_subject: "mathematics")
+
+        expect { expect(form.save).to be true }.to(
+          change { claim.eligibility.reload.eligible_itt_subject }
+          .from("mathematics").to(nil)
+        )
+      end
+    end
+  end
+
+  describe "#backlink_path" do
+    let(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: ActionController::Parameters.new(
+          {
+            journey: "additional-payments",
+            slug: "qualification"
+          }
+        )
+      )
+    end
+
+    it "returns the previous page in the journey" do
+      expect(form.backlink_path).to eq("/additional-payments/poor-performance")
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe Claim, type: :model do
 
     # Tests a single attribute, possibly should test multiple attributes
     it "validates eligibility" do
-      expect(claim).not_to be_valid(:"nqt-in-academic-year-after-itt")
-      expect(claim.errors.first.message).to eq("Select yes if you are currently teaching as a qualified teacher")
+      expect(claim).not_to be_valid(:"teaching-subject-now")
+      expect(claim.errors.first.message).to eq("Select yes if you spend at least half of your contracted hours teaching eligible subjects")
     end
   end
 

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -300,14 +300,6 @@ RSpec.describe Policies::EarlyCareerPayments::Eligibility, type: :model do
       end
     end
 
-    context "when saving in the 'nqt_in_academic_year_after_itt' context" do
-      it "is not valid without a value for 'nqt_in_academic_year_after_itt'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"nqt-in-academic-year-after-itt")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: true)).to be_valid(:"nqt-in-academic-year-after-itt")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(nqt_in_academic_year_after_itt: false)).to be_valid(:"nqt-in-academic-year-after-itt")
-      end
-    end
-
     context "when saving in the 'employed_as_supply_teacher' context" do
       it "is not valid without a value for 'employed_as_supply_teacher'" do
         expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"supply-teacher")

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -339,12 +339,6 @@ RSpec.describe Policies::EarlyCareerPayments::Eligibility, type: :model do
       end
     end
 
-    context "when saving in the 'qualification' context" do
-      it "is not valid without a value for 'qualification'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:qualification)
-      end
-    end
-
     context "when saving in the 'eligible_itt_subject' context" do
       before { create(:journey_configuration, :additional_payments) }
 


### PR DESCRIPTION
This PR is currently blocked waiting on https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2663 which is blocked on me getting access to the repo! Once I have access I'll reissue these PRs.


There's some noise in this PR's diff as it's based off my [pr branch](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2663) so probably best to review these two commits directly
* [Extracts form object for qualification step](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/0b7527c1caa4f5298eebcb8a1799104bef7d56b2)
* [Remove callback](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/f938b7f10cd13c52627fc2696f95208e872f87d9)

Hopefully on Monday I'll have access to the repo and can sort out these weird PRs!

This pr has two separate commits which should be reviewed separately. I'm happy
to break the commits out into separate PRs if that's better.

The main changes are:
* break out a form object for the qualification step
* remove a callback from the eligibility model

There's a little more details in the commit message.
I'm not familiar enough to know all the implications of removing the callback from the eligibility model but from what I can tell it seems safe todo and the test suite passes, let me know if I'm wrong and I can drop that commit.

![walk-through](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/c68c5d3b-449c-4a25-bff3-7e8946f6fff6)

