### PR TITLE
Migrate employed directly to the journey session

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/employed_directly_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/employed_directly_form.rb
@@ -8,7 +8,8 @@ module Journeys
       def save
         return false unless valid?
 
-        update!(eligibility_attributes: attributes)
+        journey_session.answers.assign_attributes(attributes)
+        journey_session.save
       end
     end
   end

--- a/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
+++ b/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
@@ -16,7 +16,7 @@ module Journeys
               employed_as_supply_teacher: employed_as_supply_teacher,
               qualification: journey_session.answers.qualification,
               has_entire_term_contract: has_entire_term_contract,
-              employed_directly: employed_directly,
+              employed_directly: journey_session.answers.employed_directly,
               subject_to_disciplinary_action: subject_to_disciplinary_action,
               subject_to_formal_performance_action: subject_to_formal_performance_action,
               eligible_itt_subject: eligible_itt_subject,
@@ -43,10 +43,6 @@ module Journeys
 
       def has_entire_term_contract
         journey_session.answers.has_entire_term_contract || try_eligibility(:has_entire_term_contract)
-      end
-
-      def employed_directly
-        journey_session.answers.employed_directly || try_eligibility(:employed_directly)
       end
 
       def subject_to_disciplinary_action

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -83,6 +83,7 @@ FactoryBot.define do
       qualification { :postgraduate_itt }
       teaching_subject_now { true }
       eligible_itt_subject { :mathematics }
+      employed_directly { true }
     end
 
     trait :ecp_eligible do
@@ -97,6 +98,7 @@ FactoryBot.define do
       teaching_subject_now { true }
       itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 3 }
       eligible_itt_subject { :mathematics }
+      employed_directly { true }
     end
 
     trait :ecp_and_lup_eligible do

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
   # create a school eligible for ECP and LUP so can walk the whole journey
   let!(:journey_configuration) { create(:journey_configuration, :additional_payments, current_academic_year: AcademicYear.new(2022)) }
   let!(:school) { create(:school, :combined_journey_eligibile_for_all) }
+  let(:journey_session) { Journeys::AdditionalPaymentsForTeaching::Session.last }
   let(:current_academic_year) { journey_configuration.current_academic_year }
 
   let(:itt_year) { current_academic_year - 3 }
@@ -317,7 +318,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     choose "Yes, I'm employed by my school"
     click_on "Continue"
 
-    expect(claim.eligibility.reload.employed_directly).to eql true
+    expect(journey_session.answers.employed_directly).to eql true
 
     # - Are you currently subject to action for poor performance
     expect(page).to have_text(I18n.t("additional_payments.forms.poor_performance.questions.formal_performance_action"))


### PR DESCRIPTION
We want to store the employed_directly answer on the journey session and
move it away from the eligibility object.

This does impact how the ineligibility reason is calculated. For now I
opted to include the answers to the ineligibility checker class. This
seemed like the simplest change for the short-term.

Other work is progressing to move the logic from
`IneligibilityReasonChecker` to the journey session.

<!-- Do you need to update CHANGELOG.md? -->
