### PR TITLE
CAPT-1709: Output shortened policy names in the payroll file

### DIFF
--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -20,4 +20,8 @@ module BasePolicy
   def locale_key
     to_s.underscore
   end
+
+  def payroll_file_name
+    to_s
+  end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -43,7 +43,7 @@ class Payment < ApplicationRecord
   delegate(*(PERSONAL_DETAILS_ATTRIBUTES_PERMITTING_DISCREPANCIES + PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES), to: :claim_for_personal_details)
 
   def policies_in_payment
-    claims.map { |claim| claim.policy.to_s }.uniq.sort.join(" ")
+    claims.map { |claim| claim.policy.payroll_file_name }.uniq.sort.join(" ")
   end
 
   def confirmed?

--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -27,5 +27,10 @@ module Policies
     def payment_and_deductions_info_url
       eligibility_page_url + "#payments-and-deductions"
     end
+
+    # Agreed shorthand name to accommodate 30 character limit in payroll system (CAPT-1709)
+    def payroll_file_name
+      "SchoolsLUP"
+    end
   end
 end

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -84,5 +84,10 @@ module Policies
         "6 April #{start_year} and 5 April #{end_year}"
       end
     end
+
+    # Agreed shorthand name to accommodate 30 character limit in payroll system (CAPT-1709)
+    def payroll_file_name
+      "TSLR"
+    end
   end
 end

--- a/spec/models/early_career_payments_spec.rb
+++ b/spec/models/early_career_payments_spec.rb
@@ -31,4 +31,9 @@ RSpec.describe Policies::EarlyCareerPayments, type: :model do
       expect(described_class.first_eligible_qts_award_year(AcademicYear.new(2024))).to eq AcademicYear.new(2021)
     end
   end
+
+  describe ".payroll_file_name" do
+    subject(:payroll_file_name) { described_class.payroll_file_name }
+    it { is_expected.to eq("EarlyCareerPayments") }
+  end
 end

--- a/spec/models/levelling_up_premium_payments_spec.rb
+++ b/spec/models/levelling_up_premium_payments_spec.rb
@@ -23,4 +23,9 @@ RSpec.describe Policies::LevellingUpPremiumPayments, type: :model do
       payment_and_deductions_info_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#payments-and-deductions"
     )
   }
+
+  describe ".payroll_file_name" do
+    subject(:payroll_file_name) { described_class.payroll_file_name }
+    it { is_expected.to eq("SchoolsLUP") }
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Payment do
         create(:claim, :approved, personal_details.merge(policy: Policies::StudentLoans))
       ])
 
-      expect(payment.policies_in_payment).to eq("StudentLoans")
+      expect(payment.policies_in_payment).to eq("TSLR")
     end
 
     it "returns the correct string for a payment with multiple claims under one policy" do
@@ -224,7 +224,7 @@ RSpec.describe Payment do
         create(:claim, :approved, personal_details.merge(policy: Policies::StudentLoans))
       ])
 
-      expect(payment.policies_in_payment).to eq("StudentLoans")
+      expect(payment.policies_in_payment).to eq("TSLR")
     end
 
     it "returns the correct string for a payment with multiple claims under different policies" do
@@ -233,7 +233,7 @@ RSpec.describe Payment do
         create(:claim, :approved, personal_details.merge(policy: Policies::EarlyCareerPayments))
       ])
 
-      expect(payment.policies_in_payment).to eq("EarlyCareerPayments StudentLoans")
+      expect(payment.policies_in_payment).to eq("EarlyCareerPayments TSLR")
     end
   end
 

--- a/spec/models/student_loans_spec.rb
+++ b/spec/models/student_loans_spec.rb
@@ -56,4 +56,9 @@ RSpec.describe Policies::StudentLoans, type: :model do
       expect(described_class.current_financial_year).to eq "6 April 2019 and 5 April 2020"
     end
   end
+
+  describe ".payroll_file_name" do
+    subject(:payroll_file_name) { described_class.payroll_file_name }
+    it { is_expected.to eq("TSLR") }
+  end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-170

Shortens the policy names output in the payroll CSV file to accommodate a new 30-character limit in the payroll system which ingests them.

The 30 characters needs to include multiple policies where a single payment covers claims from more than one policy.