### PR TITLE
Remove requirement to list all form objects and their slug names

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -9,8 +9,22 @@ class Form
 
   delegate :persisted?, to: :claim
 
-  def self.model_name
-    Claim.model_name
+  class << self
+    def model_name
+      Claim.model_name
+    end
+
+    def slug_name
+      name.demodulize.delete_suffix("Form").underscore.dasherize
+    end
+
+    # Returns form classes outside of any journey-specific namespace
+    def all_shared_forms
+      ObjectSpace
+        .each_object(Class)
+        .select { |klass| klass < self }
+        .reject { |klass| klass.to_s.start_with?("Journeys::") }
+    end
   end
 
   def initialize(claim:, journey:, params:)

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -20,7 +20,7 @@ class Form
 
     # Returns form classes outside of any journey-specific namespace
     def all_shared_forms
-      ObjectSpace
+      @@all_shared_forms ||= ObjectSpace
         .each_object(Class)
         .select { |klass| klass < self }
         .reject { |klass| klass.to_s.start_with?("Journeys::") }

--- a/app/forms/journeys/additional_payments_for_teaching/itt_year_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/itt_year_form.rb
@@ -1,6 +1,6 @@
 module Journeys
   module AdditionalPaymentsForTeaching
-    class IttAcademicYearForm < Form
+    class IttYearForm < Form
       attribute :itt_academic_year
 
       validates :itt_academic_year, presence: {message: ->(object, _) { object.i18n_errors_path(object.qualification) }}

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -9,18 +9,5 @@ module Journeys
     VIEW_PATH = "additional_payments"
     I18N_NAMESPACE = "additional_payments"
     POLICIES = [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments]
-    FORMS = {
-      "induction-completed" => InductionCompletedForm,
-      "itt-year" => IttAcademicYearForm,
-      "nqt-in-academic-year-after-itt" => NqtInAcademicYearAfterIttForm,
-      "eligible-degree-subject" => EligibleDegreeSubjectForm,
-      "supply-teacher" => SupplyTeacherForm,
-      "poor-performance" => PoorPerformanceForm,
-      "entire-term-contract" => EntireTermContractForm,
-      "employed-directly" => EmployedDirectlyForm,
-      "qualification" => QualificationForm,
-      "eligible-itt-subject" => EligibleIttSubjectForm,
-      "teaching-subject-now" => TeachingSubjectNowForm
-    }.freeze
   end
 end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -19,10 +19,8 @@ module Journeys
 
     # Returns a Hash of slug => class pairs of form classes automatically determined
     def all_forms
-      Form.all_shared_forms.concat(constants
-          .select { |c| const_get(c).is_a?(Class) }
-          .map { |c| const_get(c) }
-          .select { |klass| klass < Form })
+      @@all_forms ||= Form.all_shared_forms
+        .concat(journey_forms)
         .map { |klass| [klass.slug_name, klass] }
         .to_h
     end
@@ -37,6 +35,15 @@ module Journeys
 
     def answers_for_claim(claim)
       answers_presenter.new(claim)
+    end
+
+    private
+
+    def journey_forms
+      @@journey_forms ||= constants
+        .select { |c| const_get(c).is_a?(Class) }
+        .map { |c| const_get(c) }
+        .select { |klass| klass < Form }
     end
   end
 end

--- a/config/initializers/eager_load_form_objects.rb
+++ b/config/initializers/eager_load_form_objects.rb
@@ -1,0 +1,6 @@
+# Ensures all form classes are available in the journey
+unless Rails.application.config.eager_load
+  Rails.application.reloader.to_prepare do
+    Dir["#{Rails.root}/app/forms/**/*.rb"].each { |file| require_dependency(file) }
+  end
+end

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
+class TestForm < Form; end
+
 class TestSlugForm < Form
   attribute :first_name
   attribute :student_loan_repayment_amount
@@ -18,12 +20,26 @@ module Journeys
         # NOOP
       end
     end
+
+    class TestForm < Form; end
   end
 end
 
 RSpec.describe Form, type: :model do
   describe ".model_name" do
     it { expect(TestSlugForm.model_name).to eq(Claim.model_name) }
+  end
+
+  describe ".slug_name" do
+    it { expect(TestSlugForm.slug_name).to eq("test-slug") }
+    it { expect(Journeys::TestJourney::TestForm.slug_name).to eq("test") }
+  end
+
+  describe ".all_shared_forms" do
+    it "returns only forms outside of a journey namespace" do
+      expect(described_class.all_shared_forms).to include(TestForm, TestSlugForm)
+      expect(described_class.all_shared_forms).not_to include(Journeys::TestJourney::TestForm)
+    end
   end
 
   subject(:form) { TestSlugForm.new(claim:, journey:, params:) }

--- a/spec/forms/journeys/additional_payments_for_teaching/itt_year_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/itt_year_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Journeys::AdditionalPaymentsForTeaching::IttAcademicYearForm do
+RSpec.describe Journeys::AdditionalPaymentsForTeaching::IttYearForm do
   shared_examples "itt_academic_year_form" do |journey|
     before {
       create(:journey_configuration, :additional_payments)

--- a/spec/models/journeys/additional_payments_for_teaching_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching_spec.rb
@@ -2,6 +2,18 @@
 
 require "rails_helper"
 
+class TestForm < Form; end
+
+class AnotherForm < Form; end
+
+module Journeys
+  module AdditionalPaymentsForTeaching
+    class TestForm < Form; end
+
+    class TestJourneyForm < Form; end
+  end
+end
+
 RSpec.describe Journeys::AdditionalPaymentsForTeaching do
   describe ".configuration" do
     context "with journey configuration record" do
@@ -58,5 +70,19 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching do
     subject(:presenter) { described_class.answers_presenter }
 
     it { is_expected.to eq(Journeys::AdditionalPaymentsForTeaching::AnswersPresenter) }
+  end
+
+  describe ".all_forms" do
+    it "prioritises the class in the journey namespace" do
+      expect(described_class.all_forms["test"]).to eq(Journeys::AdditionalPaymentsForTeaching::TestForm)
+    end
+
+    it "returns forms that only exist in the journey namespace" do
+      expect(described_class.all_forms["test-journey"]).to eq(Journeys::AdditionalPaymentsForTeaching::TestJourneyForm)
+    end
+
+    it "returns forms that only exist outside the journey namespace" do
+      expect(described_class.all_forms["another"]).to eq(AnotherForm)
+    end
   end
 end

--- a/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
@@ -2,6 +2,18 @@
 
 require "rails_helper"
 
+class TestForm < Form; end
+
+class AnotherForm < Form; end
+
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class TestForm < Form; end
+
+    class TestJourneyForm < Form; end
+  end
+end
+
 RSpec.describe Journeys::TeacherStudentLoanReimbursement do
   describe ".configuration" do
     context "with journey configuration record" do
@@ -58,5 +70,19 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement do
     subject(:presenter) { described_class.answers_presenter }
 
     it { is_expected.to eq(Journeys::TeacherStudentLoanReimbursement::AnswersPresenter) }
+  end
+
+  describe ".all_forms" do
+    it "prioritises the class in the journey namespace" do
+      expect(described_class.all_forms["test"]).to eq(Journeys::TeacherStudentLoanReimbursement::TestForm)
+    end
+
+    it "returns forms that only exist in the journey namespace" do
+      expect(described_class.all_forms["test-journey"]).to eq(Journeys::TeacherStudentLoanReimbursement::TestJourneyForm)
+    end
+
+    it "returns forms that only exist outside the journey namespace" do
+      expect(described_class.all_forms["another"]).to eq(AnotherForm)
+    end
   end
 end


### PR DESCRIPTION
Currently, every time we add a form object we have to update the `Journey::JourneyName::FORMS` and/or `Form::SHARED_FORMS` constants with the corresponding slug name mapping to the class.

In the spirit of convention over configuration, this change removes the need to do this. Instead, the form object is resolved dynamically based on the slug name.

Slug names resolve directly to class names, e.g. `current-school` slug resolves to `CurrentSchoolForm`.

As currently, a journey can still override a form object class with the same name as a shared class in its namespace, and it will load the class in the journey namespace in preference to the shared one. This allows for shared forms with journey-specific behaviour overrides.

Shared forms still work as currently.

Note: Given the slug name is a user supplied parameter it is unsafe, therefore I have retained the current 'form object registry' pattern rather than dynamically loading a class from the slug name.