### PR TITLE
Add teacher_reference_number form

### DIFF
--- a/app/forms/teacher_reference_number_form.rb
+++ b/app/forms/teacher_reference_number_form.rb
@@ -1,6 +1,10 @@
 class TeacherReferenceNumberForm < Form
   attribute :teacher_reference_number
 
+  before_validation do
+    self.teacher_reference_number = teacher_reference_number&.gsub(/\D/, "")
+  end
+
   validates :teacher_reference_number,
     presence: {
       message: ->(form, _) { form.i18n_errors_path("blank") }
@@ -11,11 +15,6 @@ class TeacherReferenceNumberForm < Form
       is: 7,
       message: ->(form, _) { form.i18n_errors_path("length") }
     }, if: -> { teacher_reference_number.present? }
-
-  def valid?(*)
-    self.teacher_reference_number = teacher_reference_number&.gsub(/\D/, "")
-    super
-  end
 
   def save
     return false unless valid?

--- a/app/forms/teacher_reference_number_form.rb
+++ b/app/forms/teacher_reference_number_form.rb
@@ -1,0 +1,25 @@
+class TeacherReferenceNumberForm < Form
+  attribute :teacher_reference_number
+
+  validates :teacher_reference_number,
+    presence: {
+      message: ->(form, _) { form.i18n_errors_path("blank") }
+    }
+
+  validates :teacher_reference_number,
+    length: {
+      is: 7,
+      message: ->(form, _) { form.i18n_errors_path("length") }
+    }, if: -> { teacher_reference_number.present? }
+
+  def valid?(*)
+    self.teacher_reference_number = teacher_reference_number&.gsub(/\D/, "")
+    super
+  end
+
+  def save
+    return false unless valid?
+
+    update!(teacher_reference_number: teacher_reference_number)
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -182,7 +182,7 @@ class Claim < ApplicationRecord
   validates :postcode, length: {maximum: 11, message: "Postcode must be 11 characters or less"}
   validate :postcode_is_valid, if: -> { postcode.present? }
 
-  validates :teacher_reference_number, on: [:"teacher-reference-number", :submit, :amendment], presence: {message: "Enter your teacher reference number"}
+  validates :teacher_reference_number, on: [:submit, :amendment], presence: {message: "Enter your teacher reference number"}
   validate :trn_must_be_seven_digits
 
   validates :has_student_loan, on: [:"student-loan"], inclusion: {in: [true, false]}

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -5,7 +5,8 @@ module Journeys
       "current-school" => CurrentSchoolForm,
       "personal-details" => PersonalDetailsForm,
       "select-email" => SelectEmailForm,
-      "provide-mobile-number" => ProvideMobileNumberForm
+      "provide-mobile-number" => ProvideMobileNumberForm,
+      "teacher-reference-number" => TeacherReferenceNumberForm
     }
 
     def configuration

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,13 +1,25 @@
-<% content_for(:page_title, page_title(t("questions.teacher_reference_number"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(
+  :page_title,
+  page_title(
+    t("additional_payments.forms.teacher_reference_number.questions.teacher_reference_number"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?)
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+    <% if @form.errors.any? %>
+      <%= render("shared/error_summary", instance: @form) %>
+    <% end %>
 
-    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
-      <%= form_group_tag current_claim do %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= form_group_tag f.object do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :teacher_reference_number, t("questions.teacher_reference_number"), class: "govuk-label #{label_css_class_for_journey(journey)}" %>
+          <%= f.label(
+            :teacher_reference_number,
+            t("additional_payments.forms.teacher_reference_number.questions.teacher_reference_number"),
+            class: "govuk-label #{label_css_class_for_journey(f.object.journey)}"
+          ) %>
         </h1>
 
         <div class="govuk-hint" id="teacher_reference_number-hint">
@@ -15,12 +27,14 @@
         </div>
 
         <div class="govuk-form-group">
-          <%= errors_tag current_claim, :teacher_reference_number %>
-          <%= form.text_field :teacher_reference_number,
-                              spellcheck: "false",
-                              autocomplete: "off",
-                              class: css_classes_for_input(current_claim, :teacher_reference_number, 'govuk-input--width-10'),
-                              "aria-describedby" => "teacher_reference_number-hint" %>
+          <%= errors_tag f.object, :teacher_reference_number %>
+          <%= f.text_field(
+            :teacher_reference_number,
+            spellcheck: "false",
+            autocomplete: "off",
+            class: css_classes_for_input(f.object.claim, :teacher_reference_number, 'govuk-input--width-10'),
+            "aria-describedby" => "teacher_reference_number-hint"
+          ) %>
         </div>
       <% end %>
       <details class="govuk-details" data-module="govuk-details">
@@ -37,7 +51,7 @@
           </p>
         </div>
       </details>
-      <%= form.submit "Continue", class: "govuk-button" %>
+      <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,12 @@ en:
       still_teaching:
         questions:
           which_school_currently: "Which school are you currently employed to teach at?"
+      teacher_reference_number:
+        questions:
+          teacher_reference_number: "What is your teacher reference number (TRN)?"
+        errors:
+          blank: "Enter your teacher reference number"
+          length: "Teacher reference number must be 7 digits long"
       qualification_details:
         errors:
           qualifications_details_check: "Select yes if your qualification details are correct"
@@ -376,6 +382,12 @@ en:
           employed_as_supply_teacher: Are you currently employed as a supply teacher?
         errors:
           inclusion: Select yes if you are a supply teacher
+      teacher_reference_number:
+        questions:
+          teacher_reference_number: "What is your teacher reference number (TRN)?"
+        errors:
+          blank: "Enter your teacher reference number"
+          length: "Teacher reference number must be 7 digits long"
       teaching_subject_now:
         questions:
           teaching_subject_now: "Do you spend at least half of your contracted hours teaching eligible subjects?"

--- a/spec/forms/teacher_reference_number_form_spec.rb
+++ b/spec/forms/teacher_reference_number_form_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe TeacherReferenceNumberForm do
+  before { create(:journey_configuration, :additional_payments) }
+
+  let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        teacher_reference_number: teacher_reference_number
+      }
+    )
+  end
+
+  let(:form) do
+    described_class.new(
+      journey: journey,
+      claim: current_claim,
+      params: params
+    )
+  end
+
+  describe "#validations" do
+    subject { form }
+
+    describe "teacher_reference_number" do
+      context "when the teacher_reference_number is blank" do
+        let(:teacher_reference_number) { "" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the teacher_reference_number is too short" do
+        let(:teacher_reference_number) { "12345" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the teacher_reference_number is too long" do
+        let(:teacher_reference_number) { "12345678" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the teacher_reference_number is 7 digits" do
+        context "when the teacher_reference_number contains only digits" do
+          let(:teacher_reference_number) { "1234567" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the teacher_reference_number contains non digits" do
+          let(:teacher_reference_number) { "12-34567" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    context "when valid" do
+      let(:teacher_reference_number) { "1234-567" }
+
+      it "updates the teacher_reference_number on the claim" do
+        expect(claim.teacher_reference_number).to eq "1234567"
+      end
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -177,13 +177,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  context "when saving in the “teacher-reference-number” validation context" do
-    it "validates the presence of teacher_reference_number" do
-      expect(build(:claim)).not_to be_valid(:"teacher-reference-number")
-      expect(build(:claim, teacher_reference_number: "1234567")).to be_valid(:"teacher-reference-number")
-    end
-  end
-
   context "when saving in the “student-loan” validation context" do
     it "validates the presence of has_student_loan" do
       expect(build(:claim, student_loan_plan: StudentLoan::PLAN_1, has_student_loan: nil)).not_to be_valid(:"student-loan")


### PR DESCRIPTION
Adds a form object for teacher reference number.
When we upgrade rails and get support for Normalisation we should
replace overriding the `valid?` method with a normalisation call back.
The other thing I considered was adding ActiveModel::Callbacks to the
base form and defining a before validation callback there, might be
better not sure.

Have left some validations around trn on the claim model as it seems
like it can be set on the admin side. When we extract forms for the
admin ui we can remove these validations along with normalising the trn
from the claim model.
