### PR TITLE
CAPT 1648/qualifications details form

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/qualification_details_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/qualification_details_form.rb
@@ -27,6 +27,13 @@ module Journeys
       def save
         return false unless valid?
 
+        journey_session.answers.assign_attributes(
+          qualifications_details_check: qualifications_details_check
+        )
+
+        # FIXME RL: Remove this once the qualification, eligible_itt_subject,
+        # and itt_academic_year forms are writing to the session and no longer
+        # trigger resetting dependent answers
         claim.assign_attributes(
           qualifications_details_check: qualifications_details_check
         )
@@ -41,7 +48,10 @@ module Journeys
           claim.claims.each { |c| set_nil_qualifications(c.eligibility) }
         end
 
-        claim.save!
+        ApplicationRecord.transaction do
+          journey_session.save!
+          claim.save!
+        end
       end
 
       def dqt_route_into_teaching

--- a/app/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form.rb
@@ -16,9 +16,8 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(qualifications_details_check: qualifications_details_check)
-
         journey_session.answers.assign_attributes(
+          qualifications_details_check: qualifications_details_check,
           qts_award_year: qts_award_year
         )
 

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -48,7 +48,7 @@ class ClaimJourneySessionShim
       teacher_id_user_info: teacher_id_user_info,
       email_address_check: journey_session.answers.email_address_check,
       mobile_check: journey_session.answers.mobile_check,
-      qualifications_details_check: qualifications_details_check,
+      qualifications_details_check: journey_session.answers.qualifications_details_check,
       has_student_loan: has_student_loan,
       student_loan_plan: student_loan_plan
     }
@@ -74,10 +74,6 @@ class ClaimJourneySessionShim
 
   def teacher_id_user_info
     journey_session.answers.teacher_id_user_info || current_claim.teacher_id_user_info
-  end
-
-  def qualifications_details_check
-    journey_session.answers.qualifications_details_check || current_claim.qualifications_details_check
   end
 
   def has_student_loan

--- a/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
@@ -101,7 +101,7 @@ module Journeys
       end
 
       def qualification
-        return if eligibility.claim.qualifications_details_check && answers.early_career_payments_dqt_teacher_record&.route_into_teaching
+        return if answers.qualifications_details_check && answers.early_career_payments_dqt_teacher_record&.route_into_teaching
 
         [
           t("additional_payments.forms.qualification.questions.which_route"),
@@ -111,7 +111,7 @@ module Journeys
       end
 
       def eligible_itt_subject
-        return if eligibility.claim.qualifications_details_check && answers.early_career_payments_dqt_teacher_record&.eligible_itt_subject_for_claim
+        return if answers.qualifications_details_check && answers.early_career_payments_dqt_teacher_record&.eligible_itt_subject_for_claim
 
         [
           eligible_itt_subject_translation(CurrentClaim.new(claims: [eligibility.claim])),
@@ -121,7 +121,7 @@ module Journeys
       end
 
       def eligible_degree_subject
-        return if !eligibility.respond_to?(:eligible_degree_subject) || !eligibility.eligible_degree_subject? || (eligibility.claim.qualifications_details_check && answers.levelling_up_premium_payments_dqt_reacher_record&.eligible_degree_code?)
+        return if !eligibility.respond_to?(:eligible_degree_subject) || !eligibility.eligible_degree_subject? || (answers.qualifications_details_check && answers.levelling_up_premium_payments_dqt_reacher_record&.eligible_degree_code?)
 
         [
           t("additional_payments.forms.eligible_degree_subject.questions.eligible_degree_subject"),
@@ -139,7 +139,7 @@ module Journeys
       end
 
       def itt_academic_year
-        return if eligibility.claim.qualifications_details_check && answers.early_career_payments_dqt_teacher_record&.itt_academic_year_for_claim
+        return if answers.qualifications_details_check && answers.early_career_payments_dqt_teacher_record&.itt_academic_year_for_claim
 
         [
           I18n.t("additional_payments.questions.itt_academic_year.qualification.#{eligibility.qualification}"),

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -166,7 +166,7 @@ module Journeys
           sequence.delete("personal-details") if answers.logged_in_with_tid? && personal_details_form.valid? && answers.all_personal_details_same_as_tid?
 
           if answers.logged_in_with_tid? && answers.details_check?
-            if claim.qualifications_details_check
+            if answers.qualifications_details_check
               sequence.delete("qualification") if answers.early_career_payments_dqt_teacher_record&.route_into_teaching
               sequence.delete("itt-year") if answers.early_career_payments_dqt_teacher_record&.itt_academic_year_for_claim
               sequence.delete("eligible-itt-subject") if answers.early_career_payments_dqt_teacher_record&.eligible_itt_subject_for_claim

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
@@ -16,7 +16,7 @@ module Journeys
       # [2]: slug for changing the answer.
       def eligibility_answers
         [].tap do |a|
-          a << qts_award_year unless eligibility.claim.qualifications_details_check
+          a << qts_award_year unless answers.qualifications_details_check
           a << claim_school
           a << current_school
           a << subjects_taught

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -111,7 +111,7 @@ module Journeys
           sequence.delete("teacher-reference-number") if answers.logged_in_with_tid? && answers.teacher_reference_number.present?
 
           if answers.logged_in_with_tid? && answers.details_check?
-            if claim.qualifications_details_check
+            if answers.qualifications_details_check
               sequence.delete("qts-year") if answers.dqt_teacher_record&.qts_award_date
             elsif signed_in_with_dfe_identity_and_details_match? && answers.has_no_dqt_data_for_claim?
               sequence.delete("qualification-details")

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
       teacher_reference_number { generate(:teacher_reference_number) }
     end
 
+    trait :with_qualification_details_check do
+      qualifications_details_check { true }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -45,6 +49,7 @@ FactoryBot.define do
       with_bank_details
       with_payroll_gender
       with_teacher_reference_number
+      with_qualification_details_check
     end
   end
 end

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -60,6 +60,10 @@ FactoryBot.define do
       qts_award_year { "on_or_after_cut_off_date" }
     end
 
+    trait :with_qualification_details_check do
+      qualifications_details_check { true }
+    end
+
     trait :submittable do
       with_personal_details
       with_email_details
@@ -72,6 +76,7 @@ FactoryBot.define do
       with_employment_status
       with_leadership_position
       with_qts_award_year
+      with_qualification_details_check
     end
   end
 end

--- a/spec/forms/journeys/additional_payments_for_teaching/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/qualification_details_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
 
   let(:journey_session) do
-    build(
+    create(
       :additional_payments_session,
       answers: {
         dqt_teacher_status: dqt_teacher_status
@@ -252,16 +252,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm
         it "sets the qualifications_details_check to `false`" do
           expect { form.save }.to(
             change do
-              early_career_payments_claim
-                .reload
-                .qualifications_details_check
-            end.from(nil).to(false).and(
-              change do
-                levelling_up_premium_payments_claim
-                  .reload
-                  .qualifications_details_check
-              end.from(nil).to(false)
-            )
+              journey_session.reload.answers.qualifications_details_check
+            end.from(nil).to(false)
           )
         end
 
@@ -376,16 +368,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm
           it "sets the qualifications_details_check to `true`" do
             expect { form.save }.to(
               change do
-                early_career_payments_claim
-                  .reload
-                  .qualifications_details_check
-              end.from(nil).to(true).and(
-                change do
-                  levelling_up_premium_payments_claim
-                    .reload
-                    .qualifications_details_check
-                end.from(nil).to(true)
-              )
+                journey_session.reload.answers.qualifications_details_check
+              end.from(nil).to(true)
             )
           end
 
@@ -454,16 +438,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm
           it "sets the qualifications_details_check to `true`" do
             expect { form.save }.to(
               change do
-                early_career_payments_claim
-                  .reload
-                  .qualifications_details_check
-              end.from(nil).to(true).and(
-                change do
-                  levelling_up_premium_payments_claim
-                    .reload
-                    .qualifications_details_check
-                end.from(nil).to(true)
-              )
+                journey_session.reload.answers.qualifications_details_check
+              end.from(nil).to(true)
             )
           end
 

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
@@ -3,23 +3,6 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsForm do
   before { create(:journey_configuration, :student_loans) }
 
-  let(:student_loans_eligibility) do
-    create(:student_loans_eligibility)
-  end
-
-  let(:student_loans_claim) do
-    create(
-      :claim,
-      policy: Policies::StudentLoans,
-      eligibility: student_loans_eligibility,
-      dqt_teacher_status: dqt_teacher_status
-    )
-  end
-
-  let(:current_claim) do
-    CurrentClaim.new(claims: [student_loans_claim])
-  end
-
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
 
   let(:journey_session) do
@@ -35,7 +18,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
+      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end
@@ -115,9 +98,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
         it "sets the qualifications_details_check to `false`" do
           expect { form.save }.to(
             change do
-              student_loans_claim
-                .reload
-                .qualifications_details_check
+              journey_session.reload.answers.qualifications_details_check
             end.from(nil).to(false)
           )
         end
@@ -203,7 +184,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
               it "sets the qualifications_details_check to `true`" do
                 expect { form.save }.to(
                   change do
-                    student_loans_claim.qualifications_details_check
+                    journey_session.reload.answers.qualifications_details_check
                   end.from(nil).to(true)
                 )
               end
@@ -232,7 +213,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
               it "sets the qualifications_details_check to `true`" do
                 expect { form.save }.to(
                   change do
-                    student_loans_claim.reload.qualifications_details_check
+                    journey_session.reload.answers.qualifications_details_check
                   end.from(nil).to(true)
                 )
               end
@@ -245,15 +226,13 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
             it "sets qts_award_year as nil" do
               form.save
 
-              expect(
-                student_loans_eligibility.reload.qts_award_year
-              ).to eq nil
+              expect(journey_session.reload.answers.qts_award_year).to eq nil
             end
 
             it "sets the qualifications_details_check to `true`" do
               expect { form.save }.to(
                 change do
-                  student_loans_claim.reload.qualifications_details_check
+                  journey_session.reload.answers.qualifications_details_check
                 end.from(nil).to(true)
               )
             end
@@ -266,15 +245,13 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
           it "sets qts_award_year as nil" do
             form.save
 
-            expect(
-              student_loans_eligibility.reload.qts_award_year
-            ).to eq nil
+            expect(journey_session.reload.answers.qts_award_year).to eq nil
           end
 
           it "sets the qualifications_details_check to `true`" do
             expect { form.save }.to(
               change do
-                student_loans_claim.reload.qualifications_details_check
+                journey_session.reload.answers.qualifications_details_check
               end.from(nil).to(true)
             )
           end

--- a/spec/models/journeys/additional_payments_for_teaching/answers_presenter_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching/answers_presenter_spec.rb
@@ -8,14 +8,16 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
 
   describe "#eligibility_answers" do
     let(:policy_year) { AcademicYear.new(2022) }
-    let(:claim) { build(:claim, policy:, academic_year: policy_year, eligibility: eligibility, qualifications_details_check:) }
+    let(:claim) { build(:claim, policy:, academic_year: policy_year, eligibility: eligibility) }
     let!(:journey_configuration) { create(:journey_configuration, :additional_payments, current_academic_year: policy_year) }
     let(:qualifications_details_check) { false }
 
     let(:journey_session) do
       build(
         :additional_payments_session,
-        answers: {}
+        answers: {
+          qualifications_details_check: qualifications_details_check
+        }
       )
     end
 

--- a/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
       :skipped_tid,
       policy: Policies::EarlyCareerPayments,
       academic_year: AcademicYear.new(2021),
-      eligibility: eligibility,
-      qualifications_details_check:
+      eligibility: eligibility
     )
   end
   let(:lup_claim) { create(:claim, :skipped_tid, policy: Policies::LevellingUpPremiumPayments, academic_year: AcademicYear.new(2021), eligibility: eligibility_lup) }
@@ -24,7 +23,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
       answers: {
         logged_in_with_tid: logged_in_with_tid,
         details_check: details_check,
-        dqt_teacher_status: dqt_teacher_status
+        dqt_teacher_status: dqt_teacher_status,
+        qualifications_details_check: qualifications_details_check
       }
     )
   end

--- a/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/answers_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
   describe "#eligibility_answers" do
     let(:subject_attributes) { {chemistry_taught: true, physics_taught: true} }
     let(:eligibility) { claim.eligibility }
-    let(:claim) { build(:claim, policy:, eligibility: build(:student_loans_eligibility, :eligible, subject_attributes), qualifications_details_check:) }
+    let(:claim) { build(:claim, policy:, eligibility: build(:student_loans_eligibility, :eligible, subject_attributes)) }
     let(:qualifications_details_check) { false }
 
     let(:journey_session) do
@@ -21,7 +21,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::AnswersPresenter, type
         answers: attributes_for(
           :student_loans_answers,
           :with_claim_school,
-          :with_leadership_position
+          :with_leadership_position,
+          qualifications_details_check: qualifications_details_check
         ).merge(subject_attributes)
       )
     end

--- a/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement/slug_sequence_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
   subject(:slug_sequence) { described_class.new(current_claim, journey_session) }
 
   let(:eligibility) { create(:student_loans_eligibility, :eligible) }
-  let(:claim) { build(:claim, eligibility:, qualifications_details_check:) }
+  let(:claim) { build(:claim, eligibility:) }
   let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:journey_session) do
     build(
@@ -12,7 +12,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SlugSequence do
       answers: {
         logged_in_with_tid: logged_in_with_tid,
         details_check: details_check,
-        dqt_teacher_status: dqt_teacher_status
+        dqt_teacher_status: dqt_teacher_status,
+        qualifications_details_check: qualifications_details_check
       }
     )
   end


### PR DESCRIPTION
update qualificaton details form to write to answwers

As we're still pulling the `qualification`, `eligible_itt_subject` and
`itt_academic_year` form the claim, we still need to write
`qualification_details` to the claim so that the check in reset depenent
answers is hit which removes deleting the depenencies.
Hopefully we'll soon be able to remove this reset dependent answers
stuff and just nullify the answers directly in the forms.

