### PR TITLE
[1654] Add infra team statucake contact group #2

### DIFF
--- a/azure/terraform/workspace_variables/production.tfvars.json
+++ b/azure/terraform/workspace_variables/production.tfvars.json
@@ -14,7 +14,7 @@
       "website_url": "https://claim-additional-teaching-payment.service.gov.uk/healthcheck",
       "check_rate": 30,
       "trigger_rate": 0,
-      "contact_group": [195955, 282783]
+      "contact_group": [195955, 282453]
     }
   }
 }


### PR DESCRIPTION
## Description
The infra group was added to receive statuscake alerts by default but the id of the old contact group was used. Changing for thenew id now.

