### PR TITLE
Fix DfE identity sign in page

### DIFF
--- a/app/views/claims/sign_in_or_continue.html.erb
+++ b/app/views/claims/sign_in_or_continue.html.erb
@@ -1,23 +1,22 @@
 <% @backlink_path = landing_page_path %>
-<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content">
+
+<% if @form.errors.any? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @form.errors.any? %>
-        <%= render(
-          "shared/error_summary",
-          instance: @form,
-          errored_field_id_overrides: { details_check: "claim_details_check_true" }
-        ) %>
-      <% end %>
+      <%= render(
+        "shared/error_summary",
+        instance: @form,
+        errored_field_id_overrides: { details_check: "claim_details_check_true" }) %>
     </div>
   </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-body">
-      <% if @form.signed_in_with_dfe_identity? %>
-        <%= render partial: "confirm_detail", locals: { form: @form } %>
-      <% else %>
-        <%= render partial: "sign_in_or_continue" %>
-      <% end %>
-    </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <% if @form.signed_in_with_dfe_identity? %>
+      <%= render partial: "confirm_detail", locals: { form: @form } %>
+    <% else %>
+      <%= render partial: "sign_in_or_continue" %>
+    <% end %>
   </div>
-</main>
+</div>

--- a/app/views/claims/sign_in_or_continue.html.erb
+++ b/app/views/claims/sign_in_or_continue.html.erb
@@ -1,4 +1,4 @@
-<%= link_to "Back", landing_page_path, class: "govuk-back-link" %>
+<% @backlink_path = landing_page_path %>
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_backlink.html.erb
+++ b/app/views/shared/_backlink.html.erb
@@ -1,3 +1,3 @@
 <% if @backlink_path.present? %>
-  <%= link_to 'Back', @backlink_path, class: "govuk-back-link", id: "backlink" %>
+  <%= govuk_back_link href: @backlink_path %>
 <% end %>


### PR DESCRIPTION
# Context

- The DfE identity sign in page is not quite right

# Changes

- Use GOVUK component for back link
- Removed duplicated nested `<main>` in sign in page
- Use the back link in layout rather than in view to fix visual issues
- Removed superfluous mark up on the page if there are no errors

# Screenshots

## Before
![Screenshot 2024-06-18 at 09 33 43](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/49b25ce5-983e-47ba-bc2e-c3ccbe55b729)

## After
![Screenshot 2024-06-18 at 09 34 04](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/4a215a35-e3c5-4022-9364-a312bb67c608)
