### PR TITLE
[CAPT-1731] Fix missing back link

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -5,7 +5,7 @@ class ClaimsController < BasePublicController
   before_action :initialize_session_slug_history
   before_action :check_page_is_in_sequence, only: [:show, :update]
   before_action :update_session_with_current_slug, only: [:update]
-  before_action :set_backlink_path, only: [:show]
+  before_action :set_backlink_path, only: [:show, :update]
   before_action :check_claim_not_in_progress, only: [:new]
   before_action :clear_claim_session, only: [:new]
   before_action :prepend_view_path_for_journey
@@ -53,7 +53,6 @@ class ClaimsController < BasePublicController
   end
 
   def set_backlink_path
-    previous_slug = previous_slug()
     @backlink_path = claim_path(current_journey_routing_name, previous_slug) if previous_slug.present?
   end
 

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -1,6 +1,63 @@
 require "rails_helper"
 
 RSpec.feature "Backlinking during a claim" do
+  scenario "when there is an error" do
+    create(:journey_configuration, :additional_payments)
+    lup_school = create(:school, :levelling_up_premium_payments_eligible)
+
+    visit new_claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME)
+    # - Sign in or continue page
+    expect(page).to have_text("Use DfE Identity to sign in")
+    expect(page).to have_link("Back")
+    click_on "Continue without signing in"
+
+    expect(page).to have_content("Which school do you teach at?")
+    expect(page).to have_link("Back")
+    choose_school lup_school
+
+    expect(page).to have_content("Are you currently teaching as a qualified teacher?")
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_content("Are you currently employed as a supply teacher?")
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_content("Tell us if you are currently under any performance measures or disciplinary action")
+    choose "claim_subject_to_formal_performance_action_false"
+    choose "claim_subject_to_disciplinary_action_false"
+    click_on "Continue"
+
+    expect(page).to have_content("Which route into teaching did you take?")
+    choose "Undergraduate initial teacher training (ITT)"
+    click_on "Continue"
+
+    expect(page).to have_content("In which academic year did you complete your undergraduate initial teacher training (ITT)?")
+    choose "2020 to 2021"
+    click_on "Continue"
+
+    expect(page).to have_content("Which subject did you do your undergraduate initial teacher training (ITT) in?")
+    choose "Mathematics"
+    click_on "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your contracted hours teaching eligible subjects?")
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_content("Check your answers")
+    click_on "Continue"
+
+    click_on "Apply now"
+
+    click_on "Continue"
+
+    expect(page).to have_content("What is your full name?")
+    click_on "Continue"
+
+    expect(page).to have_content("What is your full name?")
+    expect(page).to have_link("Back")
+  end
+
   scenario "Student Loans journey" do
     create(:journey_configuration, :student_loans)
     school = create(:school, :student_loans_eligible)


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1731
- When hitting the `ClaimsController` with a form submission, if there is an error the back link is missing

# Changes

- back link is generated on form `show` and `update`
