### PR TITLE
CAPT-1712: Use CRLF line endings on payroll CSV file

### DIFF
--- a/app/models/payroll/payment_csv_row.rb
+++ b/app/models/payroll/payment_csv_row.rb
@@ -6,6 +6,7 @@ require "excel_utils"
 
 module Payroll
   class PaymentCsvRow < SimpleDelegator
+    ROW_SEPARATOR = "\r\n"
     DATE_FORMAT = "%d/%m/%Y"
     UNITED_KINGDOM = "United Kingdom"
     BASIC_RATE_TAX_CODE = "BR"
@@ -19,7 +20,7 @@ module Payroll
     TITLE = "Prof."
 
     def to_s
-      CSV.generate_line(data)
+      CSV.generate_line(data, row_sep: ROW_SEPARATOR)
     end
 
     private

--- a/app/models/payroll/payments_csv.rb
+++ b/app/models/payroll/payments_csv.rb
@@ -83,7 +83,7 @@ module Payroll
     end
 
     def header_row
-      CSV.generate_line(csv_headers)
+      CSV.generate_line(csv_headers, row_sep: PaymentCsvRow::ROW_SEPARATOR)
     end
 
     def csv_headers

--- a/spec/models/payroll/payment_csv_row_spec.rb
+++ b/spec/models/payroll/payment_csv_row_spec.rb
@@ -292,5 +292,9 @@ RSpec.describe Payroll::PaymentCsvRow do
 
       expect(row[Payroll::PaymentsCsv::FIELDS_WITH_HEADERS.find_index { |k, _| k == :address_line_2 }]).to eq("\\#{claims.first.address_line_2}")
     end
+
+    it "outputs a CRLF line feed" do
+      expect(subject.to_s).to end_with("\r\n")
+    end
   end
 end

--- a/spec/models/payroll/payments_csv_spec.rb
+++ b/spec/models/payroll/payments_csv_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Payroll::PaymentsCsv do
       Payroll::PaymentCsvRow.new(payment).to_s.chomp
     end
 
-    [csv_header_row, csv_payment_rows].join("\n") + "\n"
+    [csv_header_row, csv_payment_rows].join("\r\n") + "\r\n"
   end
 
   def load_zip(buffer)


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-1712

The new payroll system is unable to ingest files with the LF character which Claim currently outputs on each line. The [RFC 4180 for CSV](https://www.ietf.org/rfc/rfc4180.txt) specifies that line endings should have a CRLF character instead. For some reason the Ruby CSV library defaults to LF.