### PR TITLE
Move backlink out of main

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,13 +90,14 @@
         </p>
       </div>
 
+      <%= render 'shared/backlink'%>
+
       <main class="govuk-main-wrapper app-main-class" id="main-content">
         <% flash.each do |name, msg| %>
           <div class="govuk-body-l govuk-flash__<%= name %>">
             <%= msg %>
           </div>
         <% end %>
-        <%= render 'shared/backlink'%>
         <%= yield %>
       </main>
     </div>


### PR DESCRIPTION
# Context

- My understanding is that the backlink should not be within `<main>` and should sit before it
- See https://design-system.service.gov.uk/styles/page-template/
- Incidentally this also fixes the fact that is no longer oddly located

# Screenshots

## Before

![Screenshot 2024-06-14 at 12 55 10](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/6c7ef6de-b0dc-4957-881e-90e708168913)

## After

![Screenshot 2024-06-14 at 12 54 32](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/32c058d0-a470-47c3-993b-cde75ed8416c)