### PR TITLE
[CAPT-1729] Use GOVUK formbuilder for address form

### DIFF
--- a/app/helpers/claims/show_helper.rb
+++ b/app/helpers/claims/show_helper.rb
@@ -4,10 +4,6 @@ module Claims
       (journey == Journeys::AdditionalPaymentsForTeaching) ? "govuk-fieldset__legend--l" : "govuk-fieldset__legend--xl"
     end
 
-    def heading_css_class_for_journey(journey)
-      (journey == Journeys::AdditionalPaymentsForTeaching) ? "govuk-heading-xl" : "govuk-fieldset__heading"
-    end
-
     def label_css_class_for_journey(journey)
       (journey == Journeys::AdditionalPaymentsForTeaching) ? "govuk-label--l" : "govuk-label--xl"
     end

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -2,66 +2,47 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: @form) if @form.errors.any? %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
-          <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
-          <h1 class="<%= heading_css_class_for_journey(journey) %>">
-            <%= t("forms.address.questions.your_address") %>
-          </h1>
-        </legend>
+      <%= f.govuk_fieldset legend: {
+        text: t("forms.address.questions.your_address"),
+        tag: "h1",
+        size: "xl"
+      },
+      caption: {
+        text: t("questions.personal_details"),
+        size: "xl"
+      } do %>
+        <%= f.govuk_text_field :address_line_1,
+          autocomplete: "address-line1",
+          label: {
+            text: "#{t('forms.address.answers.address_line_1')}<span class=\"govuk-visually-hidden\">#{ t('forms.address.answers.address_line_1_visually_hidden')}</span>".html_safe
+          } %>
 
-        <%= form_group_tag @form, :address_line_1 do %>
-          <%= f.label :address_line_1, class: "govuk-label" do %>
-            <%= t("forms.address.answers.address_line_1") %>
-            <span class="govuk-visually-hidden"><%= t("forms.address.answers.address_line_1_visually_hidden") %></span>
-          <% end %>
-          <%= errors_tag f.object, :address_line_1 %>
-          <%= f.text_field :address_line_1, autocomplete: "address-line1",
-            class: css_classes_for_input(@form, :address_line_1) %>
-        <% end %>
+        <%= f.govuk_text_field :address_line_2,
+          autocomplete: "address-line2",
+          label: {
+            text: "#{t('forms.address.answers.address_line_2')}<span class=\"govuk-visually-hidden\">#{ t('forms.address.answers.address_line_2_visually_hidden')}</span>".html_safe
+          } %>
 
-        <%= form_group_tag @form, :address_line_2 do %>
-          <%= f.label :address_line_2, class: "govuk-label" do %>
-            <%= t("forms.address.answers.address_line_2") %>
-            <span class="govuk-visually-hidden"><%= t("forms.address.answers.address_line_2_visually_hidden") %></span>
-          <% end %>
-          <%= errors_tag f.object, :address_line_2 %>
-          <%= f.text_field :address_line_2, autocomplete: "address-line2",
-            class: css_classes_for_input(@form, :address_line_2) %>
-        <% end %>
+        <%= f.govuk_text_field :address_line_3,
+          width: "two-thirds",
+          autocomplete: "address-level2",
+          label: { text: t("forms.address.answers.address_line_3") } %>
 
-        <%= form_group_tag @form, :address_line_3 do %>
-          <%= f.label :address_line_3, class: "govuk-label" do %>
-            <%= t("forms.address.answers.address_line_3") %>
-          <% end %>
-          <%= errors_tag f.object, :address_line_3 %>
-          <%= f.text_field :address_line_3, autocomplete: "address-level2",
-            class: css_classes_for_input(@form, :address_line_3, "govuk-!-width-two-thirds") %>
-        <% end %>
+        <%= f.govuk_text_field :address_line_4,
+          width: "two-thirds",
+          autocomplete: "off",
+          label: { text: t("forms.address.answers.address_line_4") } %>
 
-        <%= form_group_tag @form, :address_line_4 do %>
-          <%= f.label :address_line_4, class: "govuk-label" do %>
-            <%= t("forms.address.answers.address_line_4") %>
-          <% end %>
-          <%= errors_tag f.object, :address_line_4 %>
-          <%= f.text_field :address_line_4, autocomplete: "off",
-            class: css_classes_for_input(@form, :address_line_4, "govuk-input govuk-!-width-two-thirds") %>
-        <% end %>
+        <%= f.govuk_text_field :postcode,
+          width: 10,
+          autocomplete: "postal-code",
+          label: { text: t("forms.address.answers.postcode") } %>
+      <% end %>
 
-        <%= form_group_tag @form, :postcode do %>
-          <%= f.label :postcode, class: "govuk-label" do %>
-            <%= t("forms.address.answers.postcode") %>
-          <% end %>
-          <%= errors_tag f.object, :postcode %>
-          <%= f.text_field :postcode, autocomplete: "postal-code",
-            class: css_classes_for_input(@form, :postcode, "govuk-input--width-10") %>
-        <% end %>
-      </fieldset>
-
-      <%= f.submit "Continue", class: "govuk-button" %>
+      <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>
 </div>

--- a/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
@@ -347,8 +347,8 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
       # - What is your address
       expect(page).to have_text(I18n.t("forms.address.questions.your_address"))
 
-      fill_in :claim_address_line_1, with: "Penthouse Apartment, Millbrook Tower"
-      fill_in :claim_address_line_2, with: "Windermere Avenue"
+      fill_in "House number or name", with: "Penthouse Apartment, Millbrook Tower"
+      fill_in "Building and street", with: "Windermere Avenue"
       fill_in "Town or city", with: "Southampton"
       fill_in "County", with: "Hampshire"
       fill_in "Postcode", with: "SO16 9FX"

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -146,8 +146,8 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     # - What is your address
     expect(page).to have_text(I18n.t("forms.address.questions.your_address"))
 
-    fill_in :claim_address_line_1, with: "57"
-    fill_in :claim_address_line_2, with: "Walthamstow Drive"
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
     fill_in "Town or city", with: "Derby"
     fill_in "County", with: "City of Derby"
     fill_in "Postcode", with: "DE22 4BS"

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -134,8 +134,8 @@ RSpec.feature "Combined journey with Teacher ID" do
     # - What is your address
     expect(page).to have_text(I18n.t("forms.address.questions.your_address"))
 
-    fill_in :claim_address_line_1, with: "57"
-    fill_in :claim_address_line_2, with: "Walthamstow Drive"
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
     fill_in "Town or city", with: "Derby"
     fill_in "County", with: "City of Derby"
     fill_in "Postcode", with: "DE22 4BS"

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -140,8 +140,8 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     # - What is your address
     expect(page).to have_text(I18n.t("forms.address.questions.your_address"))
 
-    fill_in :claim_address_line_1, with: "57"
-    fill_in :claim_address_line_2, with: "Walthamstow Drive"
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
     fill_in "Town or city", with: "Derby"
     fill_in "County", with: "City of Derby"
     fill_in "Postcode", with: "DE22 4BS"
@@ -555,8 +555,8 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     # - What is your address
     expect(page).to have_text(I18n.t("forms.address.questions.your_address"))
 
-    fill_in :claim_address_line_1, with: "88"
-    fill_in :claim_address_line_2, with: "Deanborough Street"
+    fill_in "House number or name", with: "88"
+    fill_in "Building and street", with: "Deanborough Street"
     fill_in "Town or city", with: "Nottingham"
     fill_in "County", with: "Nottinghamshire"
     fill_in "Postcode", with: "M1 7HL"

--- a/spec/features/hmrc_bank_validation_spec.rb
+++ b/spec/features/hmrc_bank_validation_spec.rb
@@ -76,8 +76,8 @@ RSpec.feature "Bank account validation on claim journey", :with_hmrc_bank_valida
     click_link(I18n.t("questions.address.home.link_to_manual_address"))
 
     # - What is your address
-    fill_in :claim_address_line_1, with: "57"
-    fill_in :claim_address_line_2, with: "Walthamstow Drive"
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
     fill_in "Town or city", with: "Derby"
     fill_in "County", with: "City of Derby"
     fill_in "Postcode", with: "DE22 4BS"

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -150,8 +150,8 @@ RSpec.feature "Levelling up premium payments claims" do
     # - What is your address
     expect(page).to have_text(I18n.t("forms.address.questions.your_address"))
 
-    fill_in :claim_address_line_1, with: "57"
-    fill_in :claim_address_line_2, with: "Walthamstow Drive"
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
     fill_in "Town or city", with: "Derby"
     fill_in "County", with: "City of Derby"
     fill_in "Postcode", with: "DE22 4BS"

--- a/spec/helpers/claims/show_helper_spec.rb
+++ b/spec/helpers/claims/show_helper_spec.rb
@@ -17,22 +17,6 @@ RSpec.describe Claims::ShowHelper do
     end
   end
 
-  describe "#heading_css_class_for_journey" do
-    subject(:css_class) { helper.heading_css_class_for_journey(journey) }
-
-    context "for Journeys::AdditionalPaymentsForTeaching" do
-      let(:journey) { Journeys::AdditionalPaymentsForTeaching }
-
-      it { is_expected.to eq("govuk-heading-xl") }
-    end
-
-    context "for Journeys::TeacherStudentLoanRepayment" do
-      let(:journey) { Journeys::TeacherStudentLoanReimbursement }
-
-      it { is_expected.to eq("govuk-fieldset__heading") }
-    end
-  end
-
   describe "#policy_name" do
     subject(:name) { helper.policy_name(policy) }
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -66,8 +66,8 @@ module FeatureHelpers
   end
 
   def fill_in_address
-    fill_in :claim_address_line_1, with: "123 Main Street"
-    fill_in :claim_address_line_2, with: "Downtown"
+    fill_in "House number or name", with: "123 Main Street"
+    fill_in "Building and street", with: "Downtown"
     fill_in "Town or city", with: "Twin Peaks"
     fill_in "County", with: "Washington"
     fill_in "Postcode", with: "M1 7HL"


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1729
- Ultimate goal is to remove `module GovukFormHelper` which houses custom code for forms

# Changes

- Use `GOVUKDesignSystemFormBuilder::FormBuilder` for address search form
- Bonus: removed helper `#heading_css_class_for_journey` as didn't seem to offer any visible difference to the page which makes one thing simpler
- Updated tests to target fields via labels rather than their `id`