### PR TITLE
CAPT 1573/form object for eligible itt subject

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form.rb
@@ -1,0 +1,40 @@
+module Journeys
+  module AdditionalPaymentsForTeaching
+    class EligibleIttSubjectForm < Form
+      include Claims::IttSubjectHelper
+
+      attribute :eligible_itt_subject, :string
+
+      validates :eligible_itt_subject,
+        inclusion: {
+          in: :available_options,
+          message: ->(form, _) { form.i18n_errors_path(:inclusion) }
+        }
+
+      def initialize(journey:, claim:, params:)
+        super
+
+        self.eligible_itt_subject = permitted_params.fetch(
+          :eligible_itt_subject,
+          claim.eligibility.eligible_itt_subject
+        )
+      end
+
+      def available_options
+        subject_symbols(claim).map(&:to_s) + ["none_of_the_above"]
+      end
+
+      def save
+        return false unless valid?
+
+        claim.assign_attributes(
+          eligibility_attributes: {eligible_itt_subject: eligible_itt_subject}
+        )
+        claim.reset_eligibility_dependent_answers(["eligible_itt_subject"])
+        claim.save!
+
+        true
+      end
+    end
+  end
+end

--- a/app/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form.rb
@@ -20,8 +20,22 @@ module Journeys
         )
       end
 
+      def available_subjects
+        @available_subjects ||= subject_symbols(claim).map(&:to_s)
+      end
+
       def available_options
-        subject_symbols(claim).map(&:to_s) + ["none_of_the_above"]
+        available_subjects + ["none_of_the_above"]
+      end
+
+      def show_hint_text?
+        claim.eligibility.nqt_in_academic_year_after_itt && \
+          available_subjects.many?
+      end
+
+      def chemistry_or_physics_available?
+        available_subjects.include?("chemistry") || \
+          available_subjects.include?("physics")
       end
 
       def save

--- a/app/helpers/additional_payments_helper.rb
+++ b/app/helpers/additional_payments_helper.rb
@@ -7,17 +7,17 @@ module AdditionalPaymentsHelper
 
   def eligible_itt_subject_translation(claim)
     if claim.eligibility.trainee_teacher?
-      return I18n.t("additional_payments.questions.eligible_itt_subject_trainee_teacher")
+      return I18n.t("additional_payments.forms.eligible_itt_subject.questions.which_subject_trainee_teacher")
     end
 
     qualification_symbol = claim.eligibility.qualification.to_sym
     subjects = subject_symbols(claim)
 
     if subjects.many?
-      I18n.t("additional_payments.questions.eligible_itt_subject", qualification: qualification_to_substring(qualification_symbol))
+      I18n.t("additional_payments.forms.eligible_itt_subject.questions.which_subject", qualification: qualification_to_substring(qualification_symbol))
     else
       subject_symbol = subjects.first
-      I18n.t("additional_payments.questions.eligible_itt_subject_one_option", qualification: qualification_to_substring(qualification_symbol), subject: subject_symbol)
+      I18n.t("additional_payments.forms.eligible_itt_subject.questions.single_subject", qualification: qualification_to_substring(qualification_symbol), subject: subject_symbol)
     end
   end
 

--- a/app/helpers/claims/itt_subject_helper.rb
+++ b/app/helpers/claims/itt_subject_helper.rb
@@ -43,7 +43,7 @@ module Claims
         hint_subject_symbols.merge(all_lup_subjects)
       end
 
-      hint_subject_symbols.map { |sub| t("additional_payments.answers.eligible_itt_subject.#{sub}") }
+      hint_subject_symbols.map { |sub| t("additional_payments.forms.eligible_itt_subject.answers.#{sub}") }
         .sort
         .to_sentence(last_word_connector: " or ")
         .downcase

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -17,6 +17,7 @@ module Journeys
       "entire-term-contract" => EntireTermContractForm,
       "employed-directly" => EmployedDirectlyForm,
       "qualification" => QualificationForm,
+      "eligible-itt-subject" => EligibleIttSubjectForm,
       "teaching-subject-now" => TeachingSubjectNowForm
     }.freeze
   end

--- a/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
@@ -154,7 +154,7 @@ module Journeys
           itt_year: eligibility.itt_academic_year).current_and_future_subject_symbols(policy)
 
         if subjects.many?
-          t("early_career_payments.answers.eligible_itt_subject.#{eligibility.eligible_itt_subject}")
+          t("additional_payments.forms.eligible_itt_subject.answers.#{eligibility.eligible_itt_subject}")
         else
           subject_symbol = subjects.first
           (subject_symbol == eligibility.eligible_itt_subject.to_sym) ? "Yes" : "No"

--- a/app/models/policies/early_career_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_career_payments/admin_tasks_presenter.rb
@@ -46,7 +46,7 @@ module Policies
 
           a << [
             "ITT subject",
-            I18n.t("early_career_payments.answers.eligible_itt_subject.#{eligibility.eligible_itt_subject}")
+            I18n.t("early_career_payments.forms.eligible_itt_subject.answers.#{eligibility.eligible_itt_subject}")
           ]
         end
       end

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -78,7 +78,6 @@ module Policies
       belongs_to :current_school, optional: true, class_name: "School"
 
       validates :current_school, on: [:"correct-school"], presence: {message: "Select the school you teach at or choose somewhere else"}, unless: :school_somewhere_else?
-      validates :eligible_itt_subject, on: [:"eligible-itt-subject", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.eligible_itt_subject.blank.qualification") }}
       validates :itt_academic_year, on: [:"itt-year", :submit], presence: {message: ->(object, data) { I18n.t("activerecord.errors.models.early_career_payments_eligibilities.attributes.itt_academic_year.blank.qualification.#{object.qualification}") }}
       validates :award_amount, on: [:submit], presence: {message: "Enter an award amount"}
       validates_numericality_of :award_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7500

--- a/app/views/additional_payments/claims/eligible_itt_subject.html.erb
+++ b/app/views/additional_payments/claims/eligible_itt_subject.html.erb
@@ -1,61 +1,96 @@
-<% content_for(:page_title, page_title(eligible_itt_subject_translation(current_claim), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
+<% content_for(
+  :page_title,
+  page_title(
+    eligible_itt_subject_translation(current_claim),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+
 <% subject_symbols = subject_symbols(current_claim) %>
 
 <% if subject_symbols.present? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.eligible_itt_subject": "claim_eligibility_attributes_eligible_itt_subject_#{subject_symbols.first}" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form  do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
-          <%= fields.hidden_field :eligible_itt_subject %>
+    <% if @form.errors.any? %>
+      <%= render(
+        "shared/error_summary",
+        instance: @form,
+        errored_field_id_overrides: {
+          "eligible_itt_subject": "claim_eligible_itt_subject_#{subject_symbols.first}"
+        }
+      ) %>
+    <% end %>
 
-          <fieldset class="govuk-fieldset" aria-describedby="eligible_itt_subject-hint" role="group">
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= form_group_tag f.object.claim do %>
 
-            <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
-              <h1 class="govuk-fieldset__heading">
-                <%= eligible_itt_subject_translation(current_claim) %>
-              </h1>
-            </legend>
+        <%= f.hidden_field :eligible_itt_subject %>
 
-            <% if current_claim.eligibility.nqt_in_academic_year_after_itt && subject_symbols.many? %>
-              <div class="govuk-hint">
-                <%= t("additional_payments.questions.eligible_itt_subject_hint") %>
-              </div>
-            <% end %>
+        <fieldset class="govuk-fieldset" aria-describedby="eligible_itt_subject-hint" role="group">
 
-            <%= errors_tag current_claim.eligibility, :eligible_itt_subject %>
+          <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(f.object.journey) %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= eligible_itt_subject_translation(f.object.claim) %>
+            </h1>
+          </legend>
 
-            <div class="govuk-radios">
-              <% if subject_symbols.many? %>
-                <% subject_symbols.each do |option| %>
-                  <div class="govuk-radios__item">
-                    <%= fields.radio_button(:eligible_itt_subject, option, class: "govuk-radios__input") %>
-                    <%= fields.label "eligible_itt_subject_#{option}", t("additional_payments.answers.eligible_itt_subject.#{option}"), class: "govuk-label govuk-radios__label" %>
-                  </div>
-                <% end %>
+          <% if f.object.claim.eligibility.nqt_in_academic_year_after_itt && subject_symbols.many? %>
+            <div class="govuk-hint">
+              <%= t("additional_payments.forms.eligible_itt_subject.hints.subject") %>
+            </div>
+          <% end %>
 
-                <div class="govuk-radios__divider">or</div>
+          <%= errors_tag f.object, :eligible_itt_subject %>
 
+          <div class="govuk-radios">
+            <% if subject_symbols.many? %>
+              <% subject_symbols.each do |option| %>
                 <div class="govuk-radios__item">
-                  <%= fields.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
-                  <%= fields.label "eligible_itt_subject_none_of_the_above", t("additional_payments.answers.eligible_itt_subject.none_of_the_above"), class: "govuk-label govuk-radios__label" %>
-                </div>
-              <% else %>
-                <% subject_symbol = subject_symbols.first %>
-                <div class="govuk-radios__item">
-                  <%= fields.radio_button(:eligible_itt_subject, subject_symbol, class: "govuk-radios__input") %>
-                  <%= fields.label "eligible_itt_subject_#{subject_symbol}", "Yes", class: "govuk-label govuk-radios__label" %>
-                </div>
-                <div class="govuk-radios__item">
-                  <%= fields.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
-                  <%= fields.label "eligible_itt_subject_none_of_the_above", "No", class: "govuk-label govuk-radios__label" %>
+                  <%= f.radio_button(:eligible_itt_subject, option, class: "govuk-radios__input") %>
+                  <%= f.label(
+                    :eligible_itt_subject,
+                    t("additional_payments.forms.eligible_itt_subject.answers.#{option}"),
+                    value: option,
+                    class: "govuk-label govuk-radios__label"
+                  ) %>
                 </div>
               <% end %>
-            </div>
-          </fieldset>
-        <% end %>
+
+              <div class="govuk-radios__divider">or</div>
+
+              <div class="govuk-radios__item">
+                <%= f.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
+                <%= f.label(
+                  :eligible_itt_subject,
+                  t("additional_payments.forms.eligible_itt_subject.answers.none_of_the_above"),
+                  value: :none_of_the_above,
+                  class: "govuk-label govuk-radios__label"
+                ) %>
+              </div>
+            <% else %>
+              <% subject_symbol = subject_symbols.first %>
+              <div class="govuk-radios__item">
+                <%= f.radio_button(:eligible_itt_subject, subject_symbol, class: "govuk-radios__input") %>
+                <%= f.label(
+                  :eligible_itt_subject,
+                  "Yes",
+                  value: subject_symbol,
+                  class: "govuk-label govuk-radios__label"
+                ) %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= f.radio_button(:eligible_itt_subject, :none_of_the_above, class: "govuk-radios__input") %>
+                <%= f.label(
+                  :eligible_itt_subject,
+                  "No",
+                  value: :none_of_the_above,
+                  class: "govuk-label govuk-radios__label",
+                ) %>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
 
         <% if (subject_symbols & [:chemistry, :physics]).any? %>
           <br/>
@@ -89,7 +124,7 @@
         <% end %>
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= f.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
     <% end %>
   </div>
 </div>

--- a/app/views/additional_payments/claims/eligible_itt_subject.html.erb
+++ b/app/views/additional_payments/claims/eligible_itt_subject.html.erb
@@ -7,9 +7,7 @@
   )
 ) %>
 
-<% subject_symbols = subject_symbols(current_claim) %>
-
-<% if subject_symbols.present? %>
+<% if @form.available_subjects.present? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @form.errors.any? %>
@@ -17,7 +15,7 @@
         "shared/error_summary",
         instance: @form,
         errored_field_id_overrides: {
-          "eligible_itt_subject": "claim_eligible_itt_subject_#{subject_symbols.first}"
+          "eligible_itt_subject": "claim_eligible_itt_subject_#{@form.available_subjects.first}"
         }
       ) %>
     <% end %>
@@ -35,7 +33,7 @@
             </h1>
           </legend>
 
-          <% if f.object.claim.eligibility.nqt_in_academic_year_after_itt && subject_symbols.many? %>
+          <% if f.object.show_hint_text? %>
             <div class="govuk-hint">
               <%= t("additional_payments.forms.eligible_itt_subject.hints.subject") %>
             </div>
@@ -44,8 +42,8 @@
           <%= errors_tag f.object, :eligible_itt_subject %>
 
           <div class="govuk-radios">
-            <% if subject_symbols.many? %>
-              <% subject_symbols.each do |option| %>
+            <% if f.object.available_subjects.many? %>
+              <% f.object.available_subjects.each do |option| %>
                 <div class="govuk-radios__item">
                   <%= f.radio_button(:eligible_itt_subject, option, class: "govuk-radios__input") %>
                   <%= f.label(
@@ -69,7 +67,7 @@
                 ) %>
               </div>
             <% else %>
-              <% subject_symbol = subject_symbols.first %>
+              <% subject_symbol = f.object.available_subjects.first %>
               <div class="govuk-radios__item">
                 <%= f.radio_button(:eligible_itt_subject, subject_symbol, class: "govuk-radios__input") %>
                 <%= f.label(
@@ -92,7 +90,7 @@
           </div>
         </fieldset>
 
-        <% if (subject_symbols & [:chemistry, :physics]).any? %>
+        <% if f.object.chemistry_or_physics_available? %>
           <br/>
           <br/>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,22 @@ en:
           select_the_school_you_teach_at: "Select the school you teach at"
           the_selected_school_is_closed: "The selected school is closed"
           school_not_found: "School not found"
+      eligible_itt_subject:
+        questions:
+          which_subject: "Which subject did you do your %{qualification} in?"
+          single_subject: "Did you do your %{qualification} in %{subject}?"
+          which_subject_trainee_teacher: "Which subject are you currently doing your initial teacher training (ITT) in?"
+        answers:
+          chemistry: "Chemistry"
+          computing: "Computing"
+          mathematics: "Mathematics"
+          foreign_languages: "Languages"
+          physics: "Physics"
+          none_of_the_above: "None of the above"
+        hints:
+          subject: "The subjects listed are eligible for additional payment based on the school you teach in and the year you studied."
+        errors:
+          inclusion: "Select a subject"
       employed_directly:
         questions:
           employed_directly: Are you employed directly by your school?
@@ -377,10 +393,6 @@ en:
               Select yes if you have more than 2 years experience as a teacher.<br/>
               Select no if you have less than 2 years experience as a teacher.<br/>
               Further information can be found at <a href="https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#early-career-teacher-ect-induction" class="govuk-link govuk-link--no-visited-state" target="_blank">early-career teacher (ECT) induction periods for teachers who qualified overseas</a>
-      eligible_itt_subject: "Which subject did you do your %{qualification} in?"
-      eligible_itt_subject_one_option: "Did you do your %{qualification} in %{subject}?"
-      eligible_itt_subject_trainee_teacher: "Which subject are you currently doing your initial teacher training (ITT) in?"
-      eligible_itt_subject_hint: "The subjects listed are eligible for additional payment based on the school you teach in and the year you studied."
       itt_academic_year:
         qualification:
           undergraduate_itt: In which academic year did you complete your undergraduate initial teacher training (ITT)?
@@ -417,14 +429,6 @@ en:
           title: "Is this claim still valid despite having matching details with other claims?"
         payroll_details:
           title: "The claimant’s %{bank_or_building_society} details have not been automatically validated. Has the claimant confirmed their %{bank_or_building_society} details?"
-    answers:
-      eligible_itt_subject:
-        chemistry: "Chemistry"
-        computing: "Computing"
-        mathematics: "Mathematics"
-        foreign_languages: "Languages"
-        physics: "Physics"
-        none_of_the_above: "None of the above"
     reminders:
       full_name: Full name
   early_career_payments:
@@ -461,6 +465,3 @@ en:
                   postgraduate_itt: "Select the academic year you started your postgraduate ITT"
                   assessment_only: "Select the academic year you earned your QTS"
                   overseas_recognition: "Select the academic year you earned your QTS"
-            eligible_itt_subject:
-              blank:
-                qualification: "Select a subject"

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # Check your answers page does not include qualifications questions
     expect(page).not_to have_text(I18n.t("additional_payments.forms.qualification.questions.which_route"))
-    expect(page).not_to have_text(I18n.t("additional_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teacher training (ITT)"))
+    expect(page).not_to have_text(I18n.t("additional_payments.forms.eligible_itt_subject.questions.which_subject", qualification: "undergraduate initial teacher training (ITT)"))
     expect(page).not_to have_text(I18n.t("additional_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
     expect(page).not_to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
 
@@ -103,7 +103,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # Check your answers page includes qualifications questions
     expect(page).to have_text(I18n.t("additional_payments.forms.qualification.questions.which_route"))
-    expect(page).to have_text(I18n.t("additional_payments.questions.eligible_itt_subject_one_option", qualification: "undergraduate initial teacher training (ITT)", subject: "mathematics"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.eligible_itt_subject.questions.single_subject", qualification: "undergraduate initial teacher training (ITT)", subject: "mathematics"))
     expect(page).to have_text(I18n.t("additional_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
     expect(page).not_to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
 
@@ -208,7 +208,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # Check your answers page includes qualifications questions
     expect(page).to have_text(I18n.t("additional_payments.forms.qualification.questions.which_route"))
-    expect(page).to have_text(I18n.t("additional_payments.questions.eligible_itt_subject_one_option", qualification: "undergraduate initial teacher training (ITT)", subject: "mathematics"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.eligible_itt_subject.questions.single_subject", qualification: "undergraduate initial teacher training (ITT)", subject: "mathematics"))
     expect(page).to have_text(I18n.t("additional_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
     expect(page).not_to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
   end
@@ -288,7 +288,7 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # Check your answers page only includes missing qualifications questions
     expect(page).not_to have_text(I18n.t("additional_payments.forms.qualification.questions.which_route"))
-    expect(page).not_to have_text(I18n.t("additional_payments.questions.eligible_itt_subject", qualification: "undergraduate initial teacher training (ITT)"))
+    expect(page).not_to have_text(I18n.t("additional_payments.forms.eligible_itt_subject.questions.which_subject", qualification: "undergraduate initial teacher training (ITT)"))
     expect(page).to have_text(I18n.t("additional_payments.questions.itt_academic_year.qualification.undergraduate_itt"))
     expect(page).not_to have_text(I18n.t("additional_payments.questions.eligible_degree_subject"))
   end

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           click_on "Continue"
 
           # - Which subject did you do your postgraduate initial teacher training (ITT) in?
-          choose I18n.t("additional_payments.answers.eligible_itt_subject.#{args[:subject]}")
+          choose I18n.t("additional_payments.forms.eligible_itt_subject.answers.#{args[:subject]}")
           click_on "Continue"
 
           # - Do you teach subject now?
@@ -105,7 +105,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
 
           expect(claim.eligibility.reload.itt_academic_year).to eql args[:academic_year]
 
-          choose I18n.t("additional_payments.answers.eligible_itt_subject.#{args[:subject]}")
+          choose I18n.t("additional_payments.forms.eligible_itt_subject.answers.#{args[:subject]}")
           click_on "Continue"
 
           # - Do you teach subject now?

--- a/spec/features/trainee_teacher_subjourney_for_lup_schools_spec.rb
+++ b/spec/features/trainee_teacher_subjourney_for_lup_schools_spec.rb
@@ -124,6 +124,6 @@ RSpec.feature "Trainee teacher subjourney for LUP schools" do
     choose "No"
     click_on "Continue"
 
-    expect(page).to have_text(I18n.t("additional_payments.questions.eligible_itt_subject_trainee_teacher"))
+    expect(page).to have_text(I18n.t("additional_payments.forms.eligible_itt_subject.questions.which_subject_trainee_teacher"))
   end
 end

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
@@ -65,6 +65,145 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
     end
   end
 
+  describe "#available_subjects" do
+    let(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: ActionController::Parameters.new
+      )
+    end
+
+    subject(:available_subjects) { form.available_subjects }
+
+    context "when qualified teacher" do
+      let(:claim) { ecp_qualified_teacher_claim }
+
+      # EarlyCareerPayments policy, claim year 2023, itt_year 2020
+      # see `lib/journey_subject_eligibility_checker.rb`
+      it do
+        is_expected.to contain_exactly(
+          "chemistry",
+          "foreign_languages",
+          "mathematics",
+          "physics"
+        )
+      end
+    end
+
+    context "when trainee teacher" do
+      context "when in ECP and LUP policy year range" do
+        let(:claim) { ecp_trainee_teacher_claim }
+
+        it do
+          is_expected.to contain_exactly(
+            "chemistry",
+            "computing",
+            "mathematics",
+            "physics"
+          )
+        end
+      end
+
+      context "when not in ECP and LUP policy year range" do
+        let(:claim) { ecp_trainee_teacher_claim }
+
+        before do
+          allow(current_claim).to(
+            receive(:policy_year).and_return(AcademicYear.new(2000))
+          )
+        end
+
+        it { is_expected.to be_empty }
+      end
+    end
+  end
+
+  describe "#show_hint_text?" do
+    let(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: ActionController::Parameters.new
+      )
+    end
+
+    subject { form.show_hint_text? }
+
+    context "when the claim is for a trainee teacher" do
+      let(:claim) { ecp_trainee_teacher_claim }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the claim is for a qualified teacher" do
+      let(:claim) { ecp_qualified_teacher_claim }
+
+      context "when there is a single avaialble subject" do
+        # Single subject "mathematics". See
+        # `JourneySubjectEligibilityChecker#subject_symbols`
+        before do
+          allow(ecp_qualified_teacher_eligibility).to(
+            receive(:itt_academic_year).and_return(AcademicYear.new(2018))
+          )
+          allow(current_claim).to(
+            receive(:policy_year).and_return(AcademicYear.new(2019))
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "when there are multiple available subjects" do
+        it { is_expected.to be true }
+      end
+    end
+  end
+
+  describe "#chemistry_or_physics_available?" do
+    let(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: ActionController::Parameters.new
+      )
+    end
+
+    let(:claim) { ecp_trainee_teacher_claim }
+
+    subject { form.chemistry_or_physics_available? }
+
+    context "when the subject list contains chemistry" do
+      before do
+        allow(JourneySubjectEligibilityChecker).to(
+          receive(:fixed_lup_subject_symbols).and_return([:chemistry])
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the subject list contains physics" do
+      before do
+        allow(JourneySubjectEligibilityChecker).to(
+          receive(:fixed_lup_subject_symbols).and_return([:physics])
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the subject list does not contain chemistry or physics" do
+      before do
+        allow(JourneySubjectEligibilityChecker).to(
+          receive(:fixed_lup_subject_symbols).and_return([:mathematics])
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe "#save" do
     let(:claim) { ecp_qualified_teacher_claim }
 

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, type: :model do
+  before do
+    create(
+      :journey_configuration,
+      :additional_payments,
+      current_academic_year: AcademicYear.new(2023)
+    )
+  end
+
+  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:ecp_trainee_teacher_eligibility) do
+    create(
+      :early_career_payments_eligibility,
+      :trainee_teacher,
+      itt_academic_year: AcademicYear.new(2020)
+    )
+  end
+
+  let(:ecp_trainee_teacher_claim) do
+    create(
+      :claim,
+      :first_lup_claim_year,
+      policy: Policies::EarlyCareerPayments,
+      eligibility: ecp_trainee_teacher_eligibility
+    )
+  end
+
+  let(:ecp_qualified_teacher_eligibility) do
+    create(
+      :early_career_payments_eligibility,
+      :eligible_now,
+      :sufficient_teaching,
+      itt_academic_year: AcademicYear.new(2020)
+    )
+  end
+
+  let(:ecp_qualified_teacher_claim) do
+    create(
+      :claim,
+      policy: Policies::EarlyCareerPayments,
+      eligibility: ecp_qualified_teacher_eligibility
+    )
+  end
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  describe "validations" do
+    let(:claim) { ecp_qualified_teacher_claim }
+
+    subject(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: ActionController::Parameters.new
+      )
+    end
+
+    it do
+      is_expected.to validate_inclusion_of(:eligible_itt_subject)
+        .in_array(form.available_options)
+        .with_message("Select a subject")
+    end
+  end
+
+  describe "#save" do
+    let(:claim) { ecp_qualified_teacher_claim }
+
+    let(:form) do
+      described_class.new(
+        journey: additional_payments_journey,
+        claim: current_claim,
+        params: params
+      )
+    end
+
+    context "when invalid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            eligible_itt_subject: "invalid"
+          }
+        )
+      end
+
+      it "returns false" do
+        expect(form.save).to be(false)
+      end
+    end
+
+    context "when valid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            eligible_itt_subject: "chemistry"
+          }
+        )
+      end
+
+      it "returns true and updates the claim's eligibility" do
+        expect { expect(form.save).to be true }.to(
+          change { claim.eligibility.eligible_itt_subject }
+          .from("mathematics")
+          .to("chemistry")
+        )
+      end
+
+      it "resets dependent attributes" do
+        expect { form.save }.to(
+          change { claim.eligibility.teaching_subject_now }
+          .from(true)
+          .to(nil)
+        )
+      end
+    end
+  end
+end

--- a/spec/models/early_career_payments/eligibility_spec.rb
+++ b/spec/models/early_career_payments/eligibility_spec.rb
@@ -300,25 +300,6 @@ RSpec.describe Policies::EarlyCareerPayments::Eligibility, type: :model do
       end
     end
 
-    context "when saving in the 'eligible_itt_subject' context" do
-      before { create(:journey_configuration, :additional_payments) }
-
-      it "is not valid without a value for 'eligible_itt_subject'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"eligible-itt-subject")
-      end
-
-      it "is not valid when the value for 'eligible_itt_subject' is 'none of the above'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :none_of_the_above)).to be_valid(:"eligible-itt-subject")
-      end
-
-      it "is valid when the value for 'eligible_itt_subject' is one of 'chemistry, foreign_languages, mathematics or physics'" do
-        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :chemistry)).to be_valid(:"eligible-itt-subject")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :physics)).to be_valid(:"eligible-itt-subject")
-        expect(Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :foreign_languages)).to be_valid(:"eligible-itt-subject")
-        expect { Policies::EarlyCareerPayments::Eligibility.new(eligible_itt_subject: :languages) }.to raise_error(ArgumentError)
-      end
-    end
-
     context "when saving in the 'itt_academic_year' context" do
       it "is not valid without a value for 'itt_academic_year'" do
         expect(Policies::EarlyCareerPayments::Eligibility.new).not_to be_valid(:"itt-year")

--- a/spec/support/admin_tasks_presenter_shared_examples.rb
+++ b/spec/support/admin_tasks_presenter_shared_examples.rb
@@ -60,7 +60,7 @@ RSpec.shared_examples "ECP and LUP Combined Journey Admin Tasks Presenter" do |p
 
         it "returns array with subject #{spec[:subject_text]}" do
           expect(presenter.qualifications).to include(
-            ["ITT subject", I18n.t("additional_payments.answers.eligible_itt_subject.#{spec[:subject_text]}")]
+            ["ITT subject", I18n.t("additional_payments.forms.eligible_itt_subject.answers.#{spec[:subject_text]}")]
           )
         end
       end


### PR DESCRIPTION
<!-- Do you need to update CHANGELOG.md? -->
Extracts a form object for the `eligible_itt_subject` step.
I think the view could be cleaned up a bit more but it requires more 
substantial changes outside the scope of this ticket

There's a couple of existing issues with this page not addressed in this pr.
If there's no `available_subjects` present (or on master if there's no
`subject_symbols`) present, then an empty page can render. One scenario that
can cause this is the user choosing "No" on the "Do you spend at least half of
your contracted hours teaching eligible subjects?", reaches the ineligible page
then navigates back with the browser button. In this scenario the
`JourneySubjectEligibilityChecker#selectable_subject_symbols` method returns an
empty array as there are no eligible policies. Looking in the
`Claims::IttSubjectHelper#subject_symbols` method it also seems possible for it
to return an empty list of options for a trainee teacher, with a policy outside
the supported range, whether or not we can trigger thhis scenario in practice I
don't know!
I also considered moving the logic from
`Claims::IttSubjectHelper#subject_symbols` into the
`JourneySubjectEligibilityChecker#selectable_subject_symbols` method but opted
against doing so in case it is making a bad assumption more embedded in the
code (`JourneySubjectEligibilityChecker` is used in more places that
`subject_symbols`)
