### PR TITLE
[CAPT-1517] update zendesk slug

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -276,7 +276,7 @@ module Admin
     end
 
     def zendesk_email_search_url(email_address)
-      "https://additional-teaching-payment.zendesk.com/agent/search/1?copy&type=ticket&q=#{CGI.escape(email_address)}"
+      "https://becomingateacher.zendesk.com/agent/search/1?copy&type=ticket&q=#{CGI.escape(email_address)}"
     end
   end
 end

--- a/spec/features/admin_claim_support_tickets_spec.rb
+++ b/spec/features/admin_claim_support_tickets_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Admin claim support tickets" do
 
     click_on "Notes and support"
 
-    expect(page).to have_link("View all suppport tickets in Zendesk", href: "https://additional-teaching-payment.zendesk.com/agent/search/1?copy&type=ticket&q=person1%40example.com")
+    expect(page).to have_link("View all suppport tickets in Zendesk", href: "https://becomingateacher.zendesk.com/agent/search/1?copy&type=ticket&q=person1%40example.com")
 
     fill_in "Support ticket", with: "https://account-sub-domain.zendesk.com/agent/tickets/1638"
     click_on "Save support ticket"
@@ -25,6 +25,6 @@ RSpec.feature "Admin claim support tickets" do
     expect(claim.support_ticket.created_by).to eq(@signed_in_user)
 
     expect(page).to have_link(href: "https://account-sub-domain.zendesk.com/agent/tickets/1638")
-    expect(page).to have_link("View all suppport tickets in Zendesk", href: "https://additional-teaching-payment.zendesk.com/agent/search/1?copy&type=ticket&q=person1%40example.com")
+    expect(page).to have_link("View all suppport tickets in Zendesk", href: "https://becomingateacher.zendesk.com/agent/search/1?copy&type=ticket&q=person1%40example.com")
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1517
- Incorrect dead links to zendesk in admin area

Changes

- Update zendesk slug for links