### PR TITLE
CAPT 1697/set student loans data on answers

### DIFF
--- a/app/controllers/claims_form_callbacks.rb
+++ b/app/controllers/claims_form_callbacks.rb
@@ -102,15 +102,7 @@ module ClaimsFormCallbacks
   end
 
   def retrieve_student_loan_details
-    # FIXME RL: The ClaimStudentLoanDetailsUpdater is called from a
-    # background job that runs against submitted claims making it tricky to
-    # pass in the journey_session.answers, so we set the attributes on the
-    # current_claim from the session answers here.
-    # To be addressed in
-    # https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1697
-    current_claim.national_insurance_number = journey_session.answers.national_insurance_number
-    current_claim.date_of_birth = journey_session.answers.date_of_birth
-    ClaimStudentLoanDetailsUpdater.call(current_claim)
+    journey::AnswersStudentLoansDetailsUpdater.call(journey_session)
   end
 
   def hmrc_api_validation_attempted?

--- a/app/controllers/concerns/journey_concern.rb
+++ b/app/controllers/concerns/journey_concern.rb
@@ -2,7 +2,7 @@ module JourneyConcern
   extend ActiveSupport::Concern
 
   included do
-    helper_method :current_journey_routing_name, :journey, :journey_configuration, :current_claim, :journey_session
+    helper_method :current_journey_routing_name, :journey, :journey_configuration, :current_claim, :journey_session, :answers
   end
 
   def current_journey_routing_name
@@ -23,6 +23,10 @@ module JourneyConcern
 
   def journey_session
     @journey_session ||= find_journey_session || create_journey_session!
+  end
+
+  def answers
+    journey_session.answers
   end
 
   private

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -65,10 +65,7 @@ class PersonalDetailsForm < Form
 
     reset_depenent_answers_attributes
 
-    ApplicationRecord.transaction do
-      journey_session.save!
-      claim.save!
-    end
+    journey_session.save!
   end
 
   def show_name_section?
@@ -142,22 +139,16 @@ class PersonalDetailsForm < Form
     errors.exclude?(:national_insurance_number)
   end
 
-  # FIXME RL: Remove reseting claim attributes once we've migrated student loan
-  # data to the answers model
   def reset_depenent_answers_attributes
     journey_session.answers.assign_attributes(
       has_student_loan: nil,
       student_loan_plan: nil
     )
 
-    claim.assign_attributes(has_student_loan: nil, student_loan_plan: nil)
-
     if journey == Journeys::TeacherStudentLoanReimbursement
       journey_session.answers.assign_attributes(
         student_loan_repayment_amount: nil
       )
-
-      claim.eligibility.assign_attributes(student_loan_repayment_amount: nil)
     end
   end
 end

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -49,9 +49,9 @@ class ClaimJourneySessionShim
       email_address_check: journey_session.answers.email_address_check,
       mobile_check: journey_session.answers.mobile_check,
       qualifications_details_check: journey_session.answers.qualifications_details_check,
-      has_student_loan: has_student_loan,
-      student_loan_plan: student_loan_plan,
-      submitted_using_slc_data: current_claim.submitted_using_slc_data
+      has_student_loan: journey_session.answers.has_student_loan,
+      student_loan_plan: journey_session.answers.student_loan_plan,
+      submitted_using_slc_data: journey_session.answers.submitted_using_slc_data
     }
   end
 
@@ -75,14 +75,6 @@ class ClaimJourneySessionShim
 
   def teacher_id_user_info
     journey_session.answers.teacher_id_user_info || current_claim.teacher_id_user_info
-  end
-
-  def has_student_loan
-    journey_session.answers.has_student_loan || current_claim.has_student_loan
-  end
-
-  def student_loan_plan
-    journey_session.answers.student_loan_plan || current_claim.student_loan_plan
   end
 
   def eligibilities

--- a/app/models/claim_journey_session_shim.rb
+++ b/app/models/claim_journey_session_shim.rb
@@ -50,7 +50,8 @@ class ClaimJourneySessionShim
       mobile_check: journey_session.answers.mobile_check,
       qualifications_details_check: journey_session.answers.qualifications_details_check,
       has_student_loan: has_student_loan,
-      student_loan_plan: student_loan_plan
+      student_loan_plan: student_loan_plan,
+      submitted_using_slc_data: current_claim.submitted_using_slc_data
     }
   end
 

--- a/app/models/claim_student_loan_details_updater.rb
+++ b/app/models/claim_student_loan_details_updater.rb
@@ -11,11 +11,6 @@ class ClaimStudentLoanDetailsUpdater
     claim.transaction do
       eligibility.update!(eligibility_student_loan_attributes) if claim.has_tslr_policy?
 
-      # When the claim hasn't been submitted yet, we need a way of knowing if the student loan
-      # details on the claim were found using the SLC data we held before submission;
-      # after submission, the `submitted_using_slc_data` value must not change
-      claim.assign_attributes(submitted_using_slc_data: student_loans_data.found_data?) unless claim.submitted?
-
       claim.assign_attributes(claim_student_loan_attributes)
       claim.save!(context: :"student-loan")
     end

--- a/app/models/claim_student_loan_details_updater.rb
+++ b/app/models/claim_student_loan_details_updater.rb
@@ -14,7 +14,7 @@ class ClaimStudentLoanDetailsUpdater
       # When the claim hasn't been submitted yet, we need a way of knowing if the student loan
       # details on the claim were found using the SLC data we held before submission;
       # after submission, the `submitted_using_slc_data` value must not change
-      claim.assign_attributes(submitted_using_slc_data: found_data?) unless claim.submitted?
+      claim.assign_attributes(submitted_using_slc_data: student_loans_data.found_data?) unless claim.submitted?
 
       claim.assign_attributes(claim_student_loan_attributes)
       claim.save!(context: :"student-loan")
@@ -30,26 +30,22 @@ class ClaimStudentLoanDetailsUpdater
 
   delegate :eligibility, to: :claim
   delegate :national_insurance_number, :date_of_birth, to: :claim
-  delegate :repaying_plan_types, :total_repayment_amount, to: :student_loans_data, prefix: :slc
-
-  alias_method :nino, :national_insurance_number
-
-  def student_loans_data
-    @student_loans_data ||= StudentLoansData.where(nino:, date_of_birth:)
-  end
-
-  def found_data?
-    student_loans_data.any?
-  end
 
   def eligibility_student_loan_attributes
-    {student_loan_repayment_amount: slc_total_repayment_amount}
+    {student_loan_repayment_amount: student_loans_data.total_repayment_amount}
   end
 
   def claim_student_loan_attributes
     {
-      has_student_loan: found_data?,
-      student_loan_plan: slc_repaying_plan_types || Claim::NO_STUDENT_LOAN
+      has_student_loan: student_loans_data.found_data?,
+      student_loan_plan: student_loans_data.student_loan_plan
     }
+  end
+
+  def student_loans_data
+    @student_loans_data ||= StudentLoansDataPresenter.new(
+      national_insurance_number: national_insurance_number,
+      date_of_birth: date_of_birth
+    )
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_student_loans_details_updater.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module AdditionalPaymentsForTeaching
+    class AnswersStudentLoansDetailsUpdater < Journeys::AnswersStudentLoansDetailsUpdater
+    end
+  end
+end

--- a/app/models/journeys/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/answers_student_loans_details_updater.rb
@@ -1,0 +1,41 @@
+module Journeys
+  class AnswersStudentLoansDetailsUpdater
+    def self.call(journey_session)
+      new(journey_session).save!
+    end
+
+    def initialize(journey_session)
+      @journey_session = journey_session
+    end
+
+    def save!
+      # When the claim hasn't been submitted yet, we need a way of knowing if
+      # the student loan details on the claim were found using the SLC data we
+      # held before submission; after submission, the
+      # `submitted_using_slc_data` value must not change
+      journey_session.answers.assign_attributes(
+        has_student_loan: student_loans_data.found_data?,
+        student_loan_plan: student_loans_data.student_loan_plan,
+        submitted_using_slc_data: student_loans_data.found_data?
+      )
+
+      journey_session.save!
+    rescue => e
+      # If something goes wrong, log the error and continue
+      Rollbar.error(e)
+    end
+
+    private
+
+    attr_reader :journey_session
+
+    delegate :answers, to: :journey_session
+
+    def student_loans_data
+      @student_loans_data ||= StudentLoansDataPresenter.new(
+        national_insurance_number: answers.national_insurance_number,
+        date_of_birth: answers.date_of_birth
+      )
+    end
+  end
+end

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -90,5 +90,9 @@ module Journeys
     def qualifications_details_check?
       !!qualifications_details_check
     end
+
+    def has_student_loan?
+      !!has_student_loan
+    end
   end
 end

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -41,6 +41,7 @@ module Journeys
     attribute :dqt_teacher_status, default: {}
     attribute :has_student_loan, :boolean
     attribute :student_loan_plan, :string
+    attribute :submitted_using_slc_data, :boolean
     attribute :sent_one_time_password_at, :datetime
     attribute :answered, default: []
 

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_student_loans_details_updater.rb
@@ -1,0 +1,13 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class AnswersStudentLoansDetailsUpdater < Journeys::AnswersStudentLoansDetailsUpdater
+      def save!
+        journey_session.answers.assign_attributes(
+          student_loan_repayment_amount: student_loans_data.total_repayment_amount
+        )
+
+        super
+      end
+    end
+  end
+end

--- a/app/models/student_loans_data_presenter.rb
+++ b/app/models/student_loans_data_presenter.rb
@@ -1,0 +1,33 @@
+class StudentLoansDataPresenter
+  def initialize(national_insurance_number:, date_of_birth:)
+    @national_insurance_number = national_insurance_number
+    @date_of_birth = date_of_birth
+  end
+
+  def found_data?
+    student_loans_data.any?
+  end
+
+  def student_loan_repayment_amount
+    student_loans_data.total_repayment_amount
+  end
+
+  def student_loan_plan
+    student_loans_data.repaying_plan_types || Claim::NO_STUDENT_LOAN
+  end
+
+  def total_repayment_amount
+    student_loans_data.total_repayment_amount
+  end
+
+  private
+
+  attr_reader :national_insurance_number, :date_of_birth
+
+  def student_loans_data
+    @student_loans_data ||= StudentLoansData.where(
+      nino: national_insurance_number,
+      date_of_birth: date_of_birth
+    )
+  end
+end

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -4,8 +4,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <% if current_claim.has_student_loan? %>
-      <h1 class="govuk-heading-l">Your student loan repayment amount is <%= number_to_currency(current_claim.award_amount, precision: 2, strip_insignificant_zeros: true) %> for the <%= Policies::StudentLoans.current_financial_year %> financial year</h1>
+    <% if answers.has_student_loan? %>
+      <h1 class="govuk-heading-l">Your student loan repayment amount is <%= number_to_currency(answers.student_loan_repayment_amount, precision: 2, strip_insignificant_zeros: true) %> for the <%= Policies::StudentLoans.current_financial_year %> financial year</h1>
       <p class="govuk-body">This information is provided by the Student Loans Company (SLC).</p>
 
       <p class="govuk-body">If it is not what you expected you can still complete your application and then contact SLC.</p>

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -191,17 +191,20 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
   scenario "Teacher edits personal details, triggering the update of student loan details" do
     claim = start_student_loans_claim
-    eligibility = claim.eligibility
     journey_session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
     journey_session.update!(
-      answers: attributes_for(:student_loans_answers, :submittable)
+      answers: attributes_for(
+        :student_loans_answers,
+        :submittable,
+        current_school_id: student_loans_school.id,
+        claim_school_id: student_loans_school.id,
+        student_loan_repayment_amount: 100
+      )
     )
 
     answers = journey_session.answers
 
-    claim.update!(attributes_for(:claim, :submittable))
-    eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id, student_loan_repayment_amount: 100))
     jump_to_claim_journey_page(
       claim: claim,
       slug: "check-your-answers",

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -230,6 +230,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.postgraduate_masters_loan).to be_nil
 
       fill_in_remaining_personal_details_and_submit
+
+      claim = Claim.submitted.order(:created_at).last
+      expect(claim.submitted_using_slc_data).to eql(true)
     end
 
     scenario "Teacher claims back student loan repayments with javascript #{js_status} (no SLC data present)", js: javascript_enabled do

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -216,18 +216,16 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       answer_eligibility_questions_and_fill_in_personal_details
 
-      claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
-
       # - Student loan amount details
       expect(page).to have_title(I18n.t("student_loans.questions.student_loan_amount"))
       click_on "Continue"
 
-      expect(claim.reload).to have_student_loan
-      expect(claim.eligibility.reload.student_loan_repayment_amount).to eql(1_100)
-      expect(claim.student_loan_plan).to eq(StudentLoan::PLAN_1)
+      journey_session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+      answers = journey_session.answers
 
-      expect(claim.has_masters_doctoral_loan).to be_nil
-      expect(claim.postgraduate_masters_loan).to be_nil
+      expect(answers).to have_student_loan
+      expect(answers.student_loan_repayment_amount).to eql(1_100)
+      expect(answers.student_loan_plan).to eq(StudentLoan::PLAN_1)
 
       fill_in_remaining_personal_details_and_submit
 
@@ -238,18 +236,16 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     scenario "Teacher claims back student loan repayments with javascript #{js_status} (no SLC data present)", js: javascript_enabled do
       answer_eligibility_questions_and_fill_in_personal_details
 
-      claim = Claim.by_policy(Policies::StudentLoans).order(:created_at).last
-
       # - Student loan amount details
       expect(page).to have_title(I18n.t("student_loans.questions.student_loan_amount"))
       click_on "Continue"
 
-      expect(claim.reload).not_to have_student_loan
-      expect(claim.eligibility.reload.student_loan_repayment_amount).to eql(0)
-      expect(claim.student_loan_plan).to eql(Claim::NO_STUDENT_LOAN)
+      journey_session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
+      answers = journey_session.answers
 
-      expect(claim.has_masters_doctoral_loan).to be_nil
-      expect(claim.postgraduate_masters_loan).to be_nil
+      expect(answers).not_to have_student_loan
+      expect(answers.student_loan_repayment_amount).to eql(0)
+      expect(answers.student_loan_plan).to eql(Claim::NO_STUDENT_LOAN)
 
       fill_in_remaining_personal_details_and_submit
     end

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe PersonalDetailsForm, type: :model do
       create(:journey_configuration, :additional_payments)
     }
 
-    let(:current_claim) do
-      claims = journey::POLICIES.map { |policy| create(:claim, policy: policy) }
-      CurrentClaim.new(claims: claims)
-    end
-
     let(:journey_session) do
       build(
         :"#{journey::I18N_NAMESPACE}_session",
@@ -29,7 +24,7 @@ RSpec.describe PersonalDetailsForm, type: :model do
 
     subject(:form) do
       described_class.new(
-        claim: current_claim,
+        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: ActionController::Parameters.new(slug:, claim: params)
@@ -383,11 +378,6 @@ RSpec.describe PersonalDetailsForm, type: :model do
 
           expect(answers.has_student_loan).to be nil
           expect(answers.student_loan_plan).to be nil
-
-          current_claim.claims.each do |claim|
-            expect(claim.has_student_loan).to be nil
-            expect(claim.student_loan_plan).to be nil
-          end
         end
       end
     end
@@ -413,10 +403,6 @@ RSpec.describe PersonalDetailsForm, type: :model do
       end
 
       before do
-        current_claim.claims.each do |claim|
-          claim.eligibility.update!(student_loan_repayment_amount: 2000)
-        end
-
         journey_session.answers.assign_attributes(
           student_loan_repayment_amount: 2000
         )
@@ -430,10 +416,6 @@ RSpec.describe PersonalDetailsForm, type: :model do
         answers = journey_session.answers
 
         expect(answers.student_loan_repayment_amount).to be nil
-
-        current_claim.claims.each do |claim|
-          expect(claim.eligibility.student_loan_repayment_amount).to be nil
-        end
       end
     end
   end

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -72,10 +72,6 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
             .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1_AND_2)
             .and change { claim.eligibility.student_loan_repayment_amount }.to(110)
         end
-
-        it "sets the `submitted_using_slc_data` flag to `true`" do
-          expect { call }.to change { claim.reload.submitted_using_slc_data }.to(true)
-        end
       end
 
       [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].each do |policy|
@@ -85,10 +81,6 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           it "updates the claim with the student plan only" do
             expect { call }.to change { claim.reload.has_student_loan }.to(true)
               .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1_AND_2)
-          end
-
-          it "sets the `submitted_using_slc_data` flag to `true`" do
-            expect { call }.to change { claim.reload.submitted_using_slc_data }.to(true)
           end
         end
       end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -217,8 +217,8 @@ RSpec.describe "Claims", type: :request do
         end
 
         it "updates the student loan details" do
-          expect { request }.to change { in_progress_claim.reload.has_student_loan }
-            .and change { in_progress_claim.student_loan_plan }
+          expect { request }.to change { journey_session.reload.answers.has_student_loan }
+            .and change { journey_session.reload.answers.student_loan_plan }
         end
       end
 
@@ -264,8 +264,11 @@ RSpec.describe "Claims", type: :request do
             end
 
             it "updates the student loan details" do
-              expect { request }.to change { in_progress_claim.reload.has_student_loan }
-                .and change { in_progress_claim.student_loan_plan }
+              expect { request }.to(
+                change { journey_session.reload.answers.has_student_loan }.and(
+                  change { journey_session.reload.answers.student_loan_plan }
+                )
+              )
             end
           end
 
@@ -288,8 +291,11 @@ RSpec.describe "Claims", type: :request do
             end
 
             it "does not update the student loan details" do
-              expect { request }.to not_change { in_progress_claim.reload.has_student_loan }
-                .and not_change { in_progress_claim.student_loan_plan }
+              expect { request }.to(
+                not_change { journey_session.reload.answers.has_student_loan }.and(
+                  not_change { journey_session.reload.answers.student_loan_plan }
+                )
+              )
             end
           end
         end


### PR DESCRIPTION
Probably slightly easier to review both commits separately

Set student loans on session

There's a call back that sets student loans data on the claim, we need
to change this to set the student loans data on the session. The
ClaimStudentLoanDetailsUpdater is also used for setting data on
submitted claims so we've introduced an answers specific version and a
presenter class to share the data between the claim and answers
versions.

