### PR TITLE
CAPT-1419 ECP exit screen showing incorrect text for AY24-25 (when induction not completed)

### DIFF
--- a/app/models/concerns/eligibility_checkable.rb
+++ b/app/models/concerns/eligibility_checkable.rb
@@ -121,10 +121,18 @@ module EligibilityCheckable
   end
 
   def common_eligible_later_attributes?
-    any_future_policy_years? && indicated_eligible_school?
+    any_future_combined_policy_years? && indicated_eligible_school?
+  end
+
+  def policy_end_year
+    policy::POLICY_END_YEAR
   end
 
   def any_future_policy_years?
+    claim_year < policy_end_year
+  end
+
+  def any_future_combined_policy_years?
     claim_year < FINAL_COMBINED_ECP_AND_LUP_POLICY_YEAR
   end
 end

--- a/app/models/concerns/policies/early_career_payments/eligible.rb
+++ b/app/models/concerns/policies/early_career_payments/eligible.rb
@@ -42,7 +42,7 @@ module Policies
       end
 
       def specific_ineligible_attributes?
-        trainee_teacher? || (induction_not_completed? && !ecp_only_school?) || itt_subject_ineligible_now_and_in_the_future?
+        trainee_teacher? || (induction_not_completed? && !any_future_policy_years?) || itt_subject_ineligible_now_and_in_the_future?
       end
 
       def itt_subject_ineligible_now_and_in_the_future?
@@ -55,7 +55,7 @@ module Policies
       end
 
       def specific_eligible_later_attributes?
-        newly_qualified_teacher? && ((induction_not_completed? && ecp_only_school?) || (!itt_subject_eligible_now? && itt_subject_eligible_later?))
+        newly_qualified_teacher? && ((induction_not_completed? && any_future_policy_years?) || (!itt_subject_eligible_now? && itt_subject_eligible_later?))
       end
 
       def itt_subject_eligible_later?

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -183,13 +183,14 @@ module Journeys
         )
       end
 
-      def replace_ecp_only_induction_not_completed_slugs(sequence)
+      def replace_ecp_only_induction_not_completed_slugs(sequence, ecp_claim)
+        dead_end_slug = (ecp_claim.eligibility.status == :eligible_later) ? "eligible-later" : "ineligible"
+
         slugs = %w[
           current-school
           nqt-in-academic-year-after-itt
           induction-completed
-          eligible-later
-        ]
+        ] << dead_end_slug
 
         sequence.replace(slugs)
       end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -183,8 +183,11 @@ module Journeys
         )
       end
 
-      def replace_ecp_only_induction_not_completed_slugs(sequence, ecp_claim)
-        dead_end_slug = (ecp_claim.eligibility.status == :eligible_later) ? "eligible-later" : "ineligible"
+      def replace_ecp_only_induction_not_completed_slugs(sequence)
+        # TODO: Remove this workaround to the shim class not reloading the answers after they're updated
+        eligibility = Policies::EarlyCareerPayments::PolicyEligibilityChecker.new(answers:)
+
+        dead_end_slug = (eligibility.status == :eligible_later) ? "eligible-later" : "ineligible"
 
         slugs = %w[
           current-school

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -184,10 +184,7 @@ module Journeys
       end
 
       def replace_ecp_only_induction_not_completed_slugs(sequence)
-        # TODO: Remove this workaround to the shim class not reloading the answers after they're updated
-        eligibility = Policies::EarlyCareerPayments::PolicyEligibilityChecker.new(answers:)
-
-        dead_end_slug = (eligibility.status == :eligible_later) ? "eligible-later" : "ineligible"
+        dead_end_slug = (ecp_eligibility_checker.status == :eligible_later) ? "eligible-later" : "ineligible"
 
         slugs = %w[
           current-school

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -23,6 +23,7 @@ module Policies
     ].freeze
 
     POLICY_START_YEAR = AcademicYear.new(2021).freeze
+    POLICY_END_YEAR = AcademicYear.new(2024).freeze
 
     # Used in
     #  - checking payments with multiple policies: ClaimsPreventingPaymentFinder

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -49,14 +49,6 @@ module Policies
       "3f85a1f7-9400-4b48-9a31-eaa643d6b977"
     end
 
-    def first_eligible_qts_award_year(claim_year = nil)
-      POLICY_START_YEAR
-    end
-
-    def last_ineligible_qts_award_year
-      first_eligible_qts_award_year - 1
-    end
-
     def student_loan_balance_url
       "https://www.gov.uk/sign-in-to-manage-your-student-loan-balance"
     end

--- a/app/models/policies/early_career_payments/eligibility.rb
+++ b/app/models/policies/early_career_payments/eligibility.rb
@@ -16,7 +16,6 @@ module Policies
       self.table_name = "early_career_payments_eligibilities"
 
       FIRST_ITT_AY = "2016/2017"
-      LAST_POLICY_YEAR = "2024/2025"
 
       # Generates an object similar to
       # {
@@ -31,7 +30,7 @@ module Policies
       # and the enums would be stale until after a server restart.
       # Make all valid ITT values based on the last known policy year.
       ITT_ACADEMIC_YEARS =
-        (AcademicYear.new(FIRST_ITT_AY)...AcademicYear.new(LAST_POLICY_YEAR)).each_with_object({}) do |year, hsh|
+        (AcademicYear.new(FIRST_ITT_AY)...POLICY_END_YEAR).each_with_object({}) do |year, hsh|
           hsh[year] = AcademicYear::Type.new.serialize(year)
         end.merge({AcademicYear.new => AcademicYear::Type.new.serialize(AcademicYear.new)})
 

--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -24,6 +24,9 @@ module Policies
 
     SEARCHABLE_ELIGIBILITY_ATTRIBUTES = %w[teacher_reference_number].freeze
 
+    POLICY_START_YEAR = AcademicYear.new(2022).freeze
+    POLICY_END_YEAR = AcademicYear.new(2024).freeze
+
     def notify_reply_to_id
       "03ece7eb-2a5b-461b-9c91-6630d0051aa6"
     end

--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -36,7 +36,7 @@ module Policies
     end
 
     def eligibility_criteria_url
-      eligibility_page_url + "#eligibility-criteria-for-teachers"
+      eligibility_page_url + "#eligibility-criteria"
     end
 
     def payment_and_deductions_info_url

--- a/app/models/policies/levelling_up_premium_payments/eligibility.rb
+++ b/app/models/policies/levelling_up_premium_payments/eligibility.rb
@@ -24,7 +24,6 @@ module Policies
       AMENDABLE_ATTRIBUTES = [:teacher_reference_number, :award_amount].freeze
 
       FIRST_ITT_AY = "2017/2018"
-      LAST_POLICY_YEAR = "2024/2025"
 
       # Generates an object similar to
       # {
@@ -39,7 +38,7 @@ module Policies
       # and the enums would be stale until after a server restart.
       # Make all valid ITT values based on the last known policy year.
       ITT_ACADEMIC_YEARS =
-        (AcademicYear.new(FIRST_ITT_AY)...AcademicYear.new(LAST_POLICY_YEAR)).each_with_object({}) do |year, hsh|
+        (AcademicYear.new(FIRST_ITT_AY)...POLICY_END_YEAR).each_with_object({}) do |year, hsh|
           hsh[year] = AcademicYear::Type.new.serialize(year)
         end.merge({AcademicYear.new => AcademicYear::Type.new.serialize(AcademicYear.new)})
 

--- a/app/views/additional_payments/claims/_ineligibility_ecp_only_induction_not_completed.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_ecp_only_induction_not_completed.html.erb
@@ -1,0 +1,10 @@
+<p class="govuk-body">
+  You are not eligible for the
+  <%= link_to("early-career payment (opens in new tab)", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link", target: "_blank") %>
+  because you have not completed your induction.
+</p>
+<p class="govuk-body">
+  You are not eligible for the
+  <%= link_to("levelling up premium payment (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link", target: "_blank") %>
+  because the school you teach in is not eligible. Levelling up premium payments are offered in schools identified as having a higher need for teachers.
+</p>

--- a/app/views/additional_payments/claims/_ineligibility_ecp_only_induction_not_completed.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_ecp_only_induction_not_completed.html.erb
@@ -8,3 +8,10 @@
   <%= link_to("levelling up premium payment (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link", target: "_blank") %>
   because the school you teach in is not eligible. Levelling up premium payments are offered in schools identified as having a higher need for teachers.
 </p>
+
+<p class="govuk-body">
+  For more information, check the eligibility criteria for
+  <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
+  and
+  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+</p>

--- a/app/views/additional_payments/claims/_ineligibility_trainee_in_last_policy_year.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_trainee_in_last_policy_year.html.erb
@@ -6,7 +6,7 @@
   You will not be eligible for the
   <%= link_to("early-career payment", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   or the
-  <%= link_to("levelling up premium payment", LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   once you start work as a qualified teacher.
 </p>
 

--- a/lib/ineligibility_reason_checker.rb
+++ b/lib/ineligibility_reason_checker.rb
@@ -16,6 +16,8 @@ class IneligibilityReasonChecker
       :generic
     elsif trainee_teacher_last_policy_year?
       :trainee_in_last_policy_year
+    elsif ecp_only_induction_not_completed?
+      :ecp_only_induction_not_completed
     elsif ecp_only_trainee_teacher?
       :ecp_only_trainee_teacher
     elsif trainee_teaching_lacking_both_valid_itt_subject_and_degree?
@@ -81,6 +83,13 @@ class IneligibilityReasonChecker
       @answers.subject_to_formal_performance_action?,
       @answers.subject_to_disciplinary_action?
     ].any?
+  end
+
+  def ecp_only_induction_not_completed?
+    [
+      school_eligible_for_ecp_but_not_lup?(@current_claim.eligibility.current_school),
+      @current_claim.for_policy(Policies::EarlyCareerPayments).eligibility.induction_not_completed?
+    ].all?
   end
 
   def ecp_only_trainee_teacher?
@@ -181,8 +190,8 @@ class IneligibilityReasonChecker
   def trainee_teacher_last_policy_year?
     [
       @answers.nqt_in_academic_year_after_itt == false,
-      @answers.academic_year >= AcademicYear.new(Policies::LevellingUpPremiumPayments::Eligibility::LAST_POLICY_YEAR),
-      @answers.academic_year >= AcademicYear.new(Policies::EarlyCareerPayments::Eligibility::LAST_POLICY_YEAR)
+      @answers.academic_year >= AcademicYear.new(Policies::LevellingUpPremiumPayments::POLICY_END_YEAR),
+      @answers.academic_year >= AcademicYear.new(Policies::EarlyCareerPayments::POLICY_END_YEAR)
     ].all?
   end
 end

--- a/lib/ineligibility_reason_checker.rb
+++ b/lib/ineligibility_reason_checker.rb
@@ -87,8 +87,8 @@ class IneligibilityReasonChecker
 
   def ecp_only_induction_not_completed?
     [
-      school_eligible_for_ecp_but_not_lup?(@current_claim.eligibility.current_school),
-      @current_claim.for_policy(Policies::EarlyCareerPayments).eligibility.induction_not_completed?
+      school_eligible_for_ecp_but_not_lup?(@answers.current_school),
+      @answers.induction_not_completed?
     ].all?
   end
 

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -179,6 +179,12 @@ FactoryBot.define do
       end
     end
 
+    trait :eligible_school_ecp_only do
+      current_school_id do
+        create(:school, :early_career_payments_eligible, :levelling_up_premium_payments_ineligible).id
+      end
+    end
+
     trait :short_term_supply_teacher do
       employed_as_supply_teacher { true }
       has_entire_term_contract { false }

--- a/spec/features/ineligible_early_career_payments_claims_spec.rb
+++ b/spec/features/ineligible_early_career_payments_claims_spec.rb
@@ -20,6 +20,27 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims", slow: true do
     expect(page).to have_text("The school you have selected is not eligible")
   end
 
+  scenario "induction not completed and it's the last policy year" do
+    Journeys.for_policy(Policies::EarlyCareerPayments).configuration.update!(current_academic_year: Policies::EarlyCareerPayments::POLICY_END_YEAR)
+
+    start_early_career_payments_claim
+
+    skip_tid
+
+    choose_school eligible_school
+
+    # - Are you currently teaching as a qualified teacher?
+    choose "Yes"
+    click_on "Continue"
+
+    # - Have you completed your induction as an early-career teacher?
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("additional_payments.ineligible.heading"))
+    expect(page).to have_css("div#ecp_only_induction_not_completed")
+  end
+
   scenario "when poor performance - subject to formal performance action" do
     start_early_career_payments_claim
 

--- a/spec/models/early_career_payments_spec.rb
+++ b/spec/models/early_career_payments_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe Policies::EarlyCareerPayments, type: :model do
     )
   }
 
-  describe ".first_eligible_qts_award_year" do
-    it "can return the AcademicYear based on a passed-in academic year" do
-      expect(described_class.first_eligible_qts_award_year(AcademicYear.new(2024))).to eq AcademicYear.new(2021)
-    end
-  end
-
   describe ".payroll_file_name" do
     subject(:payroll_file_name) { described_class.payroll_file_name }
     it { is_expected.to eq("EarlyCareerPayments") }

--- a/spec/models/levelling_up_premium_payments_spec.rb
+++ b/spec/models/levelling_up_premium_payments_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Policies::LevellingUpPremiumPayments, type: :model do
       locale_key: "levelling_up_premium_payments",
       notify_reply_to_id: "03ece7eb-2a5b-461b-9c91-6630d0051aa6",
       eligibility_page_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers",
-      eligibility_criteria_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#eligibility-criteria-for-teachers",
+      eligibility_criteria_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#eligibility-criteria",
       payment_and_deductions_info_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#payments-and-deductions"
     )
   }

--- a/spec/models/policies/early_career_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/early_career_payments/policy_eligibility_checker_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe Policies::EarlyCareerPayments::PolicyEligibilityChecker, type: :m
   end
 
   describe "#status" do
-    before { create(:journey_configuration, :additional_payments) }
+    let(:claim_year) { AcademicYear.new(2022) }
+
+    before { create(:journey_configuration, :additional_payments, current_academic_year: claim_year) }
 
     subject { policy_eligibility_checker.status }
 
@@ -111,14 +113,16 @@ RSpec.describe Policies::EarlyCareerPayments::PolicyEligibilityChecker, type: :m
     end
 
     context "induction not completed" do
-      context "with an ECP-only eligible school" do
-        let(:answers) { build(:additional_payments_answers, :ecp_eligible, induction_completed: false) }
+      let(:answers) { build(:additional_payments_answers, :ecp_eligible, :eligible_school_ecp_only, induction_completed: false) }
+
+      context "when the claim year is not the same as the end policy year" do
+        let(:claim_year) { Policies::EarlyCareerPayments::POLICY_END_YEAR - 1 }
 
         it { is_expected.to eq(:eligible_later) }
       end
 
-      context "with an ECP and LUP eligible school" do
-        let(:answers) { build(:additional_payments_answers, :ecp_eligible, :eligible_school_ecp_and_lup, induction_completed: false) }
+      context "when the claim year is the same as the end policy year" do
+        let(:claim_year) { Policies::EarlyCareerPayments::POLICY_END_YEAR }
 
         it { is_expected.to eq(:ineligible) }
       end


### PR DESCRIPTION
The rationale for the changes is explained in the commits; in short, we do have the concept of start/end date for ECP (and LUP), but it's used as a "combined" value in the `EligibilityCheckable` concern... this is a problem when the end year of a particular policy affects the eligibility criteria for that policy only (like with the induction question).

https://dfedigital.atlassian.net/browse/CAPT-1419

Needs manual testing