### PR TITLE
Add canonical hostname variable

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -2,7 +2,7 @@ DfE::Analytics.configure do |config|
   # Whether to log events instead of sending them to BigQuery.
   #
   # config.log_only = true
-  config.log_only = (%w[development test].include?(ENV["RAILS_ENV"]) || ENV["ENVIRONMENT_NAME"] == "review")
+  config.log_only = (%w[development test].include?(ENV["RAILS_ENV"]) || ENV["ENVIRONMENT_NAME"].start_with?("review"))
 
   # Whether to use ActiveJob or dispatch events immediately.
   #

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -21,14 +21,14 @@ if ENV["TID_BASE_URL"].present?
   tid_sign_in_redirect_uri = URI.parse(ENV["TID_BASE_URL"])
   tid_sign_in_redirect_uri.path = "/claim/auth/tid/callback"
 
-  if ENV["ENVIRONMENT_NAME"] == "review"
+  if ENV["ENVIRONMENT_NAME"].start_with?("review")
     tid_sign_in_redirect_uri.host = ENV["CANONICAL_HOSTNAME"]
   end
 end
 
 module ::DfESignIn
   def self.bypass?
-    (Rails.env.development? || ENV["ENVIRONMENT_NAME"] == "review") && ENV["BYPASS_DFE_SIGN_IN"] == "true"
+    (Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_DFE_SIGN_IN"] == "true"
   end
 end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-domain = if ENV["ENVIRONMENT_NAME"] == "review"
+domain = if ENV["ENVIRONMENT_NAME"].start_with?("review")
   ENV["CANONICAL_HOSTNAME"]
 elsif !ENV["TID_BASE_URL"].nil?
   URI.parse(ENV["TID_BASE_URL"]).host

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -15,7 +15,8 @@ module "application_configuration" {
     {
       ENVIRONMENT_NAME = var.environment
       PGSSLMODE        = local.postgres_ssl_mode
-  })
+      CANONICAL_HOSTNAME = local.canonical_hostname
+    })
   secret_variables = {
     DATABASE_URL = module.postgres.url
   }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -2,6 +2,7 @@
   "cluster": "production",
   "namespace": "srtl-production",
   "environment": "production",
+  "canonical_hostname": "claim-additional-payments-for-teaching-production.teacherservices.cloud",
   "enable_postgres_backup_storage": true,
   "enable_monitoring": true,
   "external_url": "https://claim-additional-teaching-payment.service.gov.uk/healthcheck",

--- a/terraform/application/config/test.tfvars.json
+++ b/terraform/application/config/test.tfvars.json
@@ -1,5 +1,6 @@
 {
   "cluster": "test",
   "namespace": "srtl-test",
-  "environment": "test"
+  "environment": "test",
+  "canonical_hostname": "claim-additional-payments-for-teaching-test.test.teacherservices.cloud"
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -53,8 +53,15 @@ variable "config" {
   type = string
 }
 
+variable "canonical_hostname" {
+  type        = string
+  description = "External domain name for the app service"
+  default     = null
+}
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
+  canonical_hostname = var.canonical_hostname != null ? var.canonical_hostname : "${var.service_name}-${var.environment}.test.teacherservices.cloud"
   app_env_values_from_yml = yamldecode(file("${path.module}/config/${var.config}_app_env.yml"))
   app_env_values = merge(local.app_env_values_from_yml)
 }


### PR DESCRIPTION
## Changes in this PR

- Add canonical_hostname variable to AKS apps
- Update where we're referencing `ENV["ENVIRONMENT_NAME"] == "review"` to reflect the fact our review app environment names are now `review-PR_NUMBER`