### PR TITLE
CAPT 1718/dont reference claim in answers presenter

### DIFF
--- a/app/models/concerns/journeys/sessions/teacher_id.rb
+++ b/app/models/concerns/journeys/sessions/teacher_id.rb
@@ -32,8 +32,8 @@ module Journeys
         teacher_id_user_info["ni_number"] == national_insurance_number
       end
 
-      def trn_same_as_tid?(claim)
-        teacher_id_user_info["trn"] == claim.teacher_reference_number
+      def trn_same_as_tid?
+        teacher_id_user_info["trn"] == teacher_reference_number
       end
 
       def using_mobile_number_from_tid?

--- a/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
@@ -43,7 +43,7 @@ module Journeys
       def has_entire_term_contract
         [
           t("additional_payments.forms.entire_term_contract.questions.has_entire_term_contract"),
-          (eligibility.has_entire_term_contract? ? "Yes" : "No"),
+          (answers.has_entire_term_contract? ? "Yes" : "No"),
           "entire-term-contract"
         ]
       end
@@ -83,7 +83,7 @@ module Journeys
       def employed_directly
         [
           t("additional_payments.forms.employed_directly.questions.employed_directly"),
-          (eligibility.employed_directly? ? "Yes" : "No"),
+          (answers.employed_directly? ? "Yes" : "No"),
           "employed-directly"
         ]
       end
@@ -119,7 +119,7 @@ module Journeys
 
         [
           eligible_itt_subject_translation(
-            shim.answers,
+            answers,
             subject_symbols
           ),
           text_for_subject_answer,
@@ -173,18 +173,11 @@ module Journeys
       private
 
       def subject_symbols
-        @subject_symbols ||= JourneySubjectEligibilityChecker.current_and_future_subject_symbols(shim.answers)
+        @subject_symbols ||= JourneySubjectEligibilityChecker.current_and_future_subject_symbols(answers)
       end
 
       def claim_submission_form
-        @claim_submission_form ||= ClaimSubmissionForm.new(journey_session: shim)
-      end
-
-      def shim
-        @shim ||= ClaimJourneySessionShim.new(
-          journey_session: journey_session,
-          current_claim: claim
-        )
+        @claim_submission_form ||= ClaimSubmissionForm.new(journey_session: journey_session)
       end
     end
   end

--- a/app/models/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/app/models/journeys/additional_payments_for_teaching/session_answers.rb
@@ -138,6 +138,14 @@ module Journeys
         !!school_somewhere_else
       end
 
+      def has_entire_term_contract?
+        !!has_entire_term_contract
+      end
+
+      def employed_directly?
+        !!employed_directly
+      end
+
       private
 
       def current_academic_year

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -59,8 +59,8 @@ module Journeys
       self::AnswersPresenter
     end
 
-    def answers_for_claim(claim, journey_session)
-      answers_presenter.new(claim, journey_session)
+    def answers_for_claim(journey_session)
+      answers_presenter.new(journey_session)
     end
   end
 end

--- a/app/models/journeys/base_answers_presenter.rb
+++ b/app/models/journeys/base_answers_presenter.rb
@@ -1,22 +1,21 @@
 module Journeys
   class BaseAnswersPresenter
-    attr_reader :claim, :journey_session
+    attr_reader :journey_session
 
     delegate :answers, to: :journey_session
 
-    def initialize(claim, journey_session)
-      @claim = claim
+    def initialize(journey_session)
       @journey_session = journey_session
     end
 
     def identity_answers
       [].tap do |a|
-        a << [t("questions.name"), claim.full_name, "personal-details"] if show_name?
-        a << [t("forms.address.questions.your_address"), answers.address, "address"] unless claim.address_from_govuk_verify?
+        a << [t("questions.name"), answers.full_name, "personal-details"] if show_name?
+        a << [t("forms.address.questions.your_address"), answers.address, "address"]
         a << [t("questions.date_of_birth"), date_of_birth_string, "personal-details"] if show_dob?
-        a << [t("forms.gender.questions.payroll_gender"), t("answers.payroll_gender.#{answers.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
+        a << [t("forms.gender.questions.payroll_gender"), t("answers.payroll_gender.#{answers.payroll_gender}"), "gender"]
         a << [t("questions.teacher_reference_number"), answers.teacher_reference_number, "teacher-reference-number"] if show_trn?
-        a << [t("questions.national_insurance_number"), claim.national_insurance_number, "personal-details"] if show_nino?
+        a << [t("questions.national_insurance_number"), answers.national_insurance_number, "personal-details"] if show_nino?
         a << [t("questions.email_address"), answers.email_address, "email-address"] unless show_email_select?
         a << [text_for(:select_email), answers.email_address, "select-email"] if show_email_select?
         a << [t("questions.provide_mobile_number"), answers.provide_mobile_number? ? "Yes" : "No", "provide-mobile-number"] unless show_mobile_select?
@@ -43,7 +42,7 @@ module Journeys
     end
 
     def date_of_birth_string
-      claim.date_of_birth && l(claim.date_of_birth)
+      answers.date_of_birth && l(answers.date_of_birth)
     end
 
     def show_name?
@@ -59,7 +58,7 @@ module Journeys
     end
 
     def show_trn?
-      !(answers.logged_in_with_tid? && answers.trn_same_as_tid?(claim))
+      !(answers.logged_in_with_tid? && answers.trn_same_as_tid?)
     end
 
     def show_email_select?

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -76,6 +76,10 @@ module Journeys
       !!hmrc_bank_validation_succeeded
     end
 
+    def full_name
+      [first_name, middle_name, surname].reject(&:blank?).join(" ")
+    end
+
     def address(separator = ", ")
       [
         address_line_1,

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_presenter.rb
@@ -5,12 +5,8 @@ module Journeys
       include Policies::StudentLoans::PresenterMethods
       include ActiveSupport::NumberHelper
 
-      def eligibility
-        @eligibility = if @claim.is_a?(CurrentClaim)
-          @claim.claims.first.eligibility
-        else
-          claim.eligibility
-        end
+      def eligibility_checker
+        Policies::StudentLoans::PolicyEligibilityChecker.new(answers: answers)
       end
 
       # Formats the eligibility as a list of questions and answers, each
@@ -38,7 +34,7 @@ module Journeys
       def qts_award_year
         [
           t("student_loans.forms.qts_year.questions.qts_award_year"),
-          qts_award_year_answer(eligibility),
+          qts_award_year_answer(eligibility_checker.ineligible_qts_award_year?, answers.academic_year),
           "qts-year"
         ]
       end
@@ -47,14 +43,14 @@ module Journeys
         [
           claim_school_question,
           answers.claim_school_name,
-          (eligibility.claim_school_somewhere_else == false) ? "select-claim-school" : "claim-school"
+          (answers.claim_school_somewhere_else == false) ? "select-claim-school" : "claim-school"
         ]
       end
 
       def current_school
         [
           t("student_loans.forms.still_teaching.questions.tps_school"),
-          eligibility.current_school_name,
+          answers.current_school.name,
           "still-teaching"
         ]
       end

--- a/app/models/policies/student_loans/admin_tasks_presenter.rb
+++ b/app/models/policies/student_loans/admin_tasks_presenter.rb
@@ -15,7 +15,7 @@ module Policies
 
       def qualifications
         [
-          ["Award year", qts_award_year_answer(eligibility)]
+          ["Award year", qts_award_year_answer(eligibility.ineligible_qts_award_year?, claim.academic_year)]
         ]
       end
 

--- a/app/models/policies/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/policies/student_loans/eligibility_admin_answers_presenter.rb
@@ -34,7 +34,7 @@ module Policies
       def qts_award_year
         [
           translate("admin.qts_award_year"),
-          qts_award_year_answer(eligibility)
+          qts_award_year_answer(eligibility.ineligible_qts_award_year?, eligibility.claim.academic_year)
         ]
       end
 

--- a/app/models/policies/student_loans/presenter_methods.rb
+++ b/app/models/policies/student_loans/presenter_methods.rb
@@ -1,11 +1,11 @@
 module Policies
   module StudentLoans
     module PresenterMethods
-      def qts_award_year_answer(eligibility)
-        if eligibility.ineligible_qts_award_year?
+      def qts_award_year_answer(ineligible_qts_award_year, academic_year)
+        if ineligible_qts_award_year
           I18n.t("student_loans.answers.qts_award_years.before_cut_off_date")
         else
-          first_eligible_year = Policies::StudentLoans.first_eligible_qts_award_year(eligibility.claim.academic_year).to_s(:long)
+          first_eligible_year = Policies::StudentLoans.first_eligible_qts_award_year(academic_year).to_s(:long)
           I18n.t("student_loans.answers.qts_award_years.on_or_after_cut_off_date", year: first_eligible_year)
         end
       end

--- a/app/views/additional_payments/claims/check_your_answers.html.erb
+++ b/app/views/additional_payments/claims/check_your_answers.html.erb
@@ -17,9 +17,9 @@
       Check your answers before sending your application
     </h1>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Identity details", answers: journey.answers_for_claim(@form.claim, @form.journey_session).identity_answers} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Identity details", answers: journey.answers_for_claim(@form.journey_session).identity_answers} %>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Payment details", answers: journey.answers_for_claim(@form.claim, @form.journey_session).payment_answers} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Payment details", answers: journey.answers_for_claim(@form.journey_session).payment_answers} %>
 
     <%= form_with url: claim_submission_path do |form| %>
       <h2 class="govuk-heading-m"><%= t("additional_payments.check_your_answers.heading_send_application") %></h2>

--- a/app/views/additional_payments/claims/check_your_answers_part_one.html.erb
+++ b/app/views/additional_payments/claims/check_your_answers_part_one.html.erb
@@ -6,7 +6,7 @@
       <%= t("additional_payments.check_your_answers.part_one.primary_heading") %>
     </h1>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: journey.answers_for_claim(current_claim, journey_session).eligibility_answers} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: journey.answers_for_claim(journey_session).eligibility_answers} %>
 
     <p class="govuk-body"><%= t("additional_payments.check_your_answers.part_one.confirmation_notice") %></p>
 

--- a/app/views/student_loans/claims/check_your_answers.html.erb
+++ b/app/views/student_loans/claims/check_your_answers.html.erb
@@ -17,11 +17,11 @@
       Check your answers before sending your application
     </h1>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: journey.answers_for_claim(@form.claim, @form.journey_session).eligibility_answers} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: journey.answers_for_claim(@form.journey_session).eligibility_answers} %>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Identity details", answers: journey.answers_for_claim(@form.claim, @form.journey_session).identity_answers} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Identity details", answers: journey.answers_for_claim(@form.journey_session).identity_answers} %>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Payment details", answers: journey.answers_for_claim(@form.claim, @form.journey_session).payment_answers} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Payment details", answers: journey.answers_for_claim(@form.journey_session).payment_answers} %>
 
     <%= form_with url: claim_submission_path do |form| %>
       <h2 class="govuk-heading-m"><%= t("check_your_answers.heading_send_application") %></h2>

--- a/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/spec/factories/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -42,6 +42,10 @@ FactoryBot.define do
       claim_school_id { create(:school, :student_loans_eligible).id }
     end
 
+    trait :with_current_school do
+      current_school_id { create(:school, :student_loans_eligible).id }
+    end
+
     trait :with_subjects_taught do
       physics_taught { true }
       taught_eligible_subjects { true }
@@ -72,6 +76,7 @@ FactoryBot.define do
       with_payroll_gender
       with_teacher_reference_number
       with_claim_school
+      with_current_school
       with_subjects_taught
       with_employment_status
       with_leadership_position

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -47,8 +47,16 @@ RSpec.feature "Changing the answers on a submittable claim" do
   scenario "Teacher changes an answer which is not a dependency of any of the other answers they've given, becoming ineligible" do
     claim = start_student_loans_claim
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    session.answers.assign_attributes(
+      attributes_for(
+        :student_loans_answers,
+        :submittable,
+        current_school_id: student_loans_school.id,
+        claim_school_id: student_loans_school.id,
+        qualifications_details_check: false
+      )
+    )
+    session.save!
     jump_to_claim_journey_page(
       claim:,
       slug: "check-your-answers",

--- a/spec/models/journeys/additional_payments_for_teaching/answers_presenter_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching/answers_presenter_spec.rb
@@ -2,13 +2,10 @@ require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
   let(:policy) { Policies::EarlyCareerPayments }
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
-
   it_behaves_like "journey answers presenter"
 
   describe "#eligibility_answers" do
     let(:policy_year) { AcademicYear.new(2022) }
-    let(:claim) { build(:claim, policy:, academic_year: policy_year, eligibility: eligibility) }
     let!(:journey_configuration) { create(:journey_configuration, :additional_payments, current_academic_year: policy_year) }
     let(:qualifications_details_check) { false }
     let(:qualification) { "postgraduate_itt" }
@@ -17,15 +14,12 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
       create(:additional_payments_session, answers: answers)
     end
 
-    subject do
-      described_class.new(current_claim, journey_session).eligibility_answers
-    end
+    subject { described_class.new(journey_session).eligibility_answers }
 
     context "ECP" do
       before { journey_session.answers.nqt_in_academic_year_after_itt = true }
 
       context "long-term directly employed supply teacher" do
-        let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
         let(:answers) do
           build(
             :additional_payments_answers,
@@ -61,7 +55,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
       end
 
       context "non-supply teacher" do
-        let(:eligibility) { build(:early_career_payments_eligibility, :eligible, :not_a_supply_teacher) }
         let(:answers) { build(:additional_payments_answers, :ecp_eligible) }
 
         it { is_expected.to include(["Are you currently employed as a supply teacher?", "No", "supply-teacher"]) }
@@ -91,7 +84,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
 
       context "single subject option" do
         let(:itt_year) { AcademicYear::Type.new.serialize(AcademicYear.new(2019)) }
-        let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
         let(:answers) do
           build(
             :additional_payments_answers,
@@ -105,7 +97,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
 
       context "multiple subject options" do
         let(:itt_year) { AcademicYear::Type.new.serialize(AcademicYear.new(2020)) }
-        let(:eligibility) { build(:early_career_payments_eligibility, :eligible, itt_academic_year: itt_year) }
         let(:answers) do
           build(
             :additional_payments_answers,
@@ -119,7 +110,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
 
       context "qualifications retrieved from DQT" do
         let(:qualifications_details_check) { true }
-        let(:eligibility) { build(:early_career_payments_eligibility, :eligible) }
         let(:early_career_payments_dqt_teacher_record) do
           double(
             itt_academic_year_for_claim:,
@@ -176,8 +166,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
       let(:policy) { Policies::LevellingUpPremiumPayments }
 
       context "entire output" do
-        let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, :ineligible_itt_subject) }
-        let(:expected_itt_year) { AcademicYear.new(eligibility.itt_academic_year) }
+        let(:expected_itt_year) { AcademicYear.new(answers.itt_academic_year) }
         let(:answers) do
           build(
             :additional_payments_answers,
@@ -216,7 +205,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
 
       context "qualifications retrieved from DQT" do
         let(:qualifications_details_check) { true }
-        let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
         let(:early_career_payments_dqt_teacher_record) do
           double(
             itt_academic_year_for_claim:,
@@ -292,7 +280,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
       end
 
       context "eligible ITT" do
-        let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible) }
         let(:answers) do
           build(
             :additional_payments_answers,
@@ -321,7 +308,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::AnswersPresenter do
       end
 
       context "ineligible ITT" do
-        let(:eligibility) { build(:levelling_up_premium_payments_eligibility, :eligible, :ineligible_itt_subject) }
         let(:answers) do
           build(
             :additional_payments_answers,

--- a/spec/models/student_loans/presenter_methods_spec.rb
+++ b/spec/models/student_loans/presenter_methods_spec.rb
@@ -24,10 +24,20 @@ RSpec.describe Policies::StudentLoans::PresenterMethods, type: :helper do
         eligibility = build(:student_loans_eligibility, claim: claim)
 
         eligibility.qts_award_year = :before_cut_off_date
-        expect(helper.qts_award_year_answer(eligibility)).to eq args[:qts_award_year_answer_ineligible]
+        expect(
+          helper.qts_award_year_answer(
+            eligibility.ineligible_qts_award_year?,
+            eligibility.claim.academic_year
+          )
+        ).to eq args[:qts_award_year_answer_ineligible]
 
         eligibility.qts_award_year = :on_or_after_cut_off_date
-        expect(helper.qts_award_year_answer(eligibility)).to eq args[:qts_award_year_answer_eligible]
+        expect(
+          helper.qts_award_year_answer(
+            eligibility.ineligible_qts_award_year?,
+            eligibility.claim.academic_year
+          )
+        ).to eq args[:qts_award_year_answer_eligible]
       end
     end
   end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -71,7 +71,11 @@ RSpec.describe "Submissions", type: :request do
       before :each do
         start_student_loans_claim
         # Make the claim _almost_ submittable
-        in_progress_claim.update!(attributes_for(:claim, :submittable, email_address: nil))
+        journey_session.answers.assign_attributes(
+          attributes_for(:student_loans_answers, :submittable, email_address: nil)
+        )
+
+        journey_session.save!
 
         perform_enqueued_jobs { post claim_submission_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME) }
       end

--- a/spec/support/journey_answers_presenter_shared_examples.rb
+++ b/spec/support/journey_answers_presenter_shared_examples.rb
@@ -1,29 +1,12 @@
 require "rails_helper"
 
 RSpec.shared_examples "journey answers presenter" do
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
-
   describe "#identity_answers" do
     let(:first_name) { "Jo" }
     let(:surname) { "Bloggs" }
     let(:trn) { "1234567" }
     let(:nino) { "QQ123456C" }
     let(:dob) { Date.new(1980, 1, 10) }
-
-    let(:claim) do
-      build(
-        :claim,
-        policy:,
-        first_name:,
-        surname:,
-        date_of_birth: dob,
-        teacher_reference_number: trn,
-        national_insurance_number: nino,
-        payroll_gender: :dont_know,
-        logged_in_with_tid:,
-        teacher_id_user_info:
-      )
-    end
 
     let(:journey_session) do
       build(
@@ -51,7 +34,7 @@ RSpec.shared_examples "journey answers presenter" do
     end
 
     subject(:answers) do
-      described_class.new(current_claim, journey_session).identity_answers
+      described_class.new(journey_session).identity_answers
     end
 
     context "logged in with Teacher ID" do
@@ -192,14 +175,13 @@ RSpec.shared_examples "journey answers presenter" do
       end
 
       it "copes with a blank date of birth" do
-        claim.date_of_birth = nil
+        journey_session.answers.date_of_birth = nil
         expect(answers).to include([I18n.t("questions.date_of_birth"), nil, "personal-details"])
       end
     end
   end
 
   describe "#payment_answers" do
-    let(:claim) { create(:claim) }
     let(:journey_session) do
       create(
         :additional_payments_session,
@@ -212,7 +194,7 @@ RSpec.shared_examples "journey answers presenter" do
       )
     end
 
-    subject(:answers) { described_class.new(current_claim, journey_session).payment_answers }
+    subject(:answers) { described_class.new(journey_session).payment_answers }
 
     context "when a personal bank account is selected" do
       it "returns an array of questions and answers for displaying to the user for review" do
@@ -228,7 +210,6 @@ RSpec.shared_examples "journey answers presenter" do
     end
 
     context "when a building society is selected" do
-      let(:claim) { create(:claim) }
       let(:journey_session) do
         create(
           :additional_payments_session,


### PR DESCRIPTION
Removes claim from answers presenter

Updates the answers presenters to no londer reference the claim.

Had to make a shared base branch with Ken and Phil's latest work, once that's
merged can rebase this onto master, so for the time being it's best to **review
just the[ last commit in this pr](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2841/commits/2ddcabe4a55400a83347e901c782969c82fc9488).**
