### PR TITLE
[CAPT-529] style font for result number in search results

### DIFF
--- a/app/assets/stylesheets/components/school_search.scss
+++ b/app/assets/stylesheets/components/school_search.scss
@@ -8,6 +8,7 @@
   justify-content: space-between;
   align-items: flex-start;
 }
+
 .school-search__suggestion-main-section {
   flex: 1 1 70%;
 
@@ -15,9 +16,14 @@
     padding-left: 15px;
   }
 }
+
 .school-search__closed-status {
   flex: 0 0 9em;
   text-align: right;
   padding-left: 1em;
   padding-top: 6px;
+}
+
+span[id^="school_search__option-suffix--"] {
+  @extend .govuk-body;
 }


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-529
- Issue with font styling on school search results on iOS

# Changes

- Target css to use `govuk-body` instead of fallback font which looks like times new roman
- Should probably be fixed upstream but is quickly fixed here for now

# Screenshots

## before
![before](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/8a7dcb9d-1f6b-4709-be53-f319473f41f8)

## after
![after](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/1d495013-efff-433f-a437-244bbdd4eddb)