### PR TITLE
Store the correct school on the session

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/correct_school_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/correct_school_form.rb
@@ -10,6 +10,8 @@ module Journeys
 
       def save
         claim.update(eligibility_attributes:)
+        journey_session.answers.assign_attributes(eligibility_attributes)
+        journey_session.save
         claim.reset_eligibility_dependent_answers(["current_school_id"])
         true
       end

--- a/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
+++ b/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
@@ -25,7 +25,7 @@ module Journeys
               itt_academic_year: itt_academic_year,
               current_school_id: current_school_id,
               induction_completed: induction_completed,
-              school_somewhere_else: school_somewhere_else
+              school_somewhere_else: journey_session.answers.school_somewhere_else
             }
           )
         )
@@ -83,10 +83,6 @@ module Journeys
 
       def induction_completed
         journey_session.answers.induction_completed || try_eligibility(:induction_completed)
-      end
-
-      def school_somewhere_else
-        journey_session.answers.school_somewhere_else || try_eligibility(:school_somewhere_else)
       end
     end
   end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -141,7 +141,7 @@ module Journeys
           sequence.delete("teacher-reference-number") if answers.logged_in_with_tid? && answers.teacher_reference_number.present?
 
           sequence.delete("correct-school") unless journey_session.logged_in_with_tid_and_has_recent_tps_school?
-          sequence.delete("current-school") if claim.eligibility.school_somewhere_else == false
+          sequence.delete("current-school") if journey_session.answers.school_somewhere_else == false
 
           if answers.provide_mobile_number == false
             sequence.delete("mobile-number")

--- a/spec/forms/journeys/additional_payments_for_teaching/correct_school_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/correct_school_form_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::CorrectSchoolForm, type:
       it "resets the somewhere_else attribute" do
         expect { save }.to change { claim.reload.eligibility.school_somewhere_else }.to eq(false)
       end
+
+      it "writes to the journey session" do
+        expect { save }.to change { journey_session.answers.current_school_id }.to(school.id)
+      end
     end
 
     context "with an existing school association and wants to change school" do


### PR DESCRIPTION
As part of the migration to storing all answers on the
`Journeys::Session` object, we want to store the correct school
attributes there as part of the current journey.

In a future change we will remove the claim.update call and rely solely
on the journey session.

<!-- Do you need to update CHANGELOG.md? -->
