### PR TITLE
Fix changes logic

### DIFF
--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -23,12 +23,16 @@ module Journeys
     # current claim. Values for answers may be `nil`, so we need to explicitly
     # check that the question was answered.
     # Once all forms has been migrated to use the journey session, this method,
-    # the before_save call back and the SessionAnswer#answered attribute can be
-    # removed.
+    # the before_save and after_initialize call backs and the
+    # SessionAnswer#answered attribute can be removed.
     # This will be removed in
     # https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1637
     def answered?(attribute_name)
       answers.answered.include?(attribute_name.to_s)
+    end
+
+    after_initialize do
+      answers.clear_changes_information
     end
 
     before_save do


### PR DESCRIPTION
When we load session attributes from the database and populate the
answers object's attributes that counts as a change. To avoid this false
positive we clear the changes information after initialize.
While we're only using this changes logic during the migration from
current claim to journey session, this issue highlights the trickiness
of working with a hash backed model rather than a table backed model.
Once the migration work is completed, and everything is writing to the
session object, we should consider the maintainability of this approach
and see whether a table backed approach would meet our needs better.
