### PR TITLE
CAPT-1555 The SLC CSV upload uses British DoB formatting

### DIFF
--- a/app/models/student_loans_data_importer.rb
+++ b/app/models/student_loans_data_importer.rb
@@ -18,7 +18,7 @@ class StudentLoansDataImporter < CsvImporter::Base
   private
 
   def skip_row_conditions?(row)
-    row.fetch("NINO").blank?
+    row.fetch("NINO").blank? || cast_as_date(row.fetch("Date of birth")).nil?
   end
 
   def row_to_hash(row)
@@ -26,7 +26,7 @@ class StudentLoansDataImporter < CsvImporter::Base
       claim_reference: row.fetch("Claim reference"),
       nino: row.fetch("NINO"),
       full_name: row.fetch("Full name"),
-      date_of_birth: date_of_birth(row.fetch("Date of birth")),
+      date_of_birth: cast_as_date(row.fetch("Date of birth")),
       policy_name: row.fetch("Policy name"),
       no_of_plans_currently_repaying: row.fetch("No of Plans Currently Repaying"),
       plan_type_of_deduction: row.fetch("Plan Type of Deduction"),
@@ -34,11 +34,9 @@ class StudentLoansDataImporter < CsvImporter::Base
     }
   end
 
-  def date_of_birth(dob_str)
-    return unless dob_str.present?
-
-    Date.strptime(dob_str, "%m/%d/%Y")
-  rescue Date::Error
+  def cast_as_date(string)
+    Date.strptime(string, I18n.t("date.formats.day_month_year"))
+  rescue TypeError, Date::Error
     nil
   end
 end

--- a/spec/jobs/import_student_loans_data_job_spec.rb
+++ b/spec/jobs/import_student_loans_data_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ImportStudentLoansDataJob do
     let(:csv) do
       <<~CSV
         Claim reference,NINO,Full name,Date of birth,Policy name,No of Plans Currently Repaying,Plan Type of Deduction,Amount
-        TESTREF01,QQ123456A,,,,,,
+        TESTREF01,QQ123456A,,20/12/1999,,,,
       CSV
     end
 

--- a/spec/requests/admin_student_loans_data_upload_spec.rb
+++ b/spec/requests/admin_student_loans_data_upload_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "SLC (Student Loans Company) data upload " do
             claim_reference: "TESTREF01",
             nino: "QQ123456A",
             full_name: "John Doe",
-            date_of_birth: "12/1/1989",
+            date_of_birth: "1/12/1989",
             policy_name: "EarlyCareerPayments",
             no_of_plans_currently_repaying: "1",
             plan_type_of_deduction: "1",
@@ -73,7 +73,7 @@ RSpec.describe "SLC (Student Loans Company) data upload " do
             claim_reference: "TESTREF02",
             nino: "QQ123456B",
             full_name: "Agata Christie",
-            date_of_birth: "3/20/1977",
+            date_of_birth: "20/03/1977",
             policy_name: "LevellingUpPremiumPayments",
             no_of_plans_currently_repaying: "1",
             plan_type_of_deduction: "2",
@@ -88,7 +88,7 @@ RSpec.describe "SLC (Student Loans Company) data upload " do
             claim_reference: row[:claim_reference],
             nino: row[:nino],
             full_name: row[:full_name],
-            date_of_birth: Date.strptime(row[:date_of_birth], "%m/%d/%Y"),
+            date_of_birth: Date.strptime(row[:date_of_birth], "%d/%m/%Y"),
             policy_name: row[:policy_name],
             no_of_plans_currently_repaying: row[:no_of_plans_currently_repaying].to_i,
             plan_type_of_deduction: row[:plan_type_of_deduction].to_i,
@@ -107,6 +107,24 @@ RSpec.describe "SLC (Student Loans Company) data upload " do
           expect(StudentLoansData.where(nino: "QQ123456A").first).to have_attributes(expected_records[0])
           expect(StudentLoansData.where(nino: "QQ123456B").first).to have_attributes(expected_records[1])
         end
+      end
+
+      shared_examples :no_upload do
+        it "does not upload the rows" do
+          expect { perform_enqueued_jobs { upload } }.not_to change(StudentLoansData, :count)
+        end
+      end
+
+      context "with rows with blank 'NINO'" do
+        let(:rows) { super().map { |row| row.merge(nino: "") } }
+
+        include_examples :no_upload
+      end
+
+      context "with rows with invalid 'Date of Birth'" do
+        let(:rows) { super().map { |row| row.merge(date_of_birth: "12/20/1999") } }
+
+        include_examples :no_upload
       end
     end
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1555

Context: We use the SLC (Student Loans Company) data to playback the student loan amount to users claiming Student Loan repayments and fetch the correct plan type before sending the payments to payroll. The data is uploaded via the admin portal and can trigger the execution of certain admin checks (each policy has different tasks and rules) for claims currently awaiting a decision. This was one of the latest automations to be introduced.

With this PR, we change the accepted valid DoB date format to be DD/MM/YYYY instead of MM/DD/YYYY (as previously assumed and coded in)