### PR TITLE
CAPT-1588 Form object for /provide-mobile-number

### DIFF
--- a/app/forms/provide_mobile_number_form.rb
+++ b/app/forms/provide_mobile_number_form.rb
@@ -1,0 +1,18 @@
+class ProvideMobileNumberForm < Form
+  attribute :provide_mobile_number, :boolean
+
+  validates :provide_mobile_number,
+    inclusion: {
+      in: [true, false],
+      message: "Select yes if you would like to provide your mobile number"
+    },
+    if: -> { claim.has_ecp_or_lupp_policy? }
+
+  def save
+    return false unless valid?
+
+    claim.assign_attributes(provide_mobile_number:)
+    claim.reset_eligibility_dependent_answers(["provide_mobile_number"])
+    claim.save!
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -195,7 +195,6 @@ class Claim < ApplicationRecord
   validates :email_address, format: {with: Rails.application.config.email_regexp, message: "Enter an email address in the correct format, like name@example.com"},
     length: {maximum: 256, message: "Email address must be 256 characters or less"}, if: -> { email_address.present? }
 
-  validates :provide_mobile_number, on: [:"provide-mobile-number", :submit], inclusion: {in: [true, false], message: "Select yes if you would like to provide your mobile number"}, if: :has_ecp_or_lupp_policy?
   validates :mobile_number, on: [:"mobile-number", :submit], presence: {message: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"}, if: -> { provide_mobile_number == true && has_ecp_or_lupp_policy? }
   validates :mobile_number,
     format: {

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -1,11 +1,10 @@
 module Journeys
   module Base
-    # TODO: move app/forms/*_forms to shared and journey specific folders
-    # but needs load_paths sorting
     SHARED_FORMS = {
       "sign-in-or-continue" => SignInOrContinueForm,
       "current-school" => CurrentSchoolForm,
-      "personal-details" => PersonalDetailsForm
+      "personal-details" => PersonalDetailsForm,
+      "provide-mobile-number" => ProvideMobileNumberForm
     }
 
     def configuration

--- a/app/views/claims/provide_mobile_number.html.erb
+++ b/app/views/claims/provide_mobile_number.html.erb
@@ -1,16 +1,16 @@
-<% content_for(:page_title, page_title(t("questions.provide_mobile_number"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_journey_routing_name) : claims_path(current_journey_routing_name) %>
+<% content_for(:page_title, page_title(t("questions.provide_mobile_number"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { provide_mobile_number: "claim_provide_mobile_number_true" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form do |form| %>
+    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { provide_mobile_number: "claim_provide_mobile_number_true" }) if @form.errors.any? %>
+
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |form| %>
       <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
-      <%= form.hidden_field :provide_mobile_number %>
-      <%= form_group_tag current_claim do %>
+
+      <%= form_group_tag @form do %>
+        <%= form.hidden_field :provide_mobile_number %>
 
         <fieldset class="govuk-fieldset" aria-describedby="provide-mobile-number-hint">
-
           <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
             <h1 class="govuk-fieldset__heading">
               <%= t("questions.provide_mobile_number") %>
@@ -22,10 +22,9 @@
               down your application if we are unable to reach you.
           </div>
 
-          <%= errors_tag current_claim, :provide_mobile_number %>
+          <%= errors_tag @form, :provide_mobile_number %>
 
           <div class="govuk-radios">
-
             <div class="govuk-radios__item">
               <%= form.radio_button(:provide_mobile_number, true, class: "govuk-radios__input") %>
               <%= form.label :provide_mobile_number_true, "Yes", class: "govuk-label govuk-radios__label" %>
@@ -35,11 +34,8 @@
               <%= form.radio_button(:provide_mobile_number, false, class: "govuk-radios__input") %>
               <%= form.label :provide_mobile_number_false, "No", class: "govuk-label govuk-radios__label" %>
             </div>
-
           </div>
-
         </fieldset>
-
       <% end %>
 
       <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>

--- a/spec/forms/provide_mobile_number_form_spec.rb
+++ b/spec/forms/provide_mobile_number_form_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe ProvideMobileNumberForm, type: :model do
+  shared_examples "provide_mobile_number_form" do |journey|
+    before {
+      create(:journey_configuration, :student_loans)
+      create(:journey_configuration, :additional_payments)
+    }
+
+    let(:current_claim) do
+      claims = journey::POLICIES.map { |policy| create(:claim, policy: policy) }
+      CurrentClaim.new(claims: claims)
+    end
+
+    let(:slug) { "provide-mobile-number" }
+    let(:params) { ActionController::Parameters.new }
+
+    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+
+    context "unpermitted claim param" do
+      let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
+
+      it "raises an error" do
+        expect { form }.to raise_error ActionController::UnpermittedParameters
+      end
+    end
+
+    describe "validations" do
+      it { should allow_value(%w[true false]).for(:provide_mobile_number).with_message("Select yes if you would like to provide your mobile number") }
+    end
+
+    describe "#save" do
+      context "when submitted with valid params" do
+        let(:params) { ActionController::Parameters.new({slug: slug, claim: {provide_mobile_number: "Yes"}}) }
+
+        context "when claim is missing provide_mobile_number" do
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy: policy) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          it "saves provide_mobile_number" do
+            expect(form.save).to be true
+
+            current_claim.claims.each do |claim|
+              expect(claim.provide_mobile_number).to be_truthy
+            end
+          end
+        end
+
+        context "claim already has provide_mobile_number" do
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, policy: policy, provide_mobile_number: false) }
+            CurrentClaim.new(claims: claims)
+          end
+
+          it "updates provide_mobile_number on claim" do
+            expect(form.save).to be true
+
+            current_claim.claims.each do |claim|
+              expect(claim.provide_mobile_number).to be_truthy
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "for TeacherStudentLoanReimbursement journey" do
+    include_examples "provide_mobile_number_form", Journeys::TeacherStudentLoanReimbursement
+  end
+
+  describe "for AdditionalPaymentsForTeaching journey" do
+    include_examples "provide_mobile_number_form", Journeys::AdditionalPaymentsForTeaching
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -202,14 +202,6 @@ RSpec.describe Claim, type: :model do
   context "with early-career payments policy" do
     subject(:claim) { build(:claim, policy: Policies::EarlyCareerPayments) }
 
-    context "when saving in the “provide-mobile-number” validation context" do
-      it "validates the presence of provide_mobile_number" do
-        expect(claim).not_to be_valid(:"provide-mobile-number")
-        expect(build(:claim, provide_mobile_number: true)).to be_valid(:"provide-mobile-number")
-        expect(build(:claim, provide_mobile_number: false)).to be_valid(:"provide-mobile-number")
-      end
-    end
-
     context "with mobile number" do
       before do
         claim.provide_mobile_number = true


### PR DESCRIPTION
**Changes in this PR**

- Extracted form object for `/provide-mobile-number` page.
  This is a simple for saving the boolean `provide_mobile_number` onto a Claim.
- Removed validation from Claim model

**Points to note**
- I've kept the error messages out of locales for now until we decide on an approach for forms shared across all journeys