### PR TITLE
Introduces journey session model

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -159,6 +159,7 @@ class ClaimsController < BasePublicController
 
     current_claim.save!
     session[:claim_id] = current_claim.claim_ids
+    session[journey_session_key] = journey_session.id
     redirect_to claim_path(current_journey_routing_name, page_sequence.slugs.first.to_sym)
   end
 

--- a/app/controllers/concerns/journey_concern.rb
+++ b/app/controllers/concerns/journey_concern.rb
@@ -21,6 +21,10 @@ module JourneyConcern
     @current_claim ||= claim_from_session || build_new_claim
   end
 
+  def journey_session
+    @journey_session ||= find_journey_session || create_journey_session!
+  end
+
   private
 
   def claim_from_session
@@ -45,5 +49,17 @@ module JourneyConcern
         academic_year: journey_configuration.current_academic_year
       )
     end
+  end
+
+  def find_journey_session
+    Journeys::Session.find_by(id: session[journey_session_key])
+  end
+
+  def create_journey_session!
+    Journeys::Session.create!(journey: params[:journey])
+  end
+
+  def journey_session_key
+    :"#{params[:journey]}_journeys_session_id"
   end
 end

--- a/app/models/journeys.rb
+++ b/app/models/journeys.rb
@@ -1,6 +1,10 @@
 module Journeys
   extend self
 
+  def self.table_name_prefix
+    "journeys_"
+  end
+
   JOURNEYS = [
     AdditionalPaymentsForTeaching,
     TeacherStudentLoanReimbursement

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -1,0 +1,7 @@
+module Journeys
+  class Session < ApplicationRecord
+    validates :journey,
+      presence: true,
+      inclusion: {in: Journeys.all_routing_names}
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -296,3 +296,9 @@ shared:
     - hours_taught
     - created_at
     - updated_at
+  :journeys_sessions:
+    - id
+    - answers
+    - journey
+    - created_at
+    - updated_at

--- a/db/migrate/20240508081918_create_journeys_sessions.rb
+++ b/db/migrate/20240508081918_create_journeys_sessions.rb
@@ -1,0 +1,10 @@
+class CreateJourneysSessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :journeys_sessions, id: :uuid do |t|
+      t.jsonb :answers, default: {}
+      t.string :journey, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_24_134854) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_08_081918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -186,6 +186,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_24_134854) do
     t.string "current_academic_year", limit: 9
     t.boolean "teacher_id_enabled", default: true
     t.index ["created_at"], name: "index_journey_configurations_on_created_at"
+  end
+
+  create_table "journeys_sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "answers", default: {}
+    t.string "journey", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "levelling_up_premium_payments_awards", force: :cascade do |t|

--- a/spec/factories/journeys/sessions.rb
+++ b/spec/factories/journeys/sessions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :journeys_session, class: "Journeys::Session" do
+    journey { "additional-payments" }
+  end
+end

--- a/spec/models/journeys/session_spec.rb
+++ b/spec/models/journeys/session_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Journeys::Session, type: :model do
+  describe "validations" do
+    describe "journey" do
+      it { is_expected.to validate_presence_of(:journey) }
+
+      it do
+        is_expected.to(
+          validate_inclusion_of(:journey).in_array(Journeys.all_routing_names)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of the efforts to simplify multi claim handling we want to move
away from creating a claim at the start of the journey and instead only
create the claim at the final step where the teacher submits their
answers.

This commit introduces a new model `Journeys::Session` which will be
used to store the answers entered by the teacher. The answers will be
stored in a json column on the new model, once validated by the form
objects.

`Journeys::Session` is currently the best name we could come up with but
we're all ears for any better suggestions.
