### PR TITLE
CAPT 1678/qts year

### DIFF
--- a/app/forms/journeys/teacher_student_loan_reimbursement/qts_year_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/qts_year_form.rb
@@ -12,7 +12,11 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(eligibility_attributes: attributes)
+        journey_session.answers.assign_attributes(
+          qts_award_year: qts_award_year
+        )
+
+        journey_session.save!
       end
 
       def first_eligible_qts_award_year

--- a/app/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form.rb
@@ -16,10 +16,13 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(
-          qualifications_details_check: qualifications_details_check,
-          eligibility_attributes: {qts_award_year: qts_award_year}
+        update!(qualifications_details_check: qualifications_details_check)
+
+        journey_session.answers.assign_attributes(
+          qts_award_year: qts_award_year
         )
+
+        journey_session.save!
       end
 
       private

--- a/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/claim_journey_session_shim.rb
@@ -12,7 +12,7 @@ module Journeys
         @answers ||= SessionAnswers.new(
           super.merge(
             {
-              qts_award_year: qts_award_year,
+              qts_award_year: journey_session.answers.qts_award_year,
               claim_school_id: journey_session.answers.claim_school_id,
               current_school_id: current_school_id,
               employment_status: journey_session.answers.employment_status,
@@ -32,10 +32,6 @@ module Journeys
       end
 
       private
-
-      def qts_award_year
-        journey_session.answers.qts_award_year || try_eligibility(:qts_award_year)
-      end
 
       def current_school_id
         journey_session.answers.current_school_id || try_eligibility(:current_school_id)

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -56,6 +56,10 @@ FactoryBot.define do
       mostly_performed_leadership_duties { false }
     end
 
+    trait :with_qts_award_year do
+      qts_award_year { "on_or_after_cut_off_date" }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -67,6 +71,7 @@ FactoryBot.define do
       with_subjects_taught
       with_employment_status
       with_leadership_position
+      with_qts_award_year
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -46,12 +46,13 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
   scenario "Teacher changes an answer which is not a dependency of any of the other answers they've given, becoming ineligible" do
     claim = start_student_loans_claim
+    session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
     jump_to_claim_journey_page(
       claim:,
       slug: "check-your-answers",
-      journey_session: Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+      journey_session: session
     )
 
     find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "qts-year")}']").click
@@ -61,7 +62,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     choose_qts_year :before_cut_off_date
     click_on "Continue"
 
-    expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")
+    expect(session.reload.answers.qts_award_year).to eq("before_cut_off_date")
 
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed your initial teacher training between the start of the #{Policies::StudentLoans.first_eligible_qts_award_year.to_s(:long)} academic year and the end of the 2020 to 2021 academic year.")

--- a/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
+++ b/spec/features/dfe_identity_sign_in_for_student_loans_journey_spec.rb
@@ -67,7 +67,6 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(page).not_to have_text(I18n.t("questions.personal_details"))
 
     # check the teacher_id_user_info details are saved to the session
-    claim = Claim.order(:created_at).last
     journey_session = Journeys::TeacherStudentLoanReimbursement::Session.last
     answers = journey_session.answers
     expect(answers.teacher_id_user_info).to eq({
@@ -90,7 +89,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.teacher_reference_number).to eq("1234567")
     expect(answers.logged_in_with_tid?).to eq(true)
     expect(answers.details_check).to eq(true)
-    expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
+    expect(answers.qts_award_year).to eql("on_or_after_cut_off_date")
     expect(answers.claim_school).to eql school
     expect(answers.employment_status).to eql("claim_school")
     expect(answers.current_school).to eql(school)
@@ -214,7 +213,6 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     click_on "Continue"
 
     # check the teacher_id_user_info details are saved to the session
-    claim = Claim.order(:created_at).last
     session = Journeys::TeacherStudentLoanReimbursement::Session.last
     answers = session.answers
     expect(answers.teacher_id_user_info).to eq({
@@ -237,7 +235,7 @@ RSpec.feature "Teacher Identity Sign in for TSLR" do
     expect(answers.teacher_reference_number).to eq("1234567")
     expect(answers.logged_in_with_tid?).to eq(true)
     expect(answers.details_check).to eq(true)
-    expect(claim.eligibility.qts_award_year).to eql("on_or_after_cut_off_date")
+    expect(answers.qts_award_year).to eql("on_or_after_cut_off_date")
     expect(answers.claim_school).to eql school
     expect(answers.employment_status).to eql("claim_school")
     expect(answers.current_school).to eql(school)

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -32,9 +32,9 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     visit new_claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME)
     skip_tid
     choose_qts_year(:before_cut_off_date)
-    claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
 
-    expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
+    expect(session.answers.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed your initial teacher training between the start of the 2014 to 2015 academic year and the end of the 2020 to 2021 academic year.")
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -24,10 +24,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_link(href: "mailto:#{I18n.t("student_loans.feedback_email")}")
 
     choose_qts_year
-    claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
-    expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
+    expect(session.reload.answers.qts_award_year).to eql("on_or_after_cut_off_date")
 
     expect(page).to have_text(claim_school_question)
 
@@ -268,10 +267,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
         expect(page).to have_link(href: "mailto:#{I18n.t("student_loans.feedback_email")}")
 
         choose_qts_year
-        claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
         session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
-        expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
+        expect(session.reload.answers.qts_award_year).to eql("on_or_after_cut_off_date")
 
         expect(page).to have_text(claim_school_question)
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_spec.rb
@@ -37,8 +37,8 @@ RSpec.feature "TSLR journey with Teacher ID" do
     click_on "Continue"
 
     # Claim eligibility answers are pre-filled from DQT record
-    claim = Claim.all.order(created_at: :desc).limit(1).first
-    expect(claim.eligibility.qts_award_year).to eq("on_or_after_cut_off_date")
+    session = Journeys::TeacherStudentLoanReimbursement::Session.last
+    expect(session.answers.qts_award_year).to eq("on_or_after_cut_off_date")
 
     # Qualification pages are skipped
 
@@ -51,8 +51,8 @@ RSpec.feature "TSLR journey with Teacher ID" do
     click_on "Continue"
 
     # Claim eligibility qualification answers are wiped
-    claim.eligibility.reload
-    expect(claim.eligibility.qts_award_year).to be nil
+    session.reload
+    expect(session.answers.qts_award_year).to be nil
 
     # Qualification pages are no longer skipped
 

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qts_year_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qts_year_form_spec.rb
@@ -2,12 +2,16 @@ require "rails_helper"
 
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::QtsYearForm, type: :model do
   subject(:form) do
-    described_class.new(claim:, journey_session:, journey:, params:)
+    described_class.new(
+      claim: CurrentClaim.new(claims: [build(:claim)]),
+      journey_session:,
+      journey:,
+      params:
+    )
   end
 
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
-  let(:journey_session) { build(:student_loans_session) }
-  let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
+  let(:journey_session) { create(:student_loans_session) }
   let(:slug) { "qts-year" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }
   let(:claim_params) { {"qts_award_year" => "before_cut_off_date"} }
@@ -35,15 +39,22 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QtsYearForm, type: :mo
 
     context "valid params" do
       let(:claim_params) { {"qts_award_year" => "before_cut_off_date"} }
-      let(:expected_saved_attributes) { {eligibility_attributes: claim_params} }
 
-      it { is_expected.to have_received(:update!).with(expected_saved_attributes) }
+      it "updates the answers" do
+        expect(
+          journey_session.reload.answers.qts_award_year
+        ).to eq("before_cut_off_date")
+      end
     end
 
     context "invalid params" do
       let(:claim_params) { {"qts_award_year" => "invalid_option"} }
 
-      it { expect(form).not_to have_received(:update!) }
+      it "doesn't update the answers" do
+        expect(
+          journey_session.reload.answers.qts_award_year
+        ).to be_nil
+      end
     end
   end
 

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
         it "sets qts_award_year as nil" do
           form.save
 
-          expect(student_loans_eligibility.reload.qts_award_year).to eq nil
+          expect(journey_session.reload.answers.qts_award_year).to eq nil
         end
       end
 
@@ -195,7 +195,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
               it "sets the qts_award_year to :on_or_after_cut_off_date" do
                 expect { form.save }.to(
                   change do
-                    student_loans_eligibility.reload.qts_award_year
+                    journey_session.reload.answers.qts_award_year
                   end.from(nil).to("on_or_after_cut_off_date")
                 )
               end
@@ -203,7 +203,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
               it "sets the qualifications_details_check to `true`" do
                 expect { form.save }.to(
                   change do
-                    student_loans_claim.reload.qualifications_details_check
+                    student_loans_claim.qualifications_details_check
                   end.from(nil).to(true)
                 )
               end
@@ -221,8 +221,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
               it "sets the qts_award_year to :before_cut_off_date" do
                 expect { form.save }.to(
                   change do
-                    student_loans_eligibility
+                    journey_session
                       .reload
+                      .answers
                       .qts_award_year
                   end.from(nil).to("before_cut_off_date")
                 )

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
     end
 
     it "includes the “ineligible” slug if the claim is actually ineligible" do
-      claim.eligibility.update! qts_award_year: "before_cut_off_date"
-      expect(claim.eligibility.reload).to be_ineligible
+      journey_session.answers.assign_attributes(
+        qts_award_year: "before_cut_off_date"
+      )
       expect(slug_sequence.slugs).to include("ineligible")
     end
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Claims", type: :request do
         put claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "qts-year"), params: {claim: {qts_award_year: "on_or_after_cut_off_date"}}
 
         expect(response).to redirect_to(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "claim-school"))
-        expect(in_progress_claim.reload.eligibility.qts_award_year).to eq "on_or_after_cut_off_date"
+        expect(journey_session.reload.answers.qts_award_year).to eq "on_or_after_cut_off_date"
       end
 
       it "makes sure validations appropriate to the context are run" do


### PR DESCRIPTION
Write qts_award_year to session answers

Updates references to qts_award_year to use the session rather than the
eligibility. Partly updates the qualification_details_form as that
writes the qts_award_year.

