### PR TITLE
set attributes from journey session

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -85,6 +85,8 @@ class Form
   end
 
   def load_current_value(attribute)
+    return journey_session.answers[attribute] if journey_session.answers.key?(attribute)
+
     # TODO: re-implement when the underlying claim and eligibility data sources
     # are moved to an alternative place e.g. a session hash
 

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -69,6 +69,57 @@ RSpec.describe Form, type: :model do
     context "with no params" do
       let(:claim_params) { {} }
 
+      context "when an existing value can be found on the journey session" do
+        let(:journey_session) do
+          build(
+            :journeys_session,
+            answers: {
+              first_name: "existing-name",
+              student_loan_repayment_amount: 2000
+            }
+          )
+        end
+
+        it "initialises the attributes with values from the journey session" do
+          expect(form).to have_attributes(
+            first_name: "existing-name",
+            student_loan_repayment_amount: 2000
+          )
+        end
+      end
+
+      context "when an existing `nil` value can be found on the journey session" do
+        let(:claims) do
+          [
+            build(
+              :claim,
+              first_name: "existing-name",
+              eligibility_attributes: {
+                student_loan_repayment_amount: 100
+              },
+              policy: Policies::StudentLoans
+            )
+          ]
+        end
+
+        let(:journey_session) do
+          build(
+            :journeys_session,
+            answers: {
+              first_name: "existing-name",
+              student_loan_repayment_amount: nil
+            }
+          )
+        end
+
+        it "initialises the attributes with values from the journey session" do
+          expect(form).to have_attributes(
+            first_name: "existing-name",
+            student_loan_repayment_amount: nil
+          )
+        end
+      end
+
       context "when an existing value can be found on the claim or eligibility record" do
         let(:claims) { [build(:claim, first_name: "existing-name", eligibility_attributes: {student_loan_repayment_amount: 100}, policy: Policies::StudentLoans)] }
 
@@ -77,7 +128,7 @@ RSpec.describe Form, type: :model do
         end
       end
 
-      context "when an existing value cannot be found on the claim nor eligibility" do
+      context "when an existing value cannot be found on the claim nor eligibility nor journey session" do
         let(:claims) { [build(:claim, first_name: nil, policy: Policies::StudentLoans)] }
 
         it "initialises the attributes with nil" do


### PR DESCRIPTION
Load values from journey session

If the journey session has a value in the answers hash prefer that when
loading the initial attribute values for a form.
Note that `Journeys::Session#answers` is intended to be a "flat" data
structure, not differentiating between claim and eligibility attributes
as it's just concerned with storing answers provided by the user, not
what they're mapped to in the data base.

