### PR TITLE
Add have_received_email_matcher

### DIFF
--- a/spec/support/have_received_email_matcher.rb
+++ b/spec/support/have_received_email_matcher.rb
@@ -1,0 +1,46 @@
+RSpec::Matchers.define :have_received_email do |template_id, expected_personalisation|
+  match do |email_address|
+    emails = ActionMailer::Base.deliveries.select do |mail|
+      mail.to.include? email_address
+    end
+
+    matching_templates = emails.select do |email|
+      email["template-id"]&.unparsed_value == template_id
+    end.compact
+
+    personalisation_fields = matching_templates.map do |email|
+      email["personalisation"]
+    end.compact.map(&:unparsed_value)
+
+    personalisation_fields.any? do |personalisation|
+      expected_personalisation.all? do |key, value|
+        personalisation[key] == value
+      end
+    end
+  end
+
+  failure_message do |email_address|
+    found = ActionMailer::Base.deliveries.map do |mail|
+      <<-TEXT.squish
+        To: #{mail.to} -
+        template id: #{mail["template_id"]} -
+        personalisation: #{mail["personalisation"]}"
+      TEXT
+    end
+
+    message = <<~MSG.squish
+      Expected `ActionMailer::Base.deliveries` to include an email to
+      #{email_address}` with template_id `#{template_id}` and personalisation
+      `#{expected_personalisation}` but
+      no such email could be found.
+    MSG
+
+    message << "\n\n"
+
+    message << if found.any?
+      "The following emails were found: \n #{found.join("\n")}"
+    else
+      "`ActionMailer::Base.deliveries` was empty"
+    end
+  end
+end


### PR DESCRIPTION
Background:
When migrating some forms over to the journey session I noticed a bug that wasn't caught by our tests. As we're stubbing the mailers there's nothing to check that the passed in arguments implement the api the mailer methods expect.

---

Testing mailers with `allow(Mailer).to(receive(:method))` dosen't test
that the mailer actually works when passed the expected arguments.
This commit adds a test helper to check the mailer successfully sends
the expected email.
As we're using notify we want to test the personalisation is what we
expect. The notify mailer writes the personalisation to a field on the
email which we can test against.

Example useage of this matcher

```ruby
expect("test@example.com").to have_received_email(
  "template-id",
  email_subject: "Student loan repayment email verification",
  first_name: "Homer",
  one_time_password: "111111",
  support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
)
```

Example failure message
```
Failure/Error:
 expect(email_address).to have_received_email(
   "template-id",
   email_subject: "Student loan repayment email verification",
   first_name: "ASDF",
   one_time_password: "111111",
   support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
 )

 Expected `ActionMailer::Base.deliveries` to include an email to test@example.com` with personalisation `{:email_subject=>"Student loan repayment email verification", :first_name=>"ASDF", :one_time_password=>"111111", :support_email_address=>"studentloanteacherpayment@digital.education.gov.uk"}` but no such email could be found.

 The following emails were found:
  To: ["test@example.com"] - personalisation: {:email_subject=>"Student loan repayment email verification", :first_name=>"Jo", :one_time_password=>"111111", :support_email_address=>"studentloanteacherpayment@digital.education.gov.uk", :validity_duration=>"15 minutes"}
```

<!-- Do you need to update CHANGELOG.md? -->
