### PR TITLE
Remove claim as a form argument

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -14,10 +14,6 @@ class ClaimsController < BasePublicController
   include FormSubmittable
   include ClaimsFormCallbacks
 
-  def current_data_object
-    current_claim
-  end
-
   def timeout
   end
 

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -46,12 +46,6 @@ module FormSubmittable
     before_action :load_form_if_exists, only: [:show, :update, :create]
     around_action :handle_form_submission, only: [:update, :create]
 
-    def current_data_object
-      # This is the instance of the main resource handled by the form object,
-      # and should always be defined in the controller.
-      nil
-    end
-
     def new
       redirect_to_first_slug
     end
@@ -171,7 +165,7 @@ module FormSubmittable
     end
 
     def load_form_if_exists
-      @form ||= journey.form(claim: current_data_object, journey_session:, params:)
+      @form ||= journey.form(journey_session:, params:)
     end
   end
 end

--- a/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
+++ b/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
@@ -11,11 +11,10 @@ module Journeys
 
       private
 
-      # FIXME RL: Remove this once reminders are writing to the session
       def load_form_if_exists
         @form ||= AdditionalPaymentsForTeaching::FORMS.dig(
           "reminders", params[:slug]
-        )&.new(claim: current_reminder, journey: Journeys::AdditionalPaymentsForTeaching, journey_session:, params:)
+        )&.new(reminder: current_reminder, journey: Journeys::AdditionalPaymentsForTeaching, journey_session:, params:)
       end
 
       def claim_from_session

--- a/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
+++ b/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
@@ -11,9 +11,11 @@ module Journeys
 
       private
 
-      # Wrapping `current_reminder` with an abstract method that is fed to the form object.
-      def current_data_object
-        current_reminder
+      # FIXME RL: Remove this once reminders are writing to the session
+      def load_form_if_exists
+        @form ||= AdditionalPaymentsForTeaching::FORMS.dig(
+          "reminders", params[:slug]
+        )&.new(claim: current_reminder, journey: Journeys::AdditionalPaymentsForTeaching, journey_session:, params:)
       end
 
       def claim_from_session

--- a/app/forms/current_school_form.rb
+++ b/app/forms/current_school_form.rb
@@ -6,7 +6,7 @@ class CurrentSchoolForm < Form
   validates :current_school_id, presence: {message: i18n_error_message(:select_the_school_you_teach_at)}
   validate :current_school_must_be_open, if: -> { current_school_id.present? }
 
-  def initialize(claim:, journey_session:, journey:, params:)
+  def initialize(journey_session:, journey:, params:)
     super
 
     load_schools

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -4,7 +4,6 @@ class Form
   include ActiveModel::Serialization
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :claim
   attr_accessor :journey
   attr_accessor :journey_session
   attr_accessor :params
@@ -20,14 +19,10 @@ class Form
   end
 
   # TODO RL: remove journey param and pull it from the journey_session
-  def initialize(claim:, journey_session:, journey:, params:)
+  def initialize(journey_session:, journey:, params:)
     super
 
     assign_attributes(attributes_with_current_value)
-  end
-
-  def update!(attrs)
-    claim.update!(attrs)
   end
 
   def view_path

--- a/app/forms/journeys/additional_payments_for_teaching/correct_school_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/correct_school_form.rb
@@ -19,7 +19,7 @@ module Journeys
       private
 
       def current_school
-        @current_school ||= journey_session.recent_tps_school || claim.school
+        @current_school ||= journey_session.recent_tps_school || answers.current_school
       end
 
       def change_school?

--- a/app/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form.rb
@@ -44,7 +44,6 @@ module Journeys
         QualificationForm.new(
           journey: journey,
           journey_session: journey_session,
-          claim: claim,
           params: ActionController::Parameters.new(
             claim: {
               qualification: :postgraduate_itt

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
@@ -6,7 +6,7 @@ module Journeys
         attribute :sent_one_time_password_at
 
         # Required for shared partial in the view
-        delegate :email_address, to: :claim
+        delegate :email_address, to: :answers
 
         validate :sent_one_time_password_must_be_valid
         validate :otp_must_be_valid, if: :sent_one_time_password_at?
@@ -19,26 +19,19 @@ module Journeys
           self.one_time_password = one_time_password.gsub(/\D/, "")
         end
 
-        # TODO RL: remove this and the initializer once reminders are writing
-        # to the session
-        attr_reader :claim
+        attr_reader :reminder
 
-        def initialize(claim:, journey_session:, journey:, params:)
-          @claim = claim
+        def initialize(reminder:, journey_session:, journey:, params:)
+          @reminder = reminder
           super(journey_session:, journey:, params:)
 
           assign_attributes(attributes_with_current_value)
         end
 
-        # TODO RL: remove this once reminders are writing to the session
-        def update!(attrs)
-          claim.update!(attrs)
-        end
-
         def save
           return false unless valid?
 
-          update!(email_verified: true)
+          reminder.update!(email_verified: true)
         end
 
         private
@@ -65,19 +58,7 @@ module Journeys
         end
 
         def load_current_value(attribute)
-          # TODO: re-implement when the underlying claim and eligibility data sources
-          # are moved to an alternative place e.g. a session hash
-
-          # Some, but not all attributes are present directly on the claim record.
-          return claim.public_send(attribute) if claim.has_attribute?(attribute)
-
-          # At the moment, some attributes are unique to a policy eligibility record,
-          # so we need to loop through all the claims in the wrapper and check each
-          # eligibility individually; if the search fails, it should return `nil`.
-          claim.claims.each do |c|
-            return c.eligibility.public_send(attribute) if c.eligibility.has_attribute?(attribute)
-          end
-          nil
+          reminder.public_send(attribute) if reminder.has_attribute?(attribute)
         end
       end
     end

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
@@ -19,6 +19,22 @@ module Journeys
           self.one_time_password = one_time_password.gsub(/\D/, "")
         end
 
+        # TODO RL: remove this and the initializer once reminders are writing
+        # to the session
+        attr_reader :claim
+
+        def initialize(claim:, journey_session:, journey:, params:)
+          @claim = claim
+          super(journey_session:, journey:, params:)
+
+          assign_attributes(attributes_with_current_value)
+        end
+
+        # TODO RL: remove this once reminders are writing to the session
+        def update!(attrs)
+          claim.update!(attrs)
+        end
+
         def save
           return false unless valid?
 

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form.rb
@@ -16,26 +16,19 @@ module Journeys
           ActiveModel::Name.new(Form)
         end
 
-        # TODO RL: remove this and the initializer once reminders are writing
-        # to the session
-        attr_reader :claim
+        attr_reader :reminder
 
-        def initialize(claim:, journey_session:, journey:, params:)
-          @claim = claim
+        def initialize(reminder:, journey_session:, journey:, params:)
+          @reminder = reminder
           super(journey_session:, journey:, params:)
 
           assign_attributes(attributes_with_current_value)
         end
 
-        # TODO RL: remove this once reminders are writing to the session
-        def update!(attrs)
-          claim.update!(attrs)
-        end
-
         def save
           return false unless valid?
 
-          update!(attributes)
+          reminder.update!(attributes)
         end
 
         private
@@ -45,19 +38,7 @@ module Journeys
         end
 
         def load_current_value(attribute)
-          # TODO: re-implement when the underlying claim and eligibility data sources
-          # are moved to an alternative place e.g. a session hash
-
-          # Some, but not all attributes are present directly on the claim record.
-          return claim.public_send(attribute) if claim.has_attribute?(attribute)
-
-          # At the moment, some attributes are unique to a policy eligibility record,
-          # so we need to loop through all the claims in the wrapper and check each
-          # eligibility individually; if the search fails, it should return `nil`.
-          claim.claims.each do |c|
-            return c.eligibility.public_send(attribute) if c.eligibility.has_attribute?(attribute)
-          end
-          nil
+          reminder.public_send(attribute) if reminder.has_attribute?(attribute)
         end
       end
     end

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form.rb
@@ -16,6 +16,22 @@ module Journeys
           ActiveModel::Name.new(Form)
         end
 
+        # TODO RL: remove this and the initializer once reminders are writing
+        # to the session
+        attr_reader :claim
+
+        def initialize(claim:, journey_session:, journey:, params:)
+          @claim = claim
+          super(journey_session:, journey:, params:)
+
+          assign_attributes(attributes_with_current_value)
+        end
+
+        # TODO RL: remove this once reminders are writing to the session
+        def update!(attrs)
+          claim.update!(attrs)
+        end
+
         def save
           return false unless valid?
 

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -8,7 +8,7 @@ module Journeys
       validates :claim_school_id, presence: {message: i18n_error_message(:select_a_school)}
       validate :claim_school_must_exist, if: -> { claim_school_id.present? }
 
-      def initialize(claim:, journey_session:, journey:, params:)
+      def initialize(journey_session:, journey:, params:)
         super
 
         load_schools

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -40,7 +40,7 @@ class PersonalDetailsForm < Form
   validates :national_insurance_number, presence: {message: "Enter a National Insurance number in the correct format"}
   validate :ni_number_is_correct_format
 
-  def initialize(claim:, journey_session:, journey:, params:)
+  def initialize(journey_session:, journey:, params:)
     super
     assign_date_attributes
   end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -176,11 +176,7 @@ module Journeys
       private
 
       def personal_details_form
-        # FIXME RL: forms expect a claim argument even thought they don't use it
-        # this will be removed as part of no longer creating a claim at the
-        # start of the journey work
         PersonalDetailsForm.new(
-          claim: nil,
           journey_session: journey_session,
           journey: Journeys::AdditionalPaymentsForTeaching,
           params: ActionController::Parameters.new

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -35,10 +35,10 @@ module Journeys
       self::SlugSequence
     end
 
-    def form(claim:, journey_session:, params:)
+    def form(journey_session:, params:)
       form = SHARED_FORMS.deep_merge(forms).dig(params[:controller].split("/").last, params[:slug])
 
-      form&.new(journey: self, journey_session:, claim:, params:)
+      form&.new(journey: self, journey_session:, params:)
     end
 
     def forms

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -133,7 +133,6 @@ module Journeys
 
       def personal_details_form
         PersonalDetailsForm.new(
-          claim: nil,
           journey_session: journey_session,
           journey: Journeys::TeacherStudentLoanReimbursement,
           params: ActionController::Parameters.new

--- a/app/views/additional_payments/claims/eligible_itt_subject.html.erb
+++ b/app/views/additional_payments/claims/eligible_itt_subject.html.erb
@@ -21,7 +21,7 @@
     <% end %>
 
     <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
-      <%= form_group_tag f.object.claim do %>
+      <%= form_group_tag f.object do %>
 
         <%= f.hidden_field :eligible_itt_subject %>
 

--- a/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
+++ b/app/views/additional_payments/claims/nqt_in_academic_year_after_itt.html.erb
@@ -13,7 +13,7 @@
         ) %>
       <% end %>
 
-      <%= form_group_tag f.object.claim do %>
+      <%= form_group_tag f.object do %>
 
         <%= f.hidden_field :nqt_in_academic_year_after_itt %>
 

--- a/app/views/additional_payments/claims/qualification_details.html.erb
+++ b/app/views/additional_payments/claims/qualification_details.html.erb
@@ -69,7 +69,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t("questions.details_correct") %></legend>
 
-        <%= errors_tag f.object.claim, :qualifications_details_check %>
+        <%= errors_tag f.object, :qualifications_details_check %>
 
         <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
           <div class="govuk-radios__item">

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { payroll_gender: "claim_payroll_gender_female" }) if @form.errors.any? %>
     <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
-      <%= form_group_tag @form.claim do %>
+      <%= form_group_tag @form do %>
         <fieldset class="govuk-fieldset" aria-describedby="payroll_gender-hint" role="group">
 
           <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">

--- a/app/views/claims/mobile_number.html.erb
+++ b/app/views/claims/mobile_number.html.erb
@@ -13,7 +13,7 @@
 
     <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
       <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
-      <%= form_group_tag f.object.claim do %>
+      <%= form_group_tag f.object do %>
         <h1 class="govuk-label-wrapper">
           <%= f.label(
             :mobile_number,
@@ -31,7 +31,7 @@
         <%= f.text_field(
           :mobile_number,
           spellcheck: "false",
-          class: css_classes_for_input(f.object.claim, :mobile_number),
+          class: css_classes_for_input(f.object, :mobile_number),
           "aria-describedby" => "mobile-number-hint"
         ) %>
 

--- a/app/views/claims/select_mobile.html.erb
+++ b/app/views/claims/select_mobile.html.erb
@@ -20,7 +20,7 @@
     <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
 
       <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
-      <%= form_group_tag f.object.claim do %>
+      <%= form_group_tag f.object do %>
 
         <fieldset class="govuk-fieldset" aria-describedby="phone-number-hint">
 

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -32,7 +32,7 @@
             :teacher_reference_number,
             spellcheck: "false",
             autocomplete: "off",
-            class: css_classes_for_input(f.object.claim, :teacher_reference_number, 'govuk-input--width-10'),
+            class: css_classes_for_input(f.object, :teacher_reference_number, 'govuk-input--width-10'),
             "aria-describedby" => "teacher_reference_number-hint"
           ) %>
         </div>

--- a/app/views/student_loans/claims/qualification_details.html.erb
+++ b/app/views/student_loans/claims/qualification_details.html.erb
@@ -34,7 +34,7 @@
 
   <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
     <%= f.hidden_field :qualifications_details_check %>
-    <%= form_group_tag f.object.claim do %>
+    <%= form_group_tag f.object do %>
 
     <div class="govuk-radios">
       <fieldset class="govuk-fieldset">

--- a/app/views/student_loans/claims/still_teaching.html.erb
+++ b/app/views/student_loans/claims/still_teaching.html.erb
@@ -16,7 +16,7 @@
           <div class="govuk-radios">
             <%= form.hidden_field :employment_status %>
 
-            <%= render partial: "still_teaching_with_#{@form.tps_or_claim_school}", locals: { current_claim: @form.claim, form: form, school: @form.school }  %>
+            <%= render partial: "still_teaching_with_#{@form.tps_or_claim_school}", locals: { form: form, school: @form.school }  %>
           </div>
         </fieldset>
       <% end %>

--- a/spec/forms/address_form_spec.rb
+++ b/spec/forms/address_form_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe AddressForm, type: :model do
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey: journey,
       params: params,
       journey_session: journey_session
@@ -102,10 +101,6 @@ RSpec.describe AddressForm, type: :model do
   end
 
   describe "#save" do
-    before do
-      allow(form).to receive(:update!)
-    end
-
     context "valid params" do
       context "all required address lines provided" do
         before { form.save }

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe BankDetailsForm do
 
     subject(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: ActionController::Parameters.new(slug:, claim: params)

--- a/spec/forms/bank_or_building_society_form_spec.rb
+++ b/spec/forms/bank_or_building_society_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe BankOrBuildingSocietyForm, type: :model do
 
     subject(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: ActionController::Parameters.new({slug:, claim: claim_params})

--- a/spec/forms/current_school_form_spec.rb
+++ b/spec/forms/current_school_form_spec.rb
@@ -7,18 +7,12 @@ RSpec.describe CurrentSchoolForm do
       create(:journey_configuration, :additional_payments)
     }
 
-    let(:current_claim) do
-      claims = journey::POLICIES.map { |policy| create(:claim, policy: policy) }
-      CurrentClaim.new(claims: claims)
-    end
-
     let(:journey_session) { create(:"#{journey::I18N_NAMESPACE}_session") }
 
     let(:slug) { "current-school" }
 
     subject(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: params

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 RSpec.describe EmailAddressForm do
   shared_examples "email_address_form" do |journey|
-    let(:claims) do
-      journey::POLICIES.map { |policy| create(:claim, policy: policy) }
-    end
-
     let(:journey_session) do
       create(
         :"#{journey::I18N_NAMESPACE}_session",
@@ -28,7 +24,6 @@ RSpec.describe EmailAddressForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: current_claim,
         params: params
       )
     end

--- a/spec/forms/email_verification_form_spec.rb
+++ b/spec/forms/email_verification_form_spec.rb
@@ -2,12 +2,6 @@ require "rails_helper"
 
 RSpec.describe EmailVerificationForm do
   shared_examples "email_verification" do |journey|
-    let(:claims) do
-      journey::POLICIES.map { |policy| create(:claim, policy: policy) }
-    end
-
-    let(:current_claim) { CurrentClaim.new(claims: claims) }
-
     let(:params) do
       ActionController::Parameters.new(
         claim: {
@@ -29,7 +23,6 @@ RSpec.describe EmailVerificationForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: current_claim,
         params: params
       )
     end

--- a/spec/forms/employed_directly_form_spec.rb
+++ b/spec/forms/employed_directly_form_spec.rb
@@ -7,16 +7,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EmployedDirectlyForm do
 
   let(:journey_session) { create(:additional_payments_session) }
 
-  let(:current_claim) do
-    claims = journey::POLICIES.map { |policy| create(:claim, policy:) }
-    CurrentClaim.new(claims:)
-  end
-
   let(:slug) { "employed-directly" }
 
   subject(:form) do
     described_class.new(
-      claim: current_claim,
       journey_session:,
       journey:,
       params:

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -40,10 +40,8 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  subject(:form) { TestSlugForm.new(claim:, journey:, journey_session:, params:) }
+  subject(:form) { TestSlugForm.new(journey:, journey_session:, params:) }
 
-  let(:claim) { CurrentClaim.new(claims:) }
-  let(:claims) { [build(:claim, policy: Policies::StudentLoans)] }
   let(:journey) { Journeys::TestJourney }
   let(:journey_session) { build(:student_loans_session) }
   let(:params) { ActionController::Parameters.new({journey: "test-journey", slug: "test_slug", claim: claim_params}) }
@@ -132,25 +130,6 @@ RSpec.describe Form, type: :model do
 
   describe "#persisted?" do
     it { expect(form.persisted?).to eq(true) }
-  end
-
-  describe "#update!" do
-    context "when successful" do
-      it "updates the claim" do
-        expect { form.update!(first_name: "test-name") }
-          .to change { claim.first_name }.to("test-name")
-      end
-    end
-
-    context "when an error occurrs" do
-      before do
-        allow(claim).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
-      end
-
-      it "does not update the claim" do
-        expect { form.update!(first_name: "test-name") }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
   end
 
   describe "#view_path" do

--- a/spec/forms/gender_form_spec.rb
+++ b/spec/forms/gender_form_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe GenderForm do
 
     subject(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: params

--- a/spec/forms/journeys/additional_payments_for_teaching/correct_school_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/correct_school_form_spec.rb
@@ -12,11 +12,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::CorrectSchoolForm, type:
   describe "#save" do
     subject(:save) { form.save }
 
-    let(:claim) { CurrentClaim.new(claims: [create(:claim, policy: Policies::LevellingUpPremiumPayments)]) }
     let(:journey) { Journeys::AdditionalPaymentsForTeaching }
     let(:journey_session) { create(:additional_payments_session) }
     let(:params) { ActionController::Parameters.new }
-    let(:form) { described_class.new(claim:, journey:, journey_session:, params:) }
+    let(:form) { described_class.new(journey:, journey_session:, params:) }
     let!(:school) { create(:school, :eligible_for_journey, journey:) }
 
     context "when choosing a school" do

--- a/spec/forms/journeys/additional_payments_for_teaching/eligibility_confirmed_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligibility_confirmed_form_spec.rb
@@ -3,13 +3,10 @@ require "rails_helper"
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibilityConfirmedForm, type: :model do
   before { create(:journey_configuration, :additional_payments) }
 
-  subject(:form) { described_class.new(claim:, journey:, journey_session:, params:) }
+  subject(:form) { described_class.new(journey:, journey_session:, params:) }
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
   let(:journey_session) { create(:additional_payments_session, answers: answers) }
-  let(:ecp_claim) { create(:claim, :eligible, policy: Policies::EarlyCareerPayments) }
-  let(:lupp_claim) { create(:claim, :eligible, policy: Policies::LevellingUpPremiumPayments) }
-  let(:claim) { CurrentClaim.new(claims: [ecp_claim, lupp_claim]) }
   let(:slug) { "eligibility-confirmed" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }
   let(:claim_params) { {selected_claim_policy: "EarlyCareerPayments"} }
@@ -63,8 +60,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibilityConfirmedForm
 
   describe "#single_choice_only?" do
     context "when eligible for one policy only" do
-      let(:ecp_claim) { create(:claim, :ineligible, policy: Policies::EarlyCareerPayments) }
-      let(:lupp_claim) { create(:claim, :eligible, policy: Policies::LevellingUpPremiumPayments) }
       let(:answers) do
         build(
           :additional_payments_answers,
@@ -77,8 +72,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibilityConfirmedForm
     end
 
     context "when eligible for more than one policy" do
-      let(:ecp_claim) { create(:claim, :eligible, policy: Policies::EarlyCareerPayments) }
-      let(:lupp_claim) { create(:claim, :eligible, policy: Policies::LevellingUpPremiumPayments) }
       let(:answers) do
         build(:additional_payments_answers, :ecp_and_lup_eligible)
       end

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_degree_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_degree_subject_form_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleDegreeSubjectForm do
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey_session:,
       journey:,
       params:

--- a/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/eligible_itt_subject_form_spec.rb
@@ -31,45 +31,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
 
   let(:itt_academic_year) { AcademicYear.new(2020) }
 
-  let(:ecp_trainee_teacher_eligibility) do
-    create(
-      :early_career_payments_eligibility,
-      :trainee_teacher
-    )
-  end
-
-  let(:ecp_trainee_teacher_claim) do
-    create(
-      :claim,
-      :first_lup_claim_year,
-      policy: Policies::EarlyCareerPayments,
-      eligibility: ecp_trainee_teacher_eligibility
-    )
-  end
-
-  let(:ecp_qualified_teacher_eligibility) do
-    create(
-      :early_career_payments_eligibility,
-      :eligible_now,
-      :sufficient_teaching
-    )
-  end
-
-  let(:ecp_qualified_teacher_claim) do
-    create(
-      :claim,
-      policy: Policies::EarlyCareerPayments,
-      eligibility: ecp_qualified_teacher_eligibility
-    )
-  end
-
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
-
   let(:form) do
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
       params: params
     )
   end
@@ -77,7 +42,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
   describe "validations" do
     subject { form }
 
-    let(:claim) { ecp_qualified_teacher_claim }
     let(:params) { ActionController::Parameters.new }
 
     it do
@@ -93,8 +57,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
     let(:params) { ActionController::Parameters.new }
 
     context "when qualified teacher" do
-      let(:claim) { ecp_qualified_teacher_claim }
-
       before do
         journey_session.answers.assign_attributes(
           nqt_in_academic_year_after_itt: true
@@ -113,7 +75,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
 
     context "when trainee teacher" do
       context "when in ECP and LUP policy year range" do
-        let(:claim) { ecp_trainee_teacher_claim }
         let(:trainee_teacher) { :trainee_teacher }
 
         it do
@@ -134,8 +95,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
     let(:params) { ActionController::Parameters.new }
 
     context "when the claim is for a trainee teacher" do
-      let(:claim) { ecp_trainee_teacher_claim }
-
       before do
         journey_session.answers.nqt_in_academic_year_after_itt = false
       end
@@ -144,8 +103,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
     end
 
     context "when the claim is for a qualified teacher" do
-      let(:claim) { ecp_qualified_teacher_claim }
-
       before do
         journey_session.answers.nqt_in_academic_year_after_itt = false
       end
@@ -177,7 +134,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
 
     let(:params) { ActionController::Parameters.new }
 
-    let(:claim) { ecp_trainee_teacher_claim }
     let(:trainee_teacher) { :trainee_teacher }
 
     context "when the subject list contains chemistry" do
@@ -212,8 +168,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
   end
 
   describe "#save" do
-    let(:claim) { ecp_qualified_teacher_claim }
-
     context "when invalid" do
       let(:params) do
         ActionController::Parameters.new(
@@ -248,10 +202,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EligibleIttSubjectForm, 
             eligible_degree_subject: true
           )
         )
-      end
-
-      it "does not update the claim's eligibility" do
-        expect { form.save }.not_to change { claim.eligibility.eligible_itt_subject }
       end
 
       it "updates the answers" do

--- a/spec/forms/journeys/additional_payments_for_teaching/entire_term_contract_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/entire_term_contract_form_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EntireTermContractForm d
 
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey:,
       journey_session:,
       params:

--- a/spec/forms/journeys/additional_payments_for_teaching/induction_completed_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/induction_completed_form_spec.rb
@@ -5,15 +5,12 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::InductionCompletedForm d
     create(:journey_configuration, :additional_payments)
   }
 
-  let(:current_claim) { CurrentClaim.new(claims: [build(:claim)]) }
-
   let(:slug) { "induction_completed" }
 
   let(:journey_session) { create(:additional_payments_session) }
 
   subject(:form) do
     described_class.new(
-      claim: current_claim,
       journey_session: journey_session,
       journey: Journeys::AdditionalPaymentsForTeaching,
       params: params

--- a/spec/forms/journeys/additional_payments_for_teaching/itt_academic_year_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/itt_academic_year_form_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::IttAcademicYearForm do
 
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim, policy: Policies::EarlyCareerPayments)]),
       journey_session: journey_session,
       journey: Journeys::AdditionalPaymentsForTeaching,
       params: params

--- a/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
@@ -9,15 +9,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
     create(:additional_payments_session, answers: answers)
   end
 
-  let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
-
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
-
   subject(:form) do
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
       params: params
     )
   end
@@ -159,7 +154,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
           end
 
           it "does not set the qualification" do
-            expect(claim.eligibility.qualification).to be nil
+            expect(journey_session.reload.answers.qualification).to be nil
           end
         end
 

--- a/spec/forms/journeys/additional_payments_for_teaching/poor_performance_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/poor_performance_form_spec.rb
@@ -1,13 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::PoorPerformanceForm do
-  subject(:form) { described_class.new(claim:, journey_session:, journey:, params:) }
+  subject(:form) { described_class.new(journey_session:, journey:, params:) }
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
   let(:journey_session) { create(:additional_payments_session) }
-  let(:ecp_claim) { build(:claim, policy: Policies::EarlyCareerPayments) }
-  let(:lupp_claim) { build(:claim, policy: Policies::LevellingUpPremiumPayments) }
-  let(:claim) { CurrentClaim.new(claims: [ecp_claim, lupp_claim]) }
   let(:slug) { "poor-performance" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }
   let(:claim_params) { {subject_to_formal_performance_action: "true", subject_to_disciplinary_action: "false"} }

--- a/spec/forms/journeys/additional_payments_for_teaching/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/qualification_details_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationDetailsForm
     described_class.new(
       journey: Journeys::AdditionalPaymentsForTeaching,
       journey_session: journey_session,
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end

--- a/spec/forms/journeys/additional_payments_for_teaching/qualification_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/qualification_form_spec.rb
@@ -15,19 +15,18 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
     )
   end
 
-  let(:claim) { create(:claim, policy: Policies::EarlyCareerPayments) }
-
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
+  let(:form) do
+    described_class.new(
+      journey: journey,
+      journey_session: journey_session,
+      params: params
+    )
+  end
 
   describe "validations" do
-    subject(:form) do
-      described_class.new(
-        journey: journey,
-        journey_session: journey_session,
-        claim: current_claim,
-        params: ActionController::Parameters.new
-      )
-    end
+    subject { form }
+
+    let(:params) { ActionController::Parameters.new }
 
     it do
       is_expected.to(
@@ -39,15 +38,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
   end
 
   describe "#save" do
-    let(:form) do
-      described_class.new(
-        journey: journey,
-        journey_session: journey_session,
-        claim: current_claim,
-        params: params
-      )
-    end
-
     context "when invalid" do
       let(:params) do
         ActionController::Parameters.new(claim: {qualification: "invalid"})
@@ -75,8 +65,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
       end
 
       it "resets dependent answers if the details didn't come from dqt" do
-        claim.eligibility.update!(eligible_itt_subject: "mathematics")
-
         expect { expect(form.save).to be true }.to(
           change { journey_session.reload.answers.eligible_itt_subject }
           .from("mathematics").to(nil)
@@ -91,8 +79,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::QualificationForm, type:
       end
 
       it "doesn't reset dependent answers if the details came from dqt" do
-        claim.eligibility.update!(eligible_itt_subject: "mathematics")
-
         journey_session.answers.assign_attributes(
           qualifications_details_check: true
         )

--- a/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::EmailVerificationForm do
   subject(:form) do
-    described_class.new(claim: reminder, journey:, journey_session:, params:)
+    described_class.new(reminder: reminder, journey:, journey_session:, params:)
   end
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }

--- a/spec/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::PersonalDetailsForm, type: :model do
-  subject(:form) { described_class.new(claim: form_data_object, journey:, journey_session:, params:) }
+  subject(:form) { described_class.new(reminder: form_data_object, journey:, journey_session:, params:) }
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
   let(:journey_session) { build(:additional_payments_session) }
@@ -30,16 +30,13 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::PersonalDetai
   describe "#save" do
     subject(:save) { form.save }
 
-    before do
-      allow(form).to receive(:update!).and_return(true)
-    end
-
     context "valid params" do
       let(:form_params) { {"full_name" => "John Doe", "email_address" => "john.doe@email.com"} }
 
       it "saves the attributes" do
         expect(save).to eq(true)
-        expect(form).to have_received(:update!).with(form_params)
+        expect(form_data_object.full_name).to eq("John Doe")
+        expect(form_data_object.email_address).to eq("john.doe@email.com")
       end
     end
 
@@ -48,7 +45,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::PersonalDetai
 
       it "does not save the attributes" do
         expect(save).to eq(false)
-        expect(form).not_to have_received(:update!)
+        expect(form_data_object.full_name).to be_nil
+        expect(form_data_object.email_address).to be_nil
       end
     end
   end

--- a/spec/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/teaching_subject_now_form_spec.rb
@@ -4,20 +4,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::TeachingSubjectNowForm d
   before { create(:journey_configuration, :additional_payments) }
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
   let(:journey_session) { create(:additional_payments_session) }
-  let(:eligibility) { create(:early_career_payments_eligibility) }
-  let(:claim) do
-    create(
-      :claim,
-      policy: Policies::EarlyCareerPayments,
-      eligibility: eligibility
-    )
-  end
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
   let(:form) do
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: current_claim,
       params: params
     )
   end
@@ -82,7 +72,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::TeachingSubjectNowForm d
 
     subject(:eligible_itt_subject) { form.eligible_itt_subject }
 
-    it { is_expected.to eq claim.eligibility.eligible_itt_subject }
+    it { is_expected.to eq journey_session.answers.eligible_itt_subject }
   end
 
   describe "#teaching_physics_or_chemistry?" do

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/claim_school_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/claim_school_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSchoolForm do
 
   let(:journey_session) do
     create(
-      :"#{journey::I18N_NAMESPACE}_session",
+      :student_loans_session,
       answers: {
         taught_eligible_subjects: true,
         biology_taught: true,
@@ -28,7 +28,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSchoolForm do
 
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey_session: journey_session,
       journey: journey,
       params: params

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/leadership_position_form_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm do
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
 
-  let(:current_claim) { CurrentClaim.new(claims: [claim]) }
-
   let(:journey_session) do
     create(
       :student_loans_session,
@@ -25,7 +23,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::LeadershipPositionForm
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/mostly_performed_leadership_duties_form_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::MostlyPerformedLeaders
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qts_year_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qts_year_form_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::QtsYearForm, type: :model do
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey_session:,
       journey:,
       params:
@@ -33,7 +32,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QtsYearForm, type: :mo
 
   describe "#save" do
     before do
-      allow(form).to receive(:update!)
       form.save
     end
 

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/qualification_details_form_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::QualificationDetailsFo
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SelectClaimSchoolForm,
     let(:params) { ActionController::Parameters.new }
     let(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey:,
         journey_session:,
         params:

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::StillTeachingForm, typ
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: ActionController::Parameters.new(claim: claim_params)
     )
   end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, type: :model do
   subject(:form) do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey_session:,
       journey:,
       params:

--- a/spec/forms/mobile_number_form_spec.rb
+++ b/spec/forms/mobile_number_form_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe MobileNumberForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         params: params
       )
     end

--- a/spec/forms/mobile_verification_form_spec.rb
+++ b/spec/forms/mobile_verification_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe MobileVerificationForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         params: params
       )
     end

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe PersonalDetailsForm, type: :model do
 
     subject(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: ActionController::Parameters.new(slug:, claim: params)

--- a/spec/forms/postcode_search_form_spec.rb
+++ b/spec/forms/postcode_search_form_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe PostcodeSearchForm, type: :model do
   subject do
     described_class.new(
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       journey: journey,
       params: params,
       journey_session: journey_session

--- a/spec/forms/provide_mobile_number_form_spec.rb
+++ b/spec/forms/provide_mobile_number_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ProvideMobileNumberForm, type: :model do
 
     subject(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey_session: journey_session,
         journey: journey,
         params: params

--- a/spec/forms/reset_claim_form_spec.rb
+++ b/spec/forms/reset_claim_form_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 RSpec.describe ResetClaimForm, type: :model do
   describe "#save" do
-    subject { described_class.new(claim:, journey:, params:, journey_session:).save }
+    subject { described_class.new(journey:, params:, journey_session:).save }
 
-    let(:claim) { double }
     let(:journey) { Journeys::TeacherStudentLoanReimbursement }
     let(:params) { nil }
     let(:journey_session) { build(:"#{journey::I18N_NAMESPACE}_session") }

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SelectEmailForm, type: :model do
-  subject(:form) { described_class.new(claim:, journey_session:, journey:, params:) }
+  subject(:form) { described_class.new(journey_session:, journey:, params:) }
 
   let(:journey) { Journeys::TeacherStudentLoanReimbursement }
   let(:journey_session) do
@@ -14,7 +14,6 @@ RSpec.describe SelectEmailForm, type: :model do
       }
     )
   end
-  let(:claim) { CurrentClaim.new(claims: [build(:claim, policy: Policies::StudentLoans)]) }
   let(:slug) { "select-email" }
   let(:params) { ActionController::Parameters.new({slug:, claim: claim_params}) }
   let(:claim_params) { {email_address_check: "false"} }
@@ -75,10 +74,6 @@ RSpec.describe SelectEmailForm, type: :model do
   end
 
   describe "#save" do
-    before do
-      allow(form).to receive(:update!)
-    end
-
     context "valid params" do
       context "when the user selected to use the email address from Teacher ID" do
         let(:claim_params) { {email_address_check: "true"} }
@@ -107,14 +102,6 @@ RSpec.describe SelectEmailForm, type: :model do
           expect(journey_session.reload.answers.email_address_check).to eq(false)
         end
       end
-    end
-
-    context "invalid params" do
-      let(:claim_params) { {email_address_check: nil} }
-
-      before { form.save }
-
-      it { expect(form).not_to have_received(:update!) }
     end
   end
 end

--- a/spec/forms/select_home_address_form_spec.rb
+++ b/spec/forms/select_home_address_form_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe SelectHomeAddressForm, type: :model do
     let(:address) { "The full address:123:Main Street:Springfield:12345" }
     let(:form) do
       described_class.new(
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         journey: journey,
         journey_session: journey_session,
         params: params

--- a/spec/forms/select_mobile_form_spec.rb
+++ b/spec/forms/select_mobile_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe SelectMobileForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: CurrentClaim.new(claims: [build(:claim)]),
         params: params
       )
     end

--- a/spec/forms/sign_in_or_continue_form_spec.rb
+++ b/spec/forms/sign_in_or_continue_form_spec.rb
@@ -2,14 +2,6 @@ require "rails_helper"
 
 RSpec.describe SignInOrContinueForm do
   shared_examples "sign_in_or_continue_form" do |journey|
-    let(:current_claim) do
-      claims = journey::POLICIES.map do |policy|
-        create(:claim, policy: policy)
-      end
-
-      CurrentClaim.new(claims: claims)
-    end
-
     let(:journey_session) do
       build(
         :"#{journey::I18N_NAMESPACE}_session",
@@ -24,7 +16,6 @@ RSpec.describe SignInOrContinueForm do
       described_class.new(
         journey: journey,
         journey_session: journey_session,
-        claim: current_claim,
         params: params
       )
     end

--- a/spec/forms/supply_teacher_form_spec.rb
+++ b/spec/forms/supply_teacher_form_spec.rb
@@ -7,16 +7,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SupplyTeacherForm do
 
   let(:journey_session) { build(:"#{journey::I18N_NAMESPACE}_session") }
 
-  let(:current_claim) do
-    claims = journey::POLICIES.map { |policy| create(:claim, policy:) }
-    CurrentClaim.new(claims:)
-  end
-
   let(:slug) { "supply-teacher" }
 
   subject(:form) do
     described_class.new(
-      claim: current_claim,
       journey_session:,
       journey:,
       params:

--- a/spec/forms/teacher_reference_number_form_spec.rb
+++ b/spec/forms/teacher_reference_number_form_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe TeacherReferenceNumberForm do
     described_class.new(
       journey: journey,
       journey_session: journey_session,
-      claim: CurrentClaim.new(claims: [build(:claim)]),
       params: params
     )
   end


### PR DESCRIPTION
Now the forms no longer reference the current claim we can remove it as
an argument.
Of note we've had to hack the reminders form a bit. The reminders
controller passes in the reminder to the form as the claim argument.
We've removed the "current_data_object" method as it's too much
abstraction and added some methods to the reminder forms to still let
them work with the claim, which is really a reminder. The reminders
forms probably shouldn't share a base class with the usual forms but
unpicking that is a future exercise. These hacks will hopefully be
addressed in https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1719

A lot of files changed but most of them are just specs that needed updating