### PR TITLE
Make sure references to current school use answers

### DIFF
--- a/app/forms/current_school_form.rb
+++ b/app/forms/current_school_form.rb
@@ -17,7 +17,6 @@ class CurrentSchoolForm < Form
 
     journey_session.answers.assign_attributes(current_school_id:)
     journey_session.save!
-    update!("eligibility_attributes" => {"current_school_id" => current_school_id})
   end
 
   delegate :name, to: :current_school, prefix: true, allow_nil: true

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -34,11 +34,6 @@ module Journeys
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the current_school forms write their
-        # answers to the session
-        claim.eligibility.assign_attributes(current_school_id: nil)
-        claim.eligibility.save!
-
         true
       end
 

--- a/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
@@ -32,13 +32,6 @@ module Journeys
 
         journey_session.save!
 
-        # FIXME RL: Remove this once the current school forms write their
-        # answers to the session
-        claim.eligibility.assign_attributes(current_school_id: nil)
-        # FIXME RL: Remove this once the current school forms write their
-        # answers to the session
-        claim.eligibility.save!
-
         true
       end
 

--- a/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
+++ b/app/models/journeys/additional_payments_for_teaching/claim_journey_session_shim.rb
@@ -23,7 +23,7 @@ module Journeys
               eligible_degree_subject: journey_session.answers.eligible_degree_subject,
               teaching_subject_now: journey_session.answers.teaching_subject_now,
               itt_academic_year: journey_session.answers.itt_academic_year,
-              current_school_id: current_school_id,
+              current_school_id: journey_session.answers.current_school_id,
               induction_completed: journey_session.answers.induction_completed,
               school_somewhere_else: journey_session.answers.school_somewhere_else
             }
@@ -51,10 +51,6 @@ module Journeys
 
       def eligible_itt_subject
         journey_session.answers.eligible_itt_subject
-      end
-
-      def current_school_id
-        journey_session.answers.current_school_id || try_eligibility(:current_school_id)
       end
     end
   end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -88,8 +88,6 @@ module Journeys
       # Even though we are inside the ECP namespace, this method can modify the
       # slug sequence of both LUP and ECP claims
       def slugs
-        ecp_claim = claim.for_policy(Policies::EarlyCareerPayments)
-
         SLUGS.dup.tap do |sequence|
           if !Journeys::AdditionalPaymentsForTeaching.configuration.teacher_id_enabled?
             sequence.delete("sign-in-or-continue")
@@ -152,7 +150,7 @@ module Journeys
 
           sequence.delete("induction-completed") unless induction_question_required?
 
-          if answers.induction_not_completed? && ecp_claim.eligibility.ecp_only_school?
+          if answers.induction_not_completed? && ecp_eligibility_checker.ecp_only_school?
             replace_ecp_only_induction_not_completed_slugs(sequence)
           end
 
@@ -229,7 +227,7 @@ module Journeys
       end
 
       def ecp_school_selected?
-        school = answers&.current_school || claim.eligibility.current_school
+        school = answers.current_school
         return false unless school
 
         Policies::EarlyCareerPayments::SchoolEligibility.new(school).eligible?

--- a/app/models/journeys/page_sequence.rb
+++ b/app/models/journeys/page_sequence.rb
@@ -79,7 +79,7 @@ module Journeys
     end
 
     def lup_teacher_at_lup_school
-      answers.nqt_in_academic_year_after_itt == false && Policies::LevellingUpPremiumPayments::SchoolEligibility.new(claim.eligibility.current_school).eligible?
+      answers.nqt_in_academic_year_after_itt == false && Policies::LevellingUpPremiumPayments::SchoolEligibility.new(answers.current_school).eligible?
     end
 
     def handle_trainee_teacher

--- a/app/views/additional_payments/claims/_ineligibility_current_school.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_current_school.html.erb
@@ -3,11 +3,11 @@
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Name</th>
-      <td class="govuk-table__cell"><%= current_claim.school.name %></th>
+      <td class="govuk-table__cell"><%= answers.current_school.name %></th>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Address</th>
-      <td class="govuk-table__cell"><%= current_claim.school.address %></th>
+      <td class="govuk-table__cell"><%= answers.current_school.address %></th>
     </tr>
   </tbody>
 </table>
@@ -37,7 +37,7 @@
 </ul>
 
 <div class="govuk-!-padding-bottom-6">
-  <% if current_claim.eligibility.school_somewhere_else == false %>
+  <% if answers.school_somewhere_else == false %>
     <%= button_to "Change school", claim_path(current_journey_routing_name, "correct-school", claim: { change_school: true }), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button" } %>
   <% else %>
     <%= link_to "Change school", claim_path(current_journey_routing_name, "current-school"), class: "govuk-button", role: "button", draggable: false, data: {module: "govuk-button"} %>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You must be employed to teach at a state-funded secondary school to be eligible for
-  this payment. <%= current_claim.eligibility.current_school_name %>, where you
+  this payment. <%= answers.current_school.name %>, where you
   are currently employed to teach, is not a state-funded secondary school.
 </p>
 

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -167,6 +167,10 @@ FactoryBot.define do
       employed_directly { false }
     end
 
+    trait :sufficient_teaching do
+      teaching_subject_now { true }
+    end
+
     trait :insufficient_teaching do
       teaching_subject_now { false }
     end

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -327,35 +327,34 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     let!(:claim) do
       claim = start_early_career_payments_claim
       claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
-      claim.eligibility.update!(current_school: school)
       claim
     end
 
     let!(:lup_claim) do
       lup_claim = Claim.by_policy(Policies::LevellingUpPremiumPayments).order(:created_at).last
       lup_claim.eligibility.update!(attributes_for(:levelling_up_premium_payments_eligibility, :eligible))
-      lup_claim.eligibility.update!(current_school: school)
       lup_claim
     end
 
     let!(:journey_session) do
-      session = Journeys::AdditionalPaymentsForTeaching::Session.last
-      session.answers.assign_attributes(
+      journey_session = Journeys::AdditionalPaymentsForTeaching::Session.last
+      journey_session.answers.assign_attributes(
         attributes_for(
           :additional_payments_answers,
           :lup_eligible,
+          :ecp_and_lup_eligible,
           current_school_id: school.id
         )
       )
-      session.save!
-      session
+      journey_session.save!
+      journey_session
     end
 
     scenario "when Assessment only" do
       jump_to_claim_journey_page(
         claim: claim,
         slug: "qualification",
-        journey_session:
+        journey_session: journey_session
       )
 
       # - What route into teaching did you take?

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -19,8 +19,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           claim.eligibility.update!(
             attributes_for(
               :early_career_payments_eligibility,
-              :eligible,
-              current_school_id: school.id
+              :eligible
             )
           )
 
@@ -108,8 +107,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
             attributes_for(
               :early_career_payments_eligibility,
               :eligible,
-              eligible_itt_subject: args[:subject],
-              current_school_id: school.id
+              eligible_itt_subject: args[:subject]
             )
           )
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -304,7 +304,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
   scenario "currently works at a different school to the claim school" do
     different_school = create(:school, :student_loans_eligible)
-    claim = start_student_loans_claim
+    start_student_loans_claim
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
     choose_school school
@@ -320,7 +320,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose different_school.name
     click_on "Continue"
 
-    expect(claim.eligibility.reload.current_school).to eql different_school
+    expect(session.reload.answers.current_school).to eql different_school
 
     expect(page).to have_text(leadership_position_question)
   end

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
       attributes_for(
         :additional_payments_answers,
         trainee_teacher,
-        itt_academic_year: itt_academic_year
+        itt_academic_year: itt_academic_year,
+        current_school_id: create(:school, :early_career_payments_eligible).id
       )
     )
   end

--- a/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching/slug_sequence_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
     build(
       :additional_payments_answers,
       :submittable,
+      :ecp_eligible,
       logged_in_with_tid: logged_in_with_tid,
       details_check: details_check,
       dqt_teacher_status: dqt_teacher_status,
@@ -328,13 +329,17 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SlugSequence do
     end
 
     context "when claim is ineligible" do
-      let(:journey_session) do
+      let(:eligibility) { build(:early_career_payments_eligibility, :ineligible) }
+      let(:eligibility_lup) { build(:levelling_up_premium_payments_eligibility, :ineligible) }
+      let(:answers) do
         build(
-          :additional_payments_session,
-          answers: attributes_for(
-            :additional_payments_answers,
-            :ecp_ineligible
-          )
+          :additional_payments_answers,
+          :submittable,
+          :ecp_ineligible,
+          logged_in_with_tid: logged_in_with_tid,
+          details_check: details_check,
+          dqt_teacher_status: dqt_teacher_status,
+          qualifications_details_check: qualifications_details_check
         )
       end
 


### PR DESCRIPTION
As the current school form has been migrated to write the current
school id to the session answers we want to make sure all references to
the current school use the session answers rather than the current
claim.
