### PR TITLE
[CAPT-1647] Port poor performance to journey session

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,1 @@
+--out tmp/parallel_runtime_rspec.log

--- a/app/forms/journeys/additional_payments_for_teaching/poor_performance_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/poor_performance_form.rb
@@ -10,8 +10,11 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(eligibility_attributes: attributes.except("journey_session_id"))
-        journey_session.answers.assign_attributes(attributes.except("journey_session_id"))
+        journey_session.answers.assign_attributes(
+          subject_to_formal_performance_action:,
+          subject_to_disciplinary_action:
+        )
+
         journey_session.save
       end
     end

--- a/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
@@ -51,7 +51,7 @@ module Journeys
       def current_school
         [
           t("additional_payments.forms.current_school.questions.current_school_search"),
-          eligibility.current_school_name,
+          journey_session.answers.current_school.name,
           (journey_session.answers.school_somewhere_else == false) ? "correct-school" : "current-school"
         ]
       end
@@ -157,11 +157,13 @@ module Journeys
 
       def text_for_subject_answer
         policy = eligibility.policy
-        subjects = JourneySubjectEligibilityChecker.new(claim_year: Journeys.for_policy(policy).configuration.current_academic_year,
-          itt_year: journey_session.answers.itt_academic_year).current_and_future_subject_symbols(policy)
+        subjects = JourneySubjectEligibilityChecker.new(
+          claim_year: Journeys.for_policy(policy).configuration.current_academic_year,
+          itt_year: journey_session.answers.itt_academic_year
+        ).current_and_future_subject_symbols(policy)
 
         if subjects.many?
-          t("additional_payments.forms.eligible_itt_subject.answers.#{eligibility.eligible_itt_subject}")
+          t("additional_payments.forms.eligible_itt_subject.answers.#{journey_session.answers.eligible_itt_subject}")
         else
           subject_symbol = subjects.first
           (subject_symbol == eligibility.eligible_itt_subject.to_sym) ? "Yes" : "No"

--- a/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
+++ b/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
@@ -14,12 +14,12 @@ module Journeys
             {
               selected_policy: journey_session.answers.selected_policy,
               nqt_in_academic_year_after_itt: journey_session.answers.nqt_in_academic_year_after_itt,
-              employed_as_supply_teacher: employed_as_supply_teacher,
+              employed_as_supply_teacher: journey_session.answers.employed_as_supply_teacher,
               qualification: journey_session.answers.qualification,
               has_entire_term_contract: journey_session.answers.has_entire_term_contract,
               employed_directly: journey_session.answers.employed_directly,
-              subject_to_disciplinary_action: subject_to_disciplinary_action,
-              subject_to_formal_performance_action: subject_to_formal_performance_action,
+              subject_to_disciplinary_action: journey_session.answers.subject_to_disciplinary_action,
+              subject_to_formal_performance_action: journey_session.answers.subject_to_formal_performance_action,
               eligible_itt_subject: journey_session.answers.eligible_itt_subject,
               eligible_degree_subject: journey_session.answers.eligible_degree_subject,
               teaching_subject_now: journey_session.answers.teaching_subject_now,
@@ -30,20 +30,6 @@ module Journeys
             }
           )
         )
-      end
-
-      private
-
-      def employed_as_supply_teacher
-        journey_session.answers.employed_as_supply_teacher
-      end
-
-      def subject_to_disciplinary_action
-        journey_session.answers.subject_to_disciplinary_action || try_eligibility(:subject_to_disciplinary_action)
-      end
-
-      def subject_to_formal_performance_action
-        journey_session.answers.subject_to_formal_performance_action || try_eligibility(:subject_to_formal_performance_action)
       end
     end
   end

--- a/spec/forms/journeys/additional_payments_for_teaching/poor_performance_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/poor_performance_form_spec.rb
@@ -65,8 +65,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::PoorPerformanceForm do
       let(:claim_params) { {subject_to_formal_performance_action: "true", subject_to_disciplinary_action: "false"} }
 
       it "updates the attributes on the claim" do
-        expect { form.save }.to change { claim.eligibility.subject_to_formal_performance_action }.to(true)
-          .and change { claim.eligibility.subject_to_disciplinary_action }.to(false)
+        expect {
+          form.save
+        }.to change { journey_session.answers.subject_to_formal_performance_action }.to(true)
+          .and change { journey_session.answers.subject_to_disciplinary_action }.to(false)
       end
     end
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1647

# Changes

- The `poor_performance` form now persists answers to journey session rather than eligibility
- Update references to these fields on answers rather than on eligbility
- Also added `.rspec_parallel` with configuration that should increase local test run times for those that run the test suite in parallel