### PR TITLE
CAPT-1563 Form object for /personal-details

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -345,7 +345,7 @@ class ClaimsController < BasePublicController
     # For claims being submitted using the TID-route and where all personal details came through/are
     # valid, the student loan details must be retrieved after the `information-provided` page instead.
     if params[:slug] == "personal-details" || (params[:slug] == "information-provided" &&
-        current_claim.logged_in_with_tid? && current_claim.has_all_valid_personal_details?)
+        current_claim.logged_in_with_tid? && current_claim.all_personal_details_same_as_tid?)
       ClaimStudentLoanDetailsUpdater.call(current_claim)
     end
   end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -332,9 +332,6 @@ class ClaimsController < BasePublicController
     current_claim.claims.each { |claim| claim.eligibility.set_qualifications_from_dqt_record }
   end
 
-  # TODO: should calling `ClaimStudentLoanDetailsUpdater.call(current_claim)` be the responsibility
-  # of the PersonalDetailsForm? Then when we have a InformationProvidedForm it could use a
-  # PersonalDetailsForm to check the validity?
   def retrieve_student_loan_details
     # student loan details are currently retrieved for TSLR and ECP/LUPP journeys only
     return unless ["student-loans", "additional-payments"].include?(current_journey_routing_name)

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -75,6 +75,7 @@ class ClaimsController < BasePublicController
     # TODO: Migrate the remaining slugs to form objects.
     if (@form = journey.form(claim: current_claim, params: params))
       if @form.save
+        retrieve_student_loan_details
         redirect_to claim_path(current_journey_routing_name, next_slug)
       else
         set_any_backlink_override
@@ -87,8 +88,6 @@ class ClaimsController < BasePublicController
     case params[:slug]
     when "qualification-details"
       set_dqt_data_as_answers
-    when "personal-details"
-      check_date_params
     when "eligibility-confirmed"
       return select_claim if current_journey_routing_name == "additional-payments"
     when "personal-bank-account", "building-society-account"
@@ -177,17 +176,6 @@ class ClaimsController < BasePublicController
 
   def claim_params
     params.fetch(:claim, {}).permit(Claim::PermittedParameters.new(current_claim).keys)
-  end
-
-  def check_date_params
-    dob_params = {
-      "date_of_birth_day" => claim_params.dig("date_of_birth(3i)").to_s,
-      "date_of_birth_month" => claim_params.dig("date_of_birth(2i)").to_s,
-      "date_of_birth_year" => claim_params.dig("date_of_birth(1i)").to_s
-    }
-    current_claim.attributes = claim_params.merge!(dob_params)
-  rescue ActiveRecord::MultiparameterAssignmentErrors
-    current_claim.attributes = claim_params.except("date_of_birth(3i)", "date_of_birth(2i)", "date_of_birth(1i)") if params[:slug] == "personal-details"
   end
 
   def current_template
@@ -344,6 +332,9 @@ class ClaimsController < BasePublicController
     current_claim.claims.each { |claim| claim.eligibility.set_qualifications_from_dqt_record }
   end
 
+  # TODO: should calling `ClaimStudentLoanDetailsUpdater.call(current_claim)` be the responsibility
+  # of the PersonalDetailsForm? Then when we have a InformationProvidedForm it could use a
+  # PersonalDetailsForm to check the validity?
   def retrieve_student_loan_details
     # student loan details are currently retrieved for TSLR and ECP/LUPP journeys only
     return unless ["student-loans", "additional-payments"].include?(current_journey_routing_name)

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -58,19 +58,16 @@ class PersonalDetailsForm < Form
     update!({first_name:, middle_name:, surname:, date_of_birth:, national_insurance_number:})
   end
 
-  def has_valid_name?
-    valid?
-    errors.exclude?(:first_name) && errors.exclude?(:surname)
+  def show_name_section?
+    !(claim.logged_in_with_tid? && claim.name_same_as_tid? && has_valid_name?)
   end
 
-  def has_valid_date_of_birth?
-    valid?
-    errors.exclude?(:date_of_birth)
+  def show_date_of_birth_section?
+    !(claim.logged_in_with_tid? && claim.dob_same_as_tid? && has_valid_date_of_birth?)
   end
 
-  def has_valid_nino?
-    valid?
-    errors.exclude?(:national_insurance_number)
+  def show_nino_section?
+    !(claim.logged_in_with_tid? && claim.nino_same_as_tid? && has_valid_nino?)
   end
 
   private
@@ -115,5 +112,20 @@ class PersonalDetailsForm < Form
 
   def number_of_date_components
     [day, month, year].compact_blank.size
+  end
+
+  def has_valid_name?
+    valid?
+    errors.exclude?(:first_name) && errors.exclude?(:surname)
+  end
+
+  def has_valid_date_of_birth?
+    valid?
+    errors.exclude?(:date_of_birth)
+  end
+
+  def has_valid_nino?
+    valid?
+    errors.exclude?(:national_insurance_number)
   end
 end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -97,10 +97,10 @@ class PersonalDetailsForm < Form
       errors.add(:date_of_birth, "Date of birth must be in the past")
     elsif number_of_date_components.between?(1, 2)
       errors.add(:date_of_birth, "Date of birth must include a day, month and year in the correct format, for example 01 01 1980")
-    elsif date_of_birth.is_a?(InvalidDate) && number_of_date_components == 3
-      errors.add(:date_of_birth, "Enter a date of birth in the correct format")
     elsif number_of_date_components.zero?
       errors.add(:date_of_birth, "Enter your date of birth")
+    elsif date_of_birth.is_a?(InvalidDate)
+      errors.add(:date_of_birth, "Enter a date of birth in the correct format")
     elsif date_of_birth.year < 1000
       errors.add(:date_of_birth, "Year must include 4 numbers")
     elsif date_of_birth.year <= 1900

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -1,0 +1,113 @@
+class PersonalDetailsForm < Form
+  NAME_REGEX_FILTER = /\A[^"=$%#&*+\/\\()@?!<>0-9]*\z/
+  NINO_REGEX_FILTER = /\A[A-Z]{2}[0-9]{6}[A-D]{1}\Z/
+  DOB_PARAM_CONVERSION = {
+    "date_of_birth(3i)" => "day",
+    "date_of_birth(2i)" => "month",
+    "date_of_birth(1i)" => "year"
+  }
+
+  attribute :first_name
+  attribute :middle_name
+  attribute :surname
+  attribute :day
+  attribute :month
+  attribute :year
+  attribute :date_of_birth
+  attribute :national_insurance_number
+
+  validates :first_name, presence: {message: "Enter your first name"}
+  validates :first_name,
+    length: {maximum: 100, message: "First name must be less than 100 characters"},
+    format: {with: NAME_REGEX_FILTER, message: "First name cannot contain special characters"},
+    if: -> { first_name.present? }
+  validates :middle_name,
+    length: {maximum: 61, message: "Middle names must be less than 61 characters"},
+    format: {with: NAME_REGEX_FILTER, message: "Middle names cannot contain special characters"},
+    if: -> { middle_name.present? }
+  validates :surname, presence: {message: "Enter your last name"}
+  validates :surname,
+    length: {maximum: 100, message: "Last name must be less than 100 characters"},
+    format: {with: NAME_REGEX_FILTER, message: "Last name cannot contain special characters"},
+    if: -> { surname.present? }
+  validate :date_of_birth_criteria
+  validates :national_insurance_number, presence: {message: "Enter a National Insurance number in the correct format"}
+  validate :ni_number_is_correct_format
+
+  def initialize(claim:, journey:, params:)
+    super
+    assign_date_attributes
+  end
+
+  def date_of_birth
+    date_hash = {year:, month:, day:}
+    date_args = date_hash.values.map(&:to_i)
+
+    Date.valid_date?(*date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
+  end
+
+  def save
+    return false unless valid?
+
+    update!({first_name:, middle_name:, surname:, date_of_birth:, national_insurance_number:})
+  end
+
+  def has_valid_name?
+    valid?
+    errors.exclude?(:first_name) && errors.exclude?(:surname)
+  end
+
+  def has_valid_date_of_birth?
+    valid?
+    errors.exclude?(:date_of_birth)
+  end
+
+  def has_valid_nino?
+    valid?
+    errors.exclude?(:national_insurance_number)
+  end
+
+  private
+
+  def permitted_params
+    @permitted_params ||= params.fetch(:claim, {})
+      .permit(*attributes, *DOB_PARAM_CONVERSION.keys)
+      .transform_keys { |key| DOB_PARAM_CONVERSION.has_key?(key) ? DOB_PARAM_CONVERSION[key] : key }
+  end
+
+  def assign_date_attributes
+    self.day = permitted_params.fetch(:day, claim.date_of_birth&.day)
+    self.month = permitted_params.fetch(:month, claim.date_of_birth&.month)
+    self.year = permitted_params.fetch(:year, claim.date_of_birth&.year)
+  end
+
+  def ni_number_is_correct_format
+    errors.add(:national_insurance_number, "Enter a National Insurance number in the correct format") if national_insurance_number.present? && !normalised_ni_number.match(NINO_REGEX_FILTER)
+  end
+
+  def normalised_ni_number
+    national_insurance_number.gsub(/\s/, "").upcase
+  end
+
+  def date_of_birth_criteria
+    if date_of_birth.future?
+      errors.add(:date_of_birth, "Date of birth must be in the past")
+    elsif number_of_date_components.between?(1, 2)
+      errors.add(:date_of_birth, "Date of birth must include a day, month and year in the correct format, for example 01 01 1980")
+    elsif !date_of_birth.is_a?(Date) && number_of_date_components == 3
+      errors.add(:date_of_birth, "Enter a date of birth in the correct format")
+    elsif number_of_date_components.zero?
+      errors.add(:date_of_birth, "Enter your date of birth")
+    elsif date_of_birth.year < 1000
+      errors.add(:date_of_birth, "Year must include 4 numbers")
+    elsif date_of_birth.year <= 1900
+      errors.add(:date_of_birth, "Year must be after 1900")
+    end
+
+    errors[:date_of_birth].empty?
+  end
+
+  def number_of_date_components
+    [day, month, year].compact_blank.size
+  end
+end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -1,4 +1,10 @@
 class PersonalDetailsForm < Form
+  InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
+    def future?
+      false
+    end
+  end
+
   NAME_REGEX_FILTER = /\A[^"=$%#&*+\/\\()@?!<>0-9]*\z/
   NINO_REGEX_FILTER = /\A[A-Z]{2}[0-9]{6}[A-D]{1}\Z/
   DOB_PARAM_CONVERSION = {
@@ -94,7 +100,7 @@ class PersonalDetailsForm < Form
       errors.add(:date_of_birth, "Date of birth must be in the past")
     elsif number_of_date_components.between?(1, 2)
       errors.add(:date_of_birth, "Date of birth must include a day, month and year in the correct format, for example 01 01 1980")
-    elsif !date_of_birth.is_a?(Date) && number_of_date_components == 3
+    elsif date_of_birth.is_a?(InvalidDate) && number_of_date_components == 3
       errors.add(:date_of_birth, "Enter a date of birth in the correct format")
     elsif number_of_date_components.zero?
       errors.add(:date_of_birth, "Enter your date of birth")

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -499,12 +499,6 @@ class Claim < ApplicationRecord
     TeachersPensionsService.tps_school_for_student_loan_in_previous_financial_year(self)
   end
 
-  # dup - because we don't want to pollute the claim.errors by calling this method
-  # Used to not show the personal-details page if everything is all valid
-  def has_all_valid_personal_details?
-    dup.valid?(:"personal-details") && all_personal_details_same_as_tid?
-  end
-
   # This is used to ensure we still show the forms if the personal-details are valid
   # but are valid because they were susequently provided/changed from what was in TID
   def all_personal_details_same_as_tid?

--- a/app/models/invalid_date.rb
+++ b/app/models/invalid_date.rb
@@ -1,0 +1,9 @@
+class InvalidDate
+  include ActiveModel::Model
+
+  attr_accessor :day, :month, :year
+
+  def future?
+    false
+  end
+end

--- a/app/models/invalid_date.rb
+++ b/app/models/invalid_date.rb
@@ -1,9 +1,0 @@
-class InvalidDate
-  include ActiveModel::Model
-
-  attr_accessor :day, :month, :year
-
-  def future?
-    false
-  end
-end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -154,7 +154,7 @@ module Journeys
             replace_ecp_only_induction_not_completed_slugs(sequence)
           end
 
-          sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
+          sequence.delete("personal-details") if claim.logged_in_with_tid? && personal_details_form.valid? && claim.all_personal_details_same_as_tid?
 
           if claim.logged_in_with_tid? && claim.details_check?
             if claim.qualifications_details_check
@@ -176,6 +176,14 @@ module Journeys
       end
 
       private
+
+      def personal_details_form
+        PersonalDetailsForm.new(
+          claim:,
+          journey: Journeys::AdditionalPaymentsForTeaching,
+          params: ActionController::Parameters.new
+        )
+      end
 
       def replace_ecp_only_induction_not_completed_slugs(sequence)
         slugs = %w[

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -4,7 +4,8 @@ module Journeys
     # but needs load_paths sorting
     SHARED_FORMS = {
       "sign-in-or-continue" => SignInOrContinueForm,
-      "current-school" => CurrentSchoolForm
+      "current-school" => CurrentSchoolForm,
+      "personal-details" => PersonalDetailsForm
     }
 
     def configuration

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -86,7 +86,7 @@ module Journeys
           sequence.delete("mobile-number") if claim.provide_mobile_number == false
           sequence.delete("mobile-verification") if claim.provide_mobile_number == false
           sequence.delete("ineligible") unless claim.eligibility&.ineligible?
-          sequence.delete("personal-details") if claim.logged_in_with_tid? && claim.has_all_valid_personal_details?
+          sequence.delete("personal-details") if claim.logged_in_with_tid? && personal_details_form.valid? && claim.all_personal_details_same_as_tid?
           sequence.delete("select-email") if (claim.logged_in_with_tid == false) || claim.teacher_id_user_info["email"].nil?
           if claim.logged_in_with_tid? && claim.email_address_check?
             sequence.delete("email-address")
@@ -126,6 +126,16 @@ module Journeys
         else
           "/student-loans/claim"
         end
+      end
+
+      private
+
+      def personal_details_form
+        PersonalDetailsForm.new(
+          claim:,
+          journey: Journeys::TeacherStudentLoanReimbursement,
+          params: ActionController::Parameters.new
+        )
       end
     end
   end

--- a/app/views/claims/personal_details.html.erb
+++ b/app/views/claims/personal_details.html.erb
@@ -1,14 +1,14 @@
-<% content_for(:page_title, page_title(t("questions.personal_details"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.personal_details"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { date_of_birth: "claim_date_of_birth_3i"}) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
+    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { date_of_birth: "claim_date_of_birth_3i"}) if @form.errors.any? %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |form| %>
       <h1 class="govuk-heading-xl">
         <%= t("questions.personal_details") %>
       </h1>
 
-      <% unless current_claim.logged_in_with_tid? && current_claim.has_valid_name? && current_claim.name_same_as_tid? %>
+      <% unless current_claim.logged_in_with_tid? && @form.has_valid_name? && current_claim.name_same_as_tid? %>
       <div class="govuk-form-group govuk-!-padding-bottom-6">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="full-name-hint" id="full-name-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -17,28 +17,28 @@
             </h2>
           </legend>
 
-          <%= form_group_tag current_claim, :first_name do %>
+          <%= form_group_tag @form, :first_name do %>
             <%= form.label :first_name, "First name", class: "govuk-label" %>
-            <%= errors_tag current_claim, :first_name %>
-            <%= form.text_field :first_name, class: css_classes_for_input(current_claim, :first_name), autocomplete: "given-name" %>
+            <%= errors_tag @form, :first_name %>
+            <%= form.text_field :first_name, class: css_classes_for_input(@form, :first_name), autocomplete: "given-name" %>
           <% end %>
-          <%= form_group_tag current_claim, :middle_name do %>
+          <%= form_group_tag @form, :middle_name do %>
             <%= form.label :middle_name, "Middle names", class: "govuk-label" %>
-            <%= errors_tag current_claim, :middle_name %>
-            <%= form.text_field :middle_name, class: css_classes_for_input(current_claim, :middle_name), autocomplete: "additional-name" %>
+            <%= errors_tag @form, :middle_name %>
+            <%= form.text_field :middle_name, class: css_classes_for_input(@form, :middle_name), autocomplete: "additional-name" %>
           <% end %>
-          <%= form_group_tag current_claim, :surname do %>
+          <%= form_group_tag @form, :surname do %>
             <%= form.label :surname, "Last name", class: "govuk-label" %>
-            <%= errors_tag current_claim, :surname %>
-            <%= form.text_field :surname, class: css_classes_for_input(current_claim, :surname), autocomplete: "family-name" %>
+            <%= errors_tag @form, :surname %>
+            <%= form.text_field :surname, class: css_classes_for_input(@form, :surname), autocomplete: "family-name" %>
           <% end %>
         </fieldset>
       </div>
       <% end %>
 
-      <% unless current_claim.logged_in_with_tid? && current_claim.has_valid_date_of_birth? && current_claim.dob_same_as_tid? %>
+      <% unless current_claim.logged_in_with_tid? && @form.has_valid_date_of_birth? && current_claim.dob_same_as_tid? %>
       <div class="govuk-!-padding-bottom-6">
-        <%= form_group_tag current_claim, :date_of_birth do %>
+        <%= form_group_tag @form, :date_of_birth do %>
           <fieldset class="govuk-fieldset" role="group" aria-describedby="date-of-birth-hint" id="date-of-birth-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h2 class="govuk-fieldset__heading">
@@ -50,27 +50,27 @@
               For example, 31 03 1980. We need this information to verify your identity.
             </div>
 
-            <%= errors_tag current_claim, :date_of_birth %>
+            <%= errors_tag @form, :date_of_birth %>
             <%
-              dob_class = current_claim.errors[:date_of_birth].any? ? "govuk-input--error" : ""
+              dob_class = @form.errors[:date_of_birth].any? ? "govuk-input--error" : ""
             %>
             <div class="govuk-date-input">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
                   <%= label_tag :"claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
-                  <%= text_field_tag :"claim[date_of_birth(3i)]", form.object.date_of_birth.try(:day) || form.object.date_of_birth_day, id: "claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
+                  <%= text_field_tag :"claim[date_of_birth(3i)]", @form.date_of_birth.day, id: "claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
                 </div>
               </div>
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
                   <%= label_tag :"claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
-                  <%= text_field_tag :"claim[date_of_birth(2i)]", form.object.date_of_birth.try(:month) || form.object.date_of_birth_month, id: "claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
+                  <%= text_field_tag :"claim[date_of_birth(2i)]", @form.date_of_birth.month, id: "claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
                 </div>
               </div>
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
                   <%= label_tag :"claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
-                  <%= text_field_tag :"claim[date_of_birth(1i)]", form.object.date_of_birth.try(:year) || form.object.date_of_birth_year, id: "claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4 #{dob_class}", type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
+                  <%= text_field_tag :"claim[date_of_birth(1i)]", @form.date_of_birth.year, id: "claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4 #{dob_class}", type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
                 </div>
               </div>
             </div>
@@ -79,23 +79,22 @@
       </div>
       <% end %>
 
-      <% unless current_claim.logged_in_with_tid? && current_claim.has_valid_nino? && current_claim.nino_same_as_tid? %>
+      <% unless current_claim.logged_in_with_tid? && @form.has_valid_nino? && current_claim.nino_same_as_tid? %>
       <div class="govuk-!-padding-bottom-6">
-        <%= form_group_tag current_claim, :national_insurance_number do %>
+        <%= form_group_tag @form, :national_insurance_number do %>
           <h2 class="govuk-label-wrapper">
             <%= form.label :national_insurance_number, t("questions.national_insurance_number"), {class: "govuk-label govuk-label--l"}  %>
           </h2>
 
           <div class="govuk-hint" id="national_insurance_number-hint">
-            It's on your National Insurance card, benefit letter, payslip or P60. For
-            example 'QQ123456C'.
+            It's on your National Insurance card, benefit letter, payslip or P60. For example 'QQ123456C'.
           </div>
 
-          <%= errors_tag current_claim, :national_insurance_number %>
+          <%= errors_tag @form, :national_insurance_number %>
           <%= form.text_field :national_insurance_number,
                 spellcheck: "false",
                 autocomplete: "off",
-                class: css_classes_for_input(current_claim, :national_insurance_number, 'govuk-input--width-10'),
+                class: css_classes_for_input(@form, :national_insurance_number, 'govuk-input--width-10'),
                 "aria-describedby" => "national_insurance_number-hint" %>
           <% end %>
       </div>

--- a/app/views/claims/personal_details.html.erb
+++ b/app/views/claims/personal_details.html.erb
@@ -8,96 +8,96 @@
         <%= t("questions.personal_details") %>
       </h1>
 
-      <% unless current_claim.logged_in_with_tid? && @form.has_valid_name? && current_claim.name_same_as_tid? %>
-      <div class="govuk-form-group govuk-!-padding-bottom-6">
-        <fieldset class="govuk-fieldset" role="group" aria-describedby="full-name-hint" id="full-name-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading govuk-!-padding-bottom-3" id="full-name-hint">
-              <%= t("questions.name") %>
-            </h2>
-          </legend>
-
-          <%= form_group_tag @form, :first_name do %>
-            <%= form.label :first_name, "First name", class: "govuk-label" %>
-            <%= errors_tag @form, :first_name %>
-            <%= form.text_field :first_name, class: css_classes_for_input(@form, :first_name), autocomplete: "given-name" %>
-          <% end %>
-          <%= form_group_tag @form, :middle_name do %>
-            <%= form.label :middle_name, "Middle names", class: "govuk-label" %>
-            <%= errors_tag @form, :middle_name %>
-            <%= form.text_field :middle_name, class: css_classes_for_input(@form, :middle_name), autocomplete: "additional-name" %>
-          <% end %>
-          <%= form_group_tag @form, :surname do %>
-            <%= form.label :surname, "Last name", class: "govuk-label" %>
-            <%= errors_tag @form, :surname %>
-            <%= form.text_field :surname, class: css_classes_for_input(@form, :surname), autocomplete: "family-name" %>
-          <% end %>
-        </fieldset>
-      </div>
-      <% end %>
-
-      <% unless current_claim.logged_in_with_tid? && @form.has_valid_date_of_birth? && current_claim.dob_same_as_tid? %>
-      <div class="govuk-!-padding-bottom-6">
-        <%= form_group_tag @form, :date_of_birth do %>
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-of-birth-hint" id="date-of-birth-fieldset">
+      <% if @form.show_name_section? %>
+        <div class="govuk-form-group govuk-!-padding-bottom-6">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="full-name-hint" id="full-name-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h2 class="govuk-fieldset__heading">
-                <%= t("questions.date_of_birth") %>
+              <h2 class="govuk-fieldset__heading govuk-!-padding-bottom-3" id="full-name-hint">
+                <%= t("questions.name") %>
               </h2>
             </legend>
 
-            <div id="date-of-birth-hint" class="govuk-hint">
-              For example, 31 03 1980. We need this information to verify your identity.
-            </div>
-
-            <%= errors_tag @form, :date_of_birth %>
-            <%
-              dob_class = @form.errors[:date_of_birth].any? ? "govuk-input--error" : ""
-            %>
-            <div class="govuk-date-input">
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <%= label_tag :"claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
-                  <%= text_field_tag :"claim[date_of_birth(3i)]", @form.date_of_birth.day, id: "claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
-                </div>
-              </div>
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <%= label_tag :"claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
-                  <%= text_field_tag :"claim[date_of_birth(2i)]", @form.date_of_birth.month, id: "claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
-                </div>
-              </div>
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <%= label_tag :"claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
-                  <%= text_field_tag :"claim[date_of_birth(1i)]", @form.date_of_birth.year, id: "claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4 #{dob_class}", type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
-                </div>
-              </div>
-            </div>
+            <%= form_group_tag @form, :first_name do %>
+              <%= form.label :first_name, "First name", class: "govuk-label" %>
+              <%= errors_tag @form, :first_name %>
+              <%= form.text_field :first_name, class: css_classes_for_input(@form, :first_name), autocomplete: "given-name" %>
+            <% end %>
+            <%= form_group_tag @form, :middle_name do %>
+              <%= form.label :middle_name, "Middle names", class: "govuk-label" %>
+              <%= errors_tag @form, :middle_name %>
+              <%= form.text_field :middle_name, class: css_classes_for_input(@form, :middle_name), autocomplete: "additional-name" %>
+            <% end %>
+            <%= form_group_tag @form, :surname do %>
+              <%= form.label :surname, "Last name", class: "govuk-label" %>
+              <%= errors_tag @form, :surname %>
+              <%= form.text_field :surname, class: css_classes_for_input(@form, :surname), autocomplete: "family-name" %>
+            <% end %>
           </fieldset>
-        <% end %>
-      </div>
+        </div>
       <% end %>
 
-      <% unless current_claim.logged_in_with_tid? && @form.has_valid_nino? && current_claim.nino_same_as_tid? %>
-      <div class="govuk-!-padding-bottom-6">
-        <%= form_group_tag @form, :national_insurance_number do %>
-          <h2 class="govuk-label-wrapper">
-            <%= form.label :national_insurance_number, t("questions.national_insurance_number"), {class: "govuk-label govuk-label--l"}  %>
-          </h2>
+      <% if @form.show_date_of_birth_section? %>
+        <div class="govuk-!-padding-bottom-6">
+          <%= form_group_tag @form, :date_of_birth do %>
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-of-birth-hint" id="date-of-birth-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h2 class="govuk-fieldset__heading">
+                  <%= t("questions.date_of_birth") %>
+                </h2>
+              </legend>
 
-          <div class="govuk-hint" id="national_insurance_number-hint">
-            It's on your National Insurance card, benefit letter, payslip or P60. For example 'QQ123456C'.
-          </div>
+              <div id="date-of-birth-hint" class="govuk-hint">
+                For example, 31 03 1980. We need this information to verify your identity.
+              </div>
 
-          <%= errors_tag @form, :national_insurance_number %>
-          <%= form.text_field :national_insurance_number,
-                spellcheck: "false",
-                autocomplete: "off",
-                class: css_classes_for_input(@form, :national_insurance_number, 'govuk-input--width-10'),
-                "aria-describedby" => "national_insurance_number-hint" %>
+              <%= errors_tag @form, :date_of_birth %>
+              <%
+                dob_class = @form.errors[:date_of_birth].any? ? "govuk-input--error" : ""
+              %>
+              <div class="govuk-date-input">
+                <div class="govuk-date-input__item">
+                  <div class="govuk-form-group">
+                    <%= label_tag :"claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
+                    <%= text_field_tag :"claim[date_of_birth(3i)]", @form.date_of_birth.day, id: "claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
+                  </div>
+                </div>
+                <div class="govuk-date-input__item">
+                  <div class="govuk-form-group">
+                    <%= label_tag :"claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
+                    <%= text_field_tag :"claim[date_of_birth(2i)]", @form.date_of_birth.month, id: "claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
+                  </div>
+                </div>
+                <div class="govuk-date-input__item">
+                  <div class="govuk-form-group">
+                    <%= label_tag :"claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
+                    <%= text_field_tag :"claim[date_of_birth(1i)]", @form.date_of_birth.year, id: "claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4 #{dob_class}", type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
           <% end %>
-      </div>
+        </div>
+      <% end %>
+
+      <% if @form.show_nino_section? %>
+        <div class="govuk-!-padding-bottom-6">
+          <%= form_group_tag @form, :national_insurance_number do %>
+            <h2 class="govuk-label-wrapper">
+              <%= form.label :national_insurance_number, t("questions.national_insurance_number"), {class: "govuk-label govuk-label--l"}  %>
+            </h2>
+
+            <div class="govuk-hint" id="national_insurance_number-hint">
+              It's on your National Insurance card, benefit letter, payslip or P60. For example 'QQ123456C'.
+            </div>
+
+            <%= errors_tag @form, :national_insurance_number %>
+            <%= form.text_field :national_insurance_number,
+                  spellcheck: "false",
+                  autocomplete: "off",
+                  class: css_classes_for_input(@form, :national_insurance_number, 'govuk-input--width-10'),
+                  "aria-describedby" => "national_insurance_number-hint" %>
+            <% end %>
+        </div>
       <% end %>
 
       <%= form.submit "Continue", class: "govuk-button" %>

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -25,72 +25,178 @@ RSpec.describe PersonalDetailsForm, type: :model do
       end
     end
 
-    describe "#has_valid_name?" do
-      context "valid" do
-        let(:params) { {first_name: "John", surname: "Doe"} }
-
+    describe "#show_name_section?" do
+      context "when not logged_in_with_tid" do
         it "returns true" do
-          expect(form.has_valid_name?).to be true
+          expect(form.show_name_section?).to be_truthy
         end
       end
 
-      context "invalid first_name" do
-        let(:params) { {first_name: "J@hn", surname: "Doe"} }
+      context "when logged_in_with_tid" do
+        let(:logged_in_with_tid) { true }
+        let(:teacher_id_user_info) {
+          {
+            "given_name" => given_name,
+            "family_name" => family_name
+          }
+        }
 
-        it "returns false" do
-          expect(form.has_valid_name?).to be false
+        context "when the name is different to TID" do
+          let(:given_name) { "John" }
+          let(:family_name) { "Doe" }
+
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy:, first_name: "Different", surname: "Doe", logged_in_with_tid:, teacher_id_user_info:) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          it "returns true" do
+            expect(form.show_name_section?).to be_truthy
+          end
         end
-      end
 
-      context "invalid surname" do
-        let(:params) { {first_name: "J@hn", surname: "D@e"} }
+        context "when the name is the same as TID" do
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy:, first_name: given_name, surname: family_name, logged_in_with_tid:, teacher_id_user_info:) }
+            CurrentClaim.new(claims: claims)
+          end
 
-        it "returns false" do
-          expect(form.has_valid_name?).to be false
-        end
-      end
+          context "when the name is not valid" do
+            let(:given_name) { "John" }
+            let(:family_name) { "D@e" }
 
-      context "blank" do
-        let(:params) { {first_name: "", surname: ""} }
+            it "returns true" do
+              expect(form.show_name_section?).to be_truthy
+            end
+          end
 
-        it "returns false" do
-          expect(form.has_valid_name?).to be false
+          context "when the name is blank" do
+            let(:given_name) { "" }
+            let(:family_name) { "Doe" }
+
+            it "returns true" do
+              expect(form.show_name_section?).to be_truthy
+            end
+          end
+
+          context "when the name is valid" do
+            let(:given_name) { "John" }
+            let(:family_name) { "Doe" }
+
+            it "returns false" do
+              expect(form.show_name_section?).to be_falsey
+            end
+          end
         end
       end
     end
 
-    describe "#has_valid_date_of_birth?" do
-      context "valid" do
-        let(:params) { {day: 11, month: 1, year: 1980} }
-
+    describe "#show_date_of_birth_section?" do
+      context "when not logged_in_with_tid" do
         it "returns true" do
-          expect(form.has_valid_date_of_birth?).to be true
+          expect(form.show_date_of_birth_section?).to be_truthy
         end
       end
 
-      context "nil" do
-        let(:params) { {day: nil, month: nil, year: nil} }
+      context "when logged_in_with_tid" do
+        let(:logged_in_with_tid) { true }
+        let(:teacher_id_user_info) {
+          {
+            "birthdate" => birthdate
+          }
+        }
 
-        it "returns false" do
-          expect(form.has_valid_date_of_birth?).to be false
+        context "when the date_of_birth is different to TID" do
+          let(:birthdate) { "1990-01-01" }
+
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy:, date_of_birth: Date.new(1990, 2, 2), logged_in_with_tid:, teacher_id_user_info:) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          it "returns true" do
+            expect(form.show_date_of_birth_section?).to be_truthy
+          end
+        end
+
+        context "when the date_of_birth is the same as TID" do
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy:, date_of_birth:, logged_in_with_tid:, teacher_id_user_info:) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          context "when the date_of_birth is blank" do
+            let(:birthdate) { "" }
+            let(:date_of_birth) { nil }
+
+            it "returns true" do
+              expect(form.show_date_of_birth_section?).to be_truthy
+            end
+          end
+
+          context "when the date_of_birth is valid" do
+            let(:birthdate) { "1990-01-01" }
+            let(:date_of_birth) { Date.new(1990, 1, 1) }
+
+            it "returns false" do
+              expect(form.show_date_of_birth_section?).to be_falsey
+            end
+          end
         end
       end
     end
 
-    describe "#has_valid_nino?" do
-      context "valid" do
-        let(:params) { {national_insurance_number: "JH001234D"} }
-
+    describe "#show_nino_section?" do
+      context "when not logged_in_with_tid" do
         it "returns true" do
-          expect(form.has_valid_nino?).to be true
+          expect(form.show_nino_section?).to be_truthy
         end
       end
 
-      context "nil" do
-        let(:nino) { nil }
+      context "when logged_in_with_tid" do
+        let(:logged_in_with_tid) { true }
+        let(:teacher_id_user_info) {
+          {
+            "ni_number" => ni_number
+          }
+        }
 
-        it "returns false" do
-          expect(form.has_valid_nino?).to be false
+        context "when the national_insurance_number is different to TID" do
+          let(:ni_number) { "AB123456C" }
+
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy:, national_insurance_number: "AB123456D", logged_in_with_tid:, teacher_id_user_info:) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          it "returns true" do
+            expect(form.show_nino_section?).to be_truthy
+          end
+        end
+
+        context "when the national_insurance_number is the same as TID" do
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy:, national_insurance_number:, logged_in_with_tid:, teacher_id_user_info:) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          context "when the national_insurance_number is blank" do
+            let(:ni_number) { "" }
+            let(:national_insurance_number) { nil }
+
+            it "returns true" do
+              expect(form.show_nino_section?).to be_truthy
+            end
+          end
+
+          context "when the national_insurance_number is valid" do
+            let(:ni_number) { "AB123456C" }
+            let(:national_insurance_number) { ni_number }
+
+            it "returns false" do
+              expect(form.show_nino_section?).to be_falsey
+            end
+          end
         end
       end
     end

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -1,0 +1,209 @@
+require "rails_helper"
+
+RSpec.describe PersonalDetailsForm, type: :model do
+  shared_examples "personal_details_form" do |journey|
+    before {
+      create(:journey_configuration, :student_loans)
+      create(:journey_configuration, :additional_payments)
+    }
+
+    let(:current_claim) do
+      claims = journey::POLICIES.map { |policy| create(:claim, policy: policy) }
+      CurrentClaim.new(claims: claims)
+    end
+
+    let(:slug) { "personal-details" }
+    let(:params) { {} }
+
+    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new(slug:, claim: params)) }
+
+    context "unpermitted claim param" do
+      let(:params) { {nonsense_id: 1} }
+
+      it "raises an error" do
+        expect { form }.to raise_error ActionController::UnpermittedParameters
+      end
+    end
+
+    describe "#has_valid_name?" do
+      context "valid" do
+        let(:params) { {first_name: "John", surname: "Doe"} }
+
+        it "returns true" do
+          expect(form.has_valid_name?).to be true
+        end
+      end
+
+      context "invalid first_name" do
+        let(:params) { {first_name: "J@hn", surname: "Doe"} }
+
+        it "returns false" do
+          expect(form.has_valid_name?).to be false
+        end
+      end
+
+      context "invalid surname" do
+        let(:params) { {first_name: "J@hn", surname: "D@e"} }
+
+        it "returns false" do
+          expect(form.has_valid_name?).to be false
+        end
+      end
+
+      context "blank" do
+        let(:params) { {first_name: "", surname: ""} }
+
+        it "returns false" do
+          expect(form.has_valid_name?).to be false
+        end
+      end
+    end
+
+    describe "#has_valid_date_of_birth?" do
+      context "valid" do
+        let(:params) { {day: 11, month: 1, year: 1980} }
+
+        it "returns true" do
+          expect(form.has_valid_date_of_birth?).to be true
+        end
+      end
+
+      context "nil" do
+        let(:params) { {day: nil, month: nil, year: nil} }
+
+        it "returns false" do
+          expect(form.has_valid_date_of_birth?).to be false
+        end
+      end
+    end
+
+    describe "#has_valid_nino?" do
+      context "valid" do
+        let(:params) { {national_insurance_number: "JH001234D"} }
+
+        it "returns true" do
+          expect(form.has_valid_nino?).to be true
+        end
+      end
+
+      context "nil" do
+        let(:nino) { nil }
+
+        it "returns false" do
+          expect(form.has_valid_nino?).to be false
+        end
+      end
+    end
+
+    describe "validations" do
+      it { should validate_presence_of(:first_name).with_message("Enter your first name") }
+      it { should validate_length_of(:first_name).is_at_most(100).with_message("First name must be less than 100 characters") }
+      it { should_not allow_value("*").for(:first_name).with_message("First name cannot contain special characters") }
+      it { should allow_value("O'Brian").for(:first_name) }
+
+      it { should validate_length_of(:middle_name).is_at_most(61).with_message("Middle names must be less than 61 characters") }
+      it { should_not allow_value("&").for(:middle_name).with_message("Middle names cannot contain special characters") }
+      it { should allow_value("O'Brian").for(:middle_name) }
+
+      it { should validate_presence_of(:surname).with_message("Enter your last name") }
+      it { should validate_length_of(:surname).is_at_most(100).with_message("Last name must be less than 100 characters") }
+      it { should_not allow_value("$").for(:surname).with_message("Last name cannot contain special characters") }
+      it { should allow_value("O'Brian").for(:surname) }
+
+      it { should validate_presence_of(:national_insurance_number).with_message("Enter a National Insurance number in the correct format") }
+      it { should allow_value("QQ123456C").for(:national_insurance_number) }
+      it { should allow_value("QQ 34 56 78 C").for(:national_insurance_number) }
+      it { should_not allow_value("12 34 56 78 C").for(:national_insurance_number) }
+      it { should_not allow_value("QQ 11 56 78 DE").for(:national_insurance_number) }
+
+      describe "#date_of_birth" do
+        before do
+          form.validate
+        end
+
+        context "when in the future" do
+          let(:params) { {day: 1, month: 1, year: Time.zone.today.year + 1} }
+
+          it "returns an error" do
+            expect(form.errors[:date_of_birth]).to include("Date of birth must be in the past")
+          end
+        end
+
+        context "when it's incomplete" do
+          let(:params) { {day: nil, month: 1, year: 1990} }
+
+          it "returns an error" do
+            expect(form.errors[:date_of_birth]).to include("Date of birth must include a day, month and year in the correct format, for example 01 01 1980")
+          end
+        end
+
+        context "when it's complete but invalid" do
+          let(:params) { {day: 1, month: 13, year: 1990} }
+
+          it "returns an error" do
+            expect(form.errors[:date_of_birth]).to include("Enter a date of birth in the correct format")
+          end
+        end
+
+        context "when it's missing" do
+          let(:params) { {day: nil, month: nil, year: nil} }
+
+          it "returns an error" do
+            expect(form.errors[:date_of_birth]).to include("Enter your date of birth")
+          end
+        end
+        context "when the year doesn't have 4 digits" do
+          let(:params) { {day: 1, month: 1, year: 90} }
+
+          it "returns an error" do
+            expect(form.errors[:date_of_birth]).to include("Year must include 4 numbers")
+          end
+        end
+
+        context "when the year is before 1900" do
+          let(:params) { {day: 1, month: 1, year: 1899} }
+
+          it "returns an error" do
+            expect(form.errors[:date_of_birth]).to include("Year must be after 1900")
+          end
+        end
+      end
+    end
+
+    describe "#save" do
+      context "with valid params" do
+        let(:params) do
+          {
+            first_name: "Dr",
+            middle_name: "Bob",
+            surname: "Loblaw",
+            day: 1,
+            month: 1,
+            year: 1990,
+            national_insurance_number: "QQ123456C"
+          }
+        end
+
+        it "updates the claim" do
+          expect(form.save).to be true
+
+          current_claim.claims.each do |claim|
+            expect(claim.first_name).to eq "Dr"
+            expect(claim.middle_name).to eq "Bob"
+            expect(claim.surname).to eq "Loblaw"
+            expect(claim.date_of_birth).to eq Date.new(1990, 1, 1)
+            expect(claim.national_insurance_number).to eq "QQ123456C"
+          end
+        end
+      end
+    end
+  end
+
+  describe "for TeacherStudentLoanReimbursement journey" do
+    include_examples "personal_details_form", Journeys::TeacherStudentLoanReimbursement
+  end
+
+  describe "for AdditionalPaymentsForTeaching journey" do
+    include_examples "personal_details_form", Journeys::AdditionalPaymentsForTeaching
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1440,59 +1440,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "#has_all_valid_personal_details?" do
-    context "first_name, surname, dob and nino are the same as tid" do
-      let(:claim) {
-        create(
-          :claim,
-          :submitted,
-          first_name: "John", surname: "Doe",
-          date_of_birth: Date.new(1980, 1, 11),
-          national_insurance_number: "JH001234D",
-          teacher_id_user_info: {"given_name" => "John", "family_name" => "Doe", "birthdate" => "1980-01-11", "ni_number" => "JH001234D"}
-        )
-      }
-
-      it "returns true" do
-        expect(claim.has_all_valid_personal_details?).to be true
-      end
-    end
-
-    context "nino is empty" do
-      let(:claim) {
-        create(
-          :claim,
-          :submitted,
-          first_name: "John", surname: "Doe",
-          date_of_birth: Date.new(1980, 1, 11),
-          national_insurance_number: "JH001234D",
-          teacher_id_user_info: {"given_name" => "John", "family_name" => "Doe", "birthdate" => "1980-01-11", "ni_number" => nil}
-        )
-      }
-
-      it "returns false" do
-        expect(claim.has_all_valid_personal_details?).to be false
-      end
-    end
-
-    context "first_name and surname is invalid" do
-      let(:claim) {
-        create(
-          :claim,
-          :submitted,
-          first_name: "J@hn", surname: "D@e",
-          date_of_birth: Date.new(1980, 1, 11),
-          national_insurance_number: "JH001234D",
-          teacher_id_user_info: {"given_name" => "John", "family_name" => "Doe", "birthdate" => "1980-01-11", "ni_number" => "JH001234D"}
-        )
-      }
-
-      it "returns false" do
-        expect(claim.has_all_valid_personal_details?).to be false
-      end
-    end
-  end
-
   describe "#has_dqt_record?" do
     let(:claim) { build(:claim, dqt_teacher_status:) }
     subject(:result) { claim.has_dqt_record? }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -62,15 +62,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  context "that has a National Insurance number" do
-    it "validates that the National Insurance number is in the correct format" do
-      expect(build(:claim, national_insurance_number: "12 34 56 78 C")).not_to be_valid
-      expect(build(:claim, national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
-
-      expect(build(:claim, national_insurance_number: "QQ 34 56 78 C")).to be_valid
-    end
-  end
-
   context "that has a postcode" do
     it "validates the length of postcode is not greater than 11" do
       expect(build(:claim, postcode: "M12345 23453WD")).not_to be_valid
@@ -177,52 +168,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  context "when validating in the 'personal-details' context" do
-    describe "with first_name" do
-      it "is not valid without a value between 1 and 100 characters" do
-        expect(build(:claim, policy: Policies::EarlyCareerPayments)).not_to be_valid(:"personal-details")
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, first_name: "")).not_to be_valid(:"personal-details")
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, first_name: "A" * 101)).not_to be_valid(:"personal-details")
-      end
-
-      it "is valid when is between 1 and 100 characters in length" do
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments)).to be_valid(:"personal-details")
-      end
-
-      it "allows user to enter ' in their surname and joins the first name and surname together" do
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, first_name: "O'Brian", surname: "Isambard")).to be_valid(:"personal-details")
-      end
-    end
-
-    describe "with middle names" do
-      it "validates the length of middle name is 61 characters or less" do
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, middle_name: "ab" * 31)).not_to be_valid(:"personal-details")
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, middle_name: "a" * 61)).to be_valid(:"personal-details")
-        expect(build(:claim, middle_name: "Arnold")).to be_valid
-      end
-
-      it "allows user to enter ' in their middle name and joins the first name and surname together" do
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, first_name: "Isambard", middle_name: "O’Hara")).to be_valid(:"personal-details")
-      end
-    end
-
-    describe "with surname" do
-      it "is not valid without a value between 1 and 100 characters" do
-        expect(build(:claim, policy: Policies::EarlyCareerPayments)).not_to be_valid(:"personal-details")
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, surname: "")).not_to be_valid(:"personal-details")
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, surname: "A" * 101)).not_to be_valid(:"personal-details")
-      end
-
-      it "is valid when is between 1 and 100 characters in length" do
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, surname: "A")).to be_valid(:"personal-details")
-      end
-
-      it "allows user to enter ' in their middle_name and includes a surname when present" do
-        expect(build(:claim, :submittable, policy: Policies::EarlyCareerPayments, first_name: "Isambard", middle_name: "Brunel", surname: "O’Hara")).to be_valid(:"personal-details")
-      end
-    end
-  end
-
   context "when saving in the “address” validation context" do
     it "validates the presence of address_line_1 and postcode" do
       expect(build(:claim)).not_to be_valid(:address)
@@ -232,96 +177,10 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  context "with early-career payments policy validates 'date_of_birth' in the 'personal-details' context" do
-    it "is on or after 1st Jan 1900" do
-      expect(build(:claim, first_name: "Martha", surname: "Stevens", national_insurance_number: "AB755003B", policy: Policies::EarlyCareerPayments, date_of_birth: Date.new(1899, 12, 31))).not_to be_valid(:"personal-details")
-    end
-
-    it "must be in the past" do
-      expect(build(:claim, first_name: "Matthew", surname: "Cook", national_insurance_number: "EF755003B", policy: Policies::EarlyCareerPayments, date_of_birth: Date.today + 5)).not_to be_valid(:"personal-details")
-    end
-
-    it "must include day/month/year" do
-      expect { build(:claim, first_name: "Wayne", surname: "Lee", national_insurance_number: "TX551003B", policy: Policies::EarlyCareerPayments, date_of_birth: Date.new(2021, 31)) }.to raise_error(ArgumentError)
-    end
-
-    it "must be in the right format" do
-      expect { build(:claim, first_name: "Hannah", surname: "Clay-Simmones", national_insurance_number: "TX661003C", policy: Policies::EarlyCareerPayments, date_of_birth: Date.new(1998, 14, 12)) }.to raise_error("invalid date")
-    end
-  end
-
-  context "with student loans policy validates 'date_of_birth' in the 'personal-details' context" do
-    let(:claim) do
-      build(
-        :claim,
-        first_name: "Molly",
-        surname: "Ringwald",
-        national_insurance_number: "EF755003B",
-        policy: Policies::StudentLoans,
-        date_of_birth: date_of_birth
-      )
-    end
-
-    context "when date is on or after 1st Jan 1900" do
-      let(:date_of_birth) { Date.new(1899, 12, 31) }
-
-      it "is invalid" do
-        expect(claim).not_to be_valid(:"personal-details")
-        expect(claim.errors.messages[:date_of_birth]).to eq(["Year must be after 1900"])
-      end
-    end
-
-    context "when the year has fewer than 4 digits" do
-      let(:date_of_birth) { Date.new(999, 12, 31) }
-
-      it "is invalid" do
-        expect(claim).not_to be_valid(:"personal-details")
-        expect(claim.errors.messages[:date_of_birth]).to eq(["Year must include 4 numbers"])
-      end
-    end
-
-    context "when date is in the future" do
-      let(:date_of_birth) { Date.today + 5 }
-
-      it "is invalid" do
-        expect(claim).not_to be_valid(:"personal-details")
-        expect(claim.errors.messages[:date_of_birth]).to eq(["Date of birth must be in the past"])
-      end
-    end
-
-    context "when date is missing" do
-      let(:date_of_birth) { nil }
-
-      it "is invalid" do
-        expect(claim).not_to be_valid(:"personal-details")
-        expect(claim.errors.messages[:date_of_birth]).to eq(["Enter your date of birth"])
-      end
-    end
-
-    it "must include day/month/year" do
-      expect { build(:claim, first_name: "Grace", surname: "Hollywell", national_insurance_number: "TX668003B", policy: Policies::StudentLoans, date_of_birth: Date.new(2021, 31)) }.to raise_error(ArgumentError)
-    end
-
-    it "must be in the right format" do
-      expect { build(:claim, first_name: "Lara", surname: "Royce-Simmones", national_insurance_number: "TX113203D", policy: Policies::StudentLoans, date_of_birth: Date.new(1994, 14, 10)) }.to raise_error("invalid date")
-    end
-  end
-
   context "when saving in the “teacher-reference-number” validation context" do
     it "validates the presence of teacher_reference_number" do
       expect(build(:claim)).not_to be_valid(:"teacher-reference-number")
       expect(build(:claim, teacher_reference_number: "1234567")).to be_valid(:"teacher-reference-number")
-    end
-  end
-
-  context "when saving in the “personal-details” validation context" do
-    it "validates the presence of national_insurance_number" do
-      expect(build(:claim)).not_to be_valid(:"personal-details")
-      expect(build(:claim,
-        national_insurance_number: "QQ123456C",
-        first_name: "Walter",
-        surname: "Somersmith",
-        date_of_birth: Date.new(1987, 2, 2))).to be_valid(:"personal-details")
     end
   end
 
@@ -1630,113 +1489,6 @@ RSpec.describe Claim, type: :model do
 
       it "returns false" do
         expect(claim.has_all_valid_personal_details?).to be false
-      end
-    end
-  end
-
-  describe "#has_valid_name?" do
-    let(:claim) {
-      create(
-        :claim,
-        :submitted,
-        first_name: first_name, surname: surname,
-        date_of_birth: Date.new(1980, 1, 11),
-        national_insurance_number: "JH001234D",
-        teacher_id_user_info: {"given_name" => "John", "family_name" => "Doe", "birthdate" => "1980-01-11", "ni_number" => "JH001234D"}
-      )
-    }
-
-    context "valid" do
-      let(:first_name) { "John" }
-      let(:surname) { "Doe" }
-
-      it "returns true" do
-        expect(claim.has_valid_name?).to be true
-      end
-    end
-
-    context "invalid first_name" do
-      let(:first_name) { "J@hn" }
-      let(:surname) { "Doe" }
-
-      it "returns false" do
-        expect(claim.has_valid_name?).to be false
-      end
-    end
-
-    context "invalid surname" do
-      let(:first_name) { "John" }
-      let(:surname) { "D@e" }
-
-      it "returns false" do
-        expect(claim.has_valid_name?).to be false
-      end
-    end
-
-    context "blank" do
-      let(:first_name) { "" }
-      let(:surname) { "" }
-
-      it "returns false" do
-        expect(claim.has_valid_name?).to be false
-      end
-    end
-  end
-
-  describe "#has_valid_date_of_birth?" do
-    let(:claim) {
-      create(
-        :claim,
-        :submitted,
-        first_name: "John", surname: "Doe",
-        date_of_birth: dob,
-        national_insurance_number: "JH001234D",
-        teacher_id_user_info: {"given_name" => "John", "family_name" => "Doe", "birthdate" => "1980-01-11", "ni_number" => "JH001234D"}
-      )
-    }
-
-    context "valid" do
-      let(:dob) { Date.new(1980, 1, 11) }
-
-      it "returns true" do
-        expect(claim.has_valid_date_of_birth?).to be true
-      end
-    end
-
-    context "nil" do
-      let(:dob) { nil }
-
-      it "returns false" do
-        expect(claim.has_valid_date_of_birth?).to be false
-      end
-    end
-  end
-
-  describe "#has_valid_nino?" do
-    let(:claim) {
-      create(
-        :claim,
-        :submitted,
-        first_name: "John", surname: "Doe",
-        date_of_birth: Date.new(1980, 1, 11),
-        national_insurance_number: nino,
-        teacher_id_user_info: {"given_name" => "John", "family_name" => "Doe", "birthdate" => "1980-01-11", "ni_number" => "JH001234D"}
-      )
-    }
-
-    context "valid" do
-      let(:nino) { "JH001234D" }
-
-      it "returns true" do
-        expect(claim.has_valid_nino?).to be true
-      end
-    end
-
-    context "nil" do
-      let(:nino) { nil }
-
-      it "returns false" do
-        expect(claim.has_valid_nino?).to be false
       end
     end
   end


### PR DESCRIPTION
Extracting the /personal-details into a form object.

### Points to note

**Personal details validations being called from slug sequences** 

Before these changes, there was a method on the `Claim` model `has_all_valid_personal_details?` which checked whether the personal details were valid, and that they matched TID:

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2696/files#diff-177255fb498b99ec75c3866174729f24e11d030819b91655a5913b28669505c2R505-R507

This was called from the SlugSequences to determine whether to remove `/personal-details` completely.

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb#L160

Since this PR removes personal details validations from the model and shifts them into the form, I've had to instantiate a PersonalDetailsForm in both SlugSequences in order to perform the check.

**Before_save normalisations** 
The `before_save`s  like `normalise_first_names` are still in the `Claim` model

**Error translations**
I wasn't sure whether to shift these into locales because they are identical for both journeys so would lead to a lot of repetition in en.yml.

**Date of birth validation**
I've  tidied up the `date_of_birth` validation by introducing an `InvalidDate` struct in the form. This way the attribute `date_of_birth` always exists on the form and you can always call `day`, `month` and `year` on it.