### PR TITLE
POC - integrate IRP into claim

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
@@ -1,0 +1,11 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class ApplicationRouteForm < Form
+      attribute :application_route, :string
+
+      def application_routes
+        %i[teacher salaried_trainee other]
+      end
+    end
+  end
+end

--- a/app/models/journeys.rb
+++ b/app/models/journeys.rb
@@ -7,7 +7,8 @@ module Journeys
 
   JOURNEYS = [
     AdditionalPaymentsForTeaching,
-    TeacherStudentLoanReimbursement
+    TeacherStudentLoanReimbursement,
+    GetATeacherRelocationPayment
   ].freeze
 
   def all

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -1,0 +1,16 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    extend Base
+    extend self
+
+    ROUTING_NAME = "get-a-teacher-relocation-payment"
+    VIEW_PATH = "get_a_teacher_relocation_payment"
+    I18N_NAMESPACE = "get_a_teacher_relocation_payment"
+    POLICIES = []
+    FORMS = {
+      "claims" => {
+        "application-route" => ApplicationRouteForm,
+      }
+    }
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/eligibility_checker.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/eligibility_checker.rb
@@ -1,0 +1,7 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class EligibilityChecker < Journeys::EligibilityChecker
+    end
+  end
+end
+

--- a/app/models/journeys/get_a_teacher_relocation_payment/session.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session.rb
@@ -1,0 +1,8 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class Session < Journeys::Session
+      attribute :answers, SessionAnswersType.new
+    end
+  end
+end
+

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -1,0 +1,12 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SessionAnswers < Journeys::SessionAnswers
+      attribute :application_route, :string
+
+      def teacher_application?
+        true
+      end
+    end
+  end
+end
+

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers_type.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers_type.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SessionAnswersType < ::Journeys::SessionAnswersType; end
+  end
+end
+

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -1,0 +1,89 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SlugSequence
+      ELIGIBILITY_SLUGS = %w[
+        application-route
+        contract-details
+        employment-details
+        entry-date
+        school-details
+        start-date
+        subject
+        trainee-details
+        visa
+      ]
+
+      PERSONAL_DETAILS_SLUGS = [
+        "information-provided",
+        "personal-details",
+        "postcode-search",
+        "select-home-address",
+        "address",
+        "select-email",
+        "email-address",
+        "email-verification",
+        "select-mobile",
+        "provide-mobile-number",
+        "mobile-number",
+        "mobile-verification"
+      ].freeze
+
+      PAYMENT_DETAILS_SLUGS = [
+        "bank-or-building-society",
+        "personal-bank-account",
+        "building-society-account",
+        "gender",
+        "teacher-reference-number"
+      ].freeze
+
+      RESULTS_SLUGS = [
+        "check-your-answers",
+        "ineligible"
+      ].freeze
+
+      TEACHER_SPECIFIC_SLUGS = %w[
+        school-details
+        contract-details
+      ]
+
+      TRAINEE_SPECIFIC_SLUGS = %w[
+        trainee-details
+      ]
+
+      SLUGS = (
+        ELIGIBILITY_SLUGS +
+        PERSONAL_DETAILS_SLUGS +
+        PAYMENT_DETAILS_SLUGS +
+        RESULTS_SLUGS
+     )
+
+      attr_reader :journey_session
+
+      delegate :answers, to: :journey_session
+
+      def initialize(journey_session)
+        @journey_session = journey_session
+      end
+
+      def slugs
+        SLUGS.dup.tap do |sequence|
+          if answers.teacher_application?
+            sequence.delete(*TRAINEE_SPECIFIC_SLUGS)
+          else
+            sequence.delete(*TEACHER_SPECIFIC_SLUGS)
+          end
+        end
+      end
+    end
+
+    # FIXME RL: Double check what this should be
+    def self.start_page_url
+      if Rails.env.production?
+        "https://www.gov.uk/government/publications/international-relocation-payments/international-relocation-payments"
+      else
+        Rails.application.routes.url_helpers.landing_page_path("get-a-teacher-relocation-payment")
+      end
+    end
+  end
+end
+

--- a/app/views/get_a_teacher_relocation_payment/claims/application_route.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/application_route.html.erb
@@ -1,0 +1,68 @@
+<% content_for(
+  :page_title,
+  page_title(
+      t(
+        "get_a_teacher_relocation_payment.forms.application_route.questions.which_route"
+      ),
+      journey: current_journey_routing_name,
+      show_error: @form.errors.any?
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: @form) if @form.errors.any? %>
+
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= form_group_tag f.object do %>
+
+        <%= f.hidden_field :application_route %>
+
+        <fieldset class="govuk-fieldset" role="group">
+
+          <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">
+            <h1 class="govuk-fieldset__heading">
+              <%= t(
+                "get_a_teacher_relocation_payment.forms.application_route.questions.which_route"
+              ) %>
+            </h1>
+          </legend>
+
+          <%= errors_tag f.object, :application_route %>
+
+          <div class="govuk-radios">
+            <% f.object.application_routes.each do |route| %>
+              <div class="govuk-radios__item">
+                <%= f.radio_button(
+                  :application_route,
+                  route,
+                  class: "govuk-radios__input"
+                ) %>
+
+                <%= f.label(
+                  "application_route_#{route}",
+                  t("get_a_teacher_relocation_payment.forms.application_route.answers.#{route}"),
+                  class: "govuk-label govuk-radios__label"
+                ) %>
+
+                <% if I18n.exists?("get_a_teacher_relocation_payment.forms.application_route.hints.#{route}") %>
+                  <div id="<%= "application_route_#{route}_hint" %>" class="govuk-hint govuk-radios__hint">
+                    <%= t("get_a_teacher_relocation_payment.forms.application_route.hints.#{route}") %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+
+        </fieldset>
+      <% end %>
+
+      <%= f.submit(
+        "Continue",
+        class: "govuk-button",
+        data: {module: "govuk-button"}
+      ) %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
@@ -1,0 +1,110 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Apply for the international relocation payment</h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      The international relocation payment (IRP) is a single payment of £10,000,
+      funded by the UK government, which is available to eligible non-UK trainees and teachers of:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>languages</li>
+      <li>physics</li>
+      <li>general or combined science when that includes physics</li>
+    </ul>
+
+    <p class="govuk-body">
+      Only teachers and salaried trainees need to complete this form.
+    </p>
+
+    <p class="govuk-body">
+      Before starting your application, visit
+      <%= govuk_link_to(
+            "Get an international relocation payment",
+            "https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment",
+            #{ target: "_blank" } # FIXME RL govuk link to doesn't support target
+      ) %>
+      to check the criteria you must meet to receive the IRP. You need to have started your job or course before you can apply.
+    </p>
+
+    <p class="govuk-body">
+      You should also get your documents and information ready, as you will not be able to save your entries and return to the form later. It should take approximately 15 minutes to complete.
+    </p>
+
+
+    <h2 class="govuk-heading-l">Documents and information to get ready</h2>
+
+    <p class="govuk-body">
+      You will need:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        if you are a teacher, your teaching subject and the terms of your employment contract
+      </li>
+      <li>
+        if you are a salaried trainee, details of your teacher training course, including
+        teaching subject and start date
+      </li>
+      <li>
+        your visa type and when you entered the UK
+      </li>
+      <li>
+        your passport
+      </li>
+      <li>
+        your address in England
+      </li>
+      <li>
+        contact details for the school where you are employed as a teacher or trainee
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        Start
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+        </svg>
+      </a>
+    </p>
+
+    <h2 class="govuk-heading-l">Deadline for applications</h2>
+    <p class="govuk-body">
+      Applications for the international relocation payment (IRP) are open from:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>2 April to 16 June 2024</li>
+    </ul>
+    <p class="govuk-body">
+      If you have started your teaching job or salaried teacher training course, you should apply now. If you are eligible, you should receive the money by 30 September 2024.
+    </p>
+    <p class="govuk-body">
+      To remain eligible for the IRP, you must apply in either the first or second term of your employment as a teacher or salaried trainee.
+    </p>
+    <p class="govuk-body">
+      Applications will re-open later in 2024.
+    </p>
+
+    <h2 class="govuk-heading-l">Not ready to apply?</h2>
+    <p class="govuk-body">
+      If you have not started your job or course, please visit
+      <%= govuk_link_to(
+            "Get an international relocation payment",
+            "https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment",
+            #{ target: "_blank" } # FIXME RL govuk link to doesn't support target
+      ) %>
+      for information about future applications.
+    </p>
+
+    <h2 class="govuk-heading-m">Contact us</h2>
+
+    <p class="govuk-body">
+      For help, please email us at
+      <%= govuk_link_to("teach.inengland@education.gov.uk", "mailto:teach.inengland@education.gov.uk")%>.
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -679,6 +679,20 @@ en:
     claim_amount_description: "Additional payment for teaching"
     support_email_address: "levellinguppremiumpayments@digital.education.gov.uk"
     information_provided_further_details_link_text: levelling up premium payment (opens in new tab)
+  get_a_teacher_relocation_payment:
+    journey_name: "Get a teacher relocation payment"
+    feedback_email: "teach.inengland@education.gov.uk"
+    forms:
+      application_route:
+        questions:
+          which_route:
+        answers:
+          teacher: "I am employed as a teacher in a school in England"
+          salaried_trainee: "I am enrolled on a salaried teacher training course in England"
+          other: "Other"
+        hints:
+          salaried_trainee: "‘Salaried’ means a course where you are paid a wage to work while you train."
+
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       resources :reminders, only: [:show, :update], param: :slug, constraints: {slug: %r{#{Journeys::AdditionalPaymentsForTeaching::SlugSequence::REMINDER_SLUGS.join("|")}}}, controller: "journeys/additional_payments_for_teaching/reminders"
     end
 
-    scope path: "/", constraints: {journey: /student-loans|additional-payments/} do
+    scope path: "/", constraints: {journey: /student-loans|additional-payments|get-a-teacher-relocation-payment/} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@
 if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")
   Journeys::Configuration.create!(routing_name: Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, current_academic_year: AcademicYear.current)
   Journeys::Configuration.create!(routing_name: Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, current_academic_year: AcademicYear.current)
+  Journeys::Configuration.create!(routing_name: Journeys::GetATeacherRelocationPayment::ROUTING_NAME, current_academic_year: AcademicYear.current)
 
   ENV["FIXTURES_PATH"] = "spec/fixtures"
   ENV["FIXTURES"] = "local_authorities,local_authority_districts,schools"

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       routing_name { Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME }
     end
 
+    trait :get_a_teacher_relocation_payment do
+      routing_name { Journeys::GetATeacherRelocationPayment::ROUTING_NAME }
+    end
+
     trait :early_career_payments do
       additional_payments
     end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -1,0 +1,287 @@
+require "rails_helper"
+
+describe "teacher route: completing the form" do
+  before do
+    create(:journey_configuration, :get_a_teacher_relocation_payment)
+  end
+
+  describe "navigating forward" do
+    context "eligible users" do
+      it "submits an application" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "teacher")
+        and_i_complete_the_state_school_question
+        and_i_complete_the_contract_details_question
+        and_i_enter_my_contract_start_date
+        and_i_select_my_subject("teacher")
+        and_i_select_my_visa_type
+        and_i_enter_my_entry_date("teacher")
+        and_i_enter_my_personal_details
+        and_i_enter_my_employment_details
+        and_i_submit_the_application
+
+        then_the_application_is_submitted_successfully
+      end
+    end
+
+    context "non-eligible users" do
+      it "does not allow the user to continue the journey" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "teacher")
+        and_i_complete_the_state_school_question
+        and_i_complete_the_contract_details_question
+        and_i_enter_an_invalid_date
+
+        expect(page).to have_text("Enter your contract start date")
+      end
+    end
+  end
+
+  describe "navigating backwards" do
+    it "allows the user to navigate back to the previous pages" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "teacher")
+      and_i_complete_the_state_school_question
+      and_i_complete_the_contract_details_question
+      and_i_enter_my_contract_start_date
+      and_i_select_my_subject("teacher")
+      and_i_select_my_visa_type
+      and_i_enter_my_entry_date("teacher")
+      and_i_enter_my_personal_details
+
+      # We're now on the employment details page
+      # We start going backwards
+      when_i_click_the_back_link
+      assert_i_am_in_the_personal_details_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_entry_date_question("teacher")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_visa_type_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_subject_question("teacher")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_contract_start_date_question
+
+      when_i_click_the_back_link
+      assert_i_am_on_the_contract_details_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_state_school_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_application_route_question
+    end
+  end
+
+  def then_the_application_is_submitted_successfully
+    expect(page).to have_text("You have successfully submitted")
+    expect(Application.count).to eq(1)
+    expect(Applicant.count).to eq(1)
+    expect(Address.count).to eq(2)
+    expect(ApplicationProgress.count).to eq(1)
+    expect(School.count).to eq(1)
+    expect(Application.last).to be_valid
+  end
+
+  def when_i_start_the_form
+    visit Journeys::GetATeacherRelocationPayment::SlugSequence.start_page_url
+
+    click_link("Start")
+  end
+
+  def when_i_click_the_back_link
+    click_link("Back")
+  end
+
+  def when_i_click_the_continue_button
+    click_button("Continue")
+  end
+
+  def and_i_complete_application_route_question_with(option:)
+    raise "Unexpected option: #{option}" unless %w[salaried_trainee teacher].include?(option)
+
+    choose(option:)
+
+    click_button("Continue")
+  end
+
+  def and_i_select_my_subject(route)
+    assert_i_am_in_the_subject_question(route)
+
+    choose("Physics")
+
+    click_button("Continue")
+  end
+
+  def and_i_select_my_visa_type
+    assert_i_am_in_the_visa_type_question
+
+    select("Family visa")
+
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_entry_date(route)
+    assert_i_am_in_the_entry_date_question(route)
+
+    fill_in_date
+
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_personal_details
+    assert_i_am_in_the_personal_details_question
+
+    fill_in("personal_details_step[given_name]", with: "Bob")
+    fill_in("personal_details_step[family_name]", with: "Robertson")
+    fill_in("personal_details_step[email_address]", with: "test@example.com")
+    fill_in("personal_details_step[phone_number]", with: "01234567890")
+    fill_in("Day", with: 1)
+    fill_in("Month", with: 1)
+    fill_in("Year", with: 1990)
+    fill_in("personal_details_step[phone_number]", with: "01234567890")
+    fill_in("personal_details_step[address_line_1]", with: "12 Park Gardens")
+    fill_in("personal_details_step[address_line_2]", with: "Office 20")
+    fill_in("personal_details_step[city]", with: "London")
+    fill_in("personal_details_step[postcode]", with: "AS1 1AA")
+    select("Senegalese")
+    choose("Male")
+    fill_in("personal_details_step[passport_number]", with: "000")
+    choose("No")
+
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_employment_details
+    assert_i_am_in_the_employment_details_question
+
+    fill_in("employment_details_step[school_headteacher_name]", with: "Mr Headteacher")
+    fill_in("employment_details_step[school_name]", with: "School name")
+    fill_in("employment_details_step[school_address_line_1]", with: "1, McSchool Street")
+    fill_in("employment_details_step[school_address_line_2]", with: "Schoolville")
+    fill_in("employment_details_step[school_city]", with: "Schooltown")
+    fill_in("employment_details_step[school_postcode]", with: "SC1 1AA")
+
+    click_button("Continue")
+  end
+
+  def and_i_submit_the_application
+    click_button("Submit Application")
+  end
+
+  def choose_yes
+    choose("Yes")
+
+    click_button("Continue")
+  end
+
+  def choose_no
+    choose("No")
+
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_contract_start_date
+    assert_i_am_in_the_contract_start_date_question
+
+    fill_in_date
+
+    click_button("Continue")
+  end
+
+  def and_i_complete_the_trainee_employment_conditions(choose: "Yes")
+    assert_i_am_in_the_trainee_employment_conditions_question
+
+    choose == "Yes" ? choose_yes : choose_no
+  end
+
+  def and_i_complete_the_trainee_contract_details_question
+    choose_yes
+  end
+
+  def and_i_enter_an_invalid_date
+    fill_in("Day", with: 31)
+    fill_in("Month", with: 2)
+    fill_in("Year", with: 2019)
+
+    click_button("Continue")
+  end
+
+  def fill_in_date
+    three_months_ago = Time.zone.today - 3.months
+
+    fill_in("Day", with: three_months_ago.day)
+    fill_in("Month", with: three_months_ago.month)
+    fill_in("Year", with: three_months_ago.year)
+  end
+
+  def assert_i_am_in_the_subject_question(route)
+    expect(page).to have_text(
+      "What subject are you employed to teach at your school?"
+    )
+  end
+
+  def assert_i_am_in_the_contract_start_date_question
+    expect(page).to have_text("Enter the start date of your contract")
+  end
+
+  def assert_i_am_in_the_employment_details_question
+    expect(page).to have_text("Employment information")
+  end
+
+  def assert_i_am_in_the_personal_details_question
+    expect(page).to have_text("Personal information")
+  end
+
+  def assert_i_am_in_the_entry_date_question(route)
+    expect(page).to have_text(
+      "Enter the date you moved to England to start your teaching job"
+    )
+  end
+
+  def assert_i_am_in_the_visa_type_question
+    expect(page).to have_text("Select the visa you used to move to England")
+  end
+
+  def assert_i_am_in_the_application_route_question
+    expect(page).to have_text("What is your employment status?")
+  end
+
+  def assert_i_am_in_the_trainee_employment_conditions_question
+    expect(page).to have_text(
+      "Are you on a teacher training course in England which meets the following conditions?"
+    )
+  end
+
+  def and_i_complete_the_state_school_question
+    assert_i_am_in_the_state_school_question
+
+    choose_yes
+  end
+
+  def and_i_complete_the_contract_details_question
+    assert_i_am_on_the_contract_details_question
+
+    choose_yes
+  end
+
+  def then_i_can_see_the_landing_page
+    expect(page).to have_text("Apply for the international relocation payment")
+  end
+
+  def assert_i_am_in_the_state_school_question
+    expect(page).to have_text(
+      "Are you employed by an English state secondary school?"
+    )
+  end
+
+  def assert_i_am_on_the_contract_details_question
+    expect(page).to have_text(
+      "Are you employed on a contract lasting at least one year?"
+    )
+  end
+end

--- a/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+xdescribe "trainee route: completing the form" do
+  describe "navigating forward" do
+    context "eligible users" do
+      it "submits an application" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "salaried_trainee")
+        and_i_complete_the_trainee_employment_conditions
+        and_i_enter_my_contract_start_date
+        and_i_select_my_subject("salaried_trainee")
+        and_i_select_my_visa_type
+        and_i_enter_my_entry_date("salaried_trainee")
+        and_i_enter_my_personal_details
+        and_i_enter_my_employment_details
+        and_i_submit_the_application
+
+        then_the_application_is_submitted_successfully
+      end
+    end
+
+    context "non-eligible users" do
+      it "shows ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "salaried_trainee")
+        and_i_complete_the_trainee_employment_conditions(choose: "No")
+
+        expect(page).to have_text("We’re sorry")
+      end
+    end
+  end
+
+  describe "navigating backwards" do
+    it "allows the user to navigate back to the previous pages" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "salaried_trainee")
+      and_i_complete_the_trainee_employment_conditions
+      and_i_enter_my_contract_start_date
+      and_i_select_my_subject("salaried_trainee")
+      and_i_select_my_visa_type
+      and_i_enter_my_entry_date("salaried_trainee")
+      and_i_enter_my_personal_details
+
+      # We're now on the employment details page
+      # We start going backwards
+      when_i_click_the_back_link
+      assert_i_am_in_the_personal_details_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_entry_date_question("salaried_trainee")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_visa_type_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_subject_question("salaried_trainee")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_contract_start_date_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_trainee_employment_conditions_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_application_route_question
+    end
+  end
+
+  describe "navigating backwards, then forward" do
+    it "allows the user to navigate back & forth" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "salaried_trainee")
+      and_i_complete_the_trainee_employment_conditions
+      and_i_enter_my_contract_start_date
+      and_i_select_my_subject("salaried_trainee")
+      and_i_select_my_visa_type
+      and_i_enter_my_entry_date("salaried_trainee")
+      and_i_enter_my_personal_details
+
+      # We're now on the employment details page
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      assert_i_am_in_the_trainee_employment_conditions_question
+
+      # We start going forward again from the first question
+      when_i_click_the_continue_button
+      assert_i_am_in_the_contract_start_date_question
+
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+
+      assert_i_am_in_the_employment_details_question
+    end
+  end
+end


### PR DESCRIPTION
Need to sort out the slug sequence, check some personal details differences between IRP and claim with Laura, and fix up the other feature tests, but the initial question page renders. Not sure what we want to see on the admin side when we successfully submit a claim

**Note** will abandon this pr and issue a separate pr to set up the initial scaffolding. This was just a proof of concept to see what adding a new journey would involve. Currently this just works up to rendering the start page and the initial form