### PR TITLE
CAPT 1575 - Remove form and errors from /check-your-answers-part-one

### DIFF
--- a/app/views/additional_payments/claims/check_your_answers_part_one.html.erb
+++ b/app/views/additional_payments/claims/check_your_answers_part_one.html.erb
@@ -1,23 +1,15 @@
-<% content_for(:page_title, page_title(t("additional_payments.check_your_answers.part_one.primary_heading"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
+<% content_for(:page_title, page_title(t("additional_payments.check_your_answers.part_one.primary_heading"), journey: current_journey_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
-
     <h1 class="govuk-heading-l">
       <%= t("additional_payments.check_your_answers.part_one.primary_heading") %>
     </h1>
 
     <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: journey.answers_for_claim(current_claim).eligibility_answers} %>
 
-    <%= form_for current_claim, url: path_for_form  do |form| %>
+    <p class="govuk-body"><%= t("additional_payments.check_your_answers.part_one.confirmation_notice") %></p>
 
-      <p class="govuk-body"><%= t("additional_payments.check_your_answers.part_one.confirmation_notice") %></p>
-
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
-      </div>
-    <% end %>
+    <%= button_to "Continue", claim_path(current_journey_routing_name), method: :patch, class: "govuk-button" %>
   </div>
 </div>


### PR DESCRIPTION
## Context

We currently refactoring all our eligibility checker pages to use form objects. We were planning to do the same to this page however i noticed a couple of things:

- even though there's a form on the page, it doesn't update anything
- even though it looks like it renders errors:
  - there shouldn't be any errors at this point
  - if there were errors, the standard error summary would be broken since there are no form fields to link to

## Changes in this PR

Due to the above, I decided to:

- remove the html form and error summary
- **_not_** create a new form object, since there are no attributes to update nor validations to run
- stick with an `update` button so as not to break the page sequence (see below)

## Why can't we just link to the next page?

As the `ClaimsController` currently stands, if we link to GET `eligibility-confirmed` from this page:

1. the `update` action isn't hit for the current slug (`check-your-answers-part-one`)
2. `check-your-answers-part-one` is not added to `sessions[:slugs]`
3. `check-your-answers-part-one` is missing from the list of `completed_slugs` passed into `PageSequence`
4. the `before_action` `check_page_is_in_sequence` flags up that it's missing
5. we're redirected back to `check-your-answers-part-one`

and we're stuck.