### PR TITLE
Make journey_session available in forms

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -31,7 +31,7 @@ class ClaimsController < BasePublicController
     end
 
     # TODO: Migrate the remaining slugs to form objects.
-    if @form ||= journey.form(claim: current_claim, params:)
+    if @form ||= journey.form(claim: current_claim, journey_session:, params:)
       set_any_backlink_override
       render current_template
       return
@@ -63,7 +63,7 @@ class ClaimsController < BasePublicController
     params[:claim][:hmrc_validation_attempt_count] = session[:hmrc_validation_attempt_count] || 0 if on_banking_page?
 
     # TODO: Migrate the remaining slugs to form objects.
-    if (@form = journey.form(claim: current_claim, params:))
+    if (@form = journey.form(claim: current_claim, journey_session:, params:))
       if @form.save
         retrieve_student_loan_details
         update_session_with_selected_policy
@@ -120,7 +120,12 @@ class ClaimsController < BasePublicController
 
   def redirect_to_existing_claim_journey
     new_journey = Journeys.for_policy(current_claim.policy)
-    new_page_sequence = new_journey.page_sequence_for_claim(current_claim, session[:slugs], params[:slug])
+    new_page_sequence = new_journey.page_sequence_for_claim(
+      current_claim,
+      journey_session,
+      session[:slugs],
+      params[:slug]
+    )
     redirect_to(claim_path(new_journey::ROUTING_NAME, slug: new_page_sequence.next_required_slug))
   end
 
@@ -197,7 +202,12 @@ class ClaimsController < BasePublicController
   end
 
   def page_sequence
-    @page_sequence ||= journey.page_sequence_for_claim(current_claim, session[:slugs], params[:slug])
+    @page_sequence ||= journey.page_sequence_for_claim(
+      current_claim,
+      journey_session,
+      session[:slugs],
+      params[:slug]
+    )
   end
 
   def prepend_view_path_for_journey

--- a/app/forms/claim_school_form.rb
+++ b/app/forms/claim_school_form.rb
@@ -6,7 +6,7 @@ class ClaimSchoolForm < Form
   validates :claim_school_id, presence: {message: i18n_error_message(:select_a_school)}
   validate :claim_school_must_exist, if: -> { claim_school_id.present? }
 
-  def initialize(claim:, journey:, params:)
+  def initialize(claim:, journey_session:, journey:, params:)
     super
 
     load_schools

--- a/app/forms/current_school_form.rb
+++ b/app/forms/current_school_form.rb
@@ -6,7 +6,7 @@ class CurrentSchoolForm < Form
   validates :current_school_id, presence: {message: i18n_error_message(:select_the_school_you_teach_at)}
   validate :current_school_must_be_open, if: -> { current_school_id.present? }
 
-  def initialize(claim:, journey:, params:)
+  def initialize(claim:, journey_session:, journey:, params:)
     super
 
     load_schools

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -6,6 +6,7 @@ class Form
 
   attr_accessor :claim
   attr_accessor :journey
+  attr_accessor :journey_session
   attr_accessor :params
 
   delegate :persisted?, to: :claim
@@ -18,7 +19,8 @@ class Form
     ->(object, _) { object.i18n_errors_path(path) }
   end
 
-  def initialize(claim:, journey:, params:)
+  # TODO RL: remove journey param and pull it from the journey_session
+  def initialize(claim:, journey_session:, journey:, params:)
     super
 
     assign_attributes(attributes_with_current_value)
@@ -67,7 +69,7 @@ class Form
   def page_sequence
     @page_sequence ||= Journeys::PageSequence.new(
       claim,
-      journey.slug_sequence.new(claim),
+      journey.slug_sequence.new(claim, journey_session),
       nil,
       params[:slug]
     )

--- a/app/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form.rb
@@ -58,6 +58,7 @@ module Journeys
       def set_qualification!
         QualificationForm.new(
           journey: journey,
+          journey_session: journey_session,
           claim: claim,
           params: ActionController::Parameters.new(
             claim: {

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -40,7 +40,7 @@ class PersonalDetailsForm < Form
   validates :national_insurance_number, presence: {message: "Enter a National Insurance number in the correct format"}
   validate :ni_number_is_correct_format
 
-  def initialize(claim:, journey:, params:)
+  def initialize(claim:, journey_session:, journey:, params:)
     super
     assign_date_attributes
   end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -75,11 +75,12 @@ module Journeys
         RESULTS_SLUGS
       ).freeze
 
-      attr_reader :claim
+      attr_reader :claim, :journey_session
 
       # Really this is a combined CurrentClaim
-      def initialize(claim)
+      def initialize(claim, journey_session)
         @claim = claim
+        @journey_session = journey_session
       end
 
       # Even though we are inside the ECP namespace, this method can modify the
@@ -179,6 +180,7 @@ module Journeys
       def personal_details_form
         PersonalDetailsForm.new(
           claim:,
+          journey_session:,
           journey: Journeys::AdditionalPaymentsForTeaching,
           params: ActionController::Parameters.new
         )

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -31,18 +31,23 @@ module Journeys
       self::SlugSequence
     end
 
-    def form(claim:, params:)
+    def form(claim:, journey_session:, params:)
       form = SHARED_FORMS.merge(forms)[params[:slug]]
 
-      form&.new(journey: self, claim:, params:)
+      form&.new(journey: self, journey_session:, claim:, params:)
     end
 
     def forms
       defined?(self::FORMS) ? self::FORMS : {}
     end
 
-    def page_sequence_for_claim(claim, completed_slugs, current_slug)
-      PageSequence.new(claim, slug_sequence.new(claim), completed_slugs, current_slug)
+    def page_sequence_for_claim(claim, journey_session, completed_slugs, current_slug)
+      PageSequence.new(
+        claim,
+        slug_sequence.new(claim, journey_session),
+        completed_slugs,
+        current_slug
+      )
     end
 
     def answers_presenter

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -61,10 +61,11 @@ module Journeys
         RESULTS_SLUGS
       ).freeze
 
-      attr_reader :claim
+      attr_reader :claim, :journey_session
 
-      def initialize(claim)
+      def initialize(claim, journey_session)
         @claim = claim
+        @journey_session = journey_session
       end
 
       def slugs
@@ -132,6 +133,7 @@ module Journeys
       def personal_details_form
         PersonalDetailsForm.new(
           claim:,
+          journey_session:,
           journey: Journeys::TeacherStudentLoanReimbursement,
           params: ActionController::Parameters.new
         )

--- a/spec/forms/address_form_spec.rb
+++ b/spec/forms/address_form_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe AddressForm, type: :model do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) { described_class.new(claim:, journey:, params:, journey_session:) }
 
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
   let(:slug) { "address" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -12,12 +12,23 @@ RSpec.describe BankDetailsForm do
       CurrentClaim.new(claims: claims)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:slug) { "personal-bank-account" }
     let(:params) do
       {banking_name:, bank_sort_code:, bank_account_number:, building_society_roll_number:, hmrc_validation_attempt_count:}
     end
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new(slug:, claim: params)) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: ActionController::Parameters.new(slug:, claim: params)
+      )
+    end
 
     let(:banking_name) { "Jo Bloggs" }
     let(:bank_sort_code) { rand(100000..999999) }

--- a/spec/forms/bank_or_building_society_form_spec.rb
+++ b/spec/forms/bank_or_building_society_form_spec.rb
@@ -12,10 +12,21 @@ RSpec.describe BankOrBuildingSocietyForm, type: :model do
       CurrentClaim.new(claims:)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:slug) { "bank-or-building-society-form" }
     let(:claim_params) { {} }
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new({slug:, claim: claim_params})) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: ActionController::Parameters.new({slug:, claim: claim_params})
+      )
+    end
 
     describe "validations" do
       it { should allow_value(%w[personal_bank_account building_society]).for(:bank_or_building_society).with_message("Select if you want the money paid in to a personal bank account or building society") }

--- a/spec/forms/claim_school_form_spec.rb
+++ b/spec/forms/claim_school_form_spec.rb
@@ -10,9 +10,20 @@ RSpec.describe ClaimSchoolForm do
     CurrentClaim.new(claims: claims)
   end
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:slug) { "claim-school" }
 
-  subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+  subject(:form) do
+    described_class.new(
+      claim: current_claim,
+      journey_session: journey_session,
+      journey: journey,
+      params: params
+    )
+  end
 
   context "unpermitted claim param" do
     let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }

--- a/spec/forms/current_school_form_spec.rb
+++ b/spec/forms/current_school_form_spec.rb
@@ -12,9 +12,20 @@ RSpec.describe CurrentSchoolForm do
       CurrentClaim.new(claims: claims)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:slug) { "current-school" }
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: params
+      )
+    end
 
     context "unpermitted claim param" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe EmailAddressForm do
       end
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:current_claim) { CurrentClaim.new(claims: claims) }
 
     let(:params) do
@@ -20,7 +24,12 @@ RSpec.describe EmailAddressForm do
     end
 
     let(:form) do
-      described_class.new(journey: journey, claim: current_claim, params: params)
+      described_class.new(
+        journey: journey,
+        journey_session: journey_session,
+        claim: current_claim,
+        params: params
+      )
     end
 
     describe "validations" do

--- a/spec/forms/email_verification_form_spec.rb
+++ b/spec/forms/email_verification_form_spec.rb
@@ -22,8 +22,17 @@ RSpec.describe EmailVerificationForm do
       )
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:form) do
-      described_class.new(journey: journey, claim: current_claim, params: params)
+      described_class.new(
+        journey: journey,
+        journey_session: journey_session,
+        claim: current_claim,
+        params: params
+      )
     end
 
     around do |example|

--- a/spec/forms/employed_directly_form_spec.rb
+++ b/spec/forms/employed_directly_form_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EmployedDirectlyForm do
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:current_claim) do
     claims = journey::POLICIES.map { |policy| create(:claim, policy:) }
     CurrentClaim.new(claims:)
@@ -12,7 +16,14 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EmployedDirectlyForm do
 
   let(:slug) { "employed-directly" }
 
-  subject(:form) { described_class.new(claim: current_claim, journey:, params:) }
+  subject(:form) do
+    described_class.new(
+      claim: current_claim,
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
 
   context "unpermitted claim param" do
     let(:params) { ActionController::Parameters.new({slug:, claim: {random_param: 1}}) }

--- a/spec/forms/entire_term_contract_form_spec.rb
+++ b/spec/forms/entire_term_contract_form_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EntireTermContractForm d
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:current_claim) do
     claims = journey::POLICIES.map { |policy| create(:claim, policy:) }
     CurrentClaim.new(claims:)
@@ -12,7 +16,14 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EntireTermContractForm d
 
   let(:slug) { "entire-term-contract" }
 
-  subject(:form) { described_class.new(claim: current_claim, journey:, params:) }
+  subject(:form) do
+    described_class.new(
+      claim: current_claim,
+      journey:,
+      journey_session:,
+      params:
+    )
+  end
 
   context "unpermitted claim param" do
     let(:params) { ActionController::Parameters.new({slug:, claim: {random_param: 1}}) }

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -14,7 +14,7 @@ module Journeys
     I18N_NAMESPACE = "test_i18n_ns"
 
     class SlugSequence
-      def initialize(claim)
+      def initialize(claim, journey_session)
         # NOOP
       end
     end
@@ -40,11 +40,12 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  subject(:form) { TestSlugForm.new(claim:, journey:, params:) }
+  subject(:form) { TestSlugForm.new(claim:, journey:, journey_session:, params:) }
 
   let(:claim) { CurrentClaim.new(claims:) }
   let(:claims) { [build(:claim, policy: Policies::StudentLoans)] }
   let(:journey) { Journeys::TestJourney }
+  let(:journey_session) { build(:journeys_session) }
   let(:params) { ActionController::Parameters.new({journey: "test-journey", slug: "test_slug", claim: claim_params}) }
   let(:claim_params) { {first_name: "test-name"} }
 

--- a/spec/forms/gender_form_spec.rb
+++ b/spec/forms/gender_form_spec.rb
@@ -11,9 +11,20 @@ RSpec.describe GenderForm do
       CurrentClaim.new(claims: claims)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:slug) { "gender" }
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: params
+      )
+    end
 
     context "unpermitted claim param" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }

--- a/spec/forms/journeys/additional_payments_for_teaching/correct_school_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/correct_school_form_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::CorrectSchoolForm, type:
 
     let(:claim) { CurrentClaim.new(claims: [create(:claim, policy: Policies::LevellingUpPremiumPayments)]) }
     let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
     let(:params) { ActionController::Parameters.new }
-    let(:form) { described_class.new(claim:, journey:, params:) }
+    let(:form) { described_class.new(claim:, journey:, journey_session:, params:) }
     let!(:school) { create(:school, :eligible_for_journey, journey:) }
 
     context "when choosing a school" do

--- a/spec/forms/journeys/additional_payments_for_teaching/eligibility_confirmed_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligibility_confirmed_form_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibilityConfirmedForm, type: :model do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) { described_class.new(claim:, journey:, journey_session:, params:) }
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:ecp_claim) { build(:claim, :eligible, policy: Policies::EarlyCareerPayments) }
   let(:lupp_claim) { build(:claim, :eligible, policy: Policies::LevellingUpPremiumPayments) }
   let(:claim) { CurrentClaim.new(claims: [ecp_claim, lupp_claim], selected_policy:) }

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_degree_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_degree_subject_form_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleDegreeSubjectForm do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) do
+    described_class.new(claim:, journey_session:, journey:, params:)
+  end
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:ecp_claim) { build(:claim, policy: Policies::EarlyCareerPayments) }
   let(:lupp_claim) { build(:claim, policy: Policies::LevellingUpPremiumPayments) }
   let(:claim) { CurrentClaim.new(claims: [ecp_claim, lupp_claim]) }

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
     )
   end
 
-  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
 
   let(:ecp_trainee_teacher_eligibility) do
     create(
@@ -52,7 +56,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
 
     subject(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: ActionController::Parameters.new
       )
@@ -68,7 +73,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
   describe "#available_subjects" do
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: ActionController::Parameters.new
       )
@@ -122,7 +128,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
   describe "#show_hint_text?" do
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: ActionController::Parameters.new
       )
@@ -163,7 +170,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
   describe "#chemistry_or_physics_available?" do
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: ActionController::Parameters.new
       )
@@ -209,7 +217,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
 
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: params
       )

--- a/spec/forms/journeys/additional_payments_for_teaching/induction_completed_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/induction_completed_form_spec.rb
@@ -13,7 +13,18 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::InductionCompletedForm d
 
     let(:slug) { "induction_completed" }
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: params
+      )
+    end
 
     context "unpermitted claim param" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }

--- a/spec/forms/journeys/additional_payments_for_teaching/itt_academic_year_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/itt_academic_year_form_spec.rb
@@ -11,9 +11,20 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::IttAcademicYearForm do
       CurrentClaim.new(claims: claims)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:slug) { "itt_year" }
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: params
+      )
+    end
 
     context "unpermitted claim param" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }

--- a/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIttForm do
   before { create(:journey_configuration, :additional_payments) }
 
-  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
 
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
@@ -13,7 +17,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
     describe "#nqt_in_academic_year_after_itt" do
       subject(:form) do
         described_class.new(
-          journey: additional_payments_journey,
+          journey: journey,
+          journey_session: journey_session,
           claim: current_claim,
           params: params
         )
@@ -60,7 +65,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
   describe "#save" do
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: params
       )
@@ -194,7 +200,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
 
       let(:form) do
         described_class.new(
-          journey: additional_payments_journey,
+          journey: journey,
+          journey_session: journey_session,
           claim: current_claim,
           params: ActionController::Parameters.new({})
         )
@@ -235,7 +242,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
 
       let(:form) do
         described_class.new(
-          journey: additional_payments_journey,
+          journey: journey,
+          journey_session: journey_session,
           claim: current_claim,
           params: ActionController::Parameters.new({
             journey: "additional-payments"

--- a/spec/forms/journeys/additional_payments_for_teaching/poor_performance_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/poor_performance_form_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::PoorPerformanceForm do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) { described_class.new(claim:, journey_session:, journey:, params:) }
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:ecp_claim) { build(:claim, policy: Policies::EarlyCareerPayments) }
   let(:lupp_claim) { build(:claim, policy: Policies::LevellingUpPremiumPayments) }
   let(:claim) { CurrentClaim.new(claims: [ecp_claim, lupp_claim]) }

--- a/spec/forms/journeys/additional_payments_for_teaching/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/qualification_details_form_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm do
   before { create(:journey_configuration, :additional_payments) }
 
-  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
 
   let(:early_career_payments_eligibility) do
     create(
@@ -54,6 +58,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm
   let(:form) do
     described_class.new(
       journey: Journeys::AdditionalPaymentsForTeaching,
+      journey_session: journey_session,
       claim: current_claim,
       params: params
     )

--- a/spec/forms/journeys/additional_payments_for_teaching/qualification_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/qualification_form_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type: :model do
   before { create(:journey_configuration, :additional_payments) }
 
-  let(:additional_payments_journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
 
   let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
 
@@ -12,7 +16,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
   describe "validations" do
     subject(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: ActionController::Parameters.new
       )
@@ -30,7 +35,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
   describe "#save" do
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: params
       )
@@ -76,7 +82,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
   describe "#backlink_path" do
     let(:form) do
       described_class.new(
-        journey: additional_payments_journey,
+        journey: journey,
+        journey_session: journey_session,
         claim: current_claim,
         params: ActionController::Parameters.new(
           {

--- a/spec/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::TeachingSubjectNowForm do
   before { create(:journey_configuration, :additional_payments) }
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:eligibility) { create(:early_career_payments_eligibility) }
   let(:claim) do
     create(
@@ -15,6 +18,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::TeachingSubjectNowForm d
   let(:form) do
     described_class.new(
       journey: journey,
+      journey_session: journey_session,
       claim: current_claim,
       params: params
     )

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm
 
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:params) do
     ActionController::Parameters.new(
       claim: {had_leadership_position: had_leadership_position}
@@ -28,7 +32,12 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm
   end
 
   let(:form) do
-    described_class.new(journey: journey, claim: current_claim, params: params)
+    described_class.new(
+      journey: journey,
+      journey_session: journey_session,
+      claim: current_claim,
+      params: params
+    )
   end
 
   describe "validations" do

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeaders
     )
   end
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
   let(:params) do
@@ -30,7 +34,12 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeaders
   end
 
   let(:form) do
-    described_class.new(journey: journey, claim: current_claim, params: params)
+    described_class.new(
+      journey: journey,
+      journey_session: journey_session,
+      claim: current_claim,
+      params: params
+    )
   end
 
   describe "validations" do

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qts_year_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qts_year_form_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::QtsYearForm, type: :model do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) do
+    described_class.new(claim:, journey_session:, journey:, params:)
+  end
 
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
   let(:slug) { "qts-year" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
@@ -20,9 +20,16 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
     CurrentClaim.new(claims: [student_loans_claim])
   end
 
+  let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:form) do
     described_class.new(
-      journey: Journeys::TeacherStudentLoanReimbursement,
+      journey: journey,
+      journey_session: journey_session,
       claim: current_claim,
       params: params
     )

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SelectClaimSchoolForm,
 
     let(:claim) { CurrentClaim.new(claims: [create(:claim, policy: Policies::StudentLoans)]) }
     let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
     let(:params) { ActionController::Parameters.new }
-    let(:form) { described_class.new(claim:, journey:, params:) }
+    let(:form) { described_class.new(claim:, journey:, journey_session:, params:) }
     let!(:school) { create(:school, :eligible_for_journey, journey:) }
 
     context "when choosing a school" do

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
   let(:claim) { create(:claim, policy: Policies::StudentLoans, eligibility:) }
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:claim_params) { {} }
+  let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
 
   subject(:form) do
     described_class.new(
-      journey: Journeys::TeacherStudentLoanReimbursement,
+      journey: journey,
+      journey_session: journey_session,
       claim: current_claim,
       params: ActionController::Parameters.new(claim: claim_params)
     )

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, type: :model do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) do
+    described_class.new(claim:, journey_session:, journey:, params:)
+  end
 
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
   let(:slug) { "subjects-taught" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }

--- a/spec/forms/mobile_number_form_spec.rb
+++ b/spec/forms/mobile_number_form_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe MobileNumberForm do
       end
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:current_claim) { CurrentClaim.new(claims: claims) }
 
     let(:params) do
@@ -20,7 +24,12 @@ RSpec.describe MobileNumberForm do
     end
 
     let(:form) do
-      described_class.new(journey: journey, claim: current_claim, params: params)
+      described_class.new(
+        journey: journey,
+        journey_session: journey_session,
+        claim: current_claim,
+        params: params
+      )
     end
 
     describe "validations" do

--- a/spec/forms/mobile_verification_form_spec.rb
+++ b/spec/forms/mobile_verification_form_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe MobileVerificationForm do
 
     let(:current_claim) { CurrentClaim.new(claims: claims) }
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:params) do
       ActionController::Parameters.new(
         claim: {
@@ -23,7 +27,12 @@ RSpec.describe MobileVerificationForm do
     end
 
     let(:form) do
-      described_class.new(journey: journey, claim: current_claim, params: params)
+      described_class.new(
+        journey: journey,
+        journey_session: journey_session,
+        claim: current_claim,
+        params: params
+      )
     end
 
     around do |example|

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -12,10 +12,21 @@ RSpec.describe PersonalDetailsForm, type: :model do
       CurrentClaim.new(claims: claims)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:slug) { "personal-details" }
     let(:params) { {} }
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: ActionController::Parameters.new(slug:, claim: params)) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: ActionController::Parameters.new(slug:, claim: params)
+      )
+    end
 
     context "unpermitted claim param" do
       let(:params) { {nonsense_id: 1} }

--- a/spec/forms/postcode_search_form_spec.rb
+++ b/spec/forms/postcode_search_form_spec.rb
@@ -1,10 +1,13 @@
 require "rails_helper"
 
 RSpec.describe PostcodeSearchForm, type: :model do
-  subject { described_class.new(claim:, journey:, params:) }
+  subject { described_class.new(claim:, journey:, params:, journey_session:) }
 
   let(:claim) { CurrentClaim.new(claims: [create(:claim)]) }
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:params) { ActionController::Parameters.new }
 
   before do

--- a/spec/forms/provide_mobile_number_form_spec.rb
+++ b/spec/forms/provide_mobile_number_form_spec.rb
@@ -14,8 +14,18 @@ RSpec.describe ProvideMobileNumberForm, type: :model do
 
     let(:slug) { "provide-mobile-number" }
     let(:params) { ActionController::Parameters.new }
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
 
-    subject(:form) { described_class.new(claim: current_claim, journey: journey, params: params) }
+    subject(:form) do
+      described_class.new(
+        claim: current_claim,
+        journey_session: journey_session,
+        journey: journey,
+        params: params
+      )
+    end
 
     context "unpermitted claim param" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }

--- a/spec/forms/reset_claim_form_spec.rb
+++ b/spec/forms/reset_claim_form_spec.rb
@@ -2,11 +2,14 @@ require "rails_helper"
 
 RSpec.describe ResetClaimForm, type: :model do
   describe "#save" do
-    subject { described_class.new(claim:, journey:, params:).save }
+    subject { described_class.new(claim:, journey:, params:, journey_session:).save }
 
     let(:claim) { double }
-    let(:journey) { double }
+    let(:journey) { Journeys::TeacherStudentLoanReimbursement }
     let(:params) { nil }
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
 
     it { is_expected.to be_truthy }
   end

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe SelectEmailForm, type: :model do
-  subject(:form) { described_class.new(claim:, journey:, params:) }
+  subject(:form) { described_class.new(claim:, journey_session:, journey:, params:) }
 
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
   let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
   let(:slug) { "select-email" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }

--- a/spec/forms/select_mobile_form_spec.rb
+++ b/spec/forms/select_mobile_form_spec.rb
@@ -17,12 +17,21 @@ RSpec.describe SelectMobileForm do
 
     let(:current_claim) { CurrentClaim.new(claims: claims) }
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:params) do
       ActionController::Parameters.new(claim: {mobile_check: mobile_check})
     end
 
     let(:form) do
-      described_class.new(journey: journey, claim: current_claim, params: params)
+      described_class.new(
+        journey: journey,
+        journey_session: journey_session,
+        claim: current_claim,
+        params: params
+      )
     end
 
     describe "validations" do

--- a/spec/forms/sign_in_or_continue_form_spec.rb
+++ b/spec/forms/sign_in_or_continue_form_spec.rb
@@ -15,8 +15,17 @@ RSpec.describe SignInOrContinueForm do
       CurrentClaim.new(claims: claims)
     end
 
+    let(:journey_session) do
+      build(:journeys_session, journey: journey::ROUTING_NAME)
+    end
+
     let(:form) do
-      described_class.new(journey: journey, claim: current_claim, params: params)
+      described_class.new(
+        journey: journey,
+        journey_session: journey_session,
+        claim: current_claim,
+        params: params
+      )
     end
 
     describe "validations" do

--- a/spec/forms/supply_teacher_form_spec.rb
+++ b/spec/forms/supply_teacher_form_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SupplyTeacherForm do
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:current_claim) do
     claims = journey::POLICIES.map { |policy| create(:claim, policy:) }
     CurrentClaim.new(claims:)
@@ -12,7 +16,14 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SupplyTeacherForm do
 
   let(:slug) { "supply-teacher" }
 
-  subject(:form) { described_class.new(claim: current_claim, journey:, params:) }
+  subject(:form) do
+    described_class.new(
+      claim: current_claim,
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
 
   context "unpermitted claim param" do
     let(:params) { ActionController::Parameters.new({slug:, claim: {random_param: 1}}) }

--- a/spec/forms/teacher_reference_number_form_spec.rb
+++ b/spec/forms/teacher_reference_number_form_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe TeacherReferenceNumberForm do
 
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
+  let(:journey_session) do
+    build(:journeys_session, journey: journey::ROUTING_NAME)
+  end
+
   let(:params) do
     ActionController::Parameters.new(
       claim: {
@@ -20,6 +24,7 @@ RSpec.describe TeacherReferenceNumberForm do
   let(:form) do
     described_class.new(
       journey: journey,
+      journey_session: journey_session,
       claim: current_claim,
       params: params
     )

--- a/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
-  subject(:slug_sequence) { described_class.new(current_claim) }
+  subject(:slug_sequence) { described_class.new(current_claim, journey_session) }
 
   let(:eligibility) { create(:early_career_payments_eligibility, :eligible) }
   let(:eligibility_lup) { create(:levelling_up_premium_payments_eligibility, :eligible) }
@@ -9,6 +9,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
   let(:claim) { create(:claim, :skipped_tid, policy: Policies::EarlyCareerPayments, academic_year: AcademicYear.new(2021), eligibility: eligibility, logged_in_with_tid:, details_check:, dqt_teacher_status:, qualifications_details_check:) }
   let(:lup_claim) { create(:claim, :skipped_tid, policy: Policies::LevellingUpPremiumPayments, academic_year: AcademicYear.new(2021), eligibility: eligibility_lup) }
   let(:current_claim) { CurrentClaim.new(claims: [claim, lup_claim]) }
+  let(:journey_session) { build(:journeys_session) }
   let(:teacher_id_enabled) { true }
   let(:logged_in_with_tid) { nil }
   let(:details_check) { nil }
@@ -308,8 +309,9 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
     let(:ecp_claim) { build(:claim, policy: Policies::EarlyCareerPayments, eligibility_trait: ecp_eligibility) }
     let(:lup_claim) { build(:claim, policy: Policies::LevellingUpPremiumPayments, eligibility_trait: lup_eligibility) }
     let(:current_claim) { CurrentClaim.new(claims: [ecp_claim, lup_claim]) }
+    let(:journey_session) { build(:journeys_session) }
 
-    subject { described_class.new(current_claim).slugs }
+    subject { described_class.new(current_claim, journey_session).slugs }
 
     context "current claim is :eligible_now" do
       let(:ecp_eligibility) { :eligible_later }

--- a/spec/models/journeys/additional_payments_for_teaching_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching_spec.rb
@@ -37,8 +37,16 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching do
     let(:completed_slugs) { [:test] }
     let(:current_slug) { [:test2] }
     let(:claim) { double }
+    let(:journey_session) { build(:journeys_session) }
 
-    subject(:page_sequence) { described_class.page_sequence_for_claim(claim, completed_slugs, current_slug) }
+    subject(:page_sequence) do
+      described_class.page_sequence_for_claim(
+        claim,
+        journey_session,
+        completed_slugs,
+        current_slug
+      )
+    end
 
     it { is_expected.to be_a(Journeys::PageSequence) }
 
@@ -49,7 +57,9 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching do
     end
 
     it "creates a slug sequence" do
-      expect(Journeys::AdditionalPaymentsForTeaching::SlugSequence).to receive(:new).with(claim)
+      expect(Journeys::AdditionalPaymentsForTeaching::SlugSequence).to(
+        receive(:new).with(claim, journey_session)
+      )
       page_sequence
     end
   end

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
-  subject(:slug_sequence) { described_class.new(current_claim) }
+  subject(:slug_sequence) { described_class.new(current_claim, journey_session) }
 
   let(:eligibility) { create(:student_loans_eligibility, :eligible) }
   let(:claim) { build(:claim, eligibility:, logged_in_with_tid:, details_check:, qualifications_details_check:, dqt_teacher_status:) }
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+  let(:journey_session) { build(:journeys_session) }
   let(:logged_in_with_tid) { nil }
   let(:details_check) { nil }
   let(:qualifications_details_check) { nil }

--- a/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
@@ -36,9 +36,17 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement do
   describe ".page_sequence_for_claim" do
     let(:completed_slugs) { [:test] }
     let(:current_slug) { [:test2] }
+    let(:journey_session) { build(:journeys_session) }
     let(:claim) { double }
 
-    subject(:page_sequence) { described_class.page_sequence_for_claim(claim, completed_slugs, current_slug) }
+    subject(:page_sequence) do
+      described_class.page_sequence_for_claim(
+        claim,
+        journey_session,
+        completed_slugs,
+        current_slug
+      )
+    end
 
     it { is_expected.to be_a(Journeys::PageSequence) }
 
@@ -49,7 +57,10 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement do
     end
 
     it "creates a slug sequence" do
-      expect(Journeys::TeacherStudentLoanReimbursement::SlugSequence).to receive(:new).with(claim)
+      expect(Journeys::TeacherStudentLoanReimbursement::SlugSequence).to(
+        receive(:new).with(claim, journey_session)
+      )
+
       page_sequence
     end
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -126,7 +126,9 @@ module FeatureHelpers
 
   def set_slug_sequence_in_session(claim, slug)
     current_claim = CurrentClaim.new(claims: [claim])
-    slug_sequence = Journeys.for_policy(claim.policy).slug_sequence.new(current_claim).slugs
+    journey = Journeys.for_policy(claim.policy)
+    journey_session = build(:journeys_session, journey: journey::ROUTING_NAME)
+    slug_sequence = journey.slug_sequence.new(current_claim, journey_session).slugs
     slug_index = slug_sequence.index(slug)
     visited_slugs = slug_sequence.slice(0, slug_index)
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -29,7 +29,9 @@ module RequestHelpers
 
   def set_slug_sequence_in_session(claim, slug)
     current_claim = CurrentClaim.new(claims: [claim])
-    slug_sequence = Journeys.for_policy(claim.policy).slug_sequence.new(current_claim).slugs
+    journey = Journeys.for_policy(claim.policy)
+    journey_session = build(:journeys_session, journey: journey::ROUTING_NAME)
+    slug_sequence = journey.slug_sequence.new(current_claim, journey_session).slugs
     slug_index = slug_sequence.index(slug)
     visited_slugs = slug_sequence.slice(0, slug_index)
 


### PR DESCRIPTION
There's quite a few files changed but most of these are just updating the specs to pass in the now required `journey_session` parameter

The other option would be to override the initialiser on each form object but that's probably worse.
Once all this journey session work is done we can lose passing the `current_claim` into the forms.


---
We'll soon be writing answers to the journey session as well as to the form object. This commit makes the journey session available to, and required in, the forms.
As we use a form object in the slug sequence and the slug sequence is called by the page sequence we've had to pass the journey session through those classes as well.