### PR TITLE
CAPT 1721/remove claim from slug sequence

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -49,7 +49,6 @@ class ClaimsController < BasePublicController
     params[:journey] = new_journey::ROUTING_NAME
 
     new_page_sequence = new_journey.page_sequence_for_claim(
-      current_claim,
       journey_session,
       session[:slugs],
       params[:slug]
@@ -101,7 +100,6 @@ class ClaimsController < BasePublicController
 
   def page_sequence
     @page_sequence ||= journey.page_sequence_for_claim(
-      current_claim,
       journey_session,
       session[:slugs],
       params[:slug]

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -75,13 +75,11 @@ module Journeys
         RESULTS_SLUGS
       ).freeze
 
-      attr_reader :claim, :journey_session
+      attr_reader :journey_session
 
       delegate :answers, to: :journey_session
 
-      # Really this is a combined CurrentClaim
-      def initialize(claim, journey_session)
-        @claim = claim
+      def initialize(journey_session)
         @journey_session = journey_session
       end
 
@@ -178,8 +176,11 @@ module Journeys
       private
 
       def personal_details_form
+        # FIXME RL: forms expect a claim argument even thought they don't use it
+        # this will be removed as part of no longer creating a claim at the
+        # start of the journey work
         PersonalDetailsForm.new(
-          claim:,
+          claim: nil,
           journey_session: journey_session,
           journey: Journeys::AdditionalPaymentsForTeaching,
           params: ActionController::Parameters.new

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -47,7 +47,6 @@ module Journeys
 
     def page_sequence_for_claim(claim, journey_session, completed_slugs, current_slug)
       PageSequence.new(
-        claim,
         slug_sequence.new(claim, journey_session),
         completed_slugs,
         current_slug,

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -45,9 +45,9 @@ module Journeys
       defined?(self::FORMS) ? self::FORMS : {}
     end
 
-    def page_sequence_for_claim(claim, journey_session, completed_slugs, current_slug)
+    def page_sequence_for_claim(journey_session, completed_slugs, current_slug)
       PageSequence.new(
-        slug_sequence.new(claim, journey_session),
+        slug_sequence.new(journey_session),
         completed_slugs,
         current_slug,
         journey_session

--- a/app/models/journeys/page_sequence.rb
+++ b/app/models/journeys/page_sequence.rb
@@ -3,13 +3,12 @@
 # Used to model the sequence of pages that make up the claim process.
 module Journeys
   class PageSequence
-    attr_reader :claim, :current_slug, :completed_slugs
+    attr_reader :current_slug, :completed_slugs
 
     DEAD_END_SLUGS = %w[complete existing-session eligible-later future-eligibility ineligible]
     OPTIONAL_SLUGS = %w[postcode-search select-home-address reset-claim]
 
-    def initialize(claim, slug_sequence, completed_slugs, current_slug, journey_session)
-      @claim = claim
+    def initialize(slug_sequence, completed_slugs, current_slug, journey_session)
       @current_slug = current_slug
       @slug_sequence = slug_sequence
       @completed_slugs = completed_slugs
@@ -75,7 +74,7 @@ module Journeys
     end
 
     def lup_policy_and_trainee_teacher_at_lup_school?
-      Policies::LevellingUpPremiumPayments.in?(claim.policies) && lup_teacher_at_lup_school
+      journey == Journeys::AdditionalPaymentsForTeaching && lup_teacher_at_lup_school
     end
 
     def lup_teacher_at_lup_school

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -61,18 +61,17 @@ module Journeys
         RESULTS_SLUGS
       ).freeze
 
-      attr_reader :claim, :journey_session
+      attr_reader :journey_session
 
       delegate :answers, to: :journey_session
 
-      def initialize(claim, journey_session)
-        @claim = claim
+      def initialize(journey_session)
         @journey_session = journey_session
       end
 
       def slugs
         SLUGS.dup.tap do |sequence|
-          if !Journeys.for_policy(claim.policy).configuration.teacher_id_enabled?
+          if !Journeys::TeacherStudentLoanReimbursement.configuration.teacher_id_enabled?
             sequence.delete("sign-in-or-continue")
             sequence.delete("reset-claim")
             sequence.delete("qualification-details")
@@ -134,7 +133,7 @@ module Journeys
 
       def personal_details_form
         PersonalDetailsForm.new(
-          claim:,
+          claim: nil,
           journey_session: journey_session,
           journey: Journeys::TeacherStudentLoanReimbursement,
           params: ActionController::Parameters.new

--- a/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
+++ b/spec/features/admin_claim_tasks_update_with_dqt_api_spec.rb
@@ -32,7 +32,6 @@ RSpec.feature "Admin claim tasks update with DQT API" do
       claim.save!
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "check-your-answers",
         journey_session: journey_session
       )

--- a/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
@@ -258,10 +258,6 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
   end
 
   context "with a supplied postcode" do
-    let(:claim) do
-      Claim.by_policy(Policies::EarlyCareerPayments).order(:created_at).last
-    end
-
     let(:journey_session) do
       Journeys::AdditionalPaymentsForTeaching::Session.order(:created_at).last
     end
@@ -269,9 +265,6 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
     before do
       create(:journey_configuration, :additional_payments)
       start_early_career_payments_claim
-
-      claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
-      claim.save!
 
       journey_session.answers.assign_attributes(
         attributes_for(
@@ -287,9 +280,13 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
     end
 
     scenario "with Ordnance Survey API data" do
-      expect(claim.valid?(:submit)).to eq false
+      expect(
+        Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+          journey_session: journey_session
+        ).valid?
+      ).to eq false
+
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "postcode-search",
         journey_session: journey_session
       )
@@ -322,9 +319,12 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
     end
 
     scenario "Claimant cannot find the correct address so chooses to manually enter address" do
-      expect(claim.valid?(:submit)).to eq false
+      expect(
+        Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+          journey_session: journey_session
+        ).valid?
+      ).to eq false
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "postcode-search",
         journey_session: journey_session
       )
@@ -368,9 +368,13 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
 
     # Bugfix - did cause an exception after pressing back
     scenario "Claimant cannot find the correct address so chooses to manually enter address, presses back before filling anything to go to the postcode search again" do
-      expect(claim.valid?(:submit)).to eq false
+      expect(
+        Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+          journey_session: journey_session
+        ).valid?
+      ).to eq false
+
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "postcode-search",
         journey_session: journey_session
       )
@@ -396,9 +400,13 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
     end
 
     scenario "Claimant decides they want to change the POSTCODE from the 'select-home-address' screen" do
-      expect(claim.valid?(:submit)).to eq false
+      expect(
+        Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+          journey_session: journey_session
+        ).valid?
+      ).to eq false
+
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "postcode-search",
         journey_session: journey_session
       )
@@ -468,9 +476,13 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
     end
 
     scenario "Ordanance Survery Client raise a ResponseError" do
-      expect(claim.valid?(:submit)).to eq false
+      expect(
+        Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+          journey_session: journey_session
+        ).valid?
+      ).to eq false
+
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "postcode-search",
         journey_session: journey_session
       )

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   let(:ecp_school) { create(:school, :early_career_payments_eligible) }
 
   scenario "Teacher changes an answer which is not a dependency of any of the other answers they've given, remaining eligible" do
-    claim = start_student_loans_claim
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    start_student_loans_claim
 
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
@@ -23,7 +21,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     session.save!
 
     jump_to_claim_journey_page(
-      claim:,
       journey_session: session,
       slug: "check-your-answers"
     )
@@ -45,7 +42,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "Teacher changes an answer which is not a dependency of any of the other answers they've given, becoming ineligible" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
       attributes_for(
@@ -58,7 +55,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     )
     session.save!
     jump_to_claim_journey_page(
-      claim:,
       slug: "check-your-answers",
       journey_session: session
     )
@@ -77,9 +73,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they've given, remaining eligible" do
-    claim = start_student_loans_claim
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id))
+    start_student_loans_claim
 
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
@@ -88,7 +82,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     session.save!
 
     jump_to_claim_journey_page(
-      claim:,
       slug: "check-your-answers",
       journey_session: session
     )
@@ -128,9 +121,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they've given, making them ineligible" do
-    claim = start_student_loans_claim
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    start_student_loans_claim
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
       attributes_for(
@@ -142,7 +133,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     session.save!
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "check-your-answers",
       journey_session: session
     )
@@ -165,9 +155,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "Teacher edits but does not change an answer which is a dependency of some of the subsequent answers they've given" do
-    claim = start_student_loans_claim
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+    start_student_loans_claim
 
     session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     session.answers.assign_attributes(
@@ -176,7 +164,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     session.save!
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "check-your-answers",
       journey_session: session
     )
@@ -198,7 +185,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "Teacher edits personal details, triggering the update of student loan details" do
-    claim = start_student_loans_claim
+    start_student_loans_claim
     journey_session = Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
 
     journey_session.update!(
@@ -214,7 +201,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     answers = journey_session.answers
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "check-your-answers",
       journey_session: journey_session
     )
@@ -240,16 +226,13 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   context "User changes fields that aren't related to eligibility" do
-    let!(:claim) { start_student_loans_claim }
-    let(:eligibility) { claim.eligibility }
     let(:journey_session) do
       Journeys::TeacherStudentLoanReimbursement::Session.order(:created_at).last
     end
     let(:answers) { journey_session.answers }
 
     before do
-      claim.update!(attributes_for(:claim, :submittable))
-      eligibility.update!(attributes_for(:student_loans_eligibility, :eligible, current_school_id: student_loans_school.id, claim_school_id: student_loans_school.id))
+      start_student_loans_claim
       journey_session.update!(
         answers: attributes_for(
           :student_loans_answers,
@@ -258,7 +241,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
         )
       )
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "check-your-answers",
         journey_session: journey_session
       )
@@ -283,9 +265,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     end
 
     scenario "user can change the answer to identity details" do
-      claim.update!(govuk_verify_fields: [])
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "check-your-answers",
         journey_session: journey_session
       )
@@ -311,7 +291,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     scenario "user can change the answer to payment details" do
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "check-your-answers",
         journey_session: journey_session
       )
@@ -349,16 +328,12 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   describe "Teacher changes a field that requires OTP validation" do
-    let!(:claim) { start_early_career_payments_claim }
-    let(:eligibility) { claim.eligibility }
     let(:session) do
       Journeys::AdditionalPaymentsForTeaching::Session.order(:created_at).last
     end
 
     before do
-      claim.update!(attributes_for(:claim, :submittable))
-      eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible, current_school_id: ecp_school.id))
-      claim.update!(personal_details_attributes)
+      start_early_career_payments_claim
 
       session.answers.assign_attributes(
         attributes_for(
@@ -369,7 +344,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
       session.save!
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "check-your-answers",
         journey_session: session
       )
@@ -399,8 +373,12 @@ RSpec.feature "Changing the answers on a submittable claim" do
         fill_in "claim_one_time_password", with: otp_in_mail_sent
         click_on "Confirm"
 
-        expect(claim.reload.email_verified).to eq true
-        expect(claim.submittable?).to be true
+        expect(session.reload.answers.email_verified).to eq true
+        expect(
+          Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+            journey_session: session
+          )
+        ).to be_valid
         expect(page).to have_content("Check your answers before sending your application")
       end
     end
@@ -453,7 +431,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         expect(page).not_to have_text("Some places are both a bank and a building society")
         expect(session.reload.answers.mobile_verified).to eq true
-        expect(claim.submittable?).to be true
+        expect(
+          Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+            journey_session: session
+          )
+        ).to be_valid
         expect(page).to have_content("Check your answers before sending your application")
       end
     end
@@ -505,7 +487,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         expect(page).not_to have_text("Some places are both a bank and a building society")
         expect(session.reload.answers.mobile_verified).to eq true
-        expect(claim.submittable?).to be true
+        expect(
+          Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm.new(
+            journey_session: session
+          )
+        ).to be_valid
         expect(page).to have_content("Check your answers before sending your application")
       end
     end

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -4,34 +4,29 @@ RSpec.feature "Claim journey does not get cached" do
   before { create(:journey_configuration, :student_loans) }
 
   it "redirects the user to the start of the claim journey if they go back after the claim is completed" do
-    claim = start_student_loans_claim
-    claim.update!(attributes_for(:claim, :submittable))
+    start_student_loans_claim
     journey_session = Journeys::TeacherStudentLoanReimbursement::Session.last
     journey_session.update!(
       answers: attributes_for(:student_loans_answers, :submittable)
     )
-    claim.eligibility = create(:student_loans_eligibility, :eligible)
-    claim.save!
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "check-your-answers",
       journey_session: journey_session
     )
 
-    expect(page).to have_text(claim.first_name)
+    expect(page).to have_text(journey_session.answers.first_name)
 
     click_on "Confirm and send"
 
     expect(current_path).to eq(claim_confirmation_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME))
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "check-your-answers",
       journey_session: journey_session
     )
 
-    expect(page).to_not have_text(claim.first_name)
+    expect(page).to_not have_text(journey_session.answers.first_name)
     expect(page).to have_text("Use DfE Identity to sign in")
   end
 end

--- a/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
+++ b/spec/features/early_career_payments_eligible_now_reminder_set_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Eligible now can set a reminder for next year." do
   let(:school) { create(:school, :early_career_payments_eligible, :levelling_up_premium_payments_eligible) }
 
   it "auto-sets a reminders email and name from claim params and displays the correct year" do
-    claim = start_early_career_payments_claim
+    start_early_career_payments_claim
     reminder_year = (academic_year + 1).start_year
 
     session = Journeys::AdditionalPaymentsForTeaching::Session.last
@@ -22,11 +22,10 @@ RSpec.feature "Eligible now can set a reminder for next year." do
     session.save!
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "check-your-answers",
       journey_session: session
     )
-    expect(page).to have_text(claim.first_name)
+    expect(page).to have_text(session.answers.first_name)
     click_on "Accept and send"
     expect(page).to have_text("Set a reminder to apply next year")
     click_on "Set reminder"
@@ -75,7 +74,7 @@ RSpec.feature "Completed Applications - Reminders" do
       policy[:eligible_now].each do |scenario|
         reminder_status = (scenario[:invited_to_set_reminder] == true) ? "CAN" : "CANNOT"
         scenario "with cohort ITT subject #{scenario[:itt_subject]} in ITT academic year #{scenario[:itt_academic_year]} - a reminder #{reminder_status} be set" do
-          claim = start_early_career_payments_claim
+          start_early_career_payments_claim
           reminder_year = (academic_year + 1).start_year
 
           session = Journeys::AdditionalPaymentsForTeaching::Session.last
@@ -92,7 +91,6 @@ RSpec.feature "Completed Applications - Reminders" do
           session.save!
 
           jump_to_claim_journey_page(
-            claim: claim,
             slug: "check-your-answers",
             journey_session: session
           )

--- a/spec/features/ineligible_early_career_payments_in_2022_and_future_years_spec.rb
+++ b/spec/features/ineligible_early_career_payments_in_2022_and_future_years_spec.rb
@@ -33,17 +33,10 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims by cohort" do
 
         start_early_career_payments_claim
 
-        eligibility_attrs = attributes_for(:early_career_payments_eligibility, :ineligible_feature)
-        claim.eligibility.update!(eligibility_attrs)
-
         journey_session.answers.assign_attributes(
           qualification: "postgraduate_itt"
         )
         journey_session.save!
-      end
-
-      let(:claim) do
-        Claim.by_policy(Policies::EarlyCareerPayments).order(:created_at).last
       end
 
       let(:journey_session) do
@@ -53,7 +46,6 @@ RSpec.feature "Ineligible Teacher Early-Career Payments claims by cohort" do
       policy[:ineligible_cohorts].each do |scenario|
         scenario "with cohort ITT subject #{scenario[:itt_subject]} in ITT academic year #{scenario[:itt_academic_year]}" do
           jump_to_claim_journey_page(
-            claim: claim,
             slug: "itt-year",
             journey_session: journey_session
           )

--- a/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
+++ b/spec/features/levelling_up_premium_payments_content_change_logic_spec.rb
@@ -1,25 +1,19 @@
 require "rails_helper"
 
 RSpec.feature "Claims with different eligibilities content change logic" do
-  let(:claim) { start_early_career_payments_claim }
-  let(:journey_session) do
-    Journeys::AdditionalPaymentsForTeaching::Session.last
-  end
-
   before do
     create(:journey_configuration, :additional_payments, current_academic_year: AcademicYear.new(2022))
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    start_early_career_payments_claim
+    journey_session = Journeys::AdditionalPaymentsForTeaching::Session.last
     journey_session.answers.assign_attributes(qualification: "postgraduate_itt")
     journey_session.save!
-  end
-
-  it "shows the correct subjects for LUP-only and ECP claims" do
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "itt-year",
       journey_session: journey_session
     )
+  end
+
+  it "shows the correct subjects for LUP-only and ECP claims" do
     choose "2017 to 2018"
     click_on "Continue"
     expected_subjects = ["Chemistry", "Computing", "Mathematics", "Physics", "None of the above"]

--- a/spec/features/one_time_password_spec.rb
+++ b/spec/features/one_time_password_spec.rb
@@ -3,13 +3,10 @@ require "rails_helper"
 RSpec.feature "Given a one time password" do
   let!(:drift) { OneTimePassword::Base::DRIFT }
 
-  let(:claim) { start_early_career_payments_claim }
-
   before do
     create(:journey_configuration, :additional_payments)
-    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    start_early_career_payments_claim
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "email-address",
       journey_session: Journeys::AdditionalPaymentsForTeaching::Session.last
     )

--- a/spec/features/subject_teaching_question_spec.rb
+++ b/spec/features/subject_teaching_question_spec.rb
@@ -1,14 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
-  let(:claim) { start_early_career_payments_claim }
   let(:journey_session) { Journeys::AdditionalPaymentsForTeaching::Session.last }
 
   before { create(:journey_configuration, :additional_payments, current_academic_year: AcademicYear.new(2022)) }
 
   before do
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible, :eligible_school_ecp_and_lup))
+    start_early_career_payments_claim
     journey_session.answers.assign_attributes(
       attributes_for(
         :additional_payments_answers,
@@ -23,7 +21,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
   context "when ECP and LUP eligible" do
     it "has the correct subjects" do
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "nqt-in-academic-year-after-itt",
         journey_session: journey_session
       )
@@ -31,7 +28,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "itt-year",
         journey_session: journey_session
       )
@@ -39,7 +35,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "eligible-itt-subject",
         journey_session: journey_session
       )
@@ -47,7 +42,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "teaching-subject-now",
         journey_session: journey_session
       )
@@ -61,7 +55,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
   context "when eligible only for ECP" do
     it "has the correct subjects" do
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "nqt-in-academic-year-after-itt",
         journey_session: journey_session
       )
@@ -69,7 +62,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "itt-year",
         journey_session: journey_session
       )
@@ -77,7 +69,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "eligible-itt-subject",
         journey_session: journey_session
       )
@@ -85,7 +76,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
       click_on "Continue"
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "teaching-subject-now",
         journey_session: journey_session
       )
@@ -95,7 +85,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
 
   context "when eligible only for LUP" do
     before do
-      claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :ineligible))
       journey_session.answers.assign_attributes(
         attributes_for(
           :additional_payments_answers,
@@ -108,7 +97,6 @@ RSpec.feature "Resetting dependant attributes when the claim is ineligible" do
 
     it "has the correct subjects" do
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "teaching-subject-now",
         journey_session: journey_session
       )

--- a/spec/features/validating_user_contact_details_spec.rb
+++ b/spec/features/validating_user_contact_details_spec.rb
@@ -4,9 +4,7 @@ RSpec.feature "Confirming Claimant Contact details" do
   before { create(:journey_configuration, :additional_payments) }
 
   it "redirects to 'email-address' if 'Change email address' is clicked on the One Time Password page" do
-    claim = start_early_career_payments_claim
-    claim.update!(attributes_for(:claim, :submittable))
-    claim.eligibility.update!(attributes_for(:early_career_payments_eligibility, :eligible))
+    start_early_career_payments_claim
 
     journey_session = Journeys::AdditionalPaymentsForTeaching::Session.last
     journey_session.answers.assign_attributes(
@@ -27,7 +25,6 @@ RSpec.feature "Confirming Claimant Contact details" do
     )
 
     jump_to_claim_journey_page(
-      claim: claim,
       slug: "email-verification",
       journey_session: journey_session
     )

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -14,7 +14,7 @@ module Journeys
     I18N_NAMESPACE = "test_i18n_ns"
 
     class SlugSequence
-      def initialize(claim, journey_session)
+      def initialize(journey_session)
         # NOOP
       end
     end

--- a/spec/models/journeys/additional_payments_for_teaching_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching_spec.rb
@@ -36,15 +36,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching do
   describe ".page_sequence_for_claim" do
     let(:completed_slugs) { [:test] }
     let(:current_slug) { [:test2] }
-    let(:current_claim) do
-      claims = Journeys::AdditionalPaymentsForTeaching::POLICIES.map { |policy| create(:claim, policy: policy) }
-      CurrentClaim.new(claims: claims)
-    end
     let(:journey_session) { build(:additional_payments_session) }
 
     subject(:page_sequence) do
       described_class.page_sequence_for_claim(
-        current_claim,
         journey_session,
         completed_slugs,
         current_slug
@@ -60,7 +55,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching do
 
     it "creates a slug sequence" do
       expect(Journeys::AdditionalPaymentsForTeaching::SlugSequence).to(
-        receive(:new).with(current_claim, journey_session)
+        receive(:new).with(journey_session)
       )
       page_sequence
     end

--- a/spec/models/journeys/additional_payments_for_teaching_spec.rb
+++ b/spec/models/journeys/additional_payments_for_teaching_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching do
     it { is_expected.to be_a(Journeys::PageSequence) }
 
     it "populates the page sequence attributes" do
-      expect(page_sequence.claim).to eq(current_claim)
       expect(page_sequence.current_slug).to eq(current_slug)
       expect(page_sequence.completed_slugs).to eq(completed_slugs)
     end

--- a/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
@@ -37,11 +37,9 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement do
     let(:completed_slugs) { [:test] }
     let(:current_slug) { [:test2] }
     let(:journey_session) { build(:student_loans_session) }
-    let(:claim) { double }
 
     subject(:page_sequence) do
       described_class.page_sequence_for_claim(
-        claim,
         journey_session,
         completed_slugs,
         current_slug
@@ -57,7 +55,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement do
 
     it "creates a slug sequence" do
       expect(Journeys::TeacherStudentLoanReimbursement::SlugSequence).to(
-        receive(:new).with(claim, journey_session)
+        receive(:new).with(journey_session)
       )
 
       page_sequence

--- a/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
+++ b/spec/models/journeys/teacher_student_loan_reimbursement_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement do
     it { is_expected.to be_a(Journeys::PageSequence) }
 
     it "populates the page sequence attributes" do
-      expect(page_sequence.claim).to eq(claim)
       expect(page_sequence.current_slug).to eq(current_slug)
       expect(page_sequence.completed_slugs).to eq(completed_slugs)
     end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Claim session timing out", type: :request do
   let(:timeout_length_in_minutes) { BasePublicController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES }
-  let(:current_claim) { CurrentClaim.new(claims: [Claim.by_policy(Policies::StudentLoans).order(:created_at).last]) }
+  let(:journey_session) do
+    Journeys::TeacherStudentLoanReimbursement::Session.last
+  end
+
   before { create(:journey_configuration, :student_loans) }
 
   context "no actions performed for more than the timeout period" do
@@ -13,7 +16,9 @@ RSpec.describe "Claim session timing out", type: :request do
     let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
 
     it "clears the session and redirects to the timeout page" do
-      expect(session[:claim_id]).to eql current_claim.claim_ids
+      expect(
+        session[:"student-loans_journeys_session_id"]
+      ).to eq journey_session.id
 
       travel after_expiry do
         put claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "qts-year"), params: {claim: {qts_award_year: "on_or_after_cut_off_date"}}
@@ -27,7 +32,7 @@ RSpec.describe "Claim session timing out", type: :request do
   context "no action performed just within the timeout period" do
     before do
       start_student_loans_claim
-      set_slug_sequence_in_session(current_claim, "qts-year")
+      set_slug_sequence_in_session(journey_session, "qts-year")
     end
 
     let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }

--- a/spec/support/eligible_later_shared_examples.rb
+++ b/spec/support/eligible_later_shared_examples.rb
@@ -30,7 +30,6 @@ RSpec.shared_examples "Eligible later" do |opts|
       journey_session.save!
 
       jump_to_claim_journey_page(
-        claim: claim,
         slug: "check-your-answers-part-one",
         journey_session: journey_session
       )

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -121,15 +121,15 @@ module FeatureHelpers
   # is to spoof the session's record of visited pages in the journey.
   #
   # TODO: refactor all old feature specs which use this method
-  def jump_to_claim_journey_page(claim:, journey_session:, slug:)
-    set_slug_sequence_in_session(claim:, journey_session:, slug:)
-    visit claim_path(Journeys.for_policy(claim.policy)::ROUTING_NAME, slug)
+  def jump_to_claim_journey_page(journey_session:, slug:)
+    set_slug_sequence_in_session(journey_session:, slug:)
+    journey = Journeys.for_routing_name(journey_session.journey)
+    visit claim_path(journey::ROUTING_NAME, slug)
   end
 
-  def set_slug_sequence_in_session(claim:, journey_session:, slug:)
-    current_claim = CurrentClaim.new(claims: [claim])
-    journey = Journeys.for_policy(claim.policy)
-    slug_sequence = journey.slug_sequence.new(current_claim, journey_session).slugs
+  def set_slug_sequence_in_session(journey_session:, slug:)
+    journey = Journeys.for_routing_name(journey_session.journey)
+    slug_sequence = journey.slug_sequence.new(journey_session).slugs
     slug_index = slug_sequence.index(slug)
     visited_slugs = slug_sequence.slice(0, slug_index)
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -27,11 +27,9 @@ module RequestHelpers
     follow_redirect!
   end
 
-  def set_slug_sequence_in_session(claim, slug)
-    current_claim = CurrentClaim.new(claims: [claim])
-    journey = Journeys.for_policy(claim.policy)
-    journey_session = build(:"#{journey::I18N_NAMESPACE}_session")
-    slug_sequence = journey.slug_sequence.new(current_claim, journey_session).slugs
+  def set_slug_sequence_in_session(journey_session, slug)
+    journey = Journeys.for_routing_name(journey_session.journey)
+    slug_sequence = journey.slug_sequence.new(journey_session).slugs
     slug_index = slug_sequence.index(slug)
     visited_slugs = slug_sequence.slice(0, slug_index)
 


### PR DESCRIPTION
Removes references to the claim from the page sequence (first commit) and slug
sequence (second commit)
