### PR TITLE
Attempt to fix flaky school search specs

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -27,6 +27,8 @@ module FeatureHelpers
   end
 
   def choose_school(school)
+    expect(page).to have_text(/Which (additional )?school/) # there can be variations of the full text depending on which journey/page
+
     fill_in :school_search, with: school.name.sub("The ", "").split(" ").first
 
     click_button "Continue"


### PR DESCRIPTION
This is an attempt to fix specs which are regularly failing whenever they use the `choose_school` helper.

This type of failure can happen when the page has not yet finished loading before Capybara tries to run the next matcher. Since this page is relatively large and has Javascript instantiation on the school search field this could be the reason for the intermittent failures. The `have_text` matcher has a built in wait mechanism which usually resolves this.