### PR TITLE
Update mobile forms to write to journey session

### DIFF
--- a/app/forms/mobile_number_form.rb
+++ b/app/forms/mobile_number_form.rb
@@ -21,11 +21,13 @@ class MobileNumberForm < Form
       Time.now
     end
 
-    update!(
+    journey_session.answers.assign_attributes(
       mobile_number: mobile_number,
       mobile_verified: nil,
       sent_one_time_password_at: sent_one_time_password_at
     )
+
+    journey_session.save!
   end
 
   private
@@ -39,6 +41,6 @@ class MobileNumberForm < Form
   end
 
   def mobile_number_changed?
-    mobile_number != claim.mobile_number
+    mobile_number != answers.mobile_number
   end
 end

--- a/app/forms/mobile_verification_form.rb
+++ b/app/forms/mobile_verification_form.rb
@@ -2,7 +2,7 @@ class MobileVerificationForm < Form
   attribute :one_time_password
 
   # Required for shared partial in the view
-  delegate :mobile_number, to: :claim
+  delegate :mobile_number, to: :answers
 
   validate :otp_validate
 
@@ -13,7 +13,9 @@ class MobileVerificationForm < Form
   def save
     return false unless valid?
 
-    update!(mobile_verified: true)
+    journey_session.answers.assign_attributes(mobile_verified: true)
+
+    journey_session.save!
   end
 
   private
@@ -21,7 +23,7 @@ class MobileVerificationForm < Form
   def otp_validate
     otp = OneTimePassword::Validator.new(
       one_time_password,
-      claim.sent_one_time_password_at
+      answers.sent_one_time_password_at
     )
 
     errors.add(:one_time_password, otp.warning) unless otp.valid?

--- a/app/forms/select_mobile_form.rb
+++ b/app/forms/select_mobile_form.rb
@@ -16,21 +16,21 @@ class SelectMobileForm < Form
 
     case mobile_check
     when "use"
-      claim.update(
+      journey_session.answers.assign_attributes(
         mobile_number: phone_number,
         provide_mobile_number: true,
         mobile_check: mobile_check,
         mobile_verified: nil
       )
     when "alternative"
-      claim.update(
+      journey_session.answers.assign_attributes(
         mobile_number: nil,
         provide_mobile_number: true,
         mobile_check: mobile_check,
         mobile_verified: nil
       )
     when "declined"
-      claim.update(
+      journey_session.answers.assign_attributes(
         mobile_number: nil,
         provide_mobile_number: false,
         mobile_check: mobile_check,
@@ -40,6 +40,6 @@ class SelectMobileForm < Form
       fail "Invalid mobile_check: #{mobile_check}"
     end
 
-    true
+    journey_session.save!
   end
 end

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -38,16 +38,16 @@ class ClaimJourneySessionShim
       building_society_roll_number: building_society_roll_number,
       academic_year: academic_year,
       bank_or_building_society: bank_or_building_society,
-      provide_mobile_number: provide_mobile_number,
-      mobile_number: mobile_number,
+      provide_mobile_number: journey_session.answers.provide_mobile_number,
+      mobile_number: journey_session.answers.mobile_number,
       email_verified: journey_session.answers.email_verified,
-      mobile_verified: mobile_verified,
+      mobile_verified: journey_session.answers.mobile_verified,
       hmrc_bank_validation_succeeded: hmrc_bank_validation_succeeded,
       hmrc_bank_validation_responses: hmrc_bank_validation_responses,
       logged_in_with_tid: logged_in_with_tid,
       teacher_id_user_info: teacher_id_user_info,
       email_address_check: journey_session.answers.email_address_check,
-      mobile_check: mobile_check,
+      mobile_check: journey_session.answers.mobile_check,
       qualifications_details_check: qualifications_details_check
     }
   end
@@ -114,18 +114,6 @@ class ClaimJourneySessionShim
     journey_session.answers.bank_or_building_society || current_claim.bank_or_building_society
   end
 
-  def provide_mobile_number
-    journey_session.answers.provide_mobile_number || current_claim.provide_mobile_number
-  end
-
-  def mobile_number
-    journey_session.answers.mobile_number || current_claim.mobile_number
-  end
-
-  def mobile_verified
-    journey_session.answers.mobile_verified || current_claim.mobile_verified
-  end
-
   def hmrc_bank_validation_succeeded
     journey_session.answers.hmrc_bank_validation_succeeded || current_claim.hmrc_bank_validation_succeeded
   end
@@ -140,10 +128,6 @@ class ClaimJourneySessionShim
 
   def teacher_id_user_info
     journey_session.answers.teacher_id_user_info || current_claim.teacher_id_user_info
-  end
-
-  def mobile_check
-    journey_session.answers.mobile_check || current_claim.mobile_check
   end
 
   def qualifications_details_check

--- a/app/models/concerns/journeys/sessions/teacher_id.rb
+++ b/app/models/concerns/journeys/sessions/teacher_id.rb
@@ -35,6 +35,10 @@ module Journeys
       def trn_same_as_tid?(claim)
         teacher_id_user_info["trn"] == claim.teacher_reference_number
       end
+
+      def using_mobile_number_from_tid?
+        logged_in_with_tid? && mobile_check == "use" && provide_mobile_number && mobile_number.present?
+      end
     end
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -117,7 +117,7 @@ module Journeys
             sequence.delete("select-mobile")
           end
 
-          if answers.logged_in_with_tid? && (claim.mobile_check == "use" || claim.mobile_check == "declined")
+          if answers.logged_in_with_tid? && (answers.mobile_check == "use" || answers.mobile_check == "declined")
             sequence.delete("mobile-number")
             sequence.delete("mobile-verification")
           end
@@ -138,7 +138,7 @@ module Journeys
           sequence.delete("correct-school") unless journey_session.logged_in_with_tid_and_has_recent_tps_school?
           sequence.delete("current-school") if claim.eligibility.school_somewhere_else == false
 
-          if claim.provide_mobile_number == false
+          if answers.provide_mobile_number == false
             sequence.delete("mobile-number")
             sequence.delete("mobile-verification")
           end

--- a/app/models/journeys/base_answers_presenter.rb
+++ b/app/models/journeys/base_answers_presenter.rb
@@ -25,9 +25,9 @@ module Journeys
         a << [t("questions.national_insurance_number"), claim.national_insurance_number, "personal-details"] if show_nino?
         a << [t("questions.email_address"), answers.email_address, "email-address"] unless show_email_select?
         a << [text_for(:select_email), answers.email_address, "select-email"] if show_email_select?
-        a << [t("questions.provide_mobile_number"), claim.provide_mobile_number? ? "Yes" : "No", "provide-mobile-number"] unless show_mobile_select?
-        a << [t("questions.mobile_number"), claim.mobile_number, "mobile-number"] unless show_mobile_select? || !claim.provide_mobile_number?
-        a << [t("additional_payments.forms.select_mobile_form.questions.which_number"), claim.mobile_number? ? claim.mobile_number : t("additional_payments.forms.select_mobile_form.answers.decline"), "select-mobile"] if show_mobile_select?
+        a << [t("questions.provide_mobile_number"), answers.provide_mobile_number? ? "Yes" : "No", "provide-mobile-number"] unless show_mobile_select?
+        a << [t("questions.mobile_number"), answers.mobile_number, "mobile-number"] unless show_mobile_select? || !answers.provide_mobile_number?
+        a << [t("additional_payments.forms.select_mobile_form.questions.which_number"), answers.mobile_number.present? ? answers.mobile_number : t("additional_payments.forms.select_mobile_form.answers.decline"), "select-mobile"] if show_mobile_select?
       end
     end
 
@@ -73,7 +73,7 @@ module Journeys
     end
 
     def show_mobile_select?
-      answers.logged_in_with_tid? && claim.mobile_check.present?
+      answers.logged_in_with_tid? && answers.mobile_check.present?
     end
   end
 end

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -55,5 +55,9 @@ module Journeys
     def email_address_check?
       !!email_address_check
     end
+
+    def provide_mobile_number?
+      !!provide_mobile_number
+    end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -85,8 +85,8 @@ module Journeys
           sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
           sequence.delete("personal-bank-account") if claim.bank_or_building_society == "building_society"
           sequence.delete("building-society-account") if claim.bank_or_building_society == "personal_bank_account"
-          sequence.delete("mobile-number") if claim.provide_mobile_number == false
-          sequence.delete("mobile-verification") if claim.provide_mobile_number == false
+          sequence.delete("mobile-number") if answers.provide_mobile_number == false
+          sequence.delete("mobile-verification") if answers.provide_mobile_number == false
           sequence.delete("ineligible") unless claim.eligibility&.ineligible?
           sequence.delete("personal-details") if answers.logged_in_with_tid? && personal_details_form.valid? && answers.all_personal_details_same_as_tid?
           sequence.delete("select-email") unless set_by_teacher_id?("email")
@@ -100,7 +100,7 @@ module Journeys
           else
             sequence.delete("select-mobile")
           end
-          if answers.logged_in_with_tid? && (claim.mobile_check == "use" || claim.mobile_check == "declined")
+          if answers.logged_in_with_tid? && (answers.mobile_check == "use" || answers.mobile_check == "declined")
             sequence.delete("mobile-number")
             sequence.delete("mobile-verification")
           end

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -16,5 +16,11 @@ FactoryBot.define do
       email_address { generate(:email_address) }
       email_verified { true }
     end
+
+    trait :with_mobile_details do
+      mobile_number { "07474000123" }
+      provide_mobile_number { true }
+      mobile_verified { true }
+    end
   end
 end

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -16,5 +16,11 @@ FactoryBot.define do
       email_address { generate(:email_address) }
       email_verified { true }
     end
+
+    trait :with_mobile_details do
+      mobile_number { "07474000123" }
+      provide_mobile_number { true }
+      mobile_verified { true }
+    end
   end
 end

--- a/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
+++ b/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
@@ -16,7 +16,8 @@ RSpec.feature "Admin claim tasks update with DQT API" do
       journey_session.update!(
         answers: attributes_for(
           :"#{journey::I18N_NAMESPACE}_answers",
-          :with_email_details
+          :with_email_details,
+          :with_mobile_details
         ).merge(answers)
       )
 

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -21,7 +21,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
       attributes_for(
         :student_loans_answers,
         :with_personal_details,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
     session.save!
@@ -73,7 +74,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
       attributes_for(
         :student_loans_answers,
         :with_personal_details,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
     session.save!
@@ -121,7 +123,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
       attributes_for(
         :student_loans_answers,
         :with_personal_details,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
     session.save!
@@ -155,7 +158,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
       attributes_for(
         :student_loans_answers,
         :with_personal_details,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
     session.save!
@@ -187,7 +191,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
       answers: attributes_for(
         :student_loans_answers,
         :with_personal_details,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
 
@@ -233,6 +238,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
           :student_loans_answers,
           :with_personal_details,
           :with_email_details,
+          :with_mobile_details,
           middle_name: "Jay"
         )
       )
@@ -329,8 +335,9 @@ RSpec.feature "Changing the answers on a submittable claim" do
         attributes_for(
           :student_loans_answers,
           :with_personal_details,
-          :with_email_details
-        )
+          :with_email_details,
+          :with_mobile_details
+        ).merge(personal_details_attributes)
       )
       session.save!
 
@@ -395,7 +402,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
           choose "Yes"
           click_on "Continue"
         }.to change {
-          claim.reload.provide_mobile_number
+          session.reload.answers.provide_mobile_number
         }.from(false).to(true)
 
         expect(page).not_to have_content("Check your answers before sending your application")
@@ -404,7 +411,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         fill_in "claim_mobile_number", with: new_mobile
         click_on "Continue"
 
-        expect(claim.reload.mobile_number).to eql new_mobile
+        expect(session.reload.answers.mobile_number).to eql new_mobile
 
         # - Mobile number one-time password
         expect(page).to have_text("Mobile number verification")
@@ -414,7 +421,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         click_on "Confirm"
 
         expect(page).not_to have_text("Some places are both a bank and a building society")
-        expect(claim.reload.mobile_verified).to eq true
+        expect(session.reload.answers.mobile_verified).to eq true
         expect(claim.submittable?).to be true
         expect(page).to have_content("Check your answers before sending your application")
       end
@@ -446,14 +453,14 @@ RSpec.feature "Changing the answers on a submittable claim" do
       let(:old_mobile) { "07813090710" }
 
       scenario "is asked to provide the OTP challenge code for validation" do
-        old_mobile = claim.mobile_number
+        old_mobile = session.answers.mobile_number
 
         expect {
           page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "mobile-number")}']", minimum: 1).click
           fill_in "Mobile number", with: new_mobile
           click_on "Continue"
         }.to change {
-          claim.reload.mobile_number
+          session.reload.answers.mobile_number
         }.from(old_mobile).to(new_mobile)
 
         expect(page).not_to have_content("Check your answers before sending your application")
@@ -466,7 +473,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         click_on "Confirm"
 
         expect(page).not_to have_text("Some places are both a bank and a building society")
-        expect(claim.reload.mobile_verified).to eq true
+        expect(session.reload.answers.mobile_verified).to eq true
         expect(claim.submittable?).to be true
         expect(page).to have_content("Check your answers before sending your application")
       end

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature "Claim journey does not get cached" do
       answers: attributes_for(
         :student_loans_answers,
         :with_details_from_dfe_identity,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
     claim.eligibility = create(:student_loans_eligibility, :eligible)

--- a/spec/features/claim_with_mobile_sms_otp_spec.rb
+++ b/spec/features/claim_with_mobile_sms_otp_spec.rb
@@ -56,14 +56,18 @@ RSpec.feature "GOVUK Nofity SMS sends OTP" do
           claim.eligibility = Policies::EarlyCareerPayments::Eligibility.new
           claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
           claim.update!(early_career_payments_personal_details_attributes)
+          session = Journeys::AdditionalPaymentsForTeaching::Session.last
         elsif scenario[:policy] == Policies::StudentLoans
           claim.eligibility = Policies::StudentLoans::Eligibility.new
           claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible))
           claim.update!(student_loans_personal_details_attributes)
+          session = Journeys::TeacherStudentLoanReimbursement::Session.last
         end
 
+        session.update!(answers: {provide_mobile_number: true})
+
         jump_to_claim_journey_page(claim, "mobile-number")
-        expect(claim.reload.provide_mobile_number).to eql true
+        expect(session.reload.answers.provide_mobile_number).to eql true
 
         # - Mobile number
         expect(page).to have_text(I18n.t("questions.mobile_number"))
@@ -71,7 +75,7 @@ RSpec.feature "GOVUK Nofity SMS sends OTP" do
         fill_in "claim_mobile_number", with: scenario[:mobile_number]
         click_on "Continue"
 
-        expect(claim.reload.mobile_number).to eql(scenario[:mobile_number])
+        expect(session.reload.answers.mobile_number).to eql(scenario[:mobile_number])
 
         # # - Mobile number one-time password
         expect(page).to have_text("Mobile number verification")

--- a/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
+++ b/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
@@ -17,7 +17,8 @@ RSpec.feature "Eligible now can set a reminder for next year." do
       attributes_for(
         :additional_payments_answers,
         :with_personal_details,
-        :with_email_details
+        :with_email_details,
+        :with_mobile_details
       )
     )
     session.save!
@@ -90,7 +91,8 @@ RSpec.feature "Completed Applications - Reminders" do
             attributes_for(
               :additional_payments_answers,
               :with_personal_details,
-              :with_email_details
+              :with_email_details,
+              :with_mobile_details
             )
           )
           session.save!

--- a/spec/features/eligible_later_early_career_payments_claim_spec.rb
+++ b/spec/features/eligible_later_early_career_payments_claim_spec.rb
@@ -8,6 +8,9 @@ RSpec.feature "Eligible later Teacher Early-Career Payments" do
     let(:lup_claim) { Claim.by_policy(Policies::LevellingUpPremiumPayments).order(:created_at).last }
     let(:current_school) { create(:school, :early_career_payments_eligible) }
     let(:itt_subject) { "mathematics" }
+    let(:journey_session) do
+      Journeys::AdditionalPaymentsForTeaching::Session.order(:created_at).last
+    end
 
     context "policy year 2022/2023" do
       it_behaves_like "Eligible later", {

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose "No"
     click_on "Continue"
 
-    expect(claim.reload.provide_mobile_number).to eql false
+    expect(session.reload.answers.provide_mobile_number).to eql false
 
     # - Mobile number
     expect(page).not_to have_text(I18n.t("questions.mobile_number"))

--- a/spec/forms/mobile_verification_form_spec.rb
+++ b/spec/forms/mobile_verification_form_spec.rb
@@ -2,19 +2,14 @@ require "rails_helper"
 
 RSpec.describe MobileVerificationForm do
   shared_examples "mobile_verification" do |journey|
-    let(:claims) do
-      journey::POLICIES.map do |policy|
-        create(
-          :claim,
-          policy: policy,
+    let(:journey_session) do
+      create(
+        :"#{journey::I18N_NAMESPACE}_session",
+        answers: {
           sent_one_time_password_at: sent_one_time_password_at
-        )
-      end
+        }
+      )
     end
-
-    let(:current_claim) { CurrentClaim.new(claims: claims) }
-
-    let(:journey_session) { build(:"#{journey::I18N_NAMESPACE}_session") }
 
     let(:params) do
       ActionController::Parameters.new(
@@ -28,7 +23,7 @@ RSpec.describe MobileVerificationForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: current_claim,
+        claim: CurrentClaim.new(claims: [build(:claim)]),
         params: params
       )
     end
@@ -87,9 +82,7 @@ RSpec.describe MobileVerificationForm do
       before { form.save }
 
       it "sets the mobile_verified attribute to true" do
-        claims.each do |claim|
-          expect(claim.mobile_verified).to be true
-        end
+        expect(journey_session.reload.answers.mobile_verified).to be true
       end
     end
   end

--- a/spec/forms/select_mobile_form_spec.rb
+++ b/spec/forms/select_mobile_form_spec.rb
@@ -2,12 +2,6 @@ require "rails_helper"
 
 RSpec.describe SelectMobileForm do
   shared_examples "select_mobile_form" do |journey|
-    let(:claims) do
-      journey::POLICIES.map { |policy| create(:claim, policy: policy) }
-    end
-
-    let(:current_claim) { CurrentClaim.new(claims: claims) }
-
     let(:journey_session) do
       create(
         :"#{journey::I18N_NAMESPACE}_session",
@@ -29,7 +23,7 @@ RSpec.describe SelectMobileForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: current_claim,
+        claim: CurrentClaim.new(claims: [build(:claim)]),
         params: params
       )
     end
@@ -72,12 +66,12 @@ RSpec.describe SelectMobileForm do
           let(:mobile_check) { "use" }
 
           it "updates the claims" do
-            claims.each do |claim|
-              expect(claim.mobile_number).to eq("07123456789")
-              expect(claim.provide_mobile_number).to eq(true)
-              expect(claim.mobile_check).to eq("use")
-              expect(claim.mobile_verified).to eq(nil)
-            end
+            answers = journey_session.reload.answers
+
+            expect(answers.mobile_number).to eq("07123456789")
+            expect(answers.provide_mobile_number).to eq(true)
+            expect(answers.mobile_check).to eq("use")
+            expect(answers.mobile_verified).to eq(nil)
           end
         end
 
@@ -85,12 +79,12 @@ RSpec.describe SelectMobileForm do
           let(:mobile_check) { "alternative" }
 
           it "updates the claims" do
-            claims.each do |claim|
-              expect(claim.mobile_number).to eq(nil)
-              expect(claim.provide_mobile_number).to eq(true)
-              expect(claim.mobile_check).to eq("alternative")
-              expect(claim.mobile_verified).to eq(nil)
-            end
+            answers = journey_session.reload.answers
+
+            expect(answers.mobile_number).to eq(nil)
+            expect(answers.provide_mobile_number).to eq(true)
+            expect(answers.mobile_check).to eq("alternative")
+            expect(answers.mobile_verified).to eq(nil)
           end
         end
 
@@ -98,12 +92,12 @@ RSpec.describe SelectMobileForm do
           let(:mobile_check) { "declined" }
 
           it "updates the claimms" do
-            claims.each do |claim|
-              expect(claim.mobile_number).to eq(nil)
-              expect(claim.provide_mobile_number).to eq(false)
-              expect(claim.mobile_check).to eq("declined")
-              expect(claim.mobile_verified).to eq(nil)
-            end
+            answers = journey_session.reload.answers
+
+            expect(answers.mobile_number).to eq(nil)
+            expect(answers.provide_mobile_number).to eq(false)
+            expect(answers.mobile_check).to eq("declined")
+            expect(answers.mobile_verified).to eq(nil)
           end
         end
       end

--- a/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
@@ -278,13 +278,13 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
 
     context "when 'provide_mobile_number' is 'No'" do
       it "excludes the 'mobile-number' slug" do
-        claim.provide_mobile_number = false
+        journey_session.answers.provide_mobile_number = false
 
         expect(slug_sequence.slugs).not_to include("mobile-number")
       end
 
       it "excludes the 'mobile-verification' slug" do
-        claim.provide_mobile_number = false
+        journey_session.answers.provide_mobile_number = false
 
         expect(slug_sequence.slugs).not_to include("mobile-verification")
       end
@@ -292,13 +292,13 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
 
     context "when 'provide_mobile_number' is 'Yes'" do
       it "includes the 'mobile-number' slug" do
-        claim.provide_mobile_number = true
+        journey_session.answers.provide_mobile_number = true
 
         expect(slug_sequence.slugs).to include("mobile-number")
       end
 
       it "includes the 'mobile-verification' slug" do
-        claim.provide_mobile_number = true
+        journey_session.answers.provide_mobile_number = true
 
         expect(slug_sequence.slugs).to include("mobile-verification")
       end

--- a/spec/models/journeys/page_sequence_spec.rb
+++ b/spec/models/journeys/page_sequence_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Journeys::PageSequence do
           answers: attributes_for(
             :student_loans_answers,
             :with_personal_details,
-            :with_email_details
+            :with_email_details,
+            :with_mobile_details
           )
         )
       end

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -55,13 +55,13 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
 
     context "when 'provide_mobile_number' is 'No'" do
       it "excludes the 'mobile-number' slug" do
-        claim.provide_mobile_number = false
+        journey_session.answers.provide_mobile_number = false
 
         expect(slug_sequence.slugs).not_to include("mobile-number")
       end
 
       it "excludes the 'mobile-verification' slug" do
-        claim.provide_mobile_number = false
+        journey_session.answers.provide_mobile_number = false
 
         expect(slug_sequence.slugs).not_to include("mobile-verification")
       end
@@ -69,13 +69,13 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
 
     context "when 'provide_mobile_number' is 'Yes'" do
       it "includes the 'mobile-number' slug" do
-        claim.provide_mobile_number = true
+        journey_session.answers.provide_mobile_number = true
 
         expect(slug_sequence.slugs).to include("mobile-number")
       end
 
       it "includes the 'mobile-verification' slug" do
-        claim.provide_mobile_number = true
+        journey_session.answers.provide_mobile_number = true
 
         expect(slug_sequence.slugs).to include("mobile-verification")
       end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "Submissions", type: :request do
           answers: attributes_for(
             :student_loans_answers,
             :with_personal_details,
-            :with_email_details
+            :with_email_details,
+            :with_mobile_details
           )
         )
 

--- a/spec/support/eligible_later_shared_examples.rb
+++ b/spec/support/eligible_later_shared_examples.rb
@@ -14,6 +14,15 @@ RSpec.shared_examples "Eligible later" do |opts|
         itt_academic_year: itt_academic_year
       )
 
+      journey_session.answers.assign_attributes(
+        attributes_for(
+          :additional_payments_answers,
+          :with_personal_details,
+          :with_email_details,
+          :with_mobile_details
+        )
+      )
+
       jump_to_claim_journey_page(claim, "check-your-answers-part-one")
 
       expect(page).to have_text(I18n.t("additional_payments.check_your_answers.part_one.primary_heading"))

--- a/spec/support/journey_answers_presenter_shared_examples.rb
+++ b/spec/support/journey_answers_presenter_shared_examples.rb
@@ -23,9 +23,6 @@ RSpec.shared_examples "journey answers presenter" do
         date_of_birth: dob,
         teacher_reference_number: trn,
         national_insurance_number: nino,
-        mobile_check: logged_in_with_tid ? "use" : nil,
-        provide_mobile_number: true,
-        mobile_number: "01234567890",
         payroll_gender: :dont_know,
         logged_in_with_tid:,
         teacher_id_user_info:
@@ -44,7 +41,10 @@ RSpec.shared_examples "journey answers presenter" do
           date_of_birth: dob,
           national_insurance_number: nino,
           email_address: "test@email.com",
-          email_address_check: logged_in_with_tid ? true : false
+          email_address_check: logged_in_with_tid ? true : false,
+          mobile_check: logged_in_with_tid ? "use" : nil,
+          provide_mobile_number: true,
+          mobile_number: "01234567890"
         }
       )
     end
@@ -108,9 +108,9 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the user selected the mobile provided by Teacher ID" do
         before do
-          claim.mobile_number = "01234567890"
-          claim.mobile_check = "use"
-          claim.provide_mobile_number = true
+          journey_session.answers.mobile_number = "01234567890"
+          journey_session.answers.mobile_check = "use"
+          journey_session.answers.provide_mobile_number = true
         end
 
         it "includes the selected mobile and the change slug is `select-mobile`" do
@@ -124,9 +124,9 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the user selected to provide an alternative mobile" do
         before do
-          claim.mobile_number = "01234567891"
-          claim.mobile_check = "alternative"
-          claim.provide_mobile_number = true
+          journey_session.answers.mobile_number = "01234567891"
+          journey_session.answers.mobile_check = "alternative"
+          journey_session.answers.provide_mobile_number = true
         end
 
         it "includes the user-provided mobile and the change slug is `select-mobile`" do
@@ -140,9 +140,9 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the user declined to be contacted by mobile" do
         before do
-          claim.mobile_number = nil
-          claim.mobile_check = "declined"
-          claim.provide_mobile_number = false
+          journey_session.answers.mobile_number = nil
+          journey_session.answers.mobile_check = "declined"
+          journey_session.answers.provide_mobile_number = false
         end
 
         it "includes the answer to decline and the change slug is `select-mobile`" do
@@ -181,8 +181,8 @@ RSpec.shared_examples "journey answers presenter" do
 
       context "when the user declined to be contacted by mobile" do
         before do
-          claim.mobile_number = nil
-          claim.provide_mobile_number = false
+          journey_session.answers.mobile_number = nil
+          journey_session.answers.provide_mobile_number = false
         end
 
         it "excludes the answer to `mobile-number`" do


### PR DESCRIPTION
Updates the various mobile forms to write to the journey session and
updates the call sites to read this information from the journey
session.
We've had to change the order of things in the claim submission form
slightly as the `mobile_number_verified` validation not longer creates a
claim. When `claim_is_eligible` validation runs we need to have the
claim set up and associated with the `main_eligibility`, as this is no
longer done by the `mobile_number_verified` validation we set the claim
up in the constructor.
