### PR TITLE
Fixes flakey omniauth spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,8 @@ RSpec.configure do |config|
     clear_enqueued_jobs
     ActionMailer::Base.deliveries.clear
     OmniAuth.config.mock_auth[:dfe] = nil
+    OmniAuth.config.mock_auth[:tid] = nil
+    OmniAuth.config.mock_auth[:default] = nil
   end
 
   config.filter_run_excluding flaky: true unless ENV["RUN_FLAKY_SPECS"] == "true"


### PR DESCRIPTION
Depending on the order specs ran
`spec/requests/omniauth_callbacks_controller_spec` would fail, the
minimal reproduction case for this failure was

```
bundle exec rspec --order defined \
  spec/features/teacher_identity_sign_in_spec.rb \
  spec/requests/omniauth_callbacks_controller_spec.rb
````

This was due to omniauth mocks not being reset between test runs.
Updating the suite's before hook to nil out the mock_auths fixes the
issue.
