### PR TITLE
Install yarn packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
+      - name: Install js packages
+        run: yarn install
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -51,6 +53,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
+      - name: Install js packages
+        run: yarn install
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Cache doesn't run yarn install for us

Fixes the issues with precompiling assets on ci
<!-- Do you need to update CHANGELOG.md? -->
