### PR TITLE
CAPT 1680/claim school form

### DIFF
--- a/app/controllers/concerns/claim_session_timeout.rb
+++ b/app/controllers/concerns/claim_session_timeout.rb
@@ -14,7 +14,9 @@ module ClaimSessionTimeout
     session.delete(:tps_school_id)
     session.delete(:tps_school_name)
     session.delete(:tps_school_address)
+    session.delete(journey_session_key)
     @current_claim = nil
+    @journey_session = nil
   end
 
   def claim_session_timed_out?

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -1,55 +1,91 @@
-class Journeys::TeacherStudentLoanReimbursement::ClaimSchoolForm < Form
-  attribute :claim_school_id
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class ClaimSchoolForm < Form
+      attribute :claim_school_id
 
-  attr_reader :schools
+      attr_reader :schools
 
-  validates :claim_school_id, presence: {message: i18n_error_message(:select_a_school)}
-  validate :claim_school_must_exist, if: -> { claim_school_id.present? }
+      validates :claim_school_id, presence: {message: i18n_error_message(:select_a_school)}
+      validate :claim_school_must_exist, if: -> { claim_school_id.present? }
 
-  def initialize(claim:, journey_session:, journey:, params:)
-    super
+      def initialize(claim:, journey_session:, journey:, params:)
+        super
 
-    load_schools
-    self.claim_school_id = permitted_params[:claim_school_id]
-  end
+        load_schools
+        self.claim_school_id = permitted_params[:claim_school_id]
+      end
 
-  def save
-    return false unless valid?
+      def save
+        return false unless valid?
 
-    attrs = {"eligibility_attributes" => {"claim_school_id" => claim_school_id}}
-    claim.assign_attributes(attrs)
-    claim.reset_eligibility_dependent_answers(["claim_school_id"])
+        return true unless claim_school_changed?
 
-    claim.save!
-  end
+        journey_session.answers.assign_attributes(
+          claim_school_id: claim_school_id,
+          taught_eligible_subjects: nil,
+          biology_taught: nil,
+          physics_taught: nil,
+          chemistry_taught: nil,
+          computing_taught: nil,
+          languages_taught: nil,
+          employment_status: nil,
+          current_school_id: nil
+        )
 
-  def claim_school_name
-    claim.eligibility.claim_school_name
-  end
+        journey_session.save!
 
-  def no_search_results?
-    params[:school_search].present? && errors.empty?
-  end
+        # FIXME RL: Remove this once the subjects taught and still teaching
+        # forms write their answers to the session
+        claim.eligibility.assign_attributes(
+          claim_school_somewhere_else: true,
+          taught_eligible_subjects: nil,
+          biology_taught: nil,
+          physics_taught: nil,
+          chemistry_taught: nil,
+          computing_taught: nil,
+          languages_taught: nil,
+          employment_status: nil,
+          current_school_id: nil
+        )
 
-  def show_multiple_schools_content?
-    !params.has_key?(:additional_school)
-  end
+        claim.eligibility.save!
 
-  private
+        true
+      end
 
-  def load_schools
-    return unless params[:school_search]
+      def claim_school_name
+        answers.claim_school_name
+      end
 
-    @schools = School.search(params[:school_search])
-  rescue ArgumentError => e
-    raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
+      def no_search_results?
+        params[:school_search].present? && errors.empty?
+      end
 
-    errors.add(:school_search, i18n_errors_path("enter_a_school_or_postcode"))
-  end
+      def show_multiple_schools_content?
+        !params.has_key?(:additional_school)
+      end
 
-  def claim_school_must_exist
-    unless School.find_by(id: claim_school_id)
-      errors.add(:claim_school_id, i18n_errors_path("school_not_found"))
+      private
+
+      def load_schools
+        return unless params[:school_search]
+
+        @schools = School.search(params[:school_search])
+      rescue ArgumentError => e
+        raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
+
+        errors.add(:school_search, i18n_errors_path("enter_a_school_or_postcode"))
+      end
+
+      def claim_school_must_exist
+        unless School.find_by(id: claim_school_id)
+          errors.add(:claim_school_id, i18n_errors_path("school_not_found"))
+        end
+      end
+
+      def claim_school_changed?
+        claim_school_id != journey_session.answers.claim_school_id
+      end
     end
   end
 end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -1,4 +1,4 @@
-class ClaimSchoolForm < Form
+class Journeys::TeacherStudentLoanReimbursement::ClaimSchoolForm < Form
   attribute :claim_school_id
 
   attr_reader :schools

--- a/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
@@ -21,7 +21,7 @@ module Journeys
         if journey_session.logged_in_with_tid_and_has_recent_tps_school?
           journey_session.recent_tps_school
         else
-          claim.eligibility.claim_school
+          answers.claim_school
         end
       end
 

--- a/app/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form.rb
@@ -21,7 +21,7 @@ module Journeys
       end
 
       def claim_school_name
-        @claim_school_name ||= claim.eligibility.claim_school_name
+        @claim_school_name ||= answers.claim_school_name
       end
 
       def subject_attributes

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -48,7 +48,9 @@ class ClaimJourneySessionShim
       teacher_id_user_info: teacher_id_user_info,
       email_address_check: journey_session.answers.email_address_check,
       mobile_check: journey_session.answers.mobile_check,
-      qualifications_details_check: qualifications_details_check
+      qualifications_details_check: qualifications_details_check,
+      has_student_loan: has_student_loan,
+      student_loan_plan: student_loan_plan
     }
   end
 
@@ -76,6 +78,14 @@ class ClaimJourneySessionShim
 
   def qualifications_details_check
     journey_session.answers.qualifications_details_check || current_claim.qualifications_details_check
+  end
+
+  def has_student_loan
+    journey_session.answers.has_student_loan || current_claim.has_student_loan
+  end
+
+  def student_loan_plan
+    journey_session.answers.student_loan_plan || current_claim.student_loan_plan
   end
 
   def eligibilities

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -48,6 +48,10 @@ module Journeys
       attribute_names.include?(name.to_s)
     end
 
+    def current_school
+      @current_school ||= School.find_by(id: current_school_id)
+    end
+
     def details_check?
       !!details_check
     end

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
@@ -38,7 +38,7 @@ module Journeys
       def claim_school
         [
           claim_school_question,
-          eligibility.claim_school_name,
+          answers.claim_school_name,
           (eligibility.claim_school_somewhere_else == false) ? "select-claim-school" : "claim-school"
         ]
       end
@@ -53,7 +53,7 @@ module Journeys
 
       def subjects_taught
         [
-          subjects_taught_question(school_name: eligibility.claim_school_name),
+          subjects_taught_question(school_name: answers.claim_school_name),
           subject_list(eligibility.subjects_taught),
           "subjects-taught"
         ]

--- a/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
@@ -13,7 +13,7 @@ module Journeys
           super.merge(
             {
               qts_award_year: qts_award_year,
-              claim_school_id: claim_school_id,
+              claim_school_id: journey_session.answers.claim_school_id,
               current_school_id: current_school_id,
               employment_status: employment_status,
               biology_taught: biology_taught,
@@ -25,7 +25,7 @@ module Journeys
               student_loan_repayment_amount: student_loan_repayment_amount,
               had_leadership_position: had_leadership_position,
               mostly_performed_leadership_duties: mostly_performed_leadership_duties,
-              claim_school_somewhere_else: claim_school_somewhere_else
+              claim_school_somewhere_else: journey_session.answers.claim_school_somewhere_else
             }
           )
         )
@@ -35,10 +35,6 @@ module Journeys
 
       def qts_award_year
         journey_session.answers.qts_award_year || try_eligibility(:qts_award_year)
-      end
-
-      def claim_school_id
-        journey_session.answers.claim_school_id || try_eligibility(:claim_school_id)
       end
 
       def current_school_id
@@ -83,10 +79,6 @@ module Journeys
 
       def mostly_performed_leadership_duties
         journey_session.answers.mostly_performed_leadership_duties || try_eligibility(:mostly_performed_leadership_duties)
-      end
-
-      def claim_school_somewhere_else
-        journey_session.answers.claim_school_somewhere_else || try_eligibility(:claim_school_somewhere_else)
       end
     end
   end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -30,6 +30,18 @@ module Journeys
       def policy
         Policies::StudentLoans
       end
+
+      def claim_school
+        @claim_school ||= School.find_by(id: claim_school_id)
+      end
+
+      def claim_school_name
+        claim_school&.name
+      end
+
+      def claim_school_somewhere_else?
+        !!claim_school_somewhere_else
+      end
     end
   end
 end

--- a/app/models/policies/student_loans/eligibility_checker.rb
+++ b/app/models/policies/student_loans/eligibility_checker.rb
@@ -1,0 +1,75 @@
+module Policies
+  module StudentLoans
+    class EligibilityChecker
+      attr_reader :answers
+
+      def initialize(answers)
+        @answers = answers
+      end
+
+      def ineligible?
+        ineligible_qts_award_year? ||
+          ineligible_claim_school? ||
+          employed_at_no_school? ||
+          ineligible_current_school? ||
+          not_taught_eligible_subjects? ||
+          not_taught_enough? ||
+          made_zero_repayments?
+      end
+
+      def ineligibility_reason
+        [
+          :ineligible_qts_award_year,
+          :ineligible_claim_school,
+          :employed_at_no_school,
+          :ineligible_current_school,
+          :not_taught_eligible_subjects,
+          :not_taught_enough,
+          :made_zero_repayments
+        ].find { |eligibility_check| send(:"#{eligibility_check}?") }
+      end
+
+      def ineligible_qts_award_year?
+        awarded_qualified_status_before_cut_off_date?
+      end
+
+      def awarded_qualified_status_before_cut_off_date?
+        answers.qts_award_year.to_s == "before_cut_off_date"
+      end
+
+      private
+
+      def claim_school
+        @claim_school ||= answers.claim_school
+      end
+
+      def current_school
+        @current_school ||= answers.current_school
+      end
+
+      def ineligible_claim_school?
+        claim_school.present? && !claim_school.eligible_for_student_loans_as_claim_school?
+      end
+
+      def ineligible_current_school?
+        current_school.present? && !current_school.eligible_for_student_loans_as_current_school?
+      end
+
+      def not_taught_eligible_subjects?
+        answers.taught_eligible_subjects == false
+      end
+
+      def employed_at_no_school?
+        answers.employment_status.to_s == "no_school"
+      end
+
+      def not_taught_enough?
+        answers.mostly_performed_leadership_duties == true
+      end
+
+      def made_zero_repayments?
+        answers.has_student_loan == true && answers.student_loan_repayment_amount == 0
+      end
+    end
+  end
+end

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -2,7 +2,25 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
+    <% # FIXME RL: Once current claim is removed we'll be able to pull the
+      # reason directly off the answers rather than requiring the shim so we
+      # can do `journey_session.answers.ineligibility_reason` in the mean time
+      # we require this
+    if current_journey_routing_name == "student-loans"
+      shim = Journeys::TeacherStudentLoanReimbursement::ClaimJourneySessionShim.new(
+        current_claim: current_claim,
+        journey_session: journey_session
+      )
+      ineligibility_reason = Policies::StudentLoans::EligibilityChecker.new(shim.answers).ineligibility_reason
+    else
+      ineligibility_reason = current_claim.eligibility.ineligibility_reason
+    end %>
+    <%= render(
+      partial: "ineligibility_reason_#{ineligibility_reason}",
+      locals: {
+        claim_school_name: journey_session.answers.claim_school_name,
+      }
+    )%>
 
     <p class="govuk-body">
       If you need help with your claim, contact

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -6,7 +6,7 @@
   </h1>
 
   <p class="govuk-body">
-    <%= current_claim.eligibility.claim_school_name %> is not an eligible
+    <%= claim_school_name %> is not an eligible
     school. You can only get this payment if you were employed to teach at an
     eligible school between <%= Policies::StudentLoans.current_financial_year %>
   </p>
@@ -18,7 +18,7 @@
   </p>
 
   <div class="govuk-button-group">
-    <% if current_claim.eligibility.claim_school_somewhere_else == false %>
+    <% if journey_session.answers.claim_school_somewhere_else == false %>
       <%= button_to "Enter another school", claim_path(current_journey_routing_name, "select-claim-school", claim: { change_school: true }), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
     <% else %>
       <div><%= link_to "Enter another school", claim_path(current_journey_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %></div>

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -7,7 +7,7 @@
 
   <p class="govuk-body">
     You did not teach an eligible subject at
-    <%= current_claim.eligibility.claim_school_name %>.
+    <%= claim_school_name %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/student_loans/claims/select_claim_school.html.erb
+++ b/app/views/student_loans/claims/select_claim_school.html.erb
@@ -9,7 +9,7 @@
         </h1>
       </legend>
 
-      <%= errors_tag @form.eligibility, :current_school %>
+      <%= errors_tag @form, :current_school %>
 
       <div class="govuk-radios">
         <div class="govuk-radios__item">

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
       teacher_reference_number { generate(:teacher_reference_number) }
     end
 
+    trait :with_claim_school do
+      claim_school_id { create(:school, :student_loans_eligible).id }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -45,6 +49,7 @@ FactoryBot.define do
       with_bank_details
       with_payroll_gender
       with_teacher_reference_number
+      with_claim_school
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they've given, remaining eligible" do
     claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id))
 
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
@@ -78,11 +78,12 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     choose_school new_claim_school
 
-    expect(claim.eligibility.reload.claim_school).to eql new_claim_school
-    expect(claim.eligibility.physics_taught).to be_nil
-    expect(claim.eligibility.biology_taught).to be_nil
-    expect(claim.eligibility.employment_status).to be_nil
-    expect(claim.eligibility.current_school).to be_nil
+    session.reload
+    expect(session.answers.claim_school).to eql new_claim_school
+    expect(session.answers.physics_taught).to be_nil
+    expect(session.answers.biology_taught).to be_nil
+    expect(session.answers.employment_status).to be_nil
+    expect(session.answers.current_school).to be_nil
 
     expect(current_path).to eq(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught"))
 
@@ -308,7 +309,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
       session.answers.assign_attributes(
         attributes_for(
-          :student_loans_answers,
+          :additional_payments_answers,
           :submittable
         ).merge(personal_details_attributes)
       )

--- a/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
+++ b/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.logged_in_with_tid?).to eq(true)
     expect(answers.details_check).to eq(true)
     expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
-    expect(claim.eligibility.claim_school).to eql school
+    expect(answers.claim_school).to eql school
     expect(claim.eligibility.employment_status).to eql("claim_school")
     expect(claim.eligibility.current_school).to eql(school)
     expect(claim.eligibility.subjects_taught).to eq([:physics_taught])
@@ -238,7 +238,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.logged_in_with_tid?).to eq(true)
     expect(answers.details_check).to eq(true)
     expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
-    expect(claim.eligibility.claim_school).to eql school
+    expect(answers.claim_school).to eql school
     expect(claim.eligibility.employment_status).to eql("claim_school")
     expect(claim.eligibility.current_school).to eql(school)
     expect(claim.eligibility.subjects_taught).to eq([:physics_taught])

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -48,10 +48,11 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "chooses an ineligible claim school" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
     choose_school ineligible_school
 
-    expect(claim.eligibility.reload.claim_school).to eq ineligible_school
+    expect(session.reload.answers.claim_school).to eq ineligible_school
     expect(page).to have_text("This school is not eligible")
     expect(page).to have_text("#{ineligible_school.name} is not an eligible school.")
   end

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -6,12 +6,14 @@ RSpec.feature "Applicant worked at multiple schools" do
   let!(:journey_configuration) { create(:journey_configuration, :student_loans) }
   let!(:ineligible_school) { create(:school, :student_loans_ineligible) }
   let!(:eligible_school) { create(:school, :student_loans_eligible) }
+  let!(:other_eligible_school) { create(:school, :student_loans_eligible) }
   let!(:claim) { start_student_loans_claim }
+  let(:session) { Journeys::TeacherStudentLoanReimbursement::Session.last }
 
   scenario "first claim school is ineligible and subsequent school is eligible" do
     choose_school ineligible_school
 
-    expect(claim.eligibility.reload.claim_school).to eq ineligible_school
+    expect(session.reload.answers.claim_school).to eq ineligible_school
     expect(page).to have_text("This school is not eligible")
     expect(page).to have_text("#{ineligible_school.name} is not an eligible school.")
 
@@ -22,7 +24,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     expect(page).to_not have_text("If you taught at multiple schools")
 
     choose_school eligible_school
-    expect(claim.eligibility.reload.claim_school).to eq eligible_school
+    expect(session.reload.answers.claim_school).to eq eligible_school
 
     expect(page).to have_text(subjects_taught_question(school_name: eligible_school.name))
   end
@@ -55,7 +57,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     expect(page).to_not have_css("input[value=\"#{eligible_school.name}\"]")
     expect(page).to have_text(claim_school_question(additional_school: true))
 
-    choose_school eligible_school
+    choose_school other_eligible_school
 
     check I18n.t("student_loans.forms.subjects_taught.answers.biology_taught")
     check I18n.t("student_loans.forms.subjects_taught.answers.physics_taught")
@@ -74,13 +76,15 @@ RSpec.feature "Applicant worked at multiple schools" do
 
     click_on "Enter another school"
 
-    choose_school eligible_school
+    choose_school other_eligible_school
 
     check I18n.t("student_loans.forms.subjects_taught.answers.none_taught")
     click_on "Continue"
 
     expect(page).to have_text("You did not select an eligible subject")
-    expect(page).to have_text("You did not teach an eligible subject at #{eligible_school.name}.")
+    expect(page).to have_text(
+      "You did not teach an eligible subject at #{other_eligible_school.name}."
+    )
 
     click_on "I've tried all of my schools"
 

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -12,7 +12,8 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     let!(:school) { create(:school, :student_loans_eligible) }
 
     scenario "doesn't select a school from the search results the first time around" do
-      claim = start_student_loans_claim
+      start_student_loans_claim
+      session = Journeys::TeacherStudentLoanReimbursement::Session.last
 
       # Creates a duplicate school to test whether the school search shows closed schools
       duplicate_school = create(:school, :student_loans_eligible, :closed, name: "#{school.name} Duplicate")
@@ -30,7 +31,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
       choose duplicate_school.name
       click_on "Continue"
 
-      expect(claim.eligibility.reload.claim_school).to eql duplicate_school
+      expect(session.reload.answers.claim_school).to eql duplicate_school
       expect(page).to have_text(subjects_taught_question(school_name: duplicate_school.name))
     end
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text(claim_school_question)
 
     choose_school school
-    expect(claim.eligibility.reload.claim_school).to eql school
+    expect(session.reload.answers.claim_school).to eql school
     expect(page).to have_text(subjects_taught_question(school_name: school.name))
 
     check "Physics"
@@ -269,13 +269,14 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
         choose_qts_year
         claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
+        session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
         expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
         expect(page).to have_text(claim_school_question)
 
         choose_school school
-        expect(claim.eligibility.reload.claim_school).to eql school
+        expect(session.reload.answers.claim_school).to eql school
         expect(page).to have_text(subjects_taught_question(school_name: school.name))
 
         check "Physics"

--- a/spec/features/tslr_claim_journey_with_teacher_id_select_claim_school_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_select_claim_school_spec.rb
@@ -39,9 +39,9 @@ RSpec.feature "TSLR journey with Teacher ID school playback" do
 
     expect(current_path).to eq("/student-loans/subjects-taught")
 
-    claim = Claim.order(created_at: :desc).limit(1).first
-    expect(claim.eligibility.claim_school.id).to eq(eligible_school.id)
-    expect(claim.eligibility.claim_school_somewhere_else).to eq(false)
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.claim_school.id).to eq(eligible_school.id)
+    expect(session.answers.claim_school_somewhere_else).to eq(false)
 
     click_on "Back"
     expect(current_path).to eq("/student-loans/select-claim-school")
@@ -58,9 +58,9 @@ RSpec.feature "TSLR journey with Teacher ID school playback" do
 
     expect(current_path).to eq("/student-loans/ineligible")
 
-    claim = Claim.order(created_at: :desc).limit(1).first
-    expect(claim.eligibility.claim_school.id).to eq(ineligible_school.id)
-    expect(claim.eligibility.claim_school_somewhere_else).to eq(false)
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.claim_school.id).to eq(ineligible_school.id)
+    expect(session.answers.claim_school_somewhere_else).to eq(false)
 
     # - Tried all schools button
     click_on("I've tried all of my schools")

--- a/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
@@ -49,7 +49,8 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
     expect(current_path).to eq("/student-loans/leadership-position")
 
     eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
-    expect(eligibility.claim_school_id).to eq eligible_claim_school.id
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.claim_school_id).to eq eligible_claim_school.id
     expect(eligibility.current_school_id).to eq eligible_school.id
     expect(eligibility.employment_status).to eq "recent_tps_school"
 
@@ -62,7 +63,8 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
     expect(current_path).to eq("/student-loans/current-school")
 
     eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
-    expect(eligibility.claim_school_id).to eq eligible_claim_school.id
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.claim_school_id).to eq eligible_claim_school.id
     expect(eligibility.current_school_id).to be_nil
     expect(eligibility.employment_status).to eq "different_school"
 
@@ -75,7 +77,8 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
     expect(current_path).to eq("/student-loans/ineligible")
 
     eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
-    expect(eligibility.claim_school_id).to eq eligible_claim_school.id
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.claim_school_id).to eq eligible_claim_school.id
     expect(eligibility.current_school_id).to be_nil
     expect(eligibility.employment_status).to eq "no_school"
   end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/claim_school_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/claim_school_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ClaimSchoolForm do
+RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSchoolForm do
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
 
   before { create(:journey_configuration, :student_loans) }

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
@@ -3,13 +3,20 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, type: :model do
   before { create(:journey_configuration, :student_loans) }
 
-  let(:claim_school) { build(:school, :student_loans_eligible) }
+  let(:claim_school) { create(:school, :student_loans_eligible) }
   let(:eligibility) { create(:student_loans_eligibility, claim_school:, employment_status: nil) }
   let(:claim) { create(:claim, policy: Policies::StudentLoans, eligibility:) }
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:claim_params) { {} }
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
-  let(:journey_session) { build(:student_loans_session) }
+  let(:journey_session) do
+    create(
+      :student_loans_session,
+      answers: {
+        claim_school_id: claim_school.id
+      }
+    )
+  end
 
   subject(:form) do
     described_class.new(
@@ -30,7 +37,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
   describe "#error_message" do
     context "when the school is closed" do
-      let(:claim_school) { build(:school, :student_loans_eligible, close_date: Date.yesterday) }
+      let(:claim_school) do
+        create(:school, :student_loans_eligible, close_date: Date.yesterday)
+      end
 
       it "does not contain the school name" do
         expect(form.error_message).to eq("Select yes if you are still employed to teach at a school in England")

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
@@ -5,8 +5,17 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
     described_class.new(claim:, journey_session:, journey:, params:)
   end
 
+  let(:claim_school) { create(:school, name: "test school") }
+
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
-  let(:journey_session) { build(:student_loans_session) }
+  let(:journey_session) do
+    create(
+      :student_loans_session,
+      answers: {
+        claim_school_id: claim_school.id
+      }
+    )
+  end
   let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
   let(:slug) { "subjects-taught" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }
@@ -91,11 +100,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
   end
 
   describe "#claim_school_name" do
-    before do
-      allow(claim).to receive(:eligibility).and_return(double(claim_school_name: "test school"))
-    end
+    subject { form.claim_school_name }
 
-    it { expect(form.claim_school_name).to eq("test school") }
+    it { is_expected.to eq("test school") }
   end
 
   describe "#subject_attributes" do

--- a/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
     let(:qualifications_details_check) { false }
 
     let(:journey_session) do
-      build(
+      create(
         :student_loans_session,
-        answers: {}
+        answers: attributes_for(:student_loans_answers, :with_claim_school)
       )
     end
 
@@ -29,9 +29,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
     it "returns an array of questions, answers, and slugs for displaying to the user for review" do
       expected_answers = [
         [I18n.t("student_loans.forms.qts_year.questions.qts_award_year"), "Between the start of the 2013 to 2014 academic year and the end of the 2020 to 2021 academic year", "qts-year"],
-        [claim_school_question, eligibility.claim_school.name, "claim-school"],
+        [claim_school_question, journey_session.answers.claim_school.name, "claim-school"],
         [I18n.t("student_loans.forms.current_school.questions.current_school_search"), eligibility.current_school.name, "still-teaching"],
-        [subjects_taught_question(school_name: eligibility.current_school.name), "Chemistry and Physics", "subjects-taught"],
+        [subjects_taught_question(school_name: journey_session.answers.claim_school.name), "Chemistry and Physics", "subjects-taught"],
         [leadership_position_question, "Yes", "leadership-position"],
         [mostly_performed_leadership_duties_question, "No", "mostly-performed-leadership-duties"]
       ]

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
     it "excludes the “ineligible” slug if the claim is not actually ineligible" do
       expect(claim.eligibility).not_to be_ineligible
       expect(slug_sequence.slugs).not_to include("ineligible")
+    end
 
-      claim.eligibility.qts_award_year = "before_cut_off_date"
-      expect(claim.eligibility).to be_ineligible
+    it "includes the “ineligible” slug if the claim is actually ineligible" do
+      claim.eligibility.update! qts_award_year: "before_cut_off_date"
+      expect(claim.eligibility.reload).to be_ineligible
       expect(slug_sequence.slugs).to include("ineligible")
     end
 


### PR DESCRIPTION
Migrates claim school to session answers.

Couple of changes to note
1.) We've moved claim_school_form.rb into the TSLR namespace as it's only used on student loans journey
2.) We've introduced an eligibility checker class.

Claim school is used in a bunch of eligibility checks, so we now need to
be able to check the eligibility of the answers _and_ of the eligibility, and
as we're part way through the migration away from current claim we need
to be able to check the eligibility of the combination of both! To do so
we've introduced a new class
`Policies::StudentLoans::EligibilityChecker` which accepts either a
session answers or a claim and can be queried for eligibility status. We
can also pass the "shim" to this class for when we need to check the
eligibility across a combination of answers and current claim.
Eventually this class should probably subsume
`lib/ineligibility_reason_checker` too but that's something for a future
commit.
