### PR TITLE
CAPT 1622/github actions for ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,86 @@
+name: CI
+
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Linting - ShellCheck
+        run: bin/rake shellcheck
+      - name: Linting - Brakeman
+        run: bundle exec brakeman -c config/brakeman.ignore
+      - name: Linting - Standardrb
+        run: bin/rails standard
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [8]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - '5432:5432'
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD: password
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: localhost
+      CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+      CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Restore assets cache
+        id: assets-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+          key: assets-${{ hashFiles('**/app/assets/**/*', '**/app/javascript/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-assets-
+      - name: Prepare assets
+        if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
+        run: bin/rails assets:precompile
+      - name: Save assets cache
+        if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public/assets
+          key: ${{ steps.assets-cache.outputs.cache-primary-key }}
+      - name: Prepare DB
+        run: bin/rails db:prepare
+      - name: Run unit tests
+        env:
+          SPEC_TYPE: unit
+        run: bundle exec rspec $(bin/test_splitter)
+      - name: Run feature tests
+        env:
+          SPEC_TYPE: feature
+        run: bundle exec rspec $(bin/test_splitter)

--- a/bin/test_splitter
+++ b/bin/test_splitter
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# Use on ci to split tests by file type and split them across ci nodes
+
+all_specs = Dir["spec/**/*_spec.rb"]
+
+case ENV["SPEC_TYPE"]
+when "unit"
+  specs = all_specs.reject { |path| /\Aspec\/features\//.match? path }
+when "feature"
+  specs = all_specs.select { |path| /\Aspec\/features\//.match? path }
+else
+  specs = all_specs
+end
+
+number_of_ci_nodes = ENV.fetch("CI_NODE_TOTAL").to_i
+
+this_ci_node = ENV.fetch("CI_NODE_INDEX").to_i
+
+number_of_slices = (specs.size / number_of_ci_nodes.to_f).ceil
+
+specs_split_across_nodes = specs.each_slice(number_of_slices).to_a
+
+specs_to_run_on_this_node = specs_split_across_nodes[this_ci_node]
+
+print specs_to_run_on_this_node.join(" ")


### PR DESCRIPTION
Use github actions for ci.
Runs the linters and test suite.

We run the test over multiple nodes using github actions matrices. The newly
introduced script `bin/test_splitter` handles breaking up the test suite into
sections that run on each node.
There isn't away (at least not one I know of) to cache the set up steps between
nodes, however as the bulk of CI time is spend on running the test suite this
isn't much of an issue (~1min for set up ~9mins for longest node to run).
Splitting the test suite across nodes means we can improve our test suite time
by breaking up some of the slower running feature specs into separate files so
different nodes pick them up.
