### PR TITLE
Move eligible-later view to a Form object

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/eligible_later_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/eligible_later_form.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module AdditionalPaymentsForTeaching
+    class EligibleLaterForm < Form
+    end
+  end
+end

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -10,6 +10,7 @@ module Journeys
     I18N_NAMESPACE = "additional_payments"
     POLICIES = [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments]
     FORMS = {
+      "eligible-later" => EligibleLaterForm,
       "induction-completed" => InductionCompletedForm,
       "nqt-in-academic-year-after-itt" => NqtInAcademicYearAfterIttForm,
       "supply-teacher" => SupplyTeacherForm,

--- a/app/views/additional_payments/claims/eligible_later.html.erb
+++ b/app/views/additional_payments/claims/eligible_later.html.erb
@@ -6,14 +6,14 @@
 
     <h2 class="govuk-heading-m">You are not eligible this year</h2>
 
-    <% if current_claim.for_policy(Policies::EarlyCareerPayments)&.eligibility&.induction_not_completed? %>
+    <% if @form.claim.for_policy(Policies::EarlyCareerPayments)&.eligibility&.induction_not_completed? %>
       <p class="govuk-body">
         You are not eligible for the
         <%= link_to "early-career payment (opens in new tab)", "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>
         because you have not completed your induction.
       </p>
     <% else %>
-      <% if current_claim.eligibility.undergraduate_itt? %>
+      <% if @form.claim.eligibility.undergraduate_itt? %>
         <p class="govuk-body">
           You are not eligible for the
           <%= link_to "early-career payment (opens in new tab)", "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>
@@ -21,7 +21,7 @@
         </p>
       <% end %>
 
-      <% if current_claim.eligibility.postgraduate_itt? %>
+      <% if @form.claim.eligibility.postgraduate_itt? %>
         <p class="govuk-body">
           You are not eligible for the
           <%= link_to "early-career payment (opens in new tab)", "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>
@@ -29,11 +29,11 @@
         </p>
       <% end %>
 
-      <% if current_claim.eligibility.assessment_only? || current_claim.eligibility.overseas_recognition? %>
+      <% if @form.claim.eligibility.assessment_only? || @form.claim.eligibility.overseas_recognition? %>
         <p class="govuk-body">
           You are not eligible for the
           <%= link_to "early-career payment (opens in new tab)", "https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>
-          because you earned your qualified teacher status in the <%= current_claim.eligibility.itt_academic_year.to_s(:long) -%> academic year.
+          because you earned your qualified teacher status in the <%= @form.claim.eligibility.itt_academic_year.to_s(:long) -%> academic year.
         </p>
       <% end %>
     <% end %>
@@ -47,12 +47,12 @@
     <h2 class="govuk-heading-m">You may be eligible next year</h2>
 
     <p class="govuk-body">
-      <% if current_claim.for_policy(Policies::EarlyCareerPayments)&.eligibility&.induction_not_completed? %>
+      <% if @form.claim.for_policy(Policies::EarlyCareerPayments)&.eligibility&.induction_not_completed? %>
         If you have completed your induction,
       <% else %>
         So long as your circumstances stay the same,
       <% end %>
-      you could claim for an early-career payment in the <%= (current_claim.academic_year + 1).to_s(:long)  -%> academic year.
+      you could claim for an early-career payment in the <%= (@form.claim.academic_year + 1).to_s(:long)  -%> academic year.
     </p>
 
     <h3 class="govuk-heading-s">Set a reminder to apply next year</h3>


### PR DESCRIPTION
- Remove references to current_claim and exchange for an empty Form object
- Very minimal view change but helps to follow the new Form object pattern