### PR TITLE
CAPT-1702 Add slack notification on failure

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -113,3 +113,11 @@ jobs:
         run: |
           make ci test-aks get-cluster-credentials
           kubectl exec -n srtl-test deployment/claim-additional-payments-for-teaching-test-worker -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/prepare-database"
+
+      - name: Slack notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_TITLE: Failure deploying release to test
+          SLACK_MESSAGE: Failure deploying release to test - Docker tag ${{ needs.build.outputs.docker-image-tag }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
**Context**

For permantent environments we want to notify on Slack when a deploy fails.

**Changes in this PR**

Add an extra step to the `deploy_test` job to notify on slack if is fails.