### PR TITLE
CAPT 1683/leadership

### DIFF
--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -34,14 +34,9 @@ module Journeys
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the still teaching and current_school
-        # forms write their answers to the session
-        claim.eligibility.assign_attributes(
-          claim_school_somewhere_else: true,
-          employment_status: nil,
-          current_school_id: nil
-        )
-
+        # FIXME RL: Remove this once the current_school forms write their
+        # answers to the session
+        claim.eligibility.assign_attributes(current_school_id: nil)
         claim.eligibility.save!
 
         true

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -34,16 +34,10 @@ module Journeys
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the subjects taught and still teaching
+        # FIXME RL: Remove this once the still teaching and current_school
         # forms write their answers to the session
         claim.eligibility.assign_attributes(
           claim_school_somewhere_else: true,
-          taught_eligible_subjects: nil,
-          biology_taught: nil,
-          physics_taught: nil,
-          chemistry_taught: nil,
-          computing_taught: nil,
-          languages_taught: nil,
           employment_status: nil,
           current_school_id: nil
         )

--- a/app/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form.rb
@@ -13,18 +13,18 @@ module Journeys
         return false unless valid?
         return true unless had_leadership_position_changed?
 
-        update!(
-          eligibility_attributes: {
-            had_leadership_position: had_leadership_position,
-            mostly_performed_leadership_duties: nil
-          }
+        journey_session.answers.assign_attributes(
+          had_leadership_position: had_leadership_position,
+          mostly_performed_leadership_duties: nil
         )
+
+        journey_session.save!
       end
 
       private
 
       def had_leadership_position_changed?
-        claim.eligibility.had_leadership_position != had_leadership_position
+        answers.had_leadership_position != had_leadership_position
       end
     end
   end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form.rb
@@ -11,11 +11,11 @@ module Journeys
 
       def save
         return false unless valid?
-        claim.update!(
-          eligibility_attributes: {
-            mostly_performed_leadership_duties: mostly_performed_leadership_duties
-          }
+        journey_session.answers.assign_attributes(
+          mostly_performed_leadership_duties: mostly_performed_leadership_duties
         )
+
+        journey_session.save!
       end
     end
   end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
@@ -24,16 +24,10 @@ module Journeys
             current_school_id: nil
           )
 
-          # FIXME RL: Remove this once the subjects taught and still teaching
+          # FIXME RL: Remove this once the current school and still teaching
           # forms write their answers to the session
           claim.eligibility.assign_attributes(
             claim_school_somewhere_else: true,
-            taught_eligible_subjects: nil,
-            biology_taught: nil,
-            physics_taught: nil,
-            chemistry_taught: nil,
-            computing_taught: nil,
-            languages_taught: nil,
             employment_status: nil,
             current_school_id: nil
           )
@@ -43,16 +37,10 @@ module Journeys
             claim_school_somewhere_else: false
           )
 
-          # FIXME RL: Remove this once the subjects taught and still teaching
+          # FIXME RL: Remove this once the current school and still teaching
           # forms write their answers to the session
           claim.eligibility.assign_attributes(
             claim_school_somewhere_else: false,
-            taught_eligible_subjects: nil,
-            biology_taught: nil,
-            physics_taught: nil,
-            chemistry_taught: nil,
-            computing_taught: nil,
-            languages_taught: nil,
             employment_status: nil,
             current_school_id: nil
           )

--- a/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
@@ -23,33 +23,20 @@ module Journeys
             employment_status: nil,
             current_school_id: nil
           )
-
-          # FIXME RL: Remove this once the current school and still teaching
-          # forms write their answers to the session
-          claim.eligibility.assign_attributes(
-            claim_school_somewhere_else: true,
-            employment_status: nil,
-            current_school_id: nil
-          )
         else
           journey_session.answers.assign_attributes(
             claim_school_id: claim_school_id,
             claim_school_somewhere_else: false
           )
-
-          # FIXME RL: Remove this once the current school and still teaching
-          # forms write their answers to the session
-          claim.eligibility.assign_attributes(
-            claim_school_somewhere_else: false,
-            employment_status: nil,
-            current_school_id: nil
-          )
         end
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the subjects taught and still teaching
-        # forms write their answers to the session
+        # FIXME RL: Remove this once the current school forms write their
+        # answers to the session
+        claim.eligibility.assign_attributes(current_school_id: nil)
+        # FIXME RL: Remove this once the current school forms write their
+        # answers to the session
         claim.eligibility.save!
 
         true

--- a/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
@@ -9,12 +9,12 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(
-          eligibility_attributes: {
-            employment_status:,
-            current_school_id: currently_at_school? ? current_school_id : nil
-          }
+        journey_session.answers.assign_attributes(
+          employment_status:,
+          current_school_id: currently_at_school? ? current_school_id : nil
         )
+
+        journey_session.save!
       end
 
       def school

--- a/app/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form.rb
@@ -17,7 +17,16 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(eligibility_attributes: attributes)
+        journey_session.answers.assign_attributes(
+          taught_eligible_subjects: taught_eligible_subjects,
+          biology_taught: biology_taught,
+          chemistry_taught: chemistry_taught,
+          physics_taught: physics_taught,
+          computing_taught: computing_taught,
+          languages_taught: languages_taught
+        )
+
+        journey_session.save!
       end
 
       def claim_school_name

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -32,6 +32,6 @@ module StudentLoansHelper
   # Returns the question for the mostly-performed-leadership-duties question in
   # the Student  Loans journey.
   def mostly_performed_leadership_duties_question
-    translate("student_loans.forms.mostly_performed_leadership_duties..questions.mostly_performed_leadership_duties", financial_year: Policies::StudentLoans.current_financial_year)
+    translate("student_loans.forms.mostly_performed_leadership_duties.questions.mostly_performed_leadership_duties", financial_year: Policies::StudentLoans.current_financial_year)
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
@@ -54,7 +54,7 @@ module Journeys
       def subjects_taught
         [
           subjects_taught_question(school_name: answers.claim_school_name),
-          subject_list(eligibility.subjects_taught),
+          subject_list(answers.subjects_taught),
           "subjects-taught"
         ]
       end

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
@@ -21,7 +21,7 @@ module Journeys
           a << current_school
           a << subjects_taught
           a << leadership_position
-          a << mostly_performed_leadership_duties if eligibility.had_leadership_position?
+          a << mostly_performed_leadership_duties if answers.had_leadership_position?
         end
       end
 
@@ -62,7 +62,7 @@ module Journeys
       def leadership_position
         [
           leadership_position_question,
-          (eligibility.had_leadership_position? ? "Yes" : "No"),
+          (answers.had_leadership_position? ? "Yes" : "No"),
           "leadership-position"
         ]
       end
@@ -70,7 +70,7 @@ module Journeys
       def mostly_performed_leadership_duties
         [
           mostly_performed_leadership_duties_question,
-          (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"),
+          (answers.mostly_performed_leadership_duties? ? "Yes" : "No"),
           "mostly-performed-leadership-duties"
         ]
       end

--- a/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
@@ -15,7 +15,7 @@ module Journeys
               qts_award_year: qts_award_year,
               claim_school_id: journey_session.answers.claim_school_id,
               current_school_id: current_school_id,
-              employment_status: employment_status,
+              employment_status: journey_session.answers.employment_status,
               biology_taught: journey_session.answers.biology_taught,
               chemistry_taught: journey_session.answers.chemistry_taught,
               computing_taught: journey_session.answers.computing_taught,
@@ -39,10 +39,6 @@ module Journeys
 
       def current_school_id
         journey_session.answers.current_school_id || try_eligibility(:current_school_id)
-      end
-
-      def employment_status
-        journey_session.answers.employment_status || try_eligibility(:employment_status)
       end
 
       def student_loan_repayment_amount

--- a/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
@@ -23,8 +23,8 @@ module Journeys
               physics_taught: journey_session.answers.physics_taught,
               taught_eligible_subjects: journey_session.answers.taught_eligible_subjects,
               student_loan_repayment_amount: student_loan_repayment_amount,
-              had_leadership_position: had_leadership_position,
-              mostly_performed_leadership_duties: mostly_performed_leadership_duties,
+              had_leadership_position: journey_session.answers.had_leadership_position,
+              mostly_performed_leadership_duties: journey_session.answers.mostly_performed_leadership_duties,
               claim_school_somewhere_else: journey_session.answers.claim_school_somewhere_else
             }
           )
@@ -43,14 +43,6 @@ module Journeys
 
       def student_loan_repayment_amount
         journey_session.answers.student_loan_repayment_amount || try_eligibility(:student_loan_repayment_amount)
-      end
-
-      def had_leadership_position
-        journey_session.answers.had_leadership_position || try_eligibility(:had_leadership_position)
-      end
-
-      def mostly_performed_leadership_duties
-        journey_session.answers.mostly_performed_leadership_duties || try_eligibility(:mostly_performed_leadership_duties)
       end
     end
   end

--- a/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
@@ -16,12 +16,12 @@ module Journeys
               claim_school_id: journey_session.answers.claim_school_id,
               current_school_id: current_school_id,
               employment_status: employment_status,
-              biology_taught: biology_taught,
-              chemistry_taught: chemistry_taught,
-              computing_taught: computing_taught,
-              languages_taught: languages_taught,
-              physics_taught: physics_taught,
-              taught_eligible_subjects: taught_eligible_subjects,
+              biology_taught: journey_session.answers.biology_taught,
+              chemistry_taught: journey_session.answers.chemistry_taught,
+              computing_taught: journey_session.answers.computing_taught,
+              languages_taught: journey_session.answers.languages_taught,
+              physics_taught: journey_session.answers.physics_taught,
+              taught_eligible_subjects: journey_session.answers.taught_eligible_subjects,
               student_loan_repayment_amount: student_loan_repayment_amount,
               had_leadership_position: had_leadership_position,
               mostly_performed_leadership_duties: mostly_performed_leadership_duties,
@@ -43,30 +43,6 @@ module Journeys
 
       def employment_status
         journey_session.answers.employment_status || try_eligibility(:employment_status)
-      end
-
-      def biology_taught
-        journey_session.answers.biology_taught || try_eligibility(:biology_taught)
-      end
-
-      def chemistry_taught
-        journey_session.answers.chemistry_taught || try_eligibility(:chemistry_taught)
-      end
-
-      def computing_taught
-        journey_session.answers.computing_taught || try_eligibility(:computing_taught)
-      end
-
-      def languages_taught
-        journey_session.answers.languages_taught || try_eligibility(:languages_taught)
-      end
-
-      def physics_taught
-        journey_session.answers.physics_taught || try_eligibility(:physics_taught)
-      end
-
-      def taught_eligible_subjects
-        journey_session.answers.taught_eligible_subjects || try_eligibility(:taught_eligible_subjects)
       end
 
       def student_loan_repayment_amount

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -52,6 +52,22 @@ module Journeys
           :languages_taught
         ].select { |subject| public_send(subject) }
       end
+
+      def employed_at_no_school?
+        employment_status.to_s == "no_school"
+      end
+
+      def employed_at_different_school?
+        employment_status.to_s == "different_school"
+      end
+
+      def employed_at_claim_school?
+        employment_status.to_s == "claim_school"
+      end
+
+      def employed_at_recent_tps_school?
+        employment_status.to_s == "recent_tps_school"
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -42,6 +42,16 @@ module Journeys
       def claim_school_somewhere_else?
         !!claim_school_somewhere_else
       end
+
+      def subjects_taught
+        [
+          :biology_taught,
+          :chemistry_taught,
+          :physics_taught,
+          :computing_taught,
+          :languages_taught
+        ].select { |subject| public_send(subject) }
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -68,6 +68,14 @@ module Journeys
       def employed_at_recent_tps_school?
         employment_status.to_s == "recent_tps_school"
       end
+
+      def had_leadership_position?
+        !!had_leadership_position
+      end
+
+      def mostly_performed_leadership_duties?
+        !!mostly_performed_leadership_duties
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -82,7 +82,7 @@ module Journeys
 
           sequence.delete("reset-claim") if skipped_dfe_sign_in? || answers.details_check?
           sequence.delete("current-school") if answers.employed_at_claim_school? || answers.employed_at_recent_tps_school?
-          sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
+          sequence.delete("mostly-performed-leadership-duties") unless answers.had_leadership_position?
           sequence.delete("personal-bank-account") if answers.building_society?
           sequence.delete("building-society-account") if answers.personal_bank_account?
           sequence.delete("mobile-number") if answers.provide_mobile_number == false

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -81,7 +81,7 @@ module Journeys
           end
 
           sequence.delete("reset-claim") if skipped_dfe_sign_in? || answers.details_check?
-          sequence.delete("current-school") if claim.eligibility.employed_at_claim_school? || claim.eligibility.employed_at_recent_tps_school?
+          sequence.delete("current-school") if answers.employed_at_claim_school? || answers.employed_at_recent_tps_school?
           sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
           sequence.delete("personal-bank-account") if answers.building_society?
           sequence.delete("building-society-account") if answers.personal_bank_account?

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -47,6 +47,10 @@ FactoryBot.define do
       taught_eligible_subjects { true }
     end
 
+    trait :with_employment_status do
+      employment_status { :claim_school }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -56,6 +60,7 @@ FactoryBot.define do
       with_teacher_reference_number
       with_claim_school
       with_subjects_taught
+      with_employment_status
     end
   end
 end

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -51,6 +51,11 @@ FactoryBot.define do
       employment_status { :claim_school }
     end
 
+    trait :with_leadership_position do
+      had_leadership_position { true }
+      mostly_performed_leadership_duties { false }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -61,6 +66,7 @@ FactoryBot.define do
       with_claim_school
       with_subjects_taught
       with_employment_status
+      with_leadership_position
     end
   end
 end

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -42,6 +42,11 @@ FactoryBot.define do
       claim_school_id { create(:school, :student_loans_eligible).id }
     end
 
+    trait :with_subjects_taught do
+      physics_taught { true }
+      taught_eligible_subjects { true }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -50,6 +55,7 @@ FactoryBot.define do
       with_payroll_gender
       with_teacher_reference_number
       with_claim_school
+      with_subjects_taught
     end
   end
 end

--- a/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
+++ b/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
@@ -31,7 +31,11 @@ RSpec.feature "Admin claim tasks update with DQT API" do
       claim.eligibility = create("#{policy_underscored}_eligibility", :eligible)
       claim.save!
 
-      jump_to_claim_journey_page(claim, "check-your-answers")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers",
+        journey_session: journey_session
+      )
 
       (claim_attributes[:policy] == Policies::EarlyCareerPayments) ? click_on("Accept and send") : click_on("Confirm and send")
     end

--- a/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
@@ -288,7 +288,11 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
 
     scenario "with Ordnance Survey API data" do
       expect(claim.valid?(:submit)).to eq false
-      jump_to_claim_journey_page(claim, "postcode-search")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "postcode-search",
+        journey_session: journey_session
+      )
 
       # - What is your home address
       expect(page).to have_text(I18n.t("questions.address.home.title"))
@@ -319,7 +323,11 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
 
     scenario "Claimant cannot find the correct address so chooses to manually enter address" do
       expect(claim.valid?(:submit)).to eq false
-      jump_to_claim_journey_page(claim, "postcode-search")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "postcode-search",
+        journey_session: journey_session
+      )
 
       # - What is your home address
       expect(page).to have_text(I18n.t("questions.address.home.title"))
@@ -361,7 +369,11 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
     # Bugfix - did cause an exception after pressing back
     scenario "Claimant cannot find the correct address so chooses to manually enter address, presses back before filling anything to go to the postcode search again" do
       expect(claim.valid?(:submit)).to eq false
-      jump_to_claim_journey_page(claim, "postcode-search")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "postcode-search",
+        journey_session: journey_session
+      )
 
       # - What is your home address
       expect(page).to have_text(I18n.t("questions.address.home.title"))
@@ -385,7 +397,11 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
 
     scenario "Claimant decides they want to change the POSTCODE from the 'select-home-address' screen" do
       expect(claim.valid?(:submit)).to eq false
-      jump_to_claim_journey_page(claim, "postcode-search")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "postcode-search",
+        journey_session: journey_session
+      )
 
       # - What is your home address (1st time before making the request to change)
       expect(page).to have_text(I18n.t("questions.address.home.title"))
@@ -453,7 +469,11 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
 
     scenario "Ordanance Survery Client raise a ResponseError" do
       expect(claim.valid?(:submit)).to eq false
-      jump_to_claim_journey_page(claim, "postcode-search")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "postcode-search",
+        journey_session: journey_session
+      )
 
       # - What is your home address
       expect(page).to have_text(I18n.t("questions.address.home.title"))

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -92,8 +92,9 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     click_on "Continue"
 
-    expect(claim.eligibility.reload.biology_taught).to eq(true)
-    expect(claim.eligibility.chemistry_taught).to eq(true)
+    session.reload
+    expect(session.answers.biology_taught).to eq(true)
+    expect(session.answers.chemistry_taught).to eq(true)
 
     expect(current_path).to eq(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "still-teaching"))
 

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -22,7 +22,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
     )
     session.save!
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim:,
+      journey_session: session,
+      slug: "check-your-answers"
+    )
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught")}']").click
 
@@ -44,7 +48,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim:,
+      slug: "check-your-answers",
+      journey_session: Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+    )
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "qts-year")}']").click
 
@@ -70,7 +78,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
     )
     session.save!
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim:,
+      slug: "check-your-answers",
+      journey_session: session
+    )
 
     new_claim_school = create(:school, :student_loans_eligible, name: "Claim School")
 
@@ -109,27 +121,35 @@ RSpec.feature "Changing the answers on a submittable claim" do
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they've given, making them ineligible" do
     claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, had_leadership_position: false, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
-      attributes_for(:student_loans_answers, :submittable)
+      attributes_for(
+        :student_loans_answers,
+        :submittable,
+        had_leadership_position: false
+      )
     )
     session.save!
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "check-your-answers",
+      journey_session: session
+    )
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "leadership-position")}']").click
 
     choose "Yes"
     click_on "Continue"
 
-    expect(claim.eligibility.reload.had_leadership_position).to eq(true)
-    expect(claim.eligibility.mostly_performed_leadership_duties).to be_nil
+    expect(session.reload.answers.had_leadership_position).to eq(true)
+    expect(session.answers.mostly_performed_leadership_duties).to be_nil
 
     choose "Yes"
     click_on "Continue"
 
-    expect(claim.eligibility.reload.mostly_performed_leadership_duties).to eq(true)
+    expect(session.reload.answers.mostly_performed_leadership_duties).to eq(true)
 
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between #{Policies::StudentLoans.current_financial_year}.")
@@ -146,7 +166,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
     )
     session.save!
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "check-your-answers",
+      journey_session: session
+    )
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught")}']").click
 
@@ -177,7 +201,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     claim.update!(attributes_for(:claim, :submittable))
     eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id, student_loan_repayment_amount: 100))
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "check-your-answers",
+      journey_session: journey_session
+    )
 
     # Add student loans data for the applicant's NINO and DoB
     create(
@@ -217,7 +245,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
           middle_name: "Jay"
         )
       )
-      jump_to_claim_journey_page(claim, "check-your-answers")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers",
+        journey_session: journey_session
+      )
     end
 
     scenario "Teacher can change a field that isn't related to eligibility" do
@@ -240,7 +272,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     scenario "user can change the answer to identity details" do
       claim.update!(govuk_verify_fields: [])
-      jump_to_claim_journey_page(claim, "check-your-answers")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers",
+        journey_session: journey_session
+      )
 
       expect(page).to have_content(I18n.t("questions.name"))
       expect(page).to have_content(I18n.t("forms.address.questions.your_address"))
@@ -262,7 +298,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
     end
 
     scenario "user can change the answer to payment details" do
-      jump_to_claim_journey_page(claim, "check-your-answers")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers",
+        journey_session: journey_session
+      )
 
       expect(page).to have_content(I18n.t("questions.bank_or_building_society"))
       expect(page).to have_content("Personal bank account")
@@ -316,7 +356,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
       )
       session.save!
 
-      jump_to_claim_journey_page(claim, "check-your-answers")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers",
+        journey_session: session
+      )
     end
 
     context "when email address" do

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -100,8 +100,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     choose_still_teaching "Yes, at Claim School"
 
-    expect(claim.eligibility.reload.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql new_claim_school
+    expect(session.reload.answers.employment_status).to eql("claim_school")
+    expect(session.answers.current_school).to eql new_claim_school
 
     expect(current_path).to eq(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "check-your-answers"))
   end

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -13,7 +13,11 @@ RSpec.feature "Claim journey does not get cached" do
     claim.eligibility = create(:student_loans_eligibility, :eligible)
     claim.save!
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "check-your-answers",
+      journey_session: journey_session
+    )
 
     expect(page).to have_text(claim.first_name)
 
@@ -21,7 +25,11 @@ RSpec.feature "Claim journey does not get cached" do
 
     expect(current_path).to eq(claim_confirmation_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME))
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "check-your-answers",
+      journey_session: journey_session
+    )
 
     expect(page).to_not have_text(claim.first_name)
     expect(page).to have_text("Use DfE Identity to sign in")

--- a/spec/features/claim_with_mobile_sms_otp_spec.rb
+++ b/spec/features/claim_with_mobile_sms_otp_spec.rb
@@ -66,7 +66,11 @@ RSpec.feature "GOVUK Nofity SMS sends OTP" do
 
         session.update!(answers: {provide_mobile_number: true})
 
-        jump_to_claim_journey_page(claim, "mobile-number")
+        jump_to_claim_journey_page(
+          claim: claim,
+          slug: "mobile-number",
+          journey_session: session
+        )
         expect(session.reload.answers.provide_mobile_number).to eql true
 
         # - Mobile number

--- a/spec/features/current_school_with_closed_claim_school_spec.rb
+++ b/spec/features/current_school_with_closed_claim_school_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Current school with closed claim school" do
   before { create(:journey_configuration, :student_loans) }
 
   scenario "Still teaching only has two options" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
     choose_school claim_school
     check "Physics"
     click_on "Continue"
@@ -19,7 +19,8 @@ RSpec.feature "Current school with closed claim school" do
     # - Choosing yes to still teaching prompts to search for a school
     choose_still_teaching "Yes"
 
-    expect(claim.eligibility.employment_status).to eq("different_school")
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.employment_status).to eq("different_school")
     expect(page).to have_text(I18n.t("student_loans.forms.current_school.questions.current_school_search"))
     expect(page).to have_button("Continue")
   end

--- a/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
+++ b/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
@@ -92,8 +92,8 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.details_check).to eq(true)
     expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
     expect(answers.claim_school).to eql school
-    expect(claim.eligibility.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql(school)
+    expect(answers.employment_status).to eql("claim_school")
+    expect(answers.current_school).to eql(school)
     expect(answers.subjects_taught).to eq([:physics_taught])
     expect(claim.eligibility.had_leadership_position?).to eq(true)
     expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)
@@ -239,8 +239,8 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.details_check).to eq(true)
     expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
     expect(answers.claim_school).to eql school
-    expect(claim.eligibility.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql(school)
+    expect(answers.employment_status).to eql("claim_school")
+    expect(answers.current_school).to eql(school)
     expect(answers.subjects_taught).to eq([:physics_taught])
     expect(claim.eligibility.had_leadership_position?).to eq(true)
     expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)

--- a/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
+++ b/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.claim_school).to eql school
     expect(claim.eligibility.employment_status).to eql("claim_school")
     expect(claim.eligibility.current_school).to eql(school)
-    expect(claim.eligibility.subjects_taught).to eq([:physics_taught])
+    expect(answers.subjects_taught).to eq([:physics_taught])
     expect(claim.eligibility.had_leadership_position?).to eq(true)
     expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)
   end
@@ -241,7 +241,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.claim_school).to eql school
     expect(claim.eligibility.employment_status).to eql("claim_school")
     expect(claim.eligibility.current_school).to eql(school)
-    expect(claim.eligibility.subjects_taught).to eq([:physics_taught])
+    expect(answers.subjects_taught).to eq([:physics_taught])
     expect(claim.eligibility.had_leadership_position?).to eq(true)
     expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)
   end

--- a/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
+++ b/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
@@ -95,8 +95,8 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.employment_status).to eql("claim_school")
     expect(answers.current_school).to eql(school)
     expect(answers.subjects_taught).to eq([:physics_taught])
-    expect(claim.eligibility.had_leadership_position?).to eq(true)
-    expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)
+    expect(answers.had_leadership_position?).to eq(true)
+    expect(answers.mostly_performed_leadership_duties?).to eq(false)
   end
 
   scenario "Teacher makes claim for 'Student Loans' by logging in with teacher_id and selects no to details confirm" do
@@ -242,7 +242,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.employment_status).to eql("claim_school")
     expect(answers.current_school).to eql(school)
     expect(answers.subjects_taught).to eq([:physics_taught])
-    expect(claim.eligibility.had_leadership_position?).to eq(true)
-    expect(claim.eligibility.mostly_performed_leadership_duties?).to eq(false)
+    expect(answers.had_leadership_position?).to eq(true)
+    expect(answers.mostly_performed_leadership_duties?).to eq(false)
   end
 end

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -339,7 +339,11 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     end
 
     scenario "when Assessment only" do
-      jump_to_claim_journey_page(claim, "qualification")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "qualification",
+        journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
+      )
 
       # - What route into teaching did you take?
       expect(page).to have_text(I18n.t("additional_payments.forms.qualification.questions.which_route"))
@@ -381,7 +385,11 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     end
 
     scenario "when Overseas recognition" do
-      jump_to_claim_journey_page(claim, "qualification")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "qualification",
+        journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
+      )
 
       # - What route into teaching did you take?
       expect(page).to have_text(I18n.t("additional_payments.forms.qualification.questions.which_route"))
@@ -809,7 +817,11 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
 
     scenario "with Ordnance Survey data" do
       expect(claim.valid?(:submit)).to eq false
-      jump_to_claim_journey_page(claim, "check-your-answers-part-one")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers-part-one",
+        journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
+      )
 
       # - Check your answers for eligibility
       expect(page).to have_text(I18n.t("additional_payments.check_your_answers.part_one.primary_heading"))

--- a/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
+++ b/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
@@ -18,7 +18,11 @@ RSpec.feature "Eligible now can set a reminder for next year." do
     )
     session.save!
 
-    jump_to_claim_journey_page(claim, "check-your-answers")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "check-your-answers",
+      journey_session: session
+    )
     expect(page).to have_text(claim.first_name)
     click_on "Accept and send"
     expect(page).to have_text("Set a reminder to apply next year")
@@ -87,7 +91,11 @@ RSpec.feature "Completed Applications - Reminders" do
           )
           session.save!
 
-          jump_to_claim_journey_page(claim, "check-your-answers")
+          jump_to_claim_journey_page(
+            claim: claim,
+            slug: "check-your-answers",
+            journey_session: session
+          )
           expect(page).to have_text(claim.first_name)
 
           click_on "Accept and send"

--- a/spec/features/ineligible_early_career_payments_in_2022_and_future_years_spec.rb
+++ b/spec/features/ineligible_early_career_payments_in_2022_and_future_years_spec.rb
@@ -41,7 +41,11 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims by cohort" do
 
       policy[:ineligible_cohorts].each do |scenario|
         scenario "with cohort ITT subject #{scenario[:itt_subject]} in ITT academic year #{scenario[:itt_academic_year]}" do
-          jump_to_claim_journey_page(claim, "itt-year")
+          jump_to_claim_journey_page(
+            claim: claim,
+            slug: "itt-year",
+            journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
+          )
 
           # - In which academic year did you start your undergraduate ITT
           expect(page).to have_text(I18n.t("additional_payments.questions.itt_academic_year.qualification.#{claim.eligibility.qualification}"))

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -72,13 +72,14 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "no longer teaching" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
     choose_school school
     choose_subjects_taught
 
     choose_still_teaching "No"
 
-    expect(claim.eligibility.reload.employment_status).to eq("no_school")
+    expect(session.reload.answers.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you’re still employed to teach at a state-funded secondary school.")
   end

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
     choose_school school
     check "Biology"
     click_on "Continue"
@@ -110,7 +110,8 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose "Yes"
     click_on "Continue"
 
-    expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(true)
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.mostly_performed_leadership_duties?).to eq(true)
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between #{Policies::StudentLoans.current_financial_year}.")
   end

--- a/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
+++ b/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
@@ -10,7 +10,11 @@ RSpec.feature "Claims with different eligibilities content change logic" do
   end
 
   it "shows the correct subjects for LUP-only and ECP claims" do
-    jump_to_claim_journey_page(claim, "itt-year")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "itt-year",
+      journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
+    )
     choose "2017 to 2018"
     click_on "Continue"
     expected_subjects = ["Chemistry", "Computing", "Mathematics", "Physics", "None of the above"]

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -63,9 +63,10 @@ RSpec.feature "Applicant worked at multiple schools" do
     check I18n.t("student_loans.forms.subjects_taught.answers.physics_taught")
     click_on "Continue"
 
-    expect(claim.eligibility.reload.taught_eligible_subjects).to eq(true)
-    expect(claim.eligibility.biology_taught).to eq(true)
-    expect(claim.eligibility.physics_taught).to eq(true)
+    session.reload
+    expect(session.answers.taught_eligible_subjects).to eq(true)
+    expect(session.answers.biology_taught).to eq(true)
+    expect(session.answers.physics_taught).to eq(true)
   end
 
   scenario "didn't teach eligible subjects and did not teach eligible subjects at a different eligible school" do

--- a/spec/features/one_time_password_spec.rb
+++ b/spec/features/one_time_password_spec.rb
@@ -8,7 +8,11 @@ RSpec.feature "Given a one time password" do
   before do
     create(:journey_configuration, :additional_payments)
     claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
-    jump_to_claim_journey_page(claim, "email-address")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "email-address",
+      journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
+    )
     fill_in "Email address", with: "david.tau1988@hotmail.co.uk"
     click_on "Continue"
   end

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -26,7 +26,11 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           expect(claim.policy).to eq Policies::EarlyCareerPayments
           expect(claim.eligibility.reload.eligible_itt_subject).to eq args[:subject]
 
-          jump_to_claim_journey_page(claim, "itt-year")
+          jump_to_claim_journey_page(
+            claim:,
+            slug: "itt-year",
+            journey_session: build(:additional_payments_session)
+          )
 
           choose args[:cohort]
           click_on "Continue"
@@ -98,7 +102,11 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           expect(claim.policy).to eq Policies::EarlyCareerPayments
           expect(claim.eligibility.reload.eligible_itt_subject).to eq args[:subject]
 
-          jump_to_claim_journey_page(claim, "itt-year")
+          jump_to_claim_journey_page(
+            claim:,
+            slug: "itt-year",
+            journey_session: build(:additional_payments_session)
+          )
 
           choose args[:cohort]
           click_on "Continue"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -49,13 +49,13 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose "Yes"
     click_on "Continue"
 
-    expect(claim.eligibility.reload.had_leadership_position?).to eq(true)
+    expect(session.reload.answers.had_leadership_position?).to eq(true)
 
     expect(page).to have_text(mostly_performed_leadership_duties_question)
     choose "No"
     click_on "Continue"
 
-    expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(false)
+    expect(session.reload.answers.mostly_performed_leadership_duties?).to eq(false)
 
     expect(page).to have_text("you can claim back the student loan repayments you made between #{Policies::StudentLoans.current_financial_year}.")
     click_on "Continue"
@@ -293,13 +293,13 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
         choose "Yes"
         click_on "Continue"
 
-        expect(claim.eligibility.reload.had_leadership_position?).to eq(true)
+        expect(session.reload.answers.had_leadership_position?).to eq(true)
 
         expect(page).to have_text(mostly_performed_leadership_duties_question)
         choose "No"
         click_on "Continue"
 
-        expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(false)
+        expect(session.reload.answers.mostly_performed_leadership_duties?).to eq(false)
         expect(page).to have_text("you can claim back the student loan repayments you made between #{Policies::StudentLoans.current_financial_year}.")
       end
     end

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text(I18n.t("student_loans.forms.still_teaching.questions.claim_school"))
 
     choose_still_teaching("Yes, at #{school.name}")
-    expect(claim.eligibility.reload.employment_status).to eql("claim_school")
-    expect(claim.eligibility.current_school).to eql(school)
+    expect(session.reload.answers.employment_status).to eql("claim_school")
+    expect(session.answers.current_school).to eql(school)
 
     expect(session.reload.answers.subjects_taught).to eq([:physics_taught])
 
@@ -284,8 +284,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
         expect(page).to have_text(I18n.t("student_loans.forms.still_teaching.questions.claim_school"))
 
         choose_still_teaching("Yes, at #{school.name}")
-        expect(claim.eligibility.reload.employment_status).to eql("claim_school")
-        expect(claim.eligibility.current_school).to eql(school)
+        expect(session.reload.answers.employment_status).to eql("claim_school")
+        expect(session.answers.current_school).to eql(school)
 
         expect(session.reload.answers.subjects_taught).to eq([:physics_taught])
 
@@ -308,13 +308,14 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   scenario "currently works at a different school to the claim school" do
     different_school = create(:school, :student_loans_eligible)
     claim = start_student_loans_claim
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
     choose_school school
     choose_subjects_taught
 
     choose_still_teaching("Yes, at another school")
 
-    expect(claim.eligibility.reload.employment_status).to eql("different_school")
+    expect(session.reload.answers.employment_status).to eql("different_school")
 
     fill_in :school_search, with: different_school.name
     click_on "Continue"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.eligibility.reload.employment_status).to eql("claim_school")
     expect(claim.eligibility.current_school).to eql(school)
 
-    expect(claim.eligibility.reload.subjects_taught).to eq([:physics_taught])
+    expect(session.reload.answers.subjects_taught).to eq([:physics_taught])
 
     expect(page).to have_text(leadership_position_question)
     choose "Yes"
@@ -287,7 +287,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
         expect(claim.eligibility.reload.employment_status).to eql("claim_school")
         expect(claim.eligibility.current_school).to eql(school)
 
-        expect(claim.eligibility.reload.subjects_taught).to eq([:physics_taught])
+        expect(session.reload.answers.subjects_taught).to eq([:physics_taught])
 
         expect(page).to have_text(leadership_position_question)
         choose "Yes"

--- a/spec/features/subject_teaching_question_spec.rb
+++ b/spec/features/subject_teaching_question_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
   let(:claim) { start_early_career_payments_claim }
+  let(:journey_session) { Journeys::AdditionalPaymentsForTeaching::Session.last }
 
   before { create(:journey_configuration, :additional_payments, current_academic_year: AcademicYear.new(2022)) }
 
@@ -12,19 +13,35 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
 
   context "when ECP and LUP eligible" do
     it "has the correct subjects" do
-      jump_to_claim_journey_page(claim, "nqt-in-academic-year-after-itt")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "nqt-in-academic-year-after-itt",
+        journey_session: journey_session
+      )
       choose "Yes"
       click_on "Continue"
 
-      jump_to_claim_journey_page(claim, "itt-year")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "itt-year",
+        journey_session: journey_session
+      )
       choose "2020 to 2021"
       click_on "Continue"
 
-      jump_to_claim_journey_page(claim, "eligible-itt-subject")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "eligible-itt-subject",
+        journey_session: journey_session
+      )
       choose "Mathematics"
       click_on "Continue"
 
-      jump_to_claim_journey_page(claim, "teaching-subject-now")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "teaching-subject-now",
+        journey_session: journey_session
+      )
       expect(page).to have_text("chemistry, computing, languages, mathematics or physics")
 
       click_on "Continue"
@@ -34,19 +51,35 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
 
   context "when eligible only for ECP" do
     it "has the correct subjects" do
-      jump_to_claim_journey_page(claim, "nqt-in-academic-year-after-itt")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "nqt-in-academic-year-after-itt",
+        journey_session: journey_session
+      )
       choose "Yes"
       click_on "Continue"
 
-      jump_to_claim_journey_page(claim, "itt-year")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "itt-year",
+        journey_session: journey_session
+      )
       choose "2020 to 2021"
       click_on "Continue"
 
-      jump_to_claim_journey_page(claim, "eligible-itt-subject")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "eligible-itt-subject",
+        journey_session: journey_session
+      )
       choose "Languages" # ECP-only subject
       click_on "Continue"
 
-      jump_to_claim_journey_page(claim, "teaching-subject-now")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "teaching-subject-now",
+        journey_session: journey_session
+      )
       expect(page).to have_text("chemistry, languages, mathematics or physics.")
     end
   end
@@ -57,7 +90,11 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
     end
 
     it "has the correct subjects" do
-      jump_to_claim_journey_page(claim, "teaching-subject-now")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "teaching-subject-now",
+        journey_session: journey_session
+      )
 
       expect(page).to have_text("chemistry, computing, mathematics or physics")
     end

--- a/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_still_teaching_spec.rb
@@ -48,11 +48,11 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
 
     expect(current_path).to eq("/student-loans/leadership-position")
 
-    eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
+    Claim.order(created_at: :desc).limit(1).first.eligibility
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     expect(session.answers.claim_school_id).to eq eligible_claim_school.id
-    expect(eligibility.current_school_id).to eq eligible_school.id
-    expect(eligibility.employment_status).to eq "recent_tps_school"
+    expect(session.answers.current_school_id).to eq eligible_school.id
+    expect(session.answers.employment_status).to eq "recent_tps_school"
 
     # - Selects somewhere else
 
@@ -62,11 +62,11 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
 
     expect(current_path).to eq("/student-loans/current-school")
 
-    eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
+    Claim.order(created_at: :desc).limit(1).first.eligibility
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     expect(session.answers.claim_school_id).to eq eligible_claim_school.id
-    expect(eligibility.current_school_id).to be_nil
-    expect(eligibility.employment_status).to eq "different_school"
+    expect(session.answers.current_school_id).to be_nil
+    expect(session.answers.employment_status).to eq "different_school"
 
     # - Selects No...
     click_on "Back"
@@ -76,11 +76,11 @@ RSpec.feature "TSLR journey with Teacher ID still teaching school playback" do
 
     expect(current_path).to eq("/student-loans/ineligible")
 
-    eligibility = Claim.order(created_at: :desc).limit(1).first.eligibility
+    Claim.order(created_at: :desc).limit(1).first.eligibility
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     expect(session.answers.claim_school_id).to eq eligible_claim_school.id
-    expect(eligibility.current_school_id).to be_nil
-    expect(eligibility.employment_status).to eq "no_school"
+    expect(session.answers.current_school_id).to be_nil
+    expect(session.answers.employment_status).to eq "no_school"
   end
 
   def navigate_to_still_teaching_page

--- a/spec/features/validating_user_contact_details_spec.rb
+++ b/spec/features/validating_user_contact_details_spec.rb
@@ -26,7 +26,11 @@ RSpec.feature "Confirming Claimant Contact details" do
       eq("david.tau1988@hotmail.co.uk")
     )
 
-    jump_to_claim_journey_page(claim, "email-verification")
+    jump_to_claim_journey_page(
+      claim: claim,
+      slug: "email-verification",
+      journey_session: journey_session
+    )
 
     expect(page).to have_text("Enter the 6-digit passcode")
     expect(page).to have_link(href: claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "email-address"))

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
@@ -3,25 +3,17 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm do
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
 
-  let(:eligibility) do
-    create(
-      :student_loans_eligibility,
-      mostly_performed_leadership_duties: true,
-      had_leadership_position: true
-    )
-  end
-
-  let(:claim) do
-    create(
-      :claim,
-      policy: Policies::StudentLoans,
-      eligibility: eligibility
-    )
-  end
-
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
-  let(:journey_session) { build(:student_loans_session) }
+  let(:journey_session) do
+    create(
+      :student_loans_session,
+      answers: {
+        had_leadership_position: true,
+        mostly_performed_leadership_duties: true
+      }
+    )
+  end
 
   let(:params) do
     ActionController::Parameters.new(
@@ -33,7 +25,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
+      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end
@@ -71,11 +63,15 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm
       let(:had_leadership_position) { true }
 
       it "doesn't update the eligibility had_leadership_position attribute" do
-        expect(eligibility.reload.had_leadership_position).to eq(true)
+        expect(
+          journey_session.reload.answers.had_leadership_position
+        ).to eq(true)
       end
 
       it "doesn't reset the mostly_performed_leadership_duties attribute" do
-        expect(eligibility.reload.mostly_performed_leadership_duties).to eq(true)
+        expect(
+          journey_session.reload.answers.mostly_performed_leadership_duties
+        ).to eq(true)
       end
     end
 
@@ -83,11 +79,15 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm
       let(:had_leadership_position) { false }
 
       it "updates the eligibility had_leadership_position attribute" do
-        expect(eligibility.reload.had_leadership_position).to eq(false)
+        expect(
+          journey_session.reload.answers.had_leadership_position
+        ).to eq(false)
       end
 
       it "resets the mostly_performed_leadership_duties attribute" do
-        expect(eligibility.reload.mostly_performed_leadership_duties).to eq(nil)
+        expect(
+          journey_session.reload.answers.mostly_performed_leadership_duties
+        ).to eq(nil)
       end
     end
   end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
@@ -3,25 +3,14 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeadershipDutiesForm do
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
 
-  let(:eligibility) do
+  let(:journey_session) do
     create(
-      :student_loans_eligibility,
-      mostly_performed_leadership_duties: true,
-      had_leadership_position: true
+      :student_loans_session,
+      answers: {
+        had_leadership_position: true
+      }
     )
   end
-
-  let(:claim) do
-    create(
-      :claim,
-      policy: Policies::StudentLoans,
-      eligibility: eligibility
-    )
-  end
-
-  let(:journey_session) { build(:student_loans_session) }
-
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
 
   let(:params) do
     ActionController::Parameters.new(
@@ -35,7 +24,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeaders
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
+      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end
@@ -70,9 +59,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeaders
     let(:mostly_performed_leadership_duties) { true }
 
     it "updates the eligibility with the mostly_performed_leadership_duties" do
-      expect(eligibility.mostly_performed_leadership_duties).to(
-        eq(true)
-      )
+      expect(
+        journey_session.answers.mostly_performed_leadership_duties
+      ).to(eq(true))
     end
   end
 end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
@@ -4,16 +4,14 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
   before { create(:journey_configuration, :student_loans) }
 
   let(:claim_school) { create(:school, :student_loans_eligible) }
-  let(:eligibility) { create(:student_loans_eligibility, claim_school:, employment_status: nil) }
-  let(:claim) { create(:claim, policy: Policies::StudentLoans, eligibility:) }
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:claim_params) { {} }
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
   let(:journey_session) do
     create(
       :student_loans_session,
       answers: {
-        claim_school_id: claim_school.id
+        claim_school_id: claim_school.id,
+        employment_status: nil
       }
     )
   end
@@ -22,7 +20,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
+      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: ActionController::Parameters.new(claim: claim_params)
     )
   end
@@ -53,8 +51,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id to nil and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to be_nil
-        expect(claim.eligibility).to be_employed_at_no_school
+        expect(journey_session.answers.current_school_id).to be_nil
+        expect(journey_session.answers.employed_at_no_school?).to be true
       end
     end
 
@@ -63,8 +61,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id to nil and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to be_nil
-        expect(claim.eligibility).to be_employed_at_different_school
+        expect(journey_session.answers.current_school_id).to be_nil
+        expect(journey_session.answers.employed_at_different_school?).to be true
       end
     end
 
@@ -73,8 +71,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to eq claim_school.id
-        expect(claim.eligibility).to be_employed_at_claim_school
+        expect(journey_session.answers.current_school_id).to eq claim_school.id
+        expect(journey_session.answers.employed_at_claim_school?).to be true
       end
     end
 
@@ -83,8 +81,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
 
       it "set the current_school_id and saves employment status" do
         expect(form.save).to be true
-        expect(claim.eligibility.current_school_id).to eq claim_school.id
-        expect(claim.eligibility).to be_employed_at_recent_tps_school
+        expect(journey_session.answers.current_school_id).to eq claim_school.id
+        expect(journey_session.answers.employed_at_recent_tps_school?).to be true
       end
     end
   end

--- a/spec/models/journeys/page_sequence_spec.rb
+++ b/spec/models/journeys/page_sequence_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Journeys::PageSequence do
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:slug_sequence) { OpenStruct.new(slugs: ["first-slug", "second-slug", "third-slug"]) }
   let(:completed_slugs) { [] }
-  let(:journey_session) { build(:student_loans_session) }
+  let(:journey_session) { create(:student_loans_session) }
 
   subject(:page_sequence) do
     described_class.new(
@@ -44,7 +44,14 @@ RSpec.describe Journeys::PageSequence do
     end
 
     context "with an ineligible claim" do
-      let(:claim) { build(:claim, eligibility: build(:student_loans_eligibility, employment_status: :no_school)) }
+      let(:journey_session) do
+        create(
+          :student_loans_session,
+          answers: {
+            employment_status: "no_school"
+          }
+        )
+      end
       let(:current_slug) { "second-slug" }
       let(:completed_slugs) { ["first-slug", "second-slug"] }
 

--- a/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
         :student_loans_session,
         answers: attributes_for(
           :student_loans_answers,
-          :with_claim_school
+          :with_claim_school,
+          :with_leadership_position
         ).merge(subject_attributes)
       )
     end
@@ -59,7 +60,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
     end
 
     it "excludes questions skipped from the flow" do
-      eligibility.had_leadership_position = false
+      journey_session.answers.assign_attributes(had_leadership_position: false)
       expect(answers).to_not include([mostly_performed_leadership_duties_question, "Yes", "mostly-performed-leadership-duties"])
       expect(answers).to_not include([mostly_performed_leadership_duties_question, "No", "mostly-performed-leadership-duties"])
     end

--- a/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
     let(:journey_session) do
       create(
         :student_loans_session,
-        answers: attributes_for(:student_loans_answers, :with_claim_school)
+        answers: attributes_for(
+          :student_loans_answers,
+          :with_claim_school
+        ).merge(subject_attributes)
       )
     end
 

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
     end
 
     it "excludes “current-school” if the claimant still works at the school they are claiming against" do
-      claim.eligibility.employment_status = :claim_school
+      journey_session.answers.employment_status = :claim_school
 
       expect(slug_sequence.slugs).not_to include("current-school")
     end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -315,12 +315,18 @@ RSpec.describe "Claims", type: :request do
       end
 
       it "resets depenent eligibility attributes when appropriate" do
-        in_progress_claim.update!(eligibility_attributes: {had_leadership_position: true, mostly_performed_leadership_duties: false})
+        journey_session.answers.assign_attributes(
+          had_leadership_position: true,
+          mostly_performed_leadership_duties: false
+        )
+        journey_session.save!
         set_slug_sequence_in_session(in_progress_claim, "leadership-position")
         put claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "leadership-position"), params: {claim: {had_leadership_position: false}}
 
         expect(response).to redirect_to(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "eligibility-confirmed"))
-        expect(in_progress_claim.eligibility.reload.mostly_performed_leadership_duties).to be_nil
+        expect(
+          journey_session.reload.answers.mostly_performed_leadership_duties
+        ).to be_nil
       end
 
       context "having searched for a school but not selected a school from the results on the claim-school page" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -144,7 +144,9 @@ RSpec.describe "Claims", type: :request do
       before { start_student_loans_claim }
 
       it "renders a static ineligibility page" do
-        Claim.by_policy(Policies::StudentLoans).order(:created_at).last.eligibility.update(employment_status: "no_school")
+        journey_session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+        journey_session.answers.assign_attributes(employment_status: "no_school")
+        journey_session.save!
 
         get claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "ineligible")
 

--- a/spec/support/eligible_later_shared_examples.rb
+++ b/spec/support/eligible_later_shared_examples.rb
@@ -15,10 +15,21 @@ RSpec.shared_examples "Eligible later" do |opts|
       )
 
       journey_session.answers.assign_attributes(
-        attributes_for(:additional_payments_answers, :submittable)
+        attributes_for(
+          :additional_payments_answers,
+          :submittable,
+          itt_academic_year: itt_academic_year,
+          eligible_itt_subject: itt_subject,
+          qualification: qualification,
+          current_school_id: current_school.id
+        )
       )
 
-      jump_to_claim_journey_page(claim, "check-your-answers-part-one")
+      jump_to_claim_journey_page(
+        claim: claim,
+        slug: "check-your-answers-part-one",
+        journey_session: journey_session
+      )
 
       expect(page).to have_text(I18n.t("additional_payments.check_your_answers.part_one.primary_heading"))
       expect(page).to have_text(I18n.t("additional_payments.check_your_answers.part_one.secondary_heading"))

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -119,15 +119,14 @@ module FeatureHelpers
   # is to spoof the session's record of visited pages in the journey.
   #
   # TODO: refactor all old feature specs which use this method
-  def jump_to_claim_journey_page(claim, slug)
-    set_slug_sequence_in_session(claim, slug)
+  def jump_to_claim_journey_page(claim:, journey_session:, slug:)
+    set_slug_sequence_in_session(claim:, journey_session:, slug:)
     visit claim_path(Journeys.for_policy(claim.policy)::ROUTING_NAME, slug)
   end
 
-  def set_slug_sequence_in_session(claim, slug)
+  def set_slug_sequence_in_session(claim:, journey_session:, slug:)
     current_claim = CurrentClaim.new(claims: [claim])
     journey = Journeys.for_policy(claim.policy)
-    journey_session = build(:"#{journey::I18N_NAMESPACE}_session")
     slug_sequence = journey.slug_sequence.new(current_claim, journey_session).slugs
     slug_index = slug_sequence.index(slug)
     visited_slugs = slug_sequence.slice(0, slug_index)


### PR DESCRIPTION
Update leadership forms to write to session

Updates the leadership position forms to write to the journey session
model. This has now crossed the threshold where we need to pass the
session answers into the slug sequence construced by the
`jump_to_claim_journey_page` test helper, so had to change a bunch of
spec files

