### PR TITLE
CAPT 1665/update email address form to write to session

### DIFF
--- a/app/forms/email_address_form.rb
+++ b/app/forms/email_address_form.rb
@@ -20,13 +20,6 @@ class EmailAddressForm < Form
     return false unless valid?
     return true unless email_address_changed?
 
-    # FIXME RL: Remove this once the email verification form no longer needs to
-    # access the claim
-    update!(
-      email_verified: email_verified,
-      sent_one_time_password_at: Time.now
-    )
-
     journey_session.answers.assign_attributes(
       email_address: email_address,
       email_verified: email_verified,

--- a/app/forms/email_address_form.rb
+++ b/app/forms/email_address_form.rb
@@ -20,24 +20,33 @@ class EmailAddressForm < Form
     return false unless valid?
     return true unless email_address_changed?
 
+    # FIXME RL: Remove this once the email verification form no longer needs to
+    # access the claim
     update!(
+      email_verified: email_verified,
+      sent_one_time_password_at: Time.now
+    )
+
+    journey_session.answers.assign_attributes(
       email_address: email_address,
       email_verified: email_verified,
       sent_one_time_password_at: Time.now
     )
 
-    ClaimMailer.email_verification(claim, otp_code).deliver_now
+    journey_session.save!
+
+    ClaimMailer.email_verification(answers, otp_code).deliver_now
   end
 
   private
 
   def email_address_changed?
-    email_address != claim.email_address
+    email_address != answers.email_address
   end
 
   def email_verified
     return nil if email_address_changed?
-    claim.email_verified
+    answers.email_verified
   end
 
   def otp_code

--- a/app/forms/email_verification_form.rb
+++ b/app/forms/email_verification_form.rb
@@ -14,13 +14,14 @@ class EmailVerificationForm < Form
   def save
     return false unless valid?
 
-    update!(email_verified: true)
+    journey_session.answers.assign_attributes(email_verified: true)
+    journey_session.save!
   end
 
   private
 
   def sent_one_time_password_at
-    claim.sent_one_time_password_at
+    answers.sent_one_time_password_at
   end
 
   def sent_one_time_password_must_be_valid

--- a/app/forms/email_verification_form.rb
+++ b/app/forms/email_verification_form.rb
@@ -2,7 +2,7 @@ class EmailVerificationForm < Form
   attribute :one_time_password
 
   # Required for shared partial in the view
-  delegate :email_address, to: :claim
+  delegate :email_address, to: :answers
 
   validate :sent_one_time_password_must_be_valid
   validate :otp_must_be_valid, if: :sent_one_time_password_at?

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
@@ -1,11 +1,51 @@
 module Journeys
   module AdditionalPaymentsForTeaching
     module Reminders
-      class EmailVerificationForm < ::EmailVerificationForm
+      class EmailVerificationForm < Form
+        attribute :one_time_password
         attribute :sent_one_time_password_at
+
+        # Required for shared partial in the view
+        delegate :email_address, to: :claim
+
+        validate :sent_one_time_password_must_be_valid
+        validate :otp_must_be_valid, if: :sent_one_time_password_at?
 
         def self.model_name
           ActiveModel::Name.new(Form)
+        end
+
+        before_validation do
+          self.one_time_password = one_time_password.gsub(/\D/, "")
+        end
+
+        def save
+          return false unless valid?
+
+          update!(email_verified: true)
+        end
+
+        private
+
+        def sent_one_time_password_must_be_valid
+          return if sent_one_time_password_at?
+
+          errors.add(:one_time_password, i18n_errors_path(:"one_time_password.invalid"))
+        end
+
+        def otp_must_be_valid
+          otp = OneTimePassword::Validator.new(
+            one_time_password,
+            sent_one_time_password_at
+          )
+
+          errors.add(:one_time_password, otp.warning) unless otp.valid?
+        end
+
+        def sent_one_time_password_at?
+          sent_one_time_password_at&.to_datetime || false
+        rescue Date::Error
+          false
         end
       end
     end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -19,8 +19,6 @@ class SelectEmailForm < Form
       email_address_check: email_address_check
     )
     journey_session.save!
-    # TODO RL: remove this once email verification is writing to the session
-    update!(attributes)
   end
 
   def determine_dependant_attributes

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -13,6 +13,13 @@ class SelectEmailForm < Form
   def save
     return false unless valid?
 
+    journey_session.answers.assign_attributes(
+      email_address: email_address,
+      email_verified: email_verified,
+      email_address_check: email_address_check
+    )
+    journey_session.save!
+    # TODO RL: remove this once email verification is writing to the session
     update!(attributes)
   end
 

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -26,7 +26,7 @@ class ClaimJourneySessionShim
       date_of_birth: journey_session.answers.date_of_birth,
       teacher_reference_number: teacher_reference_number,
       national_insurance_number: journey_session.answers.national_insurance_number,
-      email_address: email_address,
+      email_address: journey_session.answers.email_address,
       bank_sort_code: bank_sort_code,
       bank_account_number: bank_account_number,
       details_check: details_check,
@@ -80,10 +80,6 @@ class ClaimJourneySessionShim
 
   def teacher_reference_number
     journey_session.answers.teacher_reference_number.presence || current_claim.teacher_reference_number
-  end
-
-  def email_address
-    journey_session.answers.email_address || current_claim.email_address
   end
 
   def bank_sort_code

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -40,13 +40,13 @@ class ClaimJourneySessionShim
       bank_or_building_society: bank_or_building_society,
       provide_mobile_number: provide_mobile_number,
       mobile_number: mobile_number,
-      email_verified: email_verified,
+      email_verified: journey_session.answers.email_verified,
       mobile_verified: mobile_verified,
       hmrc_bank_validation_succeeded: hmrc_bank_validation_succeeded,
       hmrc_bank_validation_responses: hmrc_bank_validation_responses,
       logged_in_with_tid: logged_in_with_tid,
       teacher_id_user_info: teacher_id_user_info,
-      email_address_check: email_address_check,
+      email_address_check: journey_session.answers.email_address_check,
       mobile_check: mobile_check,
       qualifications_details_check: qualifications_details_check
     }
@@ -122,10 +122,6 @@ class ClaimJourneySessionShim
     journey_session.answers.mobile_number || current_claim.mobile_number
   end
 
-  def email_verified
-    journey_session.answers.email_verified || current_claim.email_verified
-  end
-
   def mobile_verified
     journey_session.answers.mobile_verified || current_claim.mobile_verified
   end
@@ -144,10 +140,6 @@ class ClaimJourneySessionShim
 
   def teacher_id_user_info
     journey_session.answers.teacher_id_user_info || current_claim.teacher_id_user_info
-  end
-
-  def email_address_check
-    journey_session.answers.email_address_check || current_claim.email_address_check
   end
 
   def mobile_check

--- a/app/models/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/app/models/journeys/additional_payments_for_teaching/session_answers.rb
@@ -49,6 +49,14 @@ module Journeys
           levelling_up_premium_payments_dqt_reacher_record.has_no_data_for_claim? ||
           early_career_payments_dqt_teacher_record.has_no_data_for_claim?
       end
+
+      def policy
+        if selected_policy.present?
+          selected_policy.constantize
+        else
+          Policies::EarlyCareerPayments
+        end
+      end
     end
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -106,7 +106,7 @@ module Journeys
 
           sequence.delete("select-email") unless set_by_teacher_id?("email")
 
-          if answers.logged_in_with_tid? && claim.email_address_check
+          if answers.logged_in_with_tid? && answers.email_address_check
             sequence.delete("email-address")
             sequence.delete("email-verification")
           end

--- a/app/models/journeys/base_answers_presenter.rb
+++ b/app/models/journeys/base_answers_presenter.rb
@@ -23,8 +23,8 @@ module Journeys
         a << [t("forms.gender.questions.payroll_gender"), t("answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
         a << [t("questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"] if show_trn?
         a << [t("questions.national_insurance_number"), claim.national_insurance_number, "personal-details"] if show_nino?
-        a << [t("questions.email_address"), claim.email_address, "email-address"] unless show_email_select?
-        a << [text_for(:select_email), claim.email_address, "select-email"] if show_email_select?
+        a << [t("questions.email_address"), answers.email_address, "email-address"] unless show_email_select?
+        a << [text_for(:select_email), answers.email_address, "select-email"] if show_email_select?
         a << [t("questions.provide_mobile_number"), claim.provide_mobile_number? ? "Yes" : "No", "provide-mobile-number"] unless show_mobile_select?
         a << [t("questions.mobile_number"), claim.mobile_number, "mobile-number"] unless show_mobile_select? || !claim.provide_mobile_number?
         a << [t("additional_payments.forms.select_mobile_form.questions.which_number"), claim.mobile_number? ? claim.mobile_number : t("additional_payments.forms.select_mobile_form.answers.decline"), "select-mobile"] if show_mobile_select?
@@ -69,7 +69,7 @@ module Journeys
     end
 
     def show_email_select?
-      answers.logged_in_with_tid? && claim.email_address_check?
+      answers.logged_in_with_tid? && answers.email_address_check?
     end
 
     def show_mobile_select?

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -41,6 +41,7 @@ module Journeys
     attribute :dqt_teacher_status, default: {}
     attribute :has_student_loan, :boolean
     attribute :student_loan_plan, :string
+    attribute :sent_one_time_password_at, :datetime
     attribute :answered, default: []
 
     def has_attribute?(name)

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -51,5 +51,9 @@ module Journeys
     def details_check?
       !!details_check
     end
+
+    def email_address_check?
+      !!email_address_check
+    end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -26,6 +26,10 @@ module Journeys
       def has_no_dqt_data_for_claim?
         dqt_teacher_status.blank? || dqt_teacher_record.has_no_data_for_claim?
       end
+
+      def policy
+        Policies::StudentLoans
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -90,7 +90,7 @@ module Journeys
           sequence.delete("ineligible") unless claim.eligibility&.ineligible?
           sequence.delete("personal-details") if answers.logged_in_with_tid? && personal_details_form.valid? && answers.all_personal_details_same_as_tid?
           sequence.delete("select-email") unless set_by_teacher_id?("email")
-          if answers.logged_in_with_tid? && claim.email_address_check?
+          if answers.logged_in_with_tid? && answers.email_address_check?
             sequence.delete("email-address")
             sequence.delete("email-verification")
           end

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -11,5 +11,10 @@ FactoryBot.define do
       with_personal_details
       teacher_reference_number { generate(:teacher_reference_number) }
     end
+
+    trait :with_email_details do
+      email_address { generate(:email_address) }
+      email_verified { true }
+    end
   end
 end

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -11,5 +11,10 @@ FactoryBot.define do
       with_personal_details
       teacher_reference_number { generate(:teacher_reference_number) }
     end
+
+    trait :with_email_details do
+      email_address { generate(:email_address) }
+      email_verified { true }
+    end
   end
 end

--- a/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
+++ b/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
@@ -9,9 +9,16 @@ RSpec.feature "Admin claim tasks update with DQT API" do
       policy_underscored = policy.to_s.underscore
       claim = send(:"start_#{policy_underscored}_claim")
 
-      journey_session = Journeys.for_policy(policy)::Session.last
+      journey = Journeys.for_policy(policy)
 
-      journey_session.update!(answers: answers)
+      journey_session = journey::Session.last
+
+      journey_session.update!(
+        answers: attributes_for(
+          :"#{journey::I18N_NAMESPACE}_answers",
+          :with_email_details
+        ).merge(answers)
+      )
 
       claim.update!(
         attributes_for(

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -16,6 +16,16 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
 
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+    session.answers.assign_attributes(
+      attributes_for(
+        :student_loans_answers,
+        :with_personal_details,
+        :with_email_details
+      )
+    )
+    session.save!
+
     jump_to_claim_journey_page(claim, "check-your-answers")
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught")}']").click
@@ -57,6 +67,17 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+    session.answers.assign_attributes(
+      attributes_for(
+        :student_loans_answers,
+        :with_personal_details,
+        :with_email_details
+      )
+    )
+    session.save!
+
     jump_to_claim_journey_page(claim, "check-your-answers")
 
     new_claim_school = create(:school, :student_loans_eligible, name: "Claim School")
@@ -95,6 +116,16 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, had_leadership_position: false, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+    session.answers.assign_attributes(
+      attributes_for(
+        :student_loans_answers,
+        :with_personal_details,
+        :with_email_details
+      )
+    )
+    session.save!
+
     jump_to_claim_journey_page(claim, "check-your-answers")
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "leadership-position")}']").click
@@ -118,6 +149,16 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+    session.answers.assign_attributes(
+      attributes_for(
+        :student_loans_answers,
+        :with_personal_details,
+        :with_email_details
+      )
+    )
+    session.save!
 
     jump_to_claim_journey_page(claim, "check-your-answers")
 
@@ -145,7 +186,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
     journey_session.update!(
       answers: attributes_for(
         :student_loans_answers,
-        :with_personal_details
+        :with_personal_details,
+        :with_email_details
       )
     )
 
@@ -190,6 +232,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         answers: attributes_for(
           :student_loans_answers,
           :with_personal_details,
+          :with_email_details,
           middle_name: "Jay"
         )
       )
@@ -273,11 +316,23 @@ RSpec.feature "Changing the answers on a submittable claim" do
   describe "Teacher changes a field that requires OTP validation" do
     let!(:claim) { start_early_career_payments_claim }
     let(:eligibility) { claim.eligibility }
+    let(:session) do
+      Journeys::AdditionalPaymentsForTeaching::Session.order(:created_at).last
+    end
 
     before do
       claim.update!(attributes_for(:claim, :submittable))
       eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible, current_school_id: ecp_school.id))
       claim.update!(personal_details_attributes)
+
+      session.answers.assign_attributes(
+        attributes_for(
+          :student_loans_answers,
+          :with_personal_details,
+          :with_email_details
+        )
+      )
+      session.save!
 
       jump_to_claim_journey_page(claim, "check-your-answers")
     end
@@ -286,7 +341,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       let(:personal_details_attributes) { {} }
 
       scenario "is asked to provide the OTP challenge code for validation" do
-        old_email = claim.email_address
+        old_email = session.answers.email_address
         new_email = "fiona.adouboux@protonmail.com"
 
         expect {
@@ -294,7 +349,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
           fill_in "Email address", with: new_email
           click_on "Continue"
         }.to change {
-          claim.reload.email_address
+          session.reload.answers.email_address
         }.from(old_email).to(new_email)
 
         expect(page).not_to have_content("Check your answers before sending your application")

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature "Claim journey does not get cached" do
     journey_session.update!(
       answers: attributes_for(
         :student_loans_answers,
-        :with_details_from_dfe_identity
+        :with_details_from_dfe_identity,
+        :with_email_details
       )
     )
     claim.eligibility = create(:student_loans_eligibility, :eligible)

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
@@ -37,13 +37,11 @@ RSpec.feature "Combined journey with Teacher ID email check" do
 
     expect(page).to have_text(I18n.t("additional_payments.forms.select_mobile_form.questions.which_number"))
 
-    claims = Claim.order(created_at: :desc).limit(2)
+    session = Journeys::AdditionalPaymentsForTeaching::Session.order(created_at: :desc).last
 
-    claims.each do |c|
-      expect(c.email_address).to eq("kelsie.oberbrunner@example.com")
-      expect(c.email_address_check).to eq(true)
-      expect(c.email_verified).to eq(true)
-    end
+    expect(session.answers.email_address).to eq("kelsie.oberbrunner@example.com")
+    expect(session.answers.email_address_check).to eq(true)
+    expect(session.answers.email_verified).to eq(true)
 
     # - Select a different email address
     click_on "Back"
@@ -56,11 +54,11 @@ RSpec.feature "Combined journey with Teacher ID email check" do
 
     expect(page).to have_text(I18n.t("questions.email_address_hint1"))
 
-    claims.reload.each do |c|
-      expect(c.email_address).to eq(nil)
-      expect(c.email_address_check).to eq(false)
-      expect(c.email_verified).to eq(nil)
-    end
+    session.reload
+
+    expect(session.answers.email_address).to eq(nil)
+    expect(session.answers.email_address_check).to eq(false)
+    expect(session.answers.email_verified).to eq(nil)
   end
 
   def navigate_to_check_email_page(school:)

--- a/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
+++ b/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
@@ -12,6 +12,15 @@ RSpec.feature "Eligible now can set a reminder for next year." do
 
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(eligibility_attributes)
+    session = Journeys::AdditionalPaymentsForTeaching::Session.last
+    session.answers.assign_attributes(
+      attributes_for(
+        :additional_payments_answers,
+        :with_personal_details,
+        :with_email_details
+      )
+    )
+    session.save!
 
     jump_to_claim_journey_page(claim, "check-your-answers")
     expect(page).to have_text(claim.first_name)
@@ -75,6 +84,16 @@ RSpec.feature "Completed Applications - Reminders" do
             itt_academic_year: scenario[:itt_academic_year]
           )
           reminder_year = (academic_year + 1).start_year
+
+          session = Journeys::AdditionalPaymentsForTeaching::Session.last
+          session.answers.assign_attributes(
+            attributes_for(
+              :additional_payments_answers,
+              :with_personal_details,
+              :with_email_details
+            )
+          )
+          session.save!
 
           jump_to_claim_journey_page(claim, "check-your-answers")
           expect(page).to have_text(claim.first_name)

--- a/spec/features/one_time_password_spec.rb
+++ b/spec/features/one_time_password_spec.rb
@@ -19,7 +19,8 @@ RSpec.feature "Given a one time password" do
 
     click_on "Confirm"
     expect(page).to have_text("Enter a valid passcode")
-    expect(Claim.by_policy(Policies::EarlyCareerPayments).order(:created_at).last.email_verified).to_not equal(true)
+    session = Journeys::AdditionalPaymentsForTeaching::Session.order(:created_at).last
+    expect(session.answers.email_verified).to_not equal(true)
 
     # - that is expired
 
@@ -28,7 +29,7 @@ RSpec.feature "Given a one time password" do
     fill_in "claim_one_time_password", with: get_otp_from_email
     click_on "Confirm"
     expect(page).to have_text("Your passcode has expired, request a new one")
-    expect(Claim.by_policy(Policies::EarlyCareerPayments).order(:created_at).last.email_verified).to_not equal(true)
+    expect(session.reload.answers.email_verified).to_not equal(true)
 
     # - that is valid
 
@@ -37,6 +38,6 @@ RSpec.feature "Given a one time password" do
     fill_in "claim_one_time_password", with: get_otp_from_email
     click_on "Confirm"
     expect(page).to_not have_css(".govuk-error-summary")
-    expect(Claim.by_policy(Policies::EarlyCareerPayments).order(:created_at).last.email_verified).to equal(true)
+    expect(session.reload.answers.email_verified).to equal(true)
   end
 end

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -91,6 +91,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
   def fill_in_remaining_personal_details_and_submit
     claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
     expect(page).to have_text(I18n.t("questions.address.home.title"))
 
@@ -118,7 +119,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     fill_in I18n.t("questions.email_address"), with: "name@example.tld"
     click_on "Continue"
 
-    expect(claim.reload.email_address).to eq("name@example.tld")
+    expect(session.reload.answers.email_address).to eq("name@example.tld")
 
     # - One time password
     expect(page).to have_text("Enter the 6-digit passcode")

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
@@ -38,11 +38,12 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
 
     expect(page).to have_text(I18n.t("additional_payments.forms.select_mobile_form.questions.which_number"))
 
-    Claim.order(created_at: :desc).limit(2).each do |c|
-      expect(c.email_address).to eq("kelsie.oberbrunner@example.com")
-      expect(c.email_address_check).to eq(true)
-      expect(c.email_verified).to eq(true)
-    end
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(created_at: :desc).last
+    answers = session.answers
+
+    expect(answers.email_address).to eq("kelsie.oberbrunner@example.com")
+    expect(answers.email_address_check).to eq(true)
+    expect(answers.email_verified).to eq(true)
   end
 
   scenario "Select a different email address" do
@@ -57,11 +58,12 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
 
     expect(page).to have_text(I18n.t("questions.email_address_hint1"))
 
-    Claim.order(created_at: :desc).limit(2).each do |c|
-      expect(c.email_address).to eq(nil)
-      expect(c.email_address_check).to eq(false)
-      expect(c.email_verified).to eq(nil)
-    end
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(created_at: :desc).last
+    answers = session.answers
+
+    expect(answers.email_address).to eq(nil)
+    expect(answers.email_address_check).to eq(false)
+    expect(answers.email_verified).to eq(nil)
   end
 
   scenario "Selects suggested email address and then changes to a different email address" do
@@ -79,11 +81,12 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
     find("#claim_email_address_check_false").click
     click_on "Continue"
 
-    Claim.order(created_at: :desc).limit(2).each do |c|
-      expect(c.email_address).to eq(nil)
-      expect(c.email_address_check).to eq(false)
-      expect(c.email_verified).to eq(nil)
-    end
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(created_at: :desc).last
+    answers = session.answers
+
+    expect(answers.email_address).to eq(nil)
+    expect(answers.email_address_check).to eq(false)
+    expect(answers.email_verified).to eq(nil)
   end
 
   scenario "Selects a different email address and then changes to the suggested email address" do
@@ -101,11 +104,12 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
     find("#claim_email_address_check_true").click
     click_on "Continue"
 
-    Claim.order(created_at: :desc).limit(2).each do |c|
-      expect(c.email_address).to eq(email)
-      expect(c.email_address_check).to eq(true)
-      expect(c.email_verified).to eq(true)
-    end
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(created_at: :desc).last
+    answers = session.answers
+
+    expect(answers.email_address).to eq(email)
+    expect(answers.email_address_check).to eq(true)
+    expect(answers.email_verified).to eq(true)
   end
 
   def navigate_to_check_email_page(school:)

--- a/spec/features/validating_user_contact_details_spec.rb
+++ b/spec/features/validating_user_contact_details_spec.rb
@@ -7,10 +7,24 @@ RSpec.feature "Confirming Claimant Contact details" do
     claim = start_early_career_payments_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
-    claim.update!(email_address: "david.tau@gmail.com")
 
-    expect(claim.reload.email_address).to eql("david.tau@gmail.com")
-    expect(claim.email_address).not_to eql("david.tau1988@hotmail.co.uk")
+    journey_session = Journeys::AdditionalPaymentsForTeaching::Session.last
+    journey_session.answers.assign_attributes(
+      attributes_for(
+        :additional_payments_answers,
+        :with_personal_details,
+        :with_email_details
+      ).merge(email_address: "david.tau@gmail.com")
+    )
+    journey_session.save!
+
+    expect(journey_session.reload.answers.email_address).to(
+      eq("david.tau@gmail.com")
+    )
+
+    expect(journey_session.answers.email_address).not_to(
+      eq("david.tau1988@hotmail.co.uk")
+    )
 
     jump_to_claim_journey_page(claim, "email-verification")
 
@@ -26,7 +40,11 @@ RSpec.feature "Confirming Claimant Contact details" do
 
     click_on "Continue"
 
-    expect(claim.reload.email_address).not_to eql("david.tau@gmail.com")
-    expect(claim.email_address).to eql("david.tau1988@hotmail.co.uk")
+    expect(journey_session.reload.answers.email_address).not_to(
+      eq("david.tau@gmail.com")
+    )
+    expect(journey_session.answers.email_address).to(
+      eql("david.tau1988@hotmail.co.uk")
+    )
   end
 end

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -103,22 +103,12 @@ RSpec.describe EmailAddressForm do
       end
 
       it "updates sent_one_time_password_at" do
-        claims.each do |claim|
-          expect(claim.sent_one_time_password_at).to(
-            eq(DateTime.new(2024, 1, 1, 12, 0, 0))
-          )
-        end
-
         expect(journey_session.answers.sent_one_time_password_at).to(
           eq(DateTime.new(2024, 1, 1, 12, 0, 0))
         )
       end
 
       it "resets email_verified" do
-        claims.each do |claim|
-          expect(claim.email_verified).to be_nil
-        end
-
         expect(journey_session.answers.email_verified).to be_nil
       end
     end

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -68,24 +68,29 @@ RSpec.describe EmailAddressForm do
           instance_double(OneTimePassword::Generator, code: "111111")
         )
 
-        allow(ClaimMailer).to receive(:email_verification).and_return(
-          claim_mailer_double
-        )
-
         form.save
       end
-
-      let(:claim_mailer_double) { double(deliver_now: true) }
 
       let(:email_address) { "test@example.com" }
 
       it "sends an email" do
-        expect(ClaimMailer).to have_received(:email_verification).with(
-          current_claim,
-          "111111"
+        policy = current_claim.policy
+
+        support_email_address = I18n.t(
+          "#{policy.locale_key}.support_email_address"
         )
 
-        expect(claim_mailer_double).to have_received(:deliver_now)
+        claim_subject = I18n.t("#{policy.locale_key}.claim_subject")
+
+        email_subject = "#{claim_subject} email verification"
+
+        expect(email_address).to have_received_email(
+          "89e8c33a-1863-4fdd-a73c-1ca01efc0c76",
+          email_subject: email_subject,
+          first_name: current_claim.first_name,
+          one_time_password: "111111",
+          support_email_address: support_email_address
+        )
       end
 
       it "updates sent_one_time_password_at" do

--- a/spec/forms/email_verification_form_spec.rb
+++ b/spec/forms/email_verification_form_spec.rb
@@ -3,13 +3,7 @@ require "rails_helper"
 RSpec.describe EmailVerificationForm do
   shared_examples "email_verification" do |journey|
     let(:claims) do
-      journey::POLICIES.map do |policy|
-        create(
-          :claim,
-          policy: policy,
-          sent_one_time_password_at: sent_one_time_password_at
-        )
-      end
+      journey::POLICIES.map { |policy| create(:claim, policy: policy) }
     end
 
     let(:current_claim) { CurrentClaim.new(claims: claims) }
@@ -22,7 +16,14 @@ RSpec.describe EmailVerificationForm do
       )
     end
 
-    let(:journey_session) { build(:"#{journey::I18N_NAMESPACE}_session") }
+    let(:journey_session) do
+      create(
+        :"#{journey::I18N_NAMESPACE}_session",
+        answers: {
+          sent_one_time_password_at: sent_one_time_password_at
+        }
+      )
+    end
 
     let(:form) do
       described_class.new(
@@ -93,9 +94,7 @@ RSpec.describe EmailVerificationForm do
       before { form.save }
 
       it "sets the email_verified attribute to true" do
-        claims.each do |claim|
-          expect(claim.email_verified).to be true
-        end
+        expect(journey_session.reload.answers.email_verified).to be true
       end
     end
   end

--- a/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::EmailVerifica
   let(:params) { ActionController::Parameters.new({slug:, form: form_params}) }
   let(:form_params) { {one_time_password: "123456"} }
 
-  it { is_expected.to be_a(EmailVerificationForm) }
-
   describe ".model_name" do
     it { expect(form.model_name).to eq(ActiveModel::Name.new(Form)) }
   end

--- a/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::EmailVerificationForm do
-  subject(:form) { described_class.new(claim: form_data_object, journey:, journey_session:, params:) }
+  subject(:form) do
+    described_class.new(claim: reminder, journey:, journey_session:, params:)
+  end
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
   let(:journey_session) { build(:additional_payments_session) }
-  let(:form_data_object) { Reminder.new }
+  let(:reminder) { Reminder.create! }
   let(:slug) { "email-verification" }
   let(:params) { ActionController::Parameters.new({slug:, form: form_params}) }
   let(:form_params) { {one_time_password: "123456"} }
@@ -17,25 +19,32 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::EmailVerifica
   describe "#save" do
     subject(:save) { form.save }
 
-    before do
-      allow(form).to receive(:update!).and_return(true)
-    end
-
     context "valid params" do
-      let(:form_params) { {"one_time_password" => OneTimePassword::Generator.new.code, "sent_one_time_password_at" => Time.now} }
+      let(:form_params) do
+        {
+          "one_time_password" => OneTimePassword::Generator.new.code,
+          "sent_one_time_password_at" => Time.now
+        }
+      end
 
       it "saves the attributes" do
         expect(save).to eq(true)
-        expect(form).to have_received(:update!).with(email_verified: true)
+        expect(reminder.reload.email_verified).to be true
       end
     end
 
     context "invalid params" do
-      let(:form_params) { {"one_time_password" => OneTimePassword::Generator.new.code, "sent_one_time_password_at" => ""} }
+      let(:form_params) do
+        {
+          "one_time_password" => OneTimePassword::Generator.new.code,
+          "sent_one_time_password_at" => ""
+        }
+      end
 
       it "does not save the attributes" do
-        expect(save).to eq(false)
-        expect(form).not_to have_received(:update!)
+        expect { expect(save).to eq(false) }.not_to(
+          change { reminder.reload.email_verified }
+        )
       end
     end
   end

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -82,17 +82,8 @@ RSpec.describe SelectEmailForm, type: :model do
     context "valid params" do
       context "when the user selected to use the email address from Teacher ID" do
         let(:claim_params) { {email_address_check: "true"} }
-        let(:expected_saved_attributes) do
-          {
-            "email_address_check" => true,
-            "email_address" => email_from_teacher_id,
-            "email_verified" => true
-          }
-        end
 
         before { form.save }
-
-        it { is_expected.to have_received(:update!).with(expected_saved_attributes) }
 
         it "updates the session" do
           expect(journey_session.reload.answers.email_address).to(
@@ -107,17 +98,8 @@ RSpec.describe SelectEmailForm, type: :model do
 
       context "when the user selected to provide a different email address" do
         let(:claim_params) { {email_address_check: "false"} }
-        let(:expected_saved_attributes) do
-          {
-            "email_address_check" => false,
-            "email_address" => nil,
-            "email_verified" => nil
-          }
-        end
 
         before { form.save }
-
-        it { is_expected.to have_received(:update!).with(expected_saved_attributes) }
 
         it "updates the session" do
           expect(journey_session.reload.answers.email_address).to eq(nil)

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe SelectEmailForm, type: :model do
         before { form.save }
 
         it { is_expected.to have_received(:update!).with(expected_saved_attributes) }
+
+        it "updates the session" do
+          expect(journey_session.reload.answers.email_address).to(
+            eq(email_from_teacher_id)
+          )
+
+          expect(journey_session.reload.answers.email_verified).to eq(true)
+
+          expect(journey_session.reload.answers.email_address_check).to eq(true)
+        end
       end
 
       context "when the user selected to provide a different email address" do
@@ -108,6 +118,12 @@ RSpec.describe SelectEmailForm, type: :model do
         before { form.save }
 
         it { is_expected.to have_received(:update!).with(expected_saved_attributes) }
+
+        it "updates the session" do
+          expect(journey_session.reload.answers.email_address).to eq(nil)
+          expect(journey_session.reload.answers.email_verified).to eq(nil)
+          expect(journey_session.reload.answers.email_address_check).to eq(false)
+        end
       end
     end
 

--- a/spec/models/journeys/page_sequence_spec.rb
+++ b/spec/models/journeys/page_sequence_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe Journeys::PageSequence do
       let(:claim) { build(:claim, :submittable) }
       let(:current_slug) { "third-slug" }
       let(:completed_slugs) { ["first-slug", "second-slug", "third-slug"] }
+      let(:journey_session) do
+        build(
+          :student_loans_session,
+          answers: attributes_for(
+            :student_loans_answers,
+            :with_personal_details,
+            :with_email_details
+          )
+        )
+      end
 
       it { is_expected.to eq("check-your-answers") }
 

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "Submissions", type: :request do
         journey_session.update!(
           answers: attributes_for(
             :student_loans_answers,
-            :with_personal_details
+            :with_personal_details,
+            :with_email_details
           )
         )
 

--- a/spec/support/journey_answers_presenter_shared_examples.rb
+++ b/spec/support/journey_answers_presenter_shared_examples.rb
@@ -23,8 +23,6 @@ RSpec.shared_examples "journey answers presenter" do
         date_of_birth: dob,
         teacher_reference_number: trn,
         national_insurance_number: nino,
-        email_address: "test@email.com",
-        email_address_check: logged_in_with_tid ? true : false,
         mobile_check: logged_in_with_tid ? "use" : nil,
         provide_mobile_number: true,
         mobile_number: "01234567890",
@@ -44,7 +42,9 @@ RSpec.shared_examples "journey answers presenter" do
           surname: surname,
           teacher_reference_number: trn,
           date_of_birth: dob,
-          national_insurance_number: nino
+          national_insurance_number: nino,
+          email_address: "test@email.com",
+          email_address_check: logged_in_with_tid ? true : false
         }
       )
     end
@@ -78,7 +78,7 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the user selected the email provided by Teacher ID" do
         before do
-          claim.email_address_check = true
+          journey_session.answers.email_address_check = true
         end
 
         it "includes the selected email and the change slug is `select-email`" do
@@ -88,7 +88,7 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the user selected to provide an alternative email" do
         before do
-          claim.email_address_check = true
+          journey_session.answers.email_address_check = true
         end
 
         it "includes the user-provided email and the change slug is `select-email`" do
@@ -98,7 +98,7 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the email was not provided by Teacher ID" do
         before do
-          claim.email_address_check = false
+          journey_session.answers.email_address_check = false
         end
 
         it "includes the user-provided email and the change slug is `email-address`" do


### PR DESCRIPTION
Updates the email related forms to write their answers to the journey session.

Notes for reviewers
All should be pretty standard, most of the changes are updating the specs.
One thing that is of note is that we've copied the logic of the email verification form into the reminders email verification form that previous just inherited from the main journey form (see [this commit](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2767/commits/1679485faf89a75bbec4f0cca387762cd3561432)). We've copied the logic over as the reminders form is writing to the current claim where as the main journey form is writing to the session object. I think copying the code over is going to be less difficult to maintain than adding concerns or something as we don't know how much these forms are going to diverge, duplication is cheaper than the wrong abstraction after all!