### PR TITLE
Remove unused methods

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -61,16 +61,6 @@ class Form
     self.class.name.demodulize.gsub("Form", "").underscore
   end
 
-  def page_sequence
-    @page_sequence ||= Journeys::PageSequence.new(
-      claim,
-      journey.slug_sequence.new(claim, journey_session),
-      nil,
-      params[:slug],
-      journey_session
-    )
-  end
-
   def attributes_with_current_value
     attributes.each_with_object({}) do |(attribute, _), attributes|
       attributes[attribute] = permitted_params[attribute]

--- a/app/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form.rb
@@ -21,16 +21,6 @@ module Journeys
         end
       end
 
-      def backlink_path
-        return unless page_sequence.in_sequence?("correct-school")
-
-        Rails
-          .application
-          .routes
-          .url_helpers
-          .claim_path(params[:journey], "correct-school")
-      end
-
       private
 
       def determine_induction_answer_from_dqt_record


### PR DESCRIPTION
Looks like these methods weren't cleaned up when how we handle back
links was changed
Backlinks are now set by https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/app/controllers/claims_form_callbacks.rb