### PR TITLE
Clean up refernces ot current claim

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form.rb
@@ -13,10 +13,6 @@ module Journeys
         eligible_itt_subject == "physics" || eligible_itt_subject == "chemistry"
       end
 
-      # FIXME RL: Once this method writes to the journey session answers update
-      # QualificationForm#save to not reset teaching subject on the claim, as
-      # it's no longer needed (still keep resetting it on the answers)
-      # (and remove this comment!)
       def save
         return false unless valid?
 


### PR DESCRIPTION
The qualification details form should no longer need to set any
attributes on the claim or eligibility

<!-- Do you need to update CHANGELOG.md? -->
