### PR TITLE
CAPT-1592 Extract form objects for banking details

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -54,8 +54,6 @@ class ClaimsController < BasePublicController
       session[:claim_postcode] = nil
       session[:claim_address_line_1] = nil
       redirect_to claim_path(current_journey_routing_name, "postcode-search") and return
-    elsif ["personal-bank-account", "building-society-account"].include?(params[:slug])
-      @bank_details_form ||= BankDetailsForm.new(claim: current_claim)
     end
 
     render current_template
@@ -81,8 +79,6 @@ class ClaimsController < BasePublicController
     end
 
     case params[:slug]
-    when "personal-bank-account", "building-society-account"
-      return bank_account
     when "select-claim-school"
       check_select_claim_school_params
     when "still-teaching"
@@ -233,21 +229,6 @@ class ClaimsController < BasePublicController
     return [] unless claim_params["eligibility_attributes"]
 
     claim_params["eligibility_attributes"].keys
-  end
-
-  def bank_account
-    @bank_details_form = BankDetailsForm.new(claim_params.merge(claim: current_claim, hmrc_validation_attempt_count: session[:bank_validation_attempt_count]))
-
-    @bank_details_form.validate!
-
-    current_claim.attributes = claim_params.merge({hmrc_bank_validation_succeeded: @bank_details_form.hmrc_api_validation_succeeded?})
-    current_claim.save!(context: page_sequence.current_slug.to_sym)
-
-    redirect_to claim_path(current_journey_routing_name, next_slug)
-  rescue ActiveModel::ValidationError
-    current_claim.attributes = claim_params
-    session[:bank_validation_attempt_count] = (session[:bank_validation_attempt_count] || 1) + 1 if @bank_details_form.hmrc_api_validation_attempted?
-    show
   end
 
   def correct_journey_for_claim_in_progress?

--- a/app/forms/bank_details_form.rb
+++ b/app/forms/bank_details_form.rb
@@ -10,10 +10,10 @@ class BankDetailsForm < Form
 
   attr_reader :hmrc_api_validation_attempted, :hmrc_api_validation_succeeded, :hmrc_api_response_error
 
-  validates :banking_name, presence: {message: "Enter a name on the account"}
-  validates :bank_sort_code, presence: {message: "Enter a sort code"}
-  validates :bank_account_number, presence: {message: "Enter an account number"}
-  validates :building_society_roll_number, presence: {message: "Enter a roll number"}, if: -> { claim.building_society? }
+  validates :banking_name, presence: {message: i18n_error_message(:enter_banking_name)}
+  validates :bank_sort_code, presence: {message: i18n_error_message(:enter_sort_code)}
+  validates :bank_account_number, presence: {message: i18n_error_message(:enter_account_number)}
+  validates :building_society_roll_number, presence: {message: i18n_error_message(:enter_roll_number)}, if: -> { claim.building_society? }
 
   validate :bank_account_number_must_be_eight_digits
   validate :bank_sort_code_must_be_six_digits
@@ -62,23 +62,23 @@ class BankDetailsForm < Form
   end
 
   def bank_account_number_must_be_eight_digits
-    errors.add(:bank_account_number, "Account number must be 8 digits") if bank_account_number.present? && normalised_bank_detail(bank_account_number) !~ /\A\d{8}\z/
+    errors.add(:bank_account_number, i18n_errors_path(:format_account_number)) if bank_account_number.present? && normalised_bank_detail(bank_account_number) !~ /\A\d{8}\z/
   end
 
   def bank_sort_code_must_be_six_digits
-    errors.add(:bank_sort_code, "Sort code must be 6 digits") if bank_sort_code.present? && normalised_bank_detail(bank_sort_code) !~ /\A\d{6}\z/
+    errors.add(:bank_sort_code, i18n_errors_path(:format_sort_code)) if bank_sort_code.present? && normalised_bank_detail(bank_sort_code) !~ /\A\d{6}\z/
   end
 
   def building_society_roll_number_must_be_between_one_and_eighteen_digits
     return unless building_society_roll_number.present?
 
-    errors.add(:building_society_roll_number, "Building society roll number must be between 1 and 18 characters") if building_society_roll_number.length > 18
+    errors.add(:building_society_roll_number, i18n_errors_path(:length_roll_number)) if building_society_roll_number.length > 18
   end
 
   def building_society_roll_number_must_be_in_a_valid_format
     return unless building_society_roll_number.present?
 
-    errors.add(:building_society_roll_number, "Building society roll number must only include letters a to z, numbers, hyphens, spaces, forward slashes and full stops") unless /\A[a-z0-9\-\s.\/]{1,18}\z/i.match?(building_society_roll_number)
+    errors.add(:building_society_roll_number, i18n_errors_path(:format_roll_number)) unless /\A[a-z0-9\-\s.\/]{1,18}\z/i.match?(building_society_roll_number)
   end
 
   def bank_account_is_valid
@@ -93,9 +93,9 @@ class BankDetailsForm < Form
       @hmrc_api_validation_succeeded = true if response.success?
 
       unless met_maximum_attempts?
-        errors.add(:bank_sort_code, "Enter a valid sort code") unless response.sort_code_correct?
-        errors.add(:bank_account_number, "Enter the account number associated with the name on the account and/or sort code") if response.sort_code_correct? && !response.account_exists?
-        errors.add(:banking_name, "Enter a valid name on the account") if response.sort_code_correct? && response.account_exists? && !response.name_match?
+        errors.add(:bank_sort_code, i18n_errors_path(:invalid_sort_code)) unless response.sort_code_correct?
+        errors.add(:bank_account_number, i18n_errors_path(:invalid_account_number)) if response.sort_code_correct? && !response.account_exists?
+        errors.add(:banking_name, i18n_errors_path(:invalid_banking_name)) if response.sort_code_correct? && response.account_exists? && !response.name_match?
       end
     rescue Hmrc::ResponseError => e
       response = e.response

--- a/app/forms/bank_details_form.rb
+++ b/app/forms/bank_details_form.rb
@@ -2,7 +2,7 @@ class BankDetailsForm < Form
   # Only validate against HMRC API if number of attempts is below threshold
   MAX_HMRC_API_VALIDATION_ATTEMPTS = 3
 
-  attribute :hmrc_validation_attempt_count
+  attribute :hmrc_validation_attempt_count, :integer
   attribute :banking_name, :string
   attribute :bank_sort_code, :string
   attribute :bank_account_number, :string
@@ -25,7 +25,7 @@ class BankDetailsForm < Form
 
   def initialize(claim:, journey:, params:)
     super
-    self.hmrc_validation_attempt_count = 0
+    self.hmrc_validation_attempt_count ||= 0
   end
 
   def save
@@ -38,7 +38,7 @@ class BankDetailsForm < Form
         hmrc_bank_validation_succeeded:
       )
     else
-      @hmrc_validation_attempt_count += 1 if hmrc_api_validation_attempted?
+      self.hmrc_validation_attempt_count += 1 if hmrc_api_validation_attempted?
       false
     end
   end
@@ -111,10 +111,10 @@ class BankDetailsForm < Form
   end
 
   def within_maximum_attempts?
-    (hmrc_validation_attempt_count || 1) <= MAX_HMRC_API_VALIDATION_ATTEMPTS
+    (hmrc_validation_attempt_count + 1) <= MAX_HMRC_API_VALIDATION_ATTEMPTS
   end
 
   def met_maximum_attempts?
-    (hmrc_validation_attempt_count || 1) >= MAX_HMRC_API_VALIDATION_ATTEMPTS
+    (hmrc_validation_attempt_count + 1) >= MAX_HMRC_API_VALIDATION_ATTEMPTS
   end
 end

--- a/app/forms/bank_details_form.rb
+++ b/app/forms/bank_details_form.rb
@@ -23,24 +23,16 @@ class BankDetailsForm < Form
   # This should be the last validation specified to prevent unnecessary API calls
   validate :bank_account_is_valid
 
-  def initialize(claim:, journey:, params:)
-    super
-    self.hmrc_validation_attempt_count ||= 0
-  end
-
   def save
-    if valid?
-      update!(
-        banking_name:,
-        bank_sort_code:,
-        bank_account_number:,
-        building_society_roll_number:,
-        hmrc_bank_validation_succeeded:
-      )
-    else
-      self.hmrc_validation_attempt_count += 1 if hmrc_api_validation_attempted?
-      false
-    end
+    return false unless valid?
+
+    update!(
+      banking_name:,
+      bank_sort_code:,
+      bank_account_number:,
+      building_society_roll_number:,
+      hmrc_bank_validation_succeeded:
+    )
   end
 
   def hmrc_bank_validation_succeeded
@@ -111,10 +103,10 @@ class BankDetailsForm < Form
   end
 
   def within_maximum_attempts?
-    (hmrc_validation_attempt_count + 1) <= MAX_HMRC_API_VALIDATION_ATTEMPTS
+    hmrc_validation_attempt_count + 1 <= MAX_HMRC_API_VALIDATION_ATTEMPTS
   end
 
   def met_maximum_attempts?
-    (hmrc_validation_attempt_count + 1) >= MAX_HMRC_API_VALIDATION_ATTEMPTS
+    hmrc_validation_attempt_count + 1 >= MAX_HMRC_API_VALIDATION_ATTEMPTS
   end
 end

--- a/app/forms/bank_or_building_society_form.rb
+++ b/app/forms/bank_or_building_society_form.rb
@@ -1,0 +1,17 @@
+class BankOrBuildingSocietyForm < Form
+  attribute :bank_or_building_society
+
+  validates :bank_or_building_society,
+    inclusion: {
+      in: Claim.bank_or_building_societies.keys,
+      message: "Select if you want the money paid in to a personal bank account or building society"
+    }
+
+  def save
+    return false unless valid?
+
+    claim.assign_attributes(bank_or_building_society:)
+    claim.reset_eligibility_dependent_answers(["bank_or_building_society"])
+    claim.save!
+  end
+end

--- a/app/forms/bank_or_building_society_form.rb
+++ b/app/forms/bank_or_building_society_form.rb
@@ -11,7 +11,7 @@ class BankOrBuildingSocietyForm < Form
     return false unless valid?
 
     claim.assign_attributes(bank_or_building_society:)
-    claim.reset_eligibility_dependent_answers(["bank_or_building_society"])
+    claim.reset_dependent_answers
     claim.save!
   end
 end

--- a/app/forms/bank_or_building_society_form.rb
+++ b/app/forms/bank_or_building_society_form.rb
@@ -4,7 +4,7 @@ class BankOrBuildingSocietyForm < Form
   validates :bank_or_building_society,
     inclusion: {
       in: Claim.bank_or_building_societies.keys,
-      message: "Select if you want the money paid in to a personal bank account or building society"
+      message: i18n_error_message(:select_bank_or_building_society)
     }
 
   def save

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -191,7 +191,6 @@ class Claim < ApplicationRecord
   validates :email_address, format: {with: Rails.application.config.email_regexp, message: "Enter an email address in the correct format, like name@example.com"},
     length: {maximum: 256, message: "Email address must be 256 characters or less"}, if: -> { email_address.present? }
 
-  validates :bank_or_building_society, on: [:"bank-or-building-society", :submit], presence: {message: "Select if you want the money paid in to a personal bank account or building society"}
   validates :banking_name, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter a name on the account"}
   validates :bank_sort_code, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter a sort code"}
   validates :bank_account_number, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter an account number"}

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -191,17 +191,7 @@ class Claim < ApplicationRecord
   validates :email_address, format: {with: Rails.application.config.email_regexp, message: "Enter an email address in the correct format, like name@example.com"},
     length: {maximum: 256, message: "Email address must be 256 characters or less"}, if: -> { email_address.present? }
 
-  validates :banking_name, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter a name on the account"}
-  validates :bank_sort_code, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter a sort code"}
-  validates :bank_account_number, on: [:"personal-bank-account", :"building-society-account", :submit, :amendment], presence: {message: "Enter an account number"}
-  validates :building_society_roll_number, on: [:"building-society-account", :submit, :amendment], presence: {message: "Enter a roll number"}, if: -> { building_society? }
-
   validates :payroll_gender, on: [:"payroll-gender-task", :submit], presence: {message: "You must select a gender that will be passed to HMRC"}
-
-  validate :bank_account_number_must_be_eight_digits
-  validate :bank_sort_code_must_be_six_digits
-  validate :building_society_roll_number_must_be_between_one_and_eighteen_digits
-  validate :building_society_roll_number_must_be_in_a_valid_format
 
   validate :claim_must_not_be_ineligible, on: :submit
 
@@ -564,26 +554,6 @@ class Claim < ApplicationRecord
 
   def normalised_bank_detail(bank_detail)
     bank_detail.gsub(/\s|-/, "")
-  end
-
-  def building_society_roll_number_must_be_between_one_and_eighteen_digits
-    return unless building_society_roll_number.present?
-
-    errors.add(:building_society_roll_number, "Building society roll number must be between 1 and 18 characters") if building_society_roll_number.length > 18
-  end
-
-  def building_society_roll_number_must_be_in_a_valid_format
-    return unless building_society_roll_number.present?
-
-    errors.add(:building_society_roll_number, "Building society roll number must only include letters a to z, numbers, hyphens, spaces, forward slashes and full stops") unless /\A[a-z0-9\-\s.\/]{1,18}\z/i.match?(building_society_roll_number)
-  end
-
-  def bank_account_number_must_be_eight_digits
-    errors.add(:bank_account_number, "Account number must be 8 digits") if bank_account_number.present? && normalised_bank_detail(bank_account_number) !~ /\A\d{8}\z/
-  end
-
-  def bank_sort_code_must_be_six_digits
-    errors.add(:bank_sort_code, "Sort code must be 6 digits") if bank_sort_code.present? && normalised_bank_detail(bank_sort_code) !~ /\A\d{6}\z/
   end
 
   def unique_reference

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -11,6 +11,8 @@ module Journeys
       "mobile-number" => MobileNumberForm,
       "mobile-verification" => MobileVerificationForm,
       "bank-or-building-society" => BankOrBuildingSocietyForm,
+      "personal-bank-account" => BankDetailsForm,
+      "building-society-account" => BankDetailsForm,
       "teacher-reference-number" => TeacherReferenceNumberForm
     }
 

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -10,6 +10,7 @@ module Journeys
       "select-mobile" => SelectMobileForm,
       "mobile-number" => MobileNumberForm,
       "mobile-verification" => MobileVerificationForm,
+      "bank-or-building-society" => BankOrBuildingSocietyForm,
       "teacher-reference-number" => TeacherReferenceNumberForm
     }
 

--- a/app/views/claims/_account_details.html.erb
+++ b/app/views/claims/_account_details.html.erb
@@ -1,7 +1,7 @@
 <% account_hint = bank_or_building_society == "personal bank account" ? "bank" : bank_or_building_society %>
 <% account_card = account_hint == "bank" ? account_hint : "" %>
 
-<%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
+<%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
   <fieldset class="govuk-fieldset" aria-describedby="bank_details-hint" role="group">
     <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
       <h1 class="govuk-fieldset__heading">
@@ -9,45 +9,45 @@
       </h1>
     </legend>
 
-    <%= form_group_tag @bank_details_form, :banking_name do %>
-      <%= form.label :banking_name, "Name on your account", class: "govuk-label" %>
+    <%= form_group_tag @form, :banking_name do %>
+      <%= f.label :banking_name, "Name on your account", class: "govuk-label" %>
       <div class="govuk-hint" id="name-on-the-account-hint">
         <%= t("questions.account_hint", bank_or_building_society: account_hint, card: account_card) %>
       </div>
-      <%= errors_tag @bank_details_form, :banking_name %>
-      <%= form.text_field :banking_name,
-        class: css_classes_for_input(@bank_details_form, :banking_name),
+      <%= errors_tag @form, :banking_name %>
+      <%= f.text_field :banking_name,
+        class: css_classes_for_input(@form, :banking_name),
         spellcheck: "false",
         "aria-describedby" => "name-on-the-account-hint" %>
     <% end %>
 
-    <%= form_group_tag @bank_details_form, :bank_sort_code do %>
-      <%= form.label :bank_sort_code, "Sort code", class: "govuk-label" %>
+    <%= form_group_tag @form, :bank_sort_code do %>
+      <%= f.label :bank_sort_code, "Sort code", class: "govuk-label" %>
       <div id="sort-code-hint" class="govuk-hint">For example: 309430</div>
-      <%= errors_tag @bank_details_form, :bank_sort_code %>
-      <%= form.text_field :bank_sort_code,
-        class: css_classes_for_input(@bank_details_form, :bank_sort_code, "govuk-!-width-one-quarter"),
+      <%= errors_tag @form, :bank_sort_code %>
+      <%= f.text_field :bank_sort_code,
+        class: css_classes_for_input(@form, :bank_sort_code, "govuk-!-width-one-quarter"),
         autocomplete: "off",
         "aria-describedby" => "sort-code-hint" %>
     <% end %>
 
-    <%= form_group_tag @bank_details_form, :bank_account_number do %>
-      <%= form.label :bank_account_number, "Account number", class: "govuk-label" %>
+    <%= form_group_tag @form, :bank_account_number do %>
+      <%= f.label :bank_account_number, "Account number", class: "govuk-label" %>
       <div id="account-number-hint" class="govuk-hint">For example: 00733445</div>
-      <%= errors_tag @bank_details_form, :bank_account_number %>
-      <%= form.text_field :bank_account_number,
-        class: css_classes_for_input(@bank_details_form, :bank_account_number, "govuk-input--width-20"),
+      <%= errors_tag @form, :bank_account_number %>
+      <%= f.text_field :bank_account_number,
+        class: css_classes_for_input(@form, :bank_account_number, "govuk-input--width-20"),
         autocomplete: "off",
         "aria-describedby" => "account-number-hint" %>
     <% end %>
 
     <% if bank_or_building_society == "building society" %>
-      <%= form_group_tag @bank_details_form, :building_society_roll_number do %>
-        <%= form.label :building_society_roll_number, "Building society roll number", class: "govuk-label" %>
+      <%= form_group_tag @form, :building_society_roll_number do %>
+        <%= f.label :building_society_roll_number, "Building society roll number", class: "govuk-label" %>
         <div id="roll-number-hint" class="govuk-hint">You can find it on your card, statement or passbook</div>
-        <%= errors_tag @bank_details_form, :building_society_roll_number %>
-        <%= form.text_field :building_society_roll_number,
-          class: css_classes_for_input(@bank_details_form, :building_society_roll_number, "govuk-input--width-20"),
+        <%= errors_tag @form, :building_society_roll_number %>
+        <%= f.text_field :building_society_roll_number,
+          class: css_classes_for_input(@form, :building_society_roll_number, "govuk-input--width-20"),
           autocomplete: "off",
           spellcheck: "false",
           "aria-describedby" => "roll-number-hint" %>
@@ -64,5 +64,5 @@
     </strong>
   </div>
 
-  <%= form.submit "Continue", class: "govuk-button", data: { "prevent-double-click" => "true" } %>
+  <%= f.submit "Continue", class: "govuk-button", data: { "prevent-double-click" => "true" } %>
 <% end %>

--- a/app/views/claims/_account_details.html.erb
+++ b/app/views/claims/_account_details.html.erb
@@ -9,8 +9,6 @@
       </h1>
     </legend>
 
-    <%= f.hidden_field :hmrc_validation_attempt_count %>
-
     <%= form_group_tag @form, :banking_name do %>
       <%= f.label :banking_name, "Name on your account", class: "govuk-label" %>
       <div class="govuk-hint" id="name-on-the-account-hint">

--- a/app/views/claims/_account_details.html.erb
+++ b/app/views/claims/_account_details.html.erb
@@ -9,6 +9,8 @@
       </h1>
     </legend>
 
+    <%= f.hidden_field :hmrc_validation_attempt_count %>
+
     <%= form_group_tag @form, :banking_name do %>
       <%= f.label :banking_name, "Name on your account", class: "govuk-label" %>
       <div class="govuk-hint" id="name-on-the-account-hint">

--- a/app/views/claims/bank_or_building_society.html.erb
+++ b/app/views/claims/bank_or_building_society.html.erb
@@ -1,11 +1,12 @@
-<% content_for(:page_title, page_title(t("questions.bank_or_building_society"), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.bank_or_building_society"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { bank_or_building_society: "claim_bank_or_building_society_personal_bank_account" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
+    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { bank_or_building_society: "claim_bank_or_building_society_personal_bank_account" }) if @form.errors.any? %>
+
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |form| %>
       <%= form.hidden_field :bank_or_building_society %>
-      <%= form_group_tag current_claim do %>
+      <%= form_group_tag @form do %>
         <fieldset class="govuk-fieldset" role="group" aria-describedby="bank_details-hint">
 
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -15,10 +16,12 @@
           </legend>
 
           <div class="govuk-hint" id="bank_details-hint">
-            Some places are both a bank and a building society. If your account requires a roll number your account with them is through the building society.
+            Some places are both a bank and a building society. If your account
+            requires a roll number your account with them is through the
+            building society.
           </div>
 
-          <%= errors_tag current_claim, :bank_or_building_society %>
+          <%= errors_tag @form, :bank_or_building_society %>
 
           <div class="govuk-radios">
             <div class="govuk-radios__item">

--- a/app/views/claims/building_society_account.html.erb
+++ b/app/views/claims/building_society_account.html.erb
@@ -1,10 +1,10 @@
 <% bank_or_building_society = current_claim.bank_or_building_society.humanize.downcase %>
-<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render("shared/error_summary", instance: @bank_details_form ) if @bank_details_form.errors.any? %>
+    <%= render("shared/error_summary", instance: @form ) if @form.errors.any? %>
 
     <%= render partial: "account_details", locals: { current_claim: current_claim, bank_or_building_society: bank_or_building_society, current_journey_routing_name: current_journey_routing_name} %>
 

--- a/app/views/claims/personal_bank_account.html.erb
+++ b/app/views/claims/personal_bank_account.html.erb
@@ -1,10 +1,10 @@
 <% bank_or_building_society = current_claim.bank_or_building_society.humanize.downcase %>
-<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), journey: current_journey_routing_name, show_error: @bank_details_form.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.account_details", bank_or_building_society: bank_or_building_society), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render("shared/error_summary", instance: @bank_details_form, errored_field_id_overrides: { banking_name: :claim_banking_name } ) if @bank_details_form.errors.any? %>
+    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { banking_name: :claim_banking_name } ) if @form.errors.any? %>
 
     <%= render partial: "account_details", locals: { current_claim: current_claim, bank_or_building_society: bank_or_building_society, current_journey_routing_name: current_journey_routing_name} %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,11 +46,15 @@ en:
   support_email_address: "additionalteachingpayment@digital.education.gov.uk"
   check_your_answers:
     heading_send_application: Confirm and send your application
-    statement: By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
+    statement:
+      By submitting this notification you are confirming that, to the best of your knowledge, the details you are
+      providing are correct.
     btn_text: Confirm and send
   one_time_password:
     title: "Enter the 6-digit passcode"
-    hint1_html: "We have sent %{email_or_mobile_message} to <b><strong>%{email_or_mobile_value}</strong></b> with a 6-digit passcode."
+    hint1_html:
+      "We have sent %{email_or_mobile_message} to <b><strong>%{email_or_mobile_value}</strong></b> with a 6-digit
+      passcode."
     validity_duration: "The passcode will expire %{duration_valid} after you receive it."
   questions:
     check_and_confirm_details: "Check and confirm your personal details"
@@ -67,8 +71,11 @@ en:
     date_of_birth: "What is your date of birth?"
     teacher_reference_number: "What is your teacher reference number (TRN)?"
     email_address: "Email address"
-    email_address_hint1: "We recommend you use a non-work email address in case your circumstances change while we process your payment."
-    email_address_hint2: "To verify your email address we will send you an email with a 6-digit passcode. You can enter the passcode on the next screen."
+    email_address_hint1:
+      "We recommend you use a non-work email address in case your circumstances change while we process your payment."
+    email_address_hint2:
+      "To verify your email address we will send you an email with a 6-digit passcode. You can enter the passcode on the
+      next screen."
     provide_mobile_number: "Would you like to provide your mobile number?"
     mobile_number: "Mobile number"
     personal_details: "Personal details"
@@ -92,7 +99,8 @@ en:
       assessment_only: Subject you did your teaching qualification in
       overseas_recognition: Subject you did your teaching qualification in
     degree_subject: Subject you did your degree in
-    select_yes_confirm: By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.
+    select_yes_confirm:
+      By selecting yes you are confirming that, to the best of your knowledge, the details above are correct.
     continue: Continue
     radio_yes: "Yes"
     radio_no: "No"
@@ -159,7 +167,9 @@ en:
     allocations:
       bulk_allocate:
         success: "Assigned %{quantity} %{allocate_to_policy} %{pluralized_or_singular_claim} to %{dfe_user}"
-        info: "No additional claims were assigned to %{dfe_user}. There are not any %{allocate_to_policy} awaiting assignment"
+        info:
+          "No additional claims were assigned to %{dfe_user}. There are not any %{allocate_to_policy} awaiting
+          assignment"
       bulk_deallocate:
         confirmation: Are you sure you want to unassign %{allocate_to_policy} claims from %{dfe_user}?
         success: All %{allocate_to_policy} claims for %{dfe_user} have been unassigned
@@ -190,11 +200,31 @@ en:
         payroll_gender: "How is your gender recorded on your school’s payroll system?"
       errors:
         select_gender: "Select the gender recorded on your school’s payroll system or select whether you do not know"
+    bank_details:
+      errors:
+        enter_account_number: Enter an account number
+        enter_banking_name: Enter a name on the account
+        enter_sort_code: Enter a sort code
+        enter_roll_number: Enter a roll number
+        format_account_number: Account number must be 8 digits
+        format_sort_code: Sort code must be 6 digits
+        format_roll_number:
+          Building society roll number must only include letters a to z, numbers, hyphens, spaces, forward slashes and
+          full stops
+        invalid_sort_code: Enter a valid sort code
+        invalid_account_number: Enter the account number associated with the name on the account and/or sort code
+        invalid_banking_name: Enter a valid name on the account
+        length_roll_number: Building society roll number must be between 1 and 18 characters
+    bank_or_building_society:
+      errors:
+        select_bank_or_building_society:
+          Select if you want the money paid in to a personal bank account or building society
     select_email:
       questions:
         select_email: Which email address should we use to contact you?
       hints:
-        non_work_email_address: We recommend you use a non-work email address in case your circumstances change while we process your payment.
+        non_work_email_address:
+          We recommend you use a non-work email address in case your circumstances change while we process your payment.
       errors:
         select_email: Select an option to indicate whether the email is correct or not
         invalid_email: Invalid email address. Please select a different email address
@@ -221,7 +251,9 @@ en:
         questions:
           leadership_position: "Were you employed in a leadership position between %{financial_year}?"
         hints:
-          leadership_position: "This includes head of subject, head of year, head of department, deputy head, head teacher or other middle leader role."
+          leadership_position:
+            "This includes head of subject, head of year, head of department, deputy head, head teacher or other middle
+            leader role."
         errors:
           inclusion: "Select yes if you were employed in a leadership position"
       mobile_number:
@@ -229,9 +261,11 @@ en:
           invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
       mostly_performed_leadership_duties:
         questions:
-          mostly_performed_leadership_duties: "Were more than half your working hours spent on leadership duties between %{financial_year}?"
+          mostly_performed_leadership_duties:
+            "Were more than half your working hours spent on leadership duties between %{financial_year}?"
         hints:
-          mostly_performed_leadership_duties: "If you were off on long-term leave or sick, include the time you would have spent."
+          mostly_performed_leadership_duties:
+            "If you were off on long-term leave or sick, include the time you would have spent."
         errors:
           inclusion: "Select yes if you spent more than half your working hours on leadership duties"
       select_mobile_form:
@@ -241,7 +275,9 @@ en:
           alternative: "A different mobile number"
           decline: "I do not want to be contacted by mobile"
         hints:
-          usage: "We will only use this number if we are unable to contact you via email. It may slow down your application if we are unable to reach you."
+          usage:
+            "We will only use this number if we are unable to contact you via email. It may slow down your application
+            if we are unable to reach you."
         errors:
           mobile_check: "Select an option to indicate whether the mobile number is correct or not"
       sign_in_or_continue:
@@ -303,7 +339,8 @@ en:
     answers:
       qts_award_years:
         before_cut_off_date: A different academic year
-        on_or_after_cut_off_date: Between the start of the %{year} academic year and the end of the 2020 to 2021 academic year
+        on_or_after_cut_off_date:
+          Between the start of the %{year} academic year and the end of the 2020 to 2021 academic year
     information_provided_further_details: For more details, you can read about payments and deductions when %{link}
     information_provided_further_details_link_text: claiming back your student loan repayments (opens in new tab)
     admin:
@@ -319,7 +356,9 @@ en:
           body: "The claimant’s identity matches DQT records. See %{link}."
           notes: "notes"
         qualifications:
-          title: "Does the claimant’s initial teacher training (ITT) qualification year match the above information from their claim?"
+          title:
+            "Does the claimant’s initial teacher training (ITT) qualification year match the above information from
+            their claim?"
         census_subjects_taught:
           title: Does the claimant’s subject match the schools workforce census subjects
         employment:
@@ -329,7 +368,9 @@ en:
         matching_details:
           title: "Is this claim still valid despite having matching details with other claims?"
         payroll_details:
-          title: "The claimant’s %{bank_or_building_society} details have not been automatically validated. Has the claimant confirmed their %{bank_or_building_society} details?"
+          title:
+            "The claimant’s %{bank_or_building_society} details have not been automatically validated. Has the claimant
+            confirmed their %{bank_or_building_society} details?"
   additional_payments: &additional_payments
     forms:
       correct_school:
@@ -363,7 +404,9 @@ en:
           physics: "Physics"
           none_of_the_above: "None of the above"
         hints:
-          subject: "The subjects listed are eligible for additional payment based on the school you teach in and the year you studied."
+          subject:
+            "The subjects listed are eligible for additional payment based on the school you teach in and the year you
+            studied."
         errors:
           inclusion: "Select a subject"
       eligible_degree_subject:
@@ -394,9 +437,14 @@ en:
         questions:
           poor_performance: Tell us if you are currently under any performance measures or disciplinary action
           disciplinary_action: "Are you currently subject to disciplinary action?"
-          disciplinary_action_hint: "This is more serious than performance measures and could be because of misconduct. It is something we may check with your school as it will affect your eligibility."
+          disciplinary_action_hint:
+            "This is more serious than performance measures and could be because of misconduct. It is something we may
+            check with your school as it will affect your eligibility."
           formal_performance_action: "Have any performance measures been started against you?"
-          formal_performance_action_hint: "This will be as a result of your underperformance as a teacher over a period of time. It could put your employment at the school at risk and is something we may check with your school as it will affect your eligibility."
+          formal_performance_action_hint:
+            "This will be as a result of your underperformance as a teacher over a period of time. It could put your
+            employment at the school at risk and is something we may check with your school as it will affect your
+            eligibility."
         errors:
           subject_to_formal_performance_action:
             inclusion: Select yes if you are subject to formal action for poor performance at work
@@ -408,7 +456,9 @@ en:
         errors:
           inclusion: Select the route you took into teaching
         hints:
-          postgraduate_itt: "Postgraduate Certificate of Education (PGCE), Teach First, School Direct ITT and School Centered ITT (SCITT)."
+          postgraduate_itt:
+            "Postgraduate Certificate of Education (PGCE), Teach First, School Direct ITT and School Centered ITT
+            (SCITT)."
           undergraduate_itt: "Bachelor of Arts (BA) or Bachelor of Science (BSc) degrees."
         answers:
           postgraduate_itt: "Postgraduate initial teacher training (ITT)"
@@ -425,7 +475,9 @@ en:
           alternative: "A different mobile number"
           decline: "I do not want to be contacted by mobile"
         hints:
-          usage: "We will only use this number if we are unable to contact you via email. It may slow down your application if we are unable to reach you."
+          usage:
+            "We will only use this number if we are unable to contact you via email. It may slow down your application
+            if we are unable to reach you."
         errors:
           mobile_check: "Select an option to indicate whether the mobile number is correct or not"
       sign_in_or_continue:
@@ -490,14 +542,19 @@ en:
             title: If you qualified as a teacher in the 2020 to 2021 academic year
             text_html: >
               Select yes if you have completed at least 1 year of your induction period as an early-career teacher.<br/>
-              Select no if you have not completed 1 year of your induction period.<br/>
-              Further information about induction periods can be found at <a href="https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools" class="govuk-link govuk-link--no-visited-state" target="_blank">Early-career payments guidance for teachers and schools</a>
+              Select no if you have not completed 1 year of your induction period.<br/> Further information about
+              induction periods can be found at <a
+              href="https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools"
+              class="govuk-link govuk-link--no-visited-state" target="_blank">Early-career payments guidance for
+              teachers and schools</a>
           overseas:
             title: If you qualified overseas
             text_html: >
-              Select yes if you have more than 2 years experience as a teacher.<br/>
-              Select no if you have less than 2 years experience as a teacher.<br/>
-              Further information can be found at <a href="https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#early-career-teacher-ect-induction" class="govuk-link govuk-link--no-visited-state" target="_blank">early-career teacher (ECT) induction periods for teachers who qualified overseas</a>
+              Select yes if you have more than 2 years experience as a teacher.<br/> Select no if you have less than 2
+              years experience as a teacher.<br/> Further information can be found at <a
+              href="https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#early-career-teacher-ect-induction"
+              class="govuk-link govuk-link--no-visited-state" target="_blank">early-career teacher (ECT) induction
+              periods for teachers who qualified overseas</a>
       itt_academic_year:
         qualification:
           undergraduate_itt: In which academic year did you complete your undergraduate initial teacher training (ITT)?
@@ -523,7 +580,9 @@ en:
           body: "The claimant’s identity matches DQT records. See %{link}."
           notes: "notes"
         qualifications:
-          title: "Does the claimant’s initial teacher training (ITT) start/end year and subject match the above information from their claim?"
+          title:
+            "Does the claimant’s initial teacher training (ITT) start/end year and subject match the above information
+            from their claim?"
         induction_confirmation:
           title: "Is the claimant’s induction data valid?"
         student_loan_plan:
@@ -533,7 +592,9 @@ en:
         matching_details:
           title: "Is this claim still valid despite having matching details with other claims?"
         payroll_details:
-          title: "The claimant’s %{bank_or_building_society} details have not been automatically validated. Has the claimant confirmed their %{bank_or_building_society} details?"
+          title:
+            "The claimant’s %{bank_or_building_society} details have not been automatically validated. Has the claimant
+            confirmed their %{bank_or_building_society} details?"
     reminders:
       full_name: Full name
     information_provided_further_details: For more details, you can read about payments and deductions for the %{link}

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -157,6 +157,12 @@ RSpec.describe BankDetailsForm do
               form.valid?
               expect(form).not_to be_hmrc_api_validation_succeeded
             end
+
+            it "increments hmrc_validation_attempt_count" do
+              expect {
+                form.save
+              }.to change { form.hmrc_validation_attempt_count }.from(0).to(1)
+            end
           end
 
           context "when the validation fails on the third attempt" do

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe BankDetailsForm do
 
           context "when the validation fails on the third attempt" do
             before do
-              allow(form).to receive(:hmrc_validation_attempt_count).and_return(3)
+              allow(form).to receive(:hmrc_validation_attempt_count).and_return(2)
             end
 
             let(:account_exists) { false }

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BankDetailsForm do
 
     let(:slug) { "personal-bank-account" }
     let(:params) do
-      {banking_name:, bank_sort_code:, bank_account_number:, building_society_roll_number:}
+      {banking_name:, bank_sort_code:, bank_account_number:, building_society_roll_number:, hmrc_validation_attempt_count:}
     end
 
     subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new(slug:, claim: params)) }
@@ -23,6 +23,7 @@ RSpec.describe BankDetailsForm do
     let(:bank_sort_code) { rand(100000..999999) }
     let(:bank_account_number) { rand(10000000..99999999) }
     let(:building_society_roll_number) { nil }
+    let(:hmrc_validation_attempt_count) { 0 }
 
     describe "#valid?" do
       context "with 200 code HMRC API response", :with_stubbed_hmrc_client do
@@ -157,19 +158,10 @@ RSpec.describe BankDetailsForm do
               form.valid?
               expect(form).not_to be_hmrc_api_validation_succeeded
             end
-
-            it "increments hmrc_validation_attempt_count" do
-              expect {
-                form.save
-              }.to change { form.hmrc_validation_attempt_count }.from(0).to(1)
-            end
           end
 
           context "when the validation fails on the third attempt" do
-            before do
-              allow(form).to receive(:hmrc_validation_attempt_count).and_return(2)
-            end
-
+            let(:hmrc_validation_attempt_count) { 2 }
             let(:account_exists) { false }
 
             it "contacts the HMRC API" do

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -1,161 +1,87 @@
 require "rails_helper"
 
 RSpec.describe BankDetailsForm do
-  let(:banking_name) { "Jo Bloggs" }
-  let(:bank_sort_code) { rand(100000..999999) }
-  let(:bank_account_number) { rand(10000000..99999999) }
-  let(:building_society_roll_number) { nil }
-  let(:claim) { create(:claim, :with_bank_details) }
-  let(:hmrc_validation_attempt_count) { nil }
+  shared_examples "bank_details_form" do |journey|
+    before {
+      create(:journey_configuration, :student_loans)
+      create(:journey_configuration, :additional_payments)
+    }
 
-  subject(:form) { described_class.new(claim: claim, hmrc_validation_attempt_count: hmrc_validation_attempt_count, banking_name: banking_name, bank_account_number: bank_account_number, bank_sort_code: bank_sort_code, building_society_roll_number: building_society_roll_number) }
+    let(:current_claim) do
+      claims = journey::POLICIES.map { |policy| create(:claim, :with_bank_details, policy:) }
+      CurrentClaim.new(claims: claims)
+    end
 
-  describe "#valid?" do
-    context "with 200 code HMRC API response", :with_stubbed_hmrc_client do
-      context "with valid account number" do
-        let(:bank_account_number) { "12-34-56-78" }
-        it { is_expected.to be_valid }
-      end
+    let(:slug) { "personal-bank-account" }
+    let(:params) do
+      {banking_name:, bank_sort_code:, bank_account_number:, building_society_roll_number:}
+    end
 
-      context "with invalid account number" do
-        let(:bank_account_number) { "ABC12 34 56 789" }
-        it { is_expected.not_to be_valid }
-      end
+    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new(slug:, claim: params)) }
 
-      context "with blank account number" do
-        let(:bank_account_number) { "" }
-        it { is_expected.not_to be_valid }
-      end
+    let(:banking_name) { "Jo Bloggs" }
+    let(:bank_sort_code) { rand(100000..999999) }
+    let(:bank_account_number) { rand(10000000..99999999) }
+    let(:building_society_roll_number) { nil }
 
-      context "with valid sort code" do
-        let(:bank_sort_code) { "12 34 56" }
-        it { is_expected.to be_valid }
-      end
-
-      context "with invalid sort code" do
-        let(:bank_sort_code) { "ABC12 34 567" }
-        it { is_expected.not_to be_valid }
-      end
-
-      context "with blank sort code" do
-        let(:bank_sort_code) { "" }
-        it { is_expected.not_to be_valid }
-      end
-
-      context "when building society" do
-        let(:claim) { build(:claim, :with_bank_details, bank_or_building_society: :building_society, policy: Policies::EarlyCareerPayments) }
-
-        context "with valid building society roll number" do
-          let(:building_society_roll_number) { "CXJ-K6 897/98X" }
+    describe "#valid?" do
+      context "with 200 code HMRC API response", :with_stubbed_hmrc_client do
+        context "with valid account number" do
+          let(:bank_account_number) { "12-34-56-78" }
           it { is_expected.to be_valid }
         end
 
-        context "with invalid building society roll number" do
-          let(:building_society_roll_number) { "123456789/ABC.CD-EFGH " }
+        context "with invalid account number" do
+          let(:bank_account_number) { "ABC12 34 56 789" }
           it { is_expected.not_to be_valid }
         end
 
-        context "with blank building society roll number" do
-          let(:building_society_roll_number) { "" }
+        context "with blank account number" do
+          let(:bank_account_number) { "" }
           it { is_expected.not_to be_valid }
         end
-      end
 
-      context "when HMRC bank validation is enabled", :with_hmrc_bank_validation_enabled do
-        it "contacts the HMRC API" do
-          form.valid?
-          expect(hmrc_client).to have_received(:verify_personal_bank_account)
+        context "with valid sort code" do
+          let(:bank_sort_code) { "12 34 56" }
+          it { is_expected.to be_valid }
         end
 
-        it "sets hmrc_api_validation_attempted" do
-          form.valid?
-          expect(form).to be_hmrc_api_validation_attempted
+        context "with invalid sort code" do
+          let(:bank_sort_code) { "ABC12 34 567" }
+          it { is_expected.not_to be_valid }
         end
 
-        it "adds the response to the claim" do
-          expect { form.valid? }.to change { claim.reload.hmrc_bank_validation_responses }.from([]).to [
-            {"body" => "Test response", "code" => 200}
-          ]
+        context "with blank sort code" do
+          let(:bank_sort_code) { "" }
+          it { is_expected.not_to be_valid }
         end
 
-        context "when the sort code doesn't pass basic validation" do
-          let(:bank_sort_code) { 99 }
+        context "when building society" do
+          let(:current_claim) do
+            claims = journey::POLICIES.map { |policy| create(:claim, :with_bank_details, bank_or_building_society: :building_society, policy:) }
+            CurrentClaim.new(claims: claims)
+          end
 
-          it { is_expected.to be_invalid }
+          context "with valid building society roll number" do
+            let(:building_society_roll_number) { "CXJ-K6 897/98X" }
+            it { is_expected.to be_valid }
+          end
 
-          it "does not contact the HMRC API" do
-            form.valid?
-            expect(hmrc_client).not_to have_received(:verify_personal_bank_account)
+          context "with invalid building society roll number" do
+            let(:building_society_roll_number) { "123456789/ABC.CD-EFGH " }
+            it { is_expected.not_to be_valid }
+          end
+
+          context "with blank building society roll number" do
+            let(:building_society_roll_number) { "" }
+            it { is_expected.not_to be_valid }
           end
         end
 
-        context "when there is an HMRC validation error with the sort code" do
-          let(:sort_code_correct) { false }
-
-          it "adds an error" do
-            form.valid?
-            expect(form.errors[:bank_sort_code].first).to eq("Enter a valid sort code")
-          end
-
-          it "does not set hmrc_api_validation_succeeded" do
-            form.valid?
-            expect(form).not_to be_hmrc_api_validation_succeeded
-          end
-        end
-
-        context "when the account number doesn't pass basic validation" do
-          let(:bank_account_number) { 99 }
-
-          it { is_expected.to be_invalid }
-
-          it "does not contact the HMRC API" do
-            form.valid?
-            expect(hmrc_client).not_to have_received(:verify_personal_bank_account)
-          end
-        end
-
-        context "when there is an HMRC validation error with the account name" do
-          let(:name_match) { false }
-
-          it "adds an error" do
-            form.valid?
-            expect(form.errors[:banking_name].first).to eq("Enter a valid name on the account")
-          end
-
-          it "does not set hmrc_api_validation_succeeded" do
-            form.valid?
-            expect(form).not_to be_hmrc_api_validation_succeeded
-          end
-        end
-
-        context "when there is an error with the account number" do
-          let(:account_exists) { false }
-
-          it "adds an error" do
-            form.valid?
-            expect(form.errors[:bank_account_number].first).to eq("Enter the account number associated with the name on the account and/or sort code")
-          end
-
-          it "does not set hmrc_api_validation_succeeded" do
-            form.valid?
-            expect(form).not_to be_hmrc_api_validation_succeeded
-          end
-        end
-
-        context "when the validation fails on the third attempt" do
-          let(:hmrc_validation_attempt_count) { 3 }
-          let(:account_exists) { false }
-
+        context "when HMRC bank validation is enabled", :with_hmrc_bank_validation_enabled do
           it "contacts the HMRC API" do
             form.valid?
             expect(hmrc_client).to have_received(:verify_personal_bank_account)
-          end
-
-          it "does not add any errors" do
-            form.valid?
-            expect(form.errors[:bank_sort_code]).to be_empty
-            expect(form.errors[:bank_account_number]).to be_empty
-            expect(form.errors[:banking_name]).to be_empty
           end
 
           it "sets hmrc_api_validation_attempted" do
@@ -163,66 +89,169 @@ RSpec.describe BankDetailsForm do
             expect(form).to be_hmrc_api_validation_attempted
           end
 
+          it "adds the response to the claim" do
+            expect { form.valid? }.to change { current_claim.reload.hmrc_bank_validation_responses }.from([]).to [
+              {"body" => "Test response", "code" => 200}
+            ]
+          end
+
+          context "when the sort code doesn't pass basic validation" do
+            let(:bank_sort_code) { 99 }
+
+            it { is_expected.to be_invalid }
+
+            it "does not contact the HMRC API" do
+              form.valid?
+              expect(hmrc_client).not_to have_received(:verify_personal_bank_account)
+            end
+          end
+
+          context "when there is an HMRC validation error with the sort code" do
+            let(:sort_code_correct) { false }
+
+            it "adds an error" do
+              form.valid?
+              expect(form.errors[:bank_sort_code].first).to eq("Enter a valid sort code")
+            end
+
+            it "does not set hmrc_api_validation_succeeded" do
+              form.valid?
+              expect(form).not_to be_hmrc_api_validation_succeeded
+            end
+          end
+
+          context "when the account number doesn't pass basic validation" do
+            let(:bank_account_number) { 99 }
+
+            it { is_expected.to be_invalid }
+
+            it "does not contact the HMRC API" do
+              form.valid?
+              expect(hmrc_client).not_to have_received(:verify_personal_bank_account)
+            end
+          end
+
+          context "when there is an HMRC validation error with the account name" do
+            let(:name_match) { false }
+
+            it "adds an error" do
+              form.valid?
+              expect(form.errors[:banking_name].first).to eq("Enter a valid name on the account")
+            end
+
+            it "does not set hmrc_api_validation_succeeded" do
+              form.valid?
+              expect(form).not_to be_hmrc_api_validation_succeeded
+            end
+          end
+
+          context "when there is an error with the account number" do
+            let(:account_exists) { false }
+
+            it "adds an error" do
+              form.valid?
+              expect(form.errors[:bank_account_number].first).to eq("Enter the account number associated with the name on the account and/or sort code")
+            end
+
+            it "does not set hmrc_api_validation_succeeded" do
+              form.valid?
+              expect(form).not_to be_hmrc_api_validation_succeeded
+            end
+          end
+
+          context "when the validation fails on the third attempt" do
+            before do
+              allow(form).to receive(:hmrc_validation_attempt_count).and_return(3)
+            end
+
+            let(:account_exists) { false }
+
+            it "contacts the HMRC API" do
+              form.valid?
+              expect(hmrc_client).to have_received(:verify_personal_bank_account)
+            end
+
+            it "does not add any errors" do
+              form.valid?
+              expect(form.errors[:bank_sort_code]).to be_empty
+              expect(form.errors[:bank_account_number]).to be_empty
+              expect(form.errors[:banking_name]).to be_empty
+            end
+
+            it "sets hmrc_api_validation_attempted" do
+              form.valid?
+              expect(form).to be_hmrc_api_validation_attempted
+            end
+
+            it "does not set hmrc_api_validation_succeeded" do
+              form.valid?
+              expect(form).not_to be_hmrc_api_validation_succeeded
+            end
+
+            it "adds the response to the claim" do
+              expect { form.valid? }.to change { current_claim.reload.hmrc_bank_validation_responses }.from([]).to [
+                {"body" => "Test response", "code" => 200}
+              ]
+            end
+          end
+        end
+
+        context "when HMRC bank validation is disabled" do
+          before { form.valid? }
+
+          it "does not contact the HMRC API" do
+            expect(hmrc_client).not_to have_received(:verify_personal_bank_account)
+          end
+
+          it "does not add any errors" do
+            expect(form.errors[:bank_sort_code]).to be_empty
+            expect(form.errors[:bank_account_number]).to be_empty
+            expect(form.errors[:banking_name]).to be_empty
+          end
+
           it "does not set hmrc_api_validation_succeeded" do
             form.valid?
             expect(form).not_to be_hmrc_api_validation_succeeded
           end
-
-          it "adds the response to the claim" do
-            expect { form.valid? }.to change { claim.reload.hmrc_bank_validation_responses }.from([]).to [
-              {"body" => "Test response", "code" => 200}
-            ]
-          end
         end
       end
 
-      context "when HMRC bank validation is disabled" do
-        before { form.valid? }
-
-        it "does not contact the HMRC API" do
-          expect(hmrc_client).not_to have_received(:verify_personal_bank_account)
-        end
-
+      context "when there is an HMRC API error", :with_hmrc_bank_validation_enabled, :with_failing_hmrc_bank_validation do
         it "does not add any errors" do
+          form.valid?
           expect(form.errors[:bank_sort_code]).to be_empty
           expect(form.errors[:bank_account_number]).to be_empty
           expect(form.errors[:banking_name]).to be_empty
+        end
+
+        it "catches the exception" do
+          expect { form.valid? }.not_to raise_error
+        end
+
+        it "does not set hmrc_api_validation_attempted" do
+          form.valid?
+          expect(form).not_to be_hmrc_api_validation_attempted
         end
 
         it "does not set hmrc_api_validation_succeeded" do
           form.valid?
           expect(form).not_to be_hmrc_api_validation_succeeded
         end
+
+        it "adds the response to the claim" do
+          expect { form.valid? }.to change { current_claim.reload.hmrc_bank_validation_responses }.from([]).to [
+            {"body" => "Test failure", "code" => 429}
+          ]
+        end
       end
     end
+  end
 
-    context "when there is an HMRC API error", :with_hmrc_bank_validation_enabled, :with_failing_hmrc_bank_validation do
-      it "does not add any errors" do
-        form.valid?
-        expect(form.errors[:bank_sort_code]).to be_empty
-        expect(form.errors[:bank_account_number]).to be_empty
-        expect(form.errors[:banking_name]).to be_empty
-      end
+  describe "for TeacherStudentLoanReimbursement journey" do
+    include_examples "bank_details_form", Journeys::TeacherStudentLoanReimbursement
+  end
 
-      it "catches the exception" do
-        expect { form.valid? }.not_to raise_error
-      end
-
-      it "does not set hmrc_api_validation_attempted" do
-        form.valid?
-        expect(form).not_to be_hmrc_api_validation_attempted
-      end
-
-      it "does not set hmrc_api_validation_succeeded" do
-        form.valid?
-        expect(form).not_to be_hmrc_api_validation_succeeded
-      end
-
-      it "adds the response to the claim" do
-        expect { form.valid? }.to change { claim.reload.hmrc_bank_validation_responses }.from([]).to [
-          {"body" => "Test failure", "code" => 429}
-        ]
-      end
-    end
+  describe "for AdditionalPaymentsForTeaching journey" do
+    include_examples "bank_details_form", Journeys::AdditionalPaymentsForTeaching
   end
 end

--- a/spec/forms/bank_or_building_society_form_spec.rb
+++ b/spec/forms/bank_or_building_society_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe BankOrBuildingSocietyForm, type: :model do
+  shared_examples "bank_or_building_society_form" do |journey|
+    before {
+      create(:journey_configuration, :student_loans)
+      create(:journey_configuration, :additional_payments)
+    }
+
+    let(:current_claim) do
+      claims = journey::POLICIES.map { |policy| create(:claim, policy: policy) }
+      CurrentClaim.new(claims:)
+    end
+
+    let(:slug) { "bank-or-building-society-form" }
+    let(:claim_params) { {} }
+
+    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new({slug:, claim: claim_params})) }
+
+    describe "validations" do
+      it { should allow_value(%w[personal_bank_account building_society]).for(:bank_or_building_society).with_message("Select if you want the money paid in to a personal bank account or building society") }
+    end
+
+    describe "#save" do
+      context "when submitted with valid params" do
+        let(:claim_params) { {bank_or_building_society: "personal_bank_account"} }
+
+        it "saves bank_or_building_society" do
+          expect(form.save).to be true
+
+          current_claim.claims.each do |claim|
+            expect(claim.bank_or_building_society).to eq "personal_bank_account"
+          end
+        end
+      end
+    end
+  end
+
+  describe "for TeacherStudentLoanReimbursement journey" do
+    include_examples "bank_or_building_society_form", Journeys::TeacherStudentLoanReimbursement
+  end
+
+  describe "for AdditionalPaymentsForTeaching journey" do
+    include_examples "bank_or_building_society_form", Journeys::AdditionalPaymentsForTeaching
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -81,29 +81,6 @@ RSpec.describe Claim, type: :model do
   context "that has bank details" do
     let(:claim) { build(:claim, policy: Policies::EarlyCareerPayments) }
 
-    it "does not validate which type of payment account was specified" do
-      expect { claim.bank_or_building_society = "visa" }.to raise_error(ArgumentError)
-    end
-
-    it "validates the format of bank_account_number and bank_sort_code" do
-      expect(build(:claim, bank_account_number: "ABC12 34 56 789")).not_to be_valid
-      expect(build(:claim, bank_account_number: "12-34-56-78-90")).not_to be_valid
-      expect(build(:claim, bank_account_number: "12-34-56-78")).to be_valid
-      expect(build(:claim, bank_account_number: "12-34-56")).not_to be_valid
-
-      expect(build(:claim, bank_sort_code: "ABC12 34 567")).not_to be_valid
-      expect(build(:claim, bank_sort_code: "12 34 56")).to be_valid
-    end
-
-    it "validates the format of the building society roll number" do
-      expect(build(:claim, building_society_roll_number: "CXJ-K6 897/98X")).to be_valid
-      expect(build(:claim, building_society_roll_number: "123456789/ABCD")).to be_valid
-      expect(build(:claim, building_society_roll_number: "123456789")).to be_valid
-
-      expect(build(:claim, building_society_roll_number: "123456789/ABC.CD-EFGH ")).not_to be_valid
-      expect(build(:claim, building_society_roll_number: "123456789/*****")).not_to be_valid
-    end
-
     context "on save" do
       it "strips out white space and the “-” character from bank_account_number and bank_sort_code" do
         claim = build(:claim, bank_sort_code: "12 34 56", bank_account_number: "12-34-56-78")
@@ -162,30 +139,6 @@ RSpec.describe Claim, type: :model do
     it "validates the presence of email_address" do
       expect(build(:claim)).not_to be_valid(:"email-address")
       expect(build(:claim, email_address: "name@example.tld")).to be_valid(:"email-address")
-    end
-  end
-
-  context "when saving in the “personal-bank-account” validation context" do
-    it "validates that the bank_account_number and bank_sort_code are present" do
-      invalid_claim = build(:claim)
-      valid_claim = build(:claim, bank_sort_code: "123456", bank_account_number: "87654321", banking_name: "Jo Bloggs")
-      expect(invalid_claim).not_to be_valid(:"personal-bank-account")
-      expect(valid_claim).to be_valid(:"personal-bank-account")
-    end
-  end
-
-  context "when saving in the “building-society-account” validation context" do
-    it "validates that the bank_account_number and bank_sort_code are present" do
-      invalid_claim = build(:claim, bank_or_building_society: :building_society)
-      valid_claim = build(
-        :claim,
-        bank_sort_code: "123456",
-        bank_account_number: "87654321",
-        banking_name: "Jo Bloggs",
-        building_society_roll_number: "CXJ-K6 897/98X"
-      )
-      expect(invalid_claim).not_to be_valid(:"building-society-account")
-      expect(valid_claim).to be_valid(:"building-society-account")
     end
   end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -81,16 +81,6 @@ RSpec.describe Claim, type: :model do
   context "that has bank details" do
     let(:claim) { build(:claim, policy: Policies::EarlyCareerPayments) }
 
-    it "validates which type of payment account was specified" do
-      expect(claim).not_to be_valid(:"bank-or-building-society")
-
-      expect { claim.bank_or_building_society = "paypal" }.to raise_error(ArgumentError)
-
-      claim.bank_or_building_society = :building_society
-
-      expect(claim).to be_valid(:"bank-or-building-society")
-    end
-
     it "does not validate which type of payment account was specified" do
       expect { claim.bank_or_building_society = "visa" }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
## Changes in this PR

- Extract form object for /bank-or-building-society
- Re-purpose existing `BankDetailsForm` to serve `/personal-bank-account` and `building-society-account` pages
- Remove page-specific logic from `ClaimsController`
- ~Switch from storing the `hmrc_validation_attempt_count` in the session to a form parameter so all logic can be encapsulated in form object~
- Move error messages to locales under shared `forms:` section

## Things to note

- I've kept some validations in the `Claim` model since looks as though these attributes can be updated via the admin interface and therefore should be validated still
  - We could look at consolidating these into shared validators once we pull out admin form objects?

<img width="753" alt="Screenshot 2024-04-30 at 09 51 43" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/18436946/6c21bd43-d5c2-4736-afa4-4d2717abb06f">
<img width="758" alt="Screenshot 2024-04-30 at 10 12 58" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/18436946/978eb32c-c247-42c0-9822-d4e8bb86c89d">
