### PR TITLE
CAPT 1682/still teaching form

### DIFF
--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -34,14 +34,9 @@ module Journeys
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the still teaching and current_school
-        # forms write their answers to the session
-        claim.eligibility.assign_attributes(
-          claim_school_somewhere_else: true,
-          employment_status: nil,
-          current_school_id: nil
-        )
-
+        # FIXME RL: Remove this once the current_school forms write their
+        # answers to the session
+        claim.eligibility.assign_attributes(current_school_id: nil)
         claim.eligibility.save!
 
         true

--- a/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
@@ -23,33 +23,20 @@ module Journeys
             employment_status: nil,
             current_school_id: nil
           )
-
-          # FIXME RL: Remove this once the current school and still teaching
-          # forms write their answers to the session
-          claim.eligibility.assign_attributes(
-            claim_school_somewhere_else: true,
-            employment_status: nil,
-            current_school_id: nil
-          )
         else
           journey_session.answers.assign_attributes(
             claim_school_id: claim_school_id,
             claim_school_somewhere_else: false
           )
-
-          # FIXME RL: Remove this once the current school and still teaching
-          # forms write their answers to the session
-          claim.eligibility.assign_attributes(
-            claim_school_somewhere_else: false,
-            employment_status: nil,
-            current_school_id: nil
-          )
         end
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the subjects taught and still teaching
-        # forms write their answers to the session
+        # FIXME RL: Remove this once the current school forms write their
+        # answers to the session
+        claim.eligibility.assign_attributes(current_school_id: nil)
+        # FIXME RL: Remove this once the current school forms write their
+        # answers to the session
         claim.eligibility.save!
 
         true

--- a/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
@@ -9,12 +9,12 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(
-          eligibility_attributes: {
-            employment_status:,
-            current_school_id: currently_at_school? ? current_school_id : nil
-          }
+        journey_session.answers.assign_attributes(
+          employment_status:,
+          current_school_id: currently_at_school? ? current_school_id : nil
         )
+
+        journey_session.save!
       end
 
       def school

--- a/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
@@ -15,7 +15,7 @@ module Journeys
               qts_award_year: qts_award_year,
               claim_school_id: journey_session.answers.claim_school_id,
               current_school_id: current_school_id,
-              employment_status: employment_status,
+              employment_status: journey_session.answers.employment_status,
               biology_taught: journey_session.answers.biology_taught,
               chemistry_taught: journey_session.answers.chemistry_taught,
               computing_taught: journey_session.answers.computing_taught,
@@ -39,10 +39,6 @@ module Journeys
 
       def current_school_id
         journey_session.answers.current_school_id || try_eligibility(:current_school_id)
-      end
-
-      def employment_status
-        journey_session.answers.employment_status || try_eligibility(:employment_status)
       end
 
       def student_loan_repayment_amount

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -52,6 +52,22 @@ module Journeys
           :languages_taught
         ].select { |subject| public_send(subject) }
       end
+
+      def employed_at_no_school?
+        employment_status.to_s == "no_school"
+      end
+
+      def employed_at_different_school?
+        employment_status.to_s == "different_school"
+      end
+
+      def employed_at_claim_school?
+        employment_status.to_s == "claim_school"
+      end
+
+      def employed_at_recent_tps_school?
+        employment_status.to_s == "recent_tps_school"
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -81,7 +81,7 @@ module Journeys
           end
 
           sequence.delete("reset-claim") if skipped_dfe_sign_in? || answers.details_check?
-          sequence.delete("current-school") if claim.eligibility.employed_at_claim_school? || claim.eligibility.employed_at_recent_tps_school?
+          sequence.delete("current-school") if answers.employed_at_claim_school? || answers.employed_at_recent_tps_school?
           sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
           sequence.delete("personal-bank-account") if answers.building_society?
           sequence.delete("building-society-account") if answers.personal_bank_account?

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -47,6 +47,10 @@ FactoryBot.define do
       taught_eligible_subjects { true }
     end
 
+    trait :with_employment_status do
+      employment_status { :claim_school }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -56,6 +60,7 @@ FactoryBot.define do
       with_teacher_reference_number
       with_claim_school
       with_subjects_taught
+      with_employment_status
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -100,8 +100,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     choose_still_teaching "Yes, at Claim School"
 
-    expect(claim.eligibility.reload.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql new_claim_school
+    expect(session.reload.answers.employment_status).to eql("claim_school")
+    expect(session.answers.current_school).to eql new_claim_school
 
     expect(current_path).to eq(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "check-your-answers"))
   end

--- a/spec/features/current_school_with_closed_claim_school_spec.rb
+++ b/spec/features/current_school_with_closed_claim_school_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Current school with closed claim school" do
   before { create(:journey_configuration, :student_loans) }
 
   scenario "Still teaching only has two options" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
     choose_school claim_school
     check "Physics"
     click_on "Continue"
@@ -19,7 +19,8 @@ RSpec.feature "Current school with closed claim school" do
     # - Choosing yes to still teaching prompts to search for a school
     choose_still_teaching "Yes"
 
-    expect(claim.eligibility.employment_status).to eq("different_school")
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.employment_status).to eq("different_school")
     expect(page).to have_text(I18n.t("student_loans.forms.current_school.questions.current_school_search"))
     expect(page).to have_button("Continue")
   end

--- a/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
+++ b/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
@@ -92,8 +92,8 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.details_check).to eq(true)
     expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
     expect(answers.claim_school).to eql school
-    expect(claim.eligibility.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql(school)
+    expect(answers.employment_status).to eql("claim_school")
+    expect(answers.current_school).to eql(school)
     expect(answers.subjects_taught).to eq([:physics_taught])
     expect(claim.eligibility.had_leadership_position?).to eq(true)
     expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)
@@ -239,8 +239,8 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.details_check).to eq(true)
     expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
     expect(answers.claim_school).to eql school
-    expect(claim.eligibility.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql(school)
+    expect(answers.employment_status).to eql("claim_school")
+    expect(answers.current_school).to eql(school)
     expect(answers.subjects_taught).to eq([:physics_taught])
     expect(claim.eligibility.had_leadership_position?).to eq(true)
     expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -72,13 +72,14 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "no longer teaching" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
     choose_school school
     choose_subjects_taught
 
     choose_still_teaching "No"
 
-    expect(claim.eligibility.reload.employment_status).to eq("no_school")
+    expect(session.reload.answers.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you’re still employed to teach at a state-funded secondary school.")
   end

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text(I18n.t("student_loans.forms.still_teaching.questions.claim_school"))
 
     choose_still_teaching("Yes, at #{school.name}")
-    expect(claim.eligibility.reload.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql(school)
+    expect(session.reload.answers.employment_status).to eql("claim_school")
+    expect(session.answers.current_school).to eql(school)
 
     expect(session.reload.answers.subjects_taught).to eq([:physics_taught])
 
@@ -284,8 +284,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
         expect(page).to have_text(I18n.t("student_loans.forms.still_teaching.questions.claim_school"))
 
         choose_still_teaching("Yes, at #{school.name}")
-        expect(claim.eligibility.reload.employment_status).to eql("claim_school")
-        expect(claim.eligibility.current_school).to eql(school)
+        expect(session.reload.answers.employment_status).to eql("claim_school")
+        expect(session.answers.current_school).to eql(school)
 
         expect(session.reload.answers.subjects_taught).to eq([:physics_taught])
 
@@ -308,13 +308,14 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   scenario "currently works at a different school to the claim school" do
     different_school = create(:school, :student_loans_eligible)
     claim = start_student_loans_claim
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
     choose_school school
     choose_subjects_taught
 
     choose_still_teaching("Yes, at another school")
 
-    expect(claim.eligibility.reload.employment_status).to eql("different_school")
+    expect(session.reload.answers.employment_status).to eql("different_school")
 
     fill_in :school_search, with: different_school.name
     click_on "Continue"

--- a/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
@@ -48,11 +48,11 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
 
     expect(current_path).to eq("/student-loans/leadership-position")
 
-    eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
+    Claim.order(created_at: :desc).limit(1).first.eligibility
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     expect(session.answers.claim_school_id).to eq eligible_claim_school.id
-    expect(eligibility.current_school_id).to eq eligible_school.id
-    expect(eligibility.employment_status).to eq "recent_tps_school"
+    expect(session.answers.current_school_id).to eq eligible_school.id
+    expect(session.answers.employment_status).to eq "recent_tps_school"
 
     # - Selects somewhere else
 
@@ -62,11 +62,11 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
 
     expect(current_path).to eq("/student-loans/current-school")
 
-    eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
+    Claim.order(created_at: :desc).limit(1).first.eligibility
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     expect(session.answers.claim_school_id).to eq eligible_claim_school.id
-    expect(eligibility.current_school_id).to be_nil
-    expect(eligibility.employment_status).to eq "different_school"
+    expect(session.answers.current_school_id).to be_nil
+    expect(session.answers.employment_status).to eq "different_school"
 
     # - Selects No...
     click_on "Back"
@@ -76,11 +76,11 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
 
     expect(current_path).to eq("/student-loans/ineligible")
 
-    eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
+    Claim.order(created_at: :desc).limit(1).first.eligibility
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     expect(session.answers.claim_school_id).to eq eligible_claim_school.id
-    expect(eligibility.current_school_id).to be_nil
-    expect(eligibility.employment_status).to eq "no_school"
+    expect(session.answers.current_school_id).to be_nil
+    expect(session.answers.employment_status).to eq "no_school"
   end
 
   def navigate_to_still_teaching_page

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
@@ -4,16 +4,14 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
   before { create(:journey_configuration, :student_loans) }
 
   let(:claim_school) { create(:school, :student_loans_eligible) }
-  let(:eligibility) { create(:student_loans_eligibility, claim_school:, employment_status: nil) }
-  let(:claim) { create(:claim, policy: Policies::StudentLoans, eligibility:) }
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:claim_params) { {} }
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
   let(:journey_session) do
     create(
       :student_loans_session,
       answers: {
-        claim_school_id: claim_school.id
+        claim_school_id: claim_school.id,
+        employment_status: nil
       }
     )
   end
@@ -22,7 +20,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
+      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: ActionController::Parameters.new(claim: claim_params)
     )
   end
@@ -53,8 +51,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id to nil and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to be_nil
-        expect(claim.eligibility).to be_employed_at_no_school
+        expect(journey_session.answers.current_school_id).to be_nil
+        expect(journey_session.answers.employed_at_no_school?).to be true
       end
     end
 
@@ -63,8 +61,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id to nil and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to be_nil
-        expect(claim.eligibility).to be_employed_at_different_school
+        expect(journey_session.answers.current_school_id).to be_nil
+        expect(journey_session.answers.employed_at_different_school?).to be true
       end
     end
 
@@ -73,8 +71,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to eq claim_school.id
-        expect(claim.eligibility).to be_employed_at_claim_school
+        expect(journey_session.answers.current_school_id).to eq claim_school.id
+        expect(journey_session.answers.employed_at_claim_school?).to be true
       end
     end
 
@@ -83,8 +81,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to eq claim_school.id
-        expect(claim.eligibility).to be_employed_at_recent_tps_school
+        expect(journey_session.answers.current_school_id).to eq claim_school.id
+        expect(journey_session.answers.employed_at_recent_tps_school?).to be true
       end
     end
   end

--- a/spec/models/journeys/page_sequence_spec.rb
+++ b/spec/models/journeys/page_sequence_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Journeys::PageSequence do
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:slug_sequence) { OpenStruct.new(slugs: ["first-slug", "second-slug", "third-slug"]) }
   let(:completed_slugs) { [] }
-  let(:journey_session) { build(:student_loans_session) }
+  let(:journey_session) { create(:student_loans_session) }
 
   subject(:page_sequence) do
     described_class.new(
@@ -44,7 +44,14 @@ RSpec.describe Journeys::PageSequence do
     end
 
     context "with an ineligible claim" do
-      let(:claim) { build(:claim, eligibility: build(:student_loans_eligibility, employment_status: :no_school)) }
+      let(:journey_session) do
+        create(
+          :student_loans_session,
+          answers: {
+            employment_status: "no_school"
+          }
+        )
+      end
       let(:current_slug) { "second-slug" }
       let(:completed_slugs) { ["first-slug", "second-slug"] }
 

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
     end
 
     it "excludes “current-school” if the claimant still works at the school they are claiming against" do
-      claim.eligibility.employment_status = :claim_school
+      journey_session.answers.employment_status = :claim_school
 
       expect(slug_sequence.slugs).not_to include("current-school")
     end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -144,7 +144,9 @@ RSpec.describe "Claims", type: :request do
       before { start_student_loans_claim }
 
       it "renders a static ineligibility page" do
-        Claim.by_policy(Policies::StudentLoans).order(:created_at).last.eligibility.update(employment_status: "no_school")
+        journey_session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+        journey_session.answers.assign_attributes(employment_status: "no_school")
+        journey_session.save!
 
         get claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "ineligible")
 


### PR DESCRIPTION
Migrate still teaching form to write to answers

Migrates the still teaching form to write to the answers and updates the
call sites to read from the answers rather than from the eligibility.
