### PR TITLE
CAPT 1602/leadership position

### DIFF
--- a/app/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form.rb
@@ -1,0 +1,31 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class LeadershipPositionForm < Form
+      attribute :had_leadership_position, :boolean
+
+      validates :had_leadership_position,
+        inclusion: {
+          in: [true, false],
+          message: ->(form, _) { form.i18n_errors_path("inclusion") }
+        }
+
+      def save
+        return false unless valid?
+        return true unless had_leadership_position_changed?
+
+        update!(
+          eligibility_attributes: {
+            had_leadership_position: had_leadership_position,
+            mostly_performed_leadership_duties: nil
+          }
+        )
+      end
+
+      private
+
+      def had_leadership_position_changed?
+        claim.eligibility.had_leadership_position != had_leadership_position
+      end
+    end
+  end
+end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form.rb
@@ -1,0 +1,22 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class MostlyPerformedLeadershipDutiesForm < Form
+      attribute :mostly_performed_leadership_duties, :boolean
+
+      validates :mostly_performed_leadership_duties,
+        inclusion: {
+          in: [true, false],
+          message: ->(form, _) { form.i18n_errors_path("inclusion") }
+        }
+
+      def save
+        return false unless valid?
+        claim.update!(
+          eligibility_attributes: {
+            mostly_performed_leadership_duties: mostly_performed_leadership_duties
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -26,7 +26,7 @@ module StudentLoansHelper
   # Returns the question for the leadership-position question in the Student
   # Loans journey.
   def leadership_position_question
-    translate("student_loans.questions.leadership_position", financial_year: Policies::StudentLoans.current_financial_year)
+    translate("student_loans.forms.leadership_position.questions.leadership_position", financial_year: Policies::StudentLoans.current_financial_year)
   end
 
   # Returns the question for the mostly-performed-leadership-duties question in

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -32,6 +32,6 @@ module StudentLoansHelper
   # Returns the question for the mostly-performed-leadership-duties question in
   # the Student  Loans journey.
   def mostly_performed_leadership_duties_question
-    translate("student_loans.questions.mostly_performed_leadership_duties", financial_year: Policies::StudentLoans.current_financial_year)
+    translate("student_loans.forms.mostly_performed_leadership_duties..questions.mostly_performed_leadership_duties", financial_year: Policies::StudentLoans.current_financial_year)
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement.rb
@@ -14,7 +14,8 @@ module Journeys
       "claim-school" => ClaimSchoolForm,
       "qualification-details" => QualificationDetailsForm,
       "qts-year" => QtsYearForm,
-      "leadership-position" => LeadershipPositionForm
+      "leadership-position" => LeadershipPositionForm,
+      "mostly-performed-leadership-duties" => MostlyPerformedLeadershipDutiesForm
     }
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement.rb
@@ -13,7 +13,8 @@ module Journeys
     FORMS = {
       "claim-school" => ClaimSchoolForm,
       "qualification-details" => QualificationDetailsForm,
-      "qts-year" => QtsYearForm
+      "qts-year" => QtsYearForm,
+      "leadership-position" => LeadershipPositionForm
     }
   end
 end

--- a/app/models/policies/student_loans/eligibility.rb
+++ b/app/models/policies/student_loans/eligibility.rb
@@ -52,7 +52,7 @@ module Policies
       validates :employment_status, on: [:"still-teaching", :submit], presence: {message: ->(object, _data) { "Select if you still work at #{object.claim_school_name}, another school or no longer teach in England" }}
       validate :one_subject_must_be_selected, on: [:"subjects-taught", :submit], unless: :not_taught_eligible_subjects?
       validates :had_leadership_position, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}
-      validates :mostly_performed_leadership_duties, on: [:"mostly-performed-leadership-duties", :submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
+      validates :mostly_performed_leadership_duties, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
       validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99999
       validates :student_loan_repayment_amount, on: :amendment, award_range: {max: 5_000}
 

--- a/app/models/policies/student_loans/eligibility.rb
+++ b/app/models/policies/student_loans/eligibility.rb
@@ -51,7 +51,7 @@ module Policies
       validates :claim_school, on: [:"select-claim-school"], presence: {message: ->(object, _data) { object.select_claim_school_presence_error_message }}, unless: :claim_school_somewhere_else?
       validates :employment_status, on: [:"still-teaching", :submit], presence: {message: ->(object, _data) { "Select if you still work at #{object.claim_school_name}, another school or no longer teach in England" }}
       validate :one_subject_must_be_selected, on: [:"subjects-taught", :submit], unless: :not_taught_eligible_subjects?
-      validates :had_leadership_position, on: [:"leadership-position", :submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}
+      validates :had_leadership_position, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}
       validates :mostly_performed_leadership_duties, on: [:"mostly-performed-leadership-duties", :submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
       validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99999
       validates :student_loan_repayment_amount, on: :amendment, award_range: {max: 5_000}

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -1,50 +1,62 @@
-<% content_for(:page_title, page_title(leadership_position_question, journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(
+  :page_title,
+  page_title(
+    leadership_position_question,
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.had_leadership_position": "claim_eligibility_attributes_had_leadership_position_true" }) if current_claim.errors.any? %>
+    <% if @form.errors.any? %>
+      <%= render(
+        "shared/error_summary",
+        instance: @form,
+        errored_field_id_overrides: {
+          "eligibility.had_leadership_position": "claim_eligibility_attributes_had_leadership_position_true"
+        }
+      ) %>
+    <% end %>
 
-    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= form_group_tag f.object do %>
 
-          <%= fields.hidden_field :had_leadership_position %>
+        <%= f.hidden_field :had_leadership_position %>
 
-          <fieldset class="govuk-fieldset" aria-describedby="had_leadership_position-hint" role="group">
+        <fieldset class="govuk-fieldset" aria-describedby="had_leadership_position-hint" role="group">
 
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading">
-                <%= leadership_position_question %>
-              </h1>
-            </legend>
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= leadership_position_question %>
+            </h1>
+          </legend>
 
-            <div class="govuk-hint" id="had_leadership_position-hint">
-              This includes head of subject, head of year, head of department,
-              deputy head, head teacher or other middle leader role.
+          <div class="govuk-hint" id="had_leadership_position-hint">
+            <%= t("student_loans.forms.leadership_position.hints.leadership_position") %>
+          </div>
+
+          <%= errors_tag f.object, :had_leadership_position %>
+
+          <div class="govuk-radios govuk-radios--inline">
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:had_leadership_position, true, class: "govuk-radios__input") %>
+              <%= f.label :had_leadership_position_true, "Yes", class: "govuk-label govuk-radios__label" %>
             </div>
 
-            <%= errors_tag current_claim.eligibility, :had_leadership_position %>
-
-            <div class="govuk-radios govuk-radios--inline">
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:had_leadership_position, true, class: "govuk-radios__input") %>
-                <%= fields.label :had_leadership_position_true, "Yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:had_leadership_position, false, class: "govuk-radios__input") %>
-                <%= fields.label :had_leadership_position_false, "No", class: "govuk-label govuk-radios__label" %>
-              </div>
-
+            <div class="govuk-radios__item">
+              <%= f.radio_button(:had_leadership_position, false, class: "govuk-radios__input") %>
+              <%= f.label :had_leadership_position_false, "No", class: "govuk-label govuk-radios__label" %>
             </div>
 
-          </fieldset>
+          </div>
 
-        <% end %>
+        </fieldset>
+
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button" %>
+      <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -1,42 +1,75 @@
-<% content_for(:page_title, page_title(mostly_performed_leadership_duties_question, journey: current_journey_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(
+  :page_title,
+  page_title(
+    mostly_performed_leadership_duties_question,
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.mostly_performed_leadership_duties": "claim_eligibility_attributes_mostly_performed_leadership_duties_true"}) if current_claim.errors.any? %>
+    <% if @form.errors.any? %>
+      <%= render(
+        "shared/error_summary",
+        instance: @form,
+        errored_field_id_overrides: {
+          "eligibility.mostly_performed_leadership_duties": "claim_eligibility_attributes_mostly_performed_leadership_duties_true"
+        }
+      ) %>
+    <% end %>
 
-    <%= form_for current_claim, url: claim_path(current_journey_routing_name) do |form| %>
-      <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
-          <%= fields.hidden_field :mostly_performed_leadership_duties %>
-          <fieldset class="govuk-fieldset" aria-describedby="mostly_performed_leadership_duties-hint" role="group">
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= form_group_tag f.object do %>
+        <%= f.hidden_field :mostly_performed_leadership_duties %>
 
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading">
-                <%= mostly_performed_leadership_duties_question %>
-              </h1>
-            </legend>
+        <fieldset class="govuk-fieldset" aria-describedby="mostly_performed_leadership_duties-hint" role="group">
 
-            <div class="govuk-hint" id="mostly_performed_leadership_duties-hint">
-              If you were off on long-term leave or sick, include the time you would have spent.
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= mostly_performed_leadership_duties_question %>
+            </h1>
+          </legend>
+
+          <div class="govuk-hint" id="mostly_performed_leadership_duties-hint">
+            <%= I18n.t("student_loans.forms.mostly_performed_leadership_duties.hints.mostly_performed_leadership_duties") %>
+          </div>
+
+          <%= errors_tag f.object, :mostly_performed_leadership_duties %>
+
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :mostly_performed_leadership_duties,
+                true,
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                :mostly_performed_leadership_duties_true,
+                "Yes",
+                class: "govuk-label govuk-radios__label"
+              ) %>
             </div>
 
-            <%= errors_tag current_claim.eligibility, :mostly_performed_leadership_duties %>
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :mostly_performed_leadership_duties,
+                false,
+                class: "govuk-radios__input"
+              ) %>
 
-            <div class="govuk-radios govuk-radios--inline">
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:mostly_performed_leadership_duties, true, class: "govuk-radios__input") %>
-                <%= fields.label :mostly_performed_leadership_duties_true, "Yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:mostly_performed_leadership_duties, false, class: "govuk-radios__input") %>
-                <%= fields.label :mostly_performed_leadership_duties_false, "No", class: "govuk-label govuk-radios__label" %>
-              </div>
+              <%= f.label(
+                :mostly_performed_leadership_duties_false,
+                "No",
+                class: "govuk-label govuk-radios__label"
+              ) %>
             </div>
+          </div>
 
-          </fieldset>
-        <% end %>
+        </fieldset>
       <% end %>
-      <%= form.submit "Continue", class: "govuk-button" %>
+
+      <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -217,6 +217,13 @@ en:
           select_the_school_you_teach_at: "Select the school you teach at"
           the_selected_school_is_closed: "The selected school is closed"
           school_not_found: "School not found"
+      leadership_position:
+        questions:
+          leadership_position: "Were you employed in a leadership position between %{financial_year}?"
+        hints:
+          leadership_position: "This includes head of subject, head of year, head of department, deputy head, head teacher or other middle leader role."
+        errors:
+          inclusion: "Select yes if you were employed in a leadership position"
       mobile_number:
         errors:
           invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
@@ -266,7 +273,6 @@ en:
       claim_school_select_error: "Select the school you taught at between %{financial_year}"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Which of the following subjects did you teach at %{school} between %{financial_year}?"
-      leadership_position: "Were you employed in a leadership position between %{financial_year}?"
       mostly_performed_leadership_duties: "Were more than half your working hours spent on leadership duties between %{financial_year}?"
       eligible_subjects:
         biology_taught: "Biology"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,6 +227,13 @@ en:
       mobile_number:
         errors:
           invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
+      mostly_performed_leadership_duties:
+        questions:
+          mostly_performed_leadership_duties: "Were more than half your working hours spent on leadership duties between %{financial_year}?"
+        hints:
+          mostly_performed_leadership_duties: "If you were off on long-term leave or sick, include the time you would have spent."
+        errors:
+          inclusion: "Select yes if you spent more than half your working hours on leadership duties"
       select_mobile_form:
         questions:
           which_number: "Which mobile number should we use to contact you?"
@@ -273,7 +280,6 @@ en:
       claim_school_select_error: "Select the school you taught at between %{financial_year}"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Which of the following subjects did you teach at %{school} between %{financial_year}?"
-      mostly_performed_leadership_duties: "Were more than half your working hours spent on leadership duties between %{financial_year}?"
       eligible_subjects:
         biology_taught: "Biology"
         chemistry_taught: "Chemistry"

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm do
+  let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+
+  let(:eligibility) do
+    create(
+      :student_loans_eligibility,
+      mostly_performed_leadership_duties: true,
+      had_leadership_position: true
+    )
+  end
+
+  let(:claim) do
+    create(
+      :claim,
+      policy: Policies::StudentLoans,
+      eligibility: eligibility
+    )
+  end
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {had_leadership_position: had_leadership_position}
+    )
+  end
+
+  let(:form) do
+    described_class.new(journey: journey, claim: current_claim, params: params)
+  end
+
+  describe "validations" do
+    subject { form }
+
+    describe "had_leadership_position" do
+      context "when `true" do
+        let(:had_leadership_position) { true }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `false`" do
+        let(:had_leadership_position) { false }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when `nil`" do
+        let(:had_leadership_position) { nil }
+
+        before { form.had_leadership_position = nil }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    context "when the had_leadership_position attribute has not changed" do
+      let(:had_leadership_position) { true }
+
+      it "doesn't update the eligibility had_leadership_position attribute" do
+        expect(eligibility.reload.had_leadership_position).to eq(true)
+      end
+
+      it "doesn't reset the mostly_performed_leadership_duties attribute" do
+        expect(eligibility.reload.mostly_performed_leadership_duties).to eq(true)
+      end
+    end
+
+    context "when the had_leadership_position attribute has changed" do
+      let(:had_leadership_position) { false }
+
+      it "updates the eligibility had_leadership_position attribute" do
+        expect(eligibility.reload.had_leadership_position).to eq(false)
+      end
+
+      it "resets the mostly_performed_leadership_duties attribute" do
+        expect(eligibility.reload.mostly_performed_leadership_duties).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeadershipDutiesForm do
+  let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+
+  let(:eligibility) do
+    create(
+      :student_loans_eligibility,
+      mostly_performed_leadership_duties: true,
+      had_leadership_position: true
+    )
+  end
+
+  let(:claim) do
+    create(
+      :claim,
+      policy: Policies::StudentLoans,
+      eligibility: eligibility
+    )
+  end
+
+  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        mostly_performed_leadership_duties: mostly_performed_leadership_duties
+      }
+    )
+  end
+
+  let(:form) do
+    described_class.new(journey: journey, claim: current_claim, params: params)
+  end
+
+  describe "validations" do
+    subject { form }
+
+    context "when `true`" do
+      let(:mostly_performed_leadership_duties) { true }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when `false`" do
+      let(:mostly_performed_leadership_duties) { false }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when `nil`" do
+      let(:mostly_performed_leadership_duties) { nil }
+
+      before { form.mostly_performed_leadership_duties = nil }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    let(:mostly_performed_leadership_duties) { true }
+
+    it "updates the eligibility with the mostly_performed_leadership_duties" do
+      expect(eligibility.mostly_performed_leadership_duties).to(
+        eq(true)
+      )
+    end
+  end
+end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -279,14 +279,6 @@ RSpec.describe Policies::StudentLoans::Eligibility, type: :model do
     end
   end
 
-  context "when saving in the “leadership-position” context" do
-    it "is not valid without a value for had_leadership_position" do
-      expect(described_class.new).not_to be_valid(:"leadership-position")
-      expect(described_class.new(had_leadership_position: true)).to be_valid(:"leadership-position")
-      expect(described_class.new(had_leadership_position: false)).to be_valid(:"leadership-position")
-    end
-  end
-
   context "when saving in the “mostly-performed-leadership-duties” context" do
     it "is valid when mostly_performed_leadership_duties is present as a boolean value and had_leadership_position is true" do
       expect(described_class.new(had_leadership_position: true)).not_to be_valid(:"mostly-performed-leadership-duties")
@@ -310,13 +302,6 @@ RSpec.describe Policies::StudentLoans::Eligibility, type: :model do
 
     it "is not valid without at least one subject being taught selected" do
       expect(build(:student_loans_eligibility, :eligible, physics_taught: nil)).not_to be_valid(:submit)
-    end
-
-    it "is not valid without a value for had_leadership_position" do
-      expect(build(:student_loans_eligibility, :eligible, had_leadership_position: nil)).not_to be_valid(:submit)
-
-      expect(build(:student_loans_eligibility, :eligible, had_leadership_position: true)).to be_valid(:submit)
-      expect(build(:student_loans_eligibility, :eligible, had_leadership_position: false)).to be_valid(:submit)
     end
 
     it "is not valid without a value for mostly_performed_leadership_duties" do

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -279,18 +279,6 @@ RSpec.describe Policies::StudentLoans::Eligibility, type: :model do
     end
   end
 
-  context "when saving in the “mostly-performed-leadership-duties” context" do
-    it "is valid when mostly_performed_leadership_duties is present as a boolean value and had_leadership_position is true" do
-      expect(described_class.new(had_leadership_position: true)).not_to be_valid(:"mostly-performed-leadership-duties")
-      expect(described_class.new(had_leadership_position: true, mostly_performed_leadership_duties: true)).to be_valid(:"mostly-performed-leadership-duties")
-      expect(described_class.new(had_leadership_position: true, mostly_performed_leadership_duties: false)).to be_valid(:"mostly-performed-leadership-duties")
-    end
-
-    it "is valid when missing if had_leadership_position is false" do
-      expect(described_class.new(had_leadership_position: false)).to be_valid(:"mostly-performed-leadership-duties")
-    end
-  end
-
   context "when saving in the “submit” context" do
     it "is valid when all attributes are present" do
       expect(build(:student_loans_eligibility, :eligible)).to be_valid(:submit)
@@ -302,10 +290,6 @@ RSpec.describe Policies::StudentLoans::Eligibility, type: :model do
 
     it "is not valid without at least one subject being taught selected" do
       expect(build(:student_loans_eligibility, :eligible, physics_taught: nil)).not_to be_valid(:submit)
-    end
-
-    it "is not valid without a value for mostly_performed_leadership_duties" do
-      expect(build(:student_loans_eligibility, :eligible, mostly_performed_leadership_duties: nil)).not_to be_valid(:submit)
     end
 
     it "is not valid without a value for student_loan_repayment_amount" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe "Claims", type: :request do
       it "resets depenent eligibility attributes when appropriate" do
         in_progress_claim.update!(eligibility_attributes: {had_leadership_position: true, mostly_performed_leadership_duties: false})
         set_slug_sequence_in_session(in_progress_claim, "leadership-position")
-        put claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "leadership-position"), params: {claim: {eligibility_attributes: {had_leadership_position: false}}}
+        put claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "leadership-position"), params: {claim: {had_leadership_position: false}}
 
         expect(response).to redirect_to(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "eligibility-confirmed"))
         expect(in_progress_claim.eligibility.reload.mostly_performed_leadership_duties).to be_nil


### PR DESCRIPTION
This pr covers both CAPT-1602 and CAPT-1603. I decided to do both together as
they're related questions. Might be easier to review each commit separately.
The only thing worth noting is that we don't call reset dependent attributes in
after changing the `had_leadership_position` question, instead we `nil`ify the
`mostly_performed_leadership_duties` question in the form update if the teacher
has changed there answer.
We may want to consider using `ActiveModel::Dirty` as this is the second form
object where we're defining a `*_changed?` method (though it's quite tricky to
get AM dirty to work with AM attributes). I think introducing
`ActiveModel::Dirty` is best done in a separate pr.

## Walk through
https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/1bfb3cf5-cea2-4376-a89d-4adc14c5f42a