### PR TITLE
capt 1571/extract form object for teaching subject now

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -23,6 +23,10 @@ class ClaimsController < BasePublicController
   end
 
   def show
+    if params[:slug] == "teaching-subject-now" && no_eligible_itt_subject?
+      return redirect_to claim_path(current_journey_routing_name, "eligible-itt-subject")
+    end
+
     # TODO: Migrate the remaining slugs to form objects.
     if @form ||= journey.form(claim: current_claim, params: params)
       set_any_backlink_override
@@ -35,8 +39,7 @@ class ClaimsController < BasePublicController
       save_and_set_teacher_id_user_info
     elsif params[:slug] == "qualification-details"
       return redirect_to claim_path(current_journey_routing_name, next_slug) if current_claim.has_no_dqt_data_for_claim?
-    elsif params[:slug] == "teaching-subject-now" && no_eligible_itt_subject?
-      return redirect_to claim_path(current_journey_routing_name, "eligible-itt-subject")
+
     elsif params[:slug] == "sign-in-or-continue"
       update_session_with_current_slug
 

--- a/app/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form.rb
@@ -1,0 +1,40 @@
+module Journeys
+  module AdditionalPaymentsForTeaching
+    class TeachingSubjectNowForm < Form
+      attribute :teaching_subject_now, :boolean
+
+      validates :teaching_subject_now,
+        inclusion: {
+          in: [true, false],
+          message: "Select yes if you spend at least half of your contracted hours teaching eligible subjects"
+        }
+
+      def initialize(journey:, claim:, params:)
+        super
+
+        self.teaching_subject_now = permitted_params.fetch(
+          :teaching_subject_now,
+          claim.eligibility.teaching_subject_now
+        )
+      end
+
+      def eligible_itt_subject
+        @eligible_itt_subject ||= claim.eligibility.eligible_itt_subject
+      end
+
+      def teaching_physics_or_chemistry?
+        eligible_itt_subject == "physics" || eligible_itt_subject == "chemistry"
+      end
+
+      def save
+        return false unless valid?
+
+        update!(
+          eligibility_attributes: {
+            teaching_subject_now: teaching_subject_now
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -16,7 +16,8 @@ module Journeys
       "poor-performance" => PoorPerformanceForm,
       "entire-term-contract" => EntireTermContractForm,
       "employed-directly" => EmployedDirectlyForm,
-      "qualification" => QualificationForm
+      "qualification" => QualificationForm,
+      "teaching-subject-now" => TeachingSubjectNowForm
     }.freeze
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
@@ -139,7 +139,7 @@ module Journeys
 
       def teaching_subject_now
         [
-          translate("additional_payments.questions.teaching_subject_now", eligible_itt_subject: eligibility.eligible_itt_subject),
+          translate("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now", eligible_itt_subject: eligibility.eligible_itt_subject),
           (eligibility.teaching_subject_now? ? "Yes" : "No"),
           "teaching-subject-now"
         ]

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -79,7 +79,6 @@ module Policies
 
       validates :current_school, on: [:"correct-school"], presence: {message: "Select the school you teach at or choose somewhere else"}, unless: :school_somewhere_else?
       validates :eligible_itt_subject, on: [:"eligible-itt-subject", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.eligible_itt_subject.blank.qualification") }}
-      validates :teaching_subject_now, on: [:"teaching-subject-now", :submit], inclusion: {in: [true, false], message: "Select yes if you spend at least half of your contracted hours teaching eligible subjects"}
       validates :itt_academic_year, on: [:"itt-year", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.itt_academic_year.blank.qualification.#{object.qualification}") }}
       validates :award_amount, on: [:submit], presence: {message: "Enter an award amount"}
       validates_numericality_of :award_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7500

--- a/app/views/additional_payments/claims/teaching_subject_now.html.erb
+++ b/app/views/additional_payments/claims/teaching_subject_now.html.erb
@@ -1,52 +1,64 @@
-<% eligible_itt_subject = current_claim.eligibility.eligible_itt_subject %>
-<% translated_eligible_itt_subject = t("additional_payments.answers.eligible_itt_subject.#{eligible_itt_subject}").downcase %>
-<% content_for(:page_title, page_title(t("additional_payments.questions.teaching_subject_now", eligible_itt_subject: eligible_itt_subject), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
+<% content_for(
+  :page_title,
+  page_title(
+    t(
+      "additional_payments.forms.teaching_subject_now.questions.teaching_subject_now",
+      eligible_itt_subject: @form.eligible_itt_subject
+    )
+  ),
+  journey: current_journey_routing_name,
+  show_error: @form.errors.any?
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.teaching_subject_now": "claim_eligibility_attributes_teaching_subject_now_true" }) if current_claim.errors.any? %>
+    <% if @form.errors.any? %>
+      <%= render(
+        "shared/error_summary",
+        instance: @form,
+        errored_field_id_overrides: {
+          "teaching_subject_now": "claim_teaching_subject_now_true"
+        }
+      ) %>
+    <% end %>
 
-    <%= form_for current_claim, url: path_for_form  do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= form_group_tag f.object do %>
+        <%= f.hidden_field :teaching_subject_now %>
 
-          <%= fields.hidden_field :teaching_subject_now %>
+        <fieldset class="govuk-fieldset" aria-describedby="teaching_subject_now-hint" role="group">
 
-          <fieldset class="govuk-fieldset" aria-describedby="teaching_subject_now-hint" role="group">
+          <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(f.object.journey) %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now") %>
+            </h1>
+          </legend>
 
-            <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
-              <h1 class="govuk-fieldset__heading">
-                <%= t("additional_payments.questions.teaching_subject_now") %>
-              </h1>
-            </legend>
+          <div class="govuk-hint" id="teaching_subject_now-hint">
+           At least 50% of your contracted hours allocated to teaching must be spent
+           teaching <%= subjects_to_sentence_for_hint_text(f.object.claim) %>.
+          </div>
 
-            <div class="govuk-hint" id="teaching_subject_now-hint">
-             At least 50% of your contracted hours allocated to teaching must be spent
-             teaching <%= subjects_to_sentence_for_hint_text(current_claim) %>.
+          <%= errors_tag f.object, :teaching_subject_now %>
+
+          <div class="govuk-radios">
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:teaching_subject_now, true, class: "govuk-radios__input") %>
+              <%= f.label :teaching_subject_now_true, "Yes", class: "govuk-label govuk-radios__label" %>
             </div>
 
-            <%= errors_tag current_claim.eligibility, :teaching_subject_now %>
-
-            <div class="govuk-radios">
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:teaching_subject_now, true, class: "govuk-radios__input") %>
-                <%= fields.label :teaching_subject_now_true, "Yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:teaching_subject_now, false, class: "govuk-radios__input") %>
-                <%= fields.label :teaching_subject_now_false, "No", class: "govuk-label govuk-radios__label" %>
-              </div>
-
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:teaching_subject_now, false, class: "govuk-radios__input") %>
+              <%= f.label :teaching_subject_now_false, "No", class: "govuk-label govuk-radios__label" %>
             </div>
 
-          </fieldset>
+          </div>
 
-        <% end %>
+        </fieldset>
 
-        <% if translated_eligible_itt_subject == "physics" || translated_eligible_itt_subject == "chemistry" %>
+
+        <% if f.object.teaching_physics_or_chemistry? %>
           <br/>
           <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
@@ -64,7 +76,7 @@
         <% end %>
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= f.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,11 +294,6 @@ en:
       induction_completed:
         errors:
           select_yes_if_completed: "Select yes if you have completed your induction"
-      supply_teacher:
-        questions:
-          employed_as_supply_teacher: Are you currently employed as a supply teacher?
-        errors:
-          select_employed_as_supply_teacher: Select yes if you are a supply teacher
       poor_performance:
         questions:
           poor_performance: Tell us if you are currently under any performance measures or disciplinary action
@@ -320,6 +315,14 @@ en:
           undergraduate_itt: "Undergraduate initial teacher training (ITT)"
           assessment_only: "Assessment only"
           overseas_recognition: "Overseas recognition"
+      supply_teacher:
+        questions:
+          employed_as_supply_teacher: Are you currently employed as a supply teacher?
+        errors:
+          select_employed_as_supply_teacher: Select yes if you are a supply teacher
+      teaching_subject_now:
+        questions:
+          teaching_subject_now: "Do you spend at least half of your contracted hours teaching eligible subjects?"
     check_your_answers:
       part_one:
         primary_heading: Check your answers
@@ -372,7 +375,6 @@ en:
       eligible_itt_subject_one_option: "Did you do your %{qualification} in %{subject}?"
       eligible_itt_subject_trainee_teacher: "Which subject are you currently doing your initial teacher training (ITT) in?"
       eligible_itt_subject_hint: "The subjects listed are eligible for additional payment based on the school you teach in and the year you studied."
-      teaching_subject_now: "Do you spend at least half of your contracted hours teaching eligible subjects?"
       itt_academic_year:
         qualification:
           undergraduate_itt: In which academic year did you complete your undergraduate initial teacher training (ITT)?

--- a/spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Combined claim journey dependent answers" do
     click_on "Continue"
 
     # - Do you teach mathematics now?
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
     choose "Yes"
     click_on "Continue"
 

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     click_on "Continue"
 
     # - Do you teach mathematics now?
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
     choose "Yes"
     click_on "Continue"
 
@@ -299,7 +299,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     click_on "Continue"
 
     # - Do you teach mathematics now?
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
     choose "Yes"
     click_on "Continue"
 

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature "Combined journey with Teacher ID email check" do
     click_on "Continue"
 
     # - Do you teach mathematics now?
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
     choose "Yes"
     click_on "Continue"
 

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # Qualification pages are skipped
 
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"
@@ -65,7 +65,7 @@ RSpec.feature "Combined journey with Teacher ID" do
     # Go back to the qualification details page
     click_link "Back"
 
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
     click_link "Back"
 
     expect(page).to have_text(I18n.t("questions.check_and_confirm_qualification_details"))
@@ -93,7 +93,7 @@ RSpec.feature "Combined journey with Teacher ID" do
     choose "Mathematics"
     click_on "Continue"
 
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"
@@ -201,7 +201,7 @@ RSpec.feature "Combined journey with Teacher ID" do
     choose "Mathematics"
     click_on "Continue"
 
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"
@@ -225,7 +225,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # Qualification pages are skipped
 
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"
@@ -278,7 +278,7 @@ RSpec.feature "Combined journey with Teacher ID" do
     # Skips subject question as supplied by DQT
 
     # - Do you teach subject now?
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/early_career_payments_claim_lupp_ineligible_spec.rb
+++ b/spec/features/early_career_payments_claim_lupp_ineligible_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Early-Career Payments claims with school ineligible for Levelling
     click_on "Continue"
 
     # - Do you teach maths now
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     expect(claim.eligibility.reload.eligible_itt_subject).to eql "mathematics"
 
     # - Do you teach maths now
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"
@@ -384,7 +384,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
       expect(claim.eligibility.reload.eligible_itt_subject).to eql "mathematics"
 
       # - Do you teach maths now
-      expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+      expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
       choose "Yes"
       click_on "Continue"
@@ -426,7 +426,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
       expect(claim.eligibility.reload.eligible_itt_subject).to eql "mathematics"
 
       # - Do you teach maths now
-      expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+      expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
       choose "Yes"
       click_on "Continue"
@@ -522,7 +522,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     expect(claim.eligibility.reload.eligible_itt_subject).to eql "mathematics"
 
     # - Do you teach maths now
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/features/ineligible_early_career_payments_claims_spec.rb
+++ b/spec/features/ineligible_early_career_payments_claims_spec.rb
@@ -348,7 +348,7 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims", slow: true do
     expect(claim.eligibility.reload.eligible_itt_subject).to eql "mathematics"
 
     # - Do you teach the eligible ITT subject now
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "No"
     click_on "Continue"

--- a/spec/features/itt_subject_selection_spec.rb
+++ b/spec/features/itt_subject_selection_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "ITT subject selection", slow: true do
         scenario "handles eligible and ineligible subject options" do
           expect_displayed_subjects(["Chemistry", "Computing", "Mathematics", "Physics"])
           select_subject("Mathematics")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           select_subject("None of the above")
           expect(page).to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
@@ -35,7 +35,7 @@ RSpec.feature "ITT subject selection", slow: true do
         scenario "handles eligible and ineligible subject options" do
           expect_displayed_subjects(["Chemistry", "Computing", "Mathematics", "Physics"])
           select_subject("Mathematics")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           select_subject("None of the above")
           expect(page).to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
@@ -49,11 +49,11 @@ RSpec.feature "ITT subject selection", slow: true do
           expect_displayed_subjects(["Chemistry", "Computing", "Mathematics", "Physics"])
           # choose subject eligible for LUP only
           select_subject("Chemistry")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           # choose subject eligible for both LUP and ECP
           select_subject("Mathematics")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           # choose ineligible subject for both ECP and LUP
           select_subject("None of the above")
@@ -68,11 +68,11 @@ RSpec.feature "ITT subject selection", slow: true do
           expect_displayed_subjects(["Chemistry", "Computing", "Languages", "Mathematics", "Physics"])
           # choose subject ineligible for LUP
           select_subject("Languages")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           # choose eligible subject
           select_subject("Mathematics")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           # choose none of the above
           select_subject("None of the above")
@@ -86,7 +86,7 @@ RSpec.feature "ITT subject selection", slow: true do
         scenario "subject options" do
           expect_displayed_subjects(["Chemistry", "Computing", "Mathematics", "Physics"])
           select_subject("Mathematics")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           select_subject("None of the above")
           expect(page).to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
@@ -119,7 +119,7 @@ RSpec.feature "ITT subject selection", slow: true do
 
         scenario "choose eligible subject and teach now" do
           select_subject("Yes")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
           choose "Yes"
           click_on "Continue"
@@ -131,7 +131,7 @@ RSpec.feature "ITT subject selection", slow: true do
 
         scenario "choose eligible subject but don't teach now" do
           select_subject("Yes")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
           choose "No"
           click_on "Continue"
@@ -146,7 +146,7 @@ RSpec.feature "ITT subject selection", slow: true do
         scenario "subject options" do
           expect_displayed_subjects(["Mathematics"])
           select_subject("Yes")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           select_subject("No")
           expect(page).to have_text(I18n.t("additional_payments.ineligible.heading"))
@@ -159,7 +159,7 @@ RSpec.feature "ITT subject selection", slow: true do
         scenario "subject options" do
           expect_displayed_subjects(["Chemistry", "Languages", "Mathematics", "Physics"])
           select_subject("Mathematics")
-          expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+          expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
           click_link "Back"
           select_subject("None of the above")
           expect(page).to have_text(I18n.t("additional_payments.ineligible.heading"))

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Levelling up premium payments claims" do
 
   def check_eligibility_after_itt_subject
     # - Do you spend at least half of your contracted hours teaching eligible subjects?
-    expect(page).to have_text(I18n.t("additional_payments.questions.teaching_subject_now"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.teaching_subject_now.questions.teaching_subject_now"))
 
     choose "Yes"
     click_on "Continue"

--- a/spec/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe Journeys::AdditionalPaymentsForTeaching::TeachingSubjectNowForm do
+  before { create(:journey_configuration, :additional_payments) }
+  let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:eligibility) { create(:early_career_payments_eligibility) }
+  let(:claim) do
+    create(
+      :claim,
+      policy: Policies::EarlyCareerPayments,
+      eligibility: eligibility
+    )
+  end
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+  let(:form) do
+    described_class.new(
+      journey: journey,
+      claim: current_claim,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject(:form_subject) { form }
+
+    describe "teaching_subject_now" do
+      context "when `true`" do
+        let(:params) do
+          ActionController::Parameters.new(claim: {teaching_subject_now: true})
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `false`" do
+        let(:params) do
+          ActionController::Parameters.new(claim: {teaching_subject_now: false})
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `nil`" do
+        let(:params) do
+          ActionController::Parameters.new(claim: {teaching_subject_now: nil})
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when invalid" do
+      let(:params) do
+        ActionController::Parameters.new(claim: {teaching_subject_now: nil})
+      end
+
+      it "returns false" do
+        expect(form.save).to be false
+      end
+    end
+
+    context "when valid" do
+      let(:params) do
+        ActionController::Parameters.new(claim: {teaching_subject_now: true})
+      end
+
+      it "returns true and updates the claim's eligibility" do
+        expect { expect(form.save).to be true }.to(
+          change { claim.reload.eligibility.teaching_subject_now }
+            .from(nil).to(true)
+        )
+      end
+    end
+  end
+
+  describe "#eligible_itt_subject" do
+    let(:params) { ActionController::Parameters.new({}) }
+
+    subject(:eligible_itt_subject) { form.eligible_itt_subject }
+
+    it { is_expected.to eq claim.eligibility.eligible_itt_subject }
+  end
+
+  describe "#teaching_physics_or_chemistry?" do
+    let(:params) { ActionController::Parameters.new({}) }
+
+    subject(:teaching_physics_or_chemistry) do
+      form.teaching_physics_or_chemistry?
+    end
+
+    context "when teaching physics" do
+      let(:eligibility) do
+        create(
+          :early_career_payments_eligibility,
+          eligible_itt_subject: "physics"
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when teaching chemistry" do
+      let(:eligibility) do
+        create(
+          :early_career_payments_eligibility,
+          eligible_itt_subject: "chemistry"
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when teaching neither physics nor chemistry" do
+      let(:eligibility) do
+        create(
+          :early_career_payments_eligibility,
+          eligible_itt_subject: "mathematics"
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe Claim, type: :model do
 
     # Tests a single attribute, possibly should test multiple attributes
     it "validates eligibility" do
-      expect(claim).not_to be_valid(:"teaching-subject-now")
-      expect(claim.errors.first.message).to eq("Select yes if you spend at least half of your contracted hours teaching eligible subjects")
+      expect(claim).not_to be_valid(:amendment)
+      expect(claim.errors.first.message).to eq("Enter a positive amount up to £7,500.00 (inclusive)")
     end
   end
 

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -319,14 +319,6 @@ RSpec.describe Policies::EarlyCareerPayments::Eligibility, type: :model do
       end
     end
 
-    context "when saving in the 'teaching_subject_now' context" do
-      it "is not valid without a value for 'teaching_subject_now'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"teaching-subject-now")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(teaching_subject_now: true)).to be_valid(:"teaching-subject-now")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(teaching_subject_now: false)).to be_valid(:"teaching-subject-now")
-      end
-    end
-
     context "when saving in the 'itt_academic_year' context" do
       it "is not valid without a value for 'itt_academic_year'" do
         expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"itt-year")


### PR DESCRIPTION
Extract form for teaching_subject_now

Extracts a form object for the teaching subject now step.

Depending on whether or not there's an eligible subject upon reaching
the `teaching-subject-now` step, we may redirect the subject to the
`eligbible-itt-subject` step rather than render the
`teaching-subject-now` form.
`eligible-itt-subject` can be reset if the `qualification` changes, and
`eligible-itt-subject` resets the `teaching-subject-now` answer.

For now we've preserved the existing behaviour of determining whether to
render the `teaching-subject-now` in the `ClaimsController#show` action.
This feels like the wrong place for this though. It makes more sense to
handle the redirect in the `ClaimsController#update` action or better
yet in the `PageSequence#next_slug` method, something to address in a
future commit.

This line from claims controller:
```ruby
if params[:slug] == "teaching-subject-now" && no_eligible_itt_subject?
  return redirect_to claim_path(current_journey_routing_name, "eligible-itt-subject")
end
```
mixes a couple of concerns.
This line needs to know if a dependent answer has been reset (a concern of
the Claim/Eligibility model) and the order of steps in the journey (a concern
of `PageSequence`).

Ideally we'd keep all this information in one place so the controller could
just do something like `redirect_to next_step_path`.

To make this tricker we need to handle the case where a user navigates to a
step via the browser url (see this test case
`spec/features/combined_teacher_claim_journey_dependent_answers_spec.rb:74`)
so we need to preform some slug checking in the `ClaimsController#show` action.

Options as I see them

1.) Do nothing, leave this line as is and wait for a pattern to emerge -
usually the best option!

2.) Add some logic to remove slugs from completed slugs if
`reset_dependent_answers` has invalidated a previously answered page and then
add a check to the show action that the current slug matches the expected slug
given the state of the claim. This may mean introducing a PageSequence for each
journey.

3.) Something else. I'm not super familar with the code base so there could be
another option I'm over looking.

Something to address in a future ticket
