### PR TITLE
[CAPT-1729] Use GOVUK formbuilder for personal details form

### DIFF
--- a/app/views/claims/personal_details.html.erb
+++ b/app/views/claims/personal_details.html.erb
@@ -2,105 +2,69 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { date_of_birth: "claim_date_of_birth_3i"}) if @form.errors.any? %>
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |form| %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t("questions.personal_details") %>
       </h1>
 
       <% if @form.show_name_section? %>
         <div class="govuk-form-group govuk-!-padding-bottom-6">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="full-name-hint" id="full-name-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h2 class="govuk-fieldset__heading govuk-!-padding-bottom-3" id="full-name-hint">
-                <%= t("questions.name") %>
-              </h2>
-            </legend>
+          <%= f.govuk_fieldset legend: {
+            text: "What is your full name?",
+            tag: "h2",
+            size: "l"
+          } do %>
+            <%= f.govuk_text_field :first_name,
+              label: { text: "First name" },
+              autocomplete: "given-name"
+            %>
 
-            <%= form_group_tag @form, :first_name do %>
-              <%= form.label :first_name, "First name", class: "govuk-label" %>
-              <%= errors_tag @form, :first_name %>
-              <%= form.text_field :first_name, class: css_classes_for_input(@form, :first_name), autocomplete: "given-name" %>
-            <% end %>
-            <%= form_group_tag @form, :middle_name do %>
-              <%= form.label :middle_name, "Middle names", class: "govuk-label" %>
-              <%= errors_tag @form, :middle_name %>
-              <%= form.text_field :middle_name, class: css_classes_for_input(@form, :middle_name), autocomplete: "additional-name" %>
-            <% end %>
-            <%= form_group_tag @form, :surname do %>
-              <%= form.label :surname, "Last name", class: "govuk-label" %>
-              <%= errors_tag @form, :surname %>
-              <%= form.text_field :surname, class: css_classes_for_input(@form, :surname), autocomplete: "family-name" %>
-            <% end %>
-          </fieldset>
+            <%= f.govuk_text_field :middle_name,
+              label: { text: "Middle names" },
+              autocomplete: "additional-name"
+            %>
+
+            <%= f.govuk_text_field :surname,
+              label: { text: "Last name" },
+              autocomplete: "family-name"
+            %>
+          <% end %>
         </div>
       <% end %>
 
       <% if @form.show_date_of_birth_section? %>
         <div class="govuk-!-padding-bottom-6">
-          <%= form_group_tag @form, :date_of_birth do %>
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-of-birth-hint" id="date-of-birth-fieldset">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                <h2 class="govuk-fieldset__heading">
-                  <%= t("questions.date_of_birth") %>
-                </h2>
-              </legend>
-
-              <div id="date-of-birth-hint" class="govuk-hint">
-                For example, 31 03 1980. We need this information to verify your identity.
-              </div>
-
-              <%= errors_tag @form, :date_of_birth %>
-              <%
-                dob_class = @form.errors[:date_of_birth].any? ? "govuk-input--error" : ""
-              %>
-              <div class="govuk-date-input">
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <%= label_tag :"claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
-                    <%= text_field_tag :"claim[date_of_birth(3i)]", @form.date_of_birth.day, id: "claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
-                  </div>
-                </div>
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <%= label_tag :"claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
-                    <%= text_field_tag :"claim[date_of_birth(2i)]", @form.date_of_birth.month, id: "claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2 #{dob_class}", type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
-                  </div>
-                </div>
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <%= label_tag :"claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
-                    <%= text_field_tag :"claim[date_of_birth(1i)]", @form.date_of_birth.year, id: "claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4 #{dob_class}", type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          <% end %>
+          <%= f.govuk_date_field :date_of_birth,
+            date_of_birth: true,
+            legend: {
+              text: "What is your date of birth?",
+              tag: "h2",
+              size: "l"
+            },
+            hint: { text: "For example, 31 03 1980. We need this information to verify your identity." } %>
         </div>
       <% end %>
 
       <% if @form.show_nino_section? %>
         <div class="govuk-!-padding-bottom-6">
-          <%= form_group_tag @form, :national_insurance_number do %>
-            <h2 class="govuk-label-wrapper">
-              <%= form.label :national_insurance_number, t("questions.national_insurance_number"), {class: "govuk-label govuk-label--l"}  %>
-            </h2>
-
-            <div class="govuk-hint" id="national_insurance_number-hint">
-              It's on your National Insurance card, benefit letter, payslip or P60. For example 'QQ123456C'.
-            </div>
-
-            <%= errors_tag @form, :national_insurance_number %>
-            <%= form.text_field :national_insurance_number,
-                  spellcheck: "false",
-                  autocomplete: "off",
-                  class: css_classes_for_input(@form, :national_insurance_number, 'govuk-input--width-10'),
-                  "aria-describedby" => "national_insurance_number-hint" %>
+          <%= f.govuk_text_field :national_insurance_number,
+            width: 10,
+            spellcheck: false,
+            autocomplete: "off",
+            label: {
+              text: t("questions.national_insurance_number"),
+              size: "l",
+              tag: "h2"
+            },
+            hint: -> do %>
+              It’s on your National Insurance card, benefit letter, payslip or P60. For example ‘QQ123456C’.
             <% end %>
         </div>
       <% end %>
 
-      <%= form.submit "Continue", class: "govuk-button" %>
+      <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>
 </div>

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -117,8 +117,8 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     expect(page).to have_text(I18n.t("questions.personal_details"))
     expect(page).to have_text(I18n.t("questions.name"))
 
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
 
     expect(page).to have_text(I18n.t("questions.date_of_birth"))
 

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -117,8 +117,8 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     expect(page).to have_text(I18n.t("questions.personal_details"))
     expect(page).to have_text(I18n.t("questions.name"))
 
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
 
     expect(page).to have_text(I18n.t("questions.date_of_birth"))
 
@@ -532,8 +532,8 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     expect(page).to have_text(I18n.t("questions.personal_details"))
     expect(page).to have_text(I18n.t("questions.name"))
 
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
 
     expect(page).to have_text(I18n.t("questions.date_of_birth"))
 
@@ -853,8 +853,8 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
       expect(page).to have_text(I18n.t("questions.personal_details"))
       expect(page).to have_text(I18n.t("questions.name"))
 
-      fill_in "claim_first_name", with: "Russell"
-      fill_in "claim_surname", with: "Wong"
+      fill_in "First name", with: "Russell"
+      fill_in "Last name", with: "Wong"
 
       expect(page).to have_text(I18n.t("questions.date_of_birth"))
 

--- a/spec/features/hmrc_bank_validation_spec.rb
+++ b/spec/features/hmrc_bank_validation_spec.rb
@@ -64,8 +64,8 @@ RSpec.feature "Bank account validation on claim journey", :with_hmrc_bank_valida
     click_on "Continue"
 
     # - Personal details
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
     fill_in "Day", with: "28"
     fill_in "Month", with: "2"
     fill_in "Year", with: "1988"

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -139,8 +139,8 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     click_on "Continue"
 
     # - Personal details
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
 
     fill_in "Day", with: Date.parse(date_of_birth).day
     fill_in "Month", with: Date.parse(date_of_birth).month

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -127,8 +127,8 @@ RSpec.feature "Levelling up premium payments claims" do
     expect(page).to have_text(I18n.t("questions.personal_details"))
     expect(page).to have_text(I18n.t("questions.name"))
 
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
 
     expect(page).to have_text(I18n.t("questions.date_of_birth"))
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -67,8 +67,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text(I18n.t("questions.personal_details"))
     expect(page).to have_text(I18n.t("questions.name"))
 
-    fill_in "claim_first_name", with: "Russell"
-    fill_in "claim_surname", with: "Wong"
+    fill_in "First name", with: "Russell"
+    fill_in "Last name", with: "Wong"
 
     expect(page).to have_text(I18n.t("questions.date_of_birth"))
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1729
- Ultimate goal is to remove `module GovukFormHelper` which houses custom code for forms

# Changes

- Use `GOVUKDesignSystemFormBuilder::FormBuilder` for personal details form
- Bonus: use smart quotes where applicable