### PR TITLE
[CAPT-1729] Use GOVUK formbuilder for TRN form

### DIFF
--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -8,50 +8,29 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @form.errors.any? %>
-      <%= render("shared/error_summary", instance: @form) %>
-    <% end %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
-      <%= form_group_tag f.object do %>
-        <h1 class="govuk-label-wrapper">
-          <%= f.label(
-            :teacher_reference_number,
-            t("additional_payments.forms.teacher_reference_number.questions.teacher_reference_number"),
-            class: "govuk-label #{label_css_class_for_journey(f.object.journey)}"
-          ) %>
-        </h1>
+      <%= f.govuk_text_field :teacher_reference_number,
+        width: 10,
+        spellcheck: "false",
+        autocomplete: "off",
+        label: {
+          text: t("additional_payments.forms.teacher_reference_number.questions.teacher_reference_number"),
+          tag: "h1",
+          size: "l"
+        },
+        hint: { text: "You can get this from your payslip, teacher pension statement or teacher training records." } %>
 
-        <div class="govuk-hint" id="teacher_reference_number-hint">
-          You can get this from your payslip, teacher pension statement or teacher training records.
-        </div>
-
-        <div class="govuk-form-group">
-          <%= errors_tag f.object, :teacher_reference_number %>
-          <%= f.text_field(
-            :teacher_reference_number,
-            spellcheck: "false",
-            autocomplete: "off",
-            class: css_classes_for_input(f.object, :teacher_reference_number, 'govuk-input--width-10'),
-            "aria-describedby" => "teacher_reference_number-hint"
-          ) %>
-        </div>
+      <%= govuk_details(summary_text: "Help to find a lost TRN") do %>
+        <p>
+          Use the online service to
+          <%= govuk_link_to "find a lost TRN (opens in new tab)", "https://find-a-lost-trn.education.gov.uk/start", target: "_blank" %>
+          if you are unable to find it on your payslip, teacher pension statement or teacher training records.
+        </p>
       <% end %>
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">
-                Help to find a lost TRN
-              </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p class="govuk-body">
-            Use the online service to
-            <%= link_to "find a lost TRN (opens in new tab)", "https://find-a-lost-trn.education.gov.uk/start", class: "govuk-link", target: "_blank" %>
-            if you are unable to find it on your payslip, teacher pension statement or teacher training records.
-          </p>
-        </div>
-      </details>
-      <%= f.submit "Continue", class: "govuk-button" %>
+
+      <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>
 </div>

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -212,7 +212,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
     # - What is your teacher reference number
     expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
-    fill_in :claim_teacher_reference_number, with: "1234567"
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
     click_on "Continue"
 
     # - Check your answers before sending your application

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -205,7 +205,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     # - What is your teacher reference number
     expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
-    fill_in :claim_teacher_reference_number, with: "1234567"
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
     click_on "Continue"
 
     # - Check your answers before sending your application
@@ -614,7 +614,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     # - What is your teacher reference number
     expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
-    fill_in :claim_teacher_reference_number, with: "1234567"
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
     click_on "Continue"
 
     # - Check your answers before sending your application
@@ -935,7 +935,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
       # - What is your teacher reference number
       expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
-      fill_in :claim_teacher_reference_number, with: "1234567"
+      fill_in "claim-teacher-reference-number-field", with: "1234567"
       click_on "Continue"
 
       # - Check your answers before sending your application

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -215,7 +215,7 @@ RSpec.feature "Levelling up premium payments claims" do
     # - What is your teacher reference number
     expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
-    fill_in :claim_teacher_reference_number, with: "1234567"
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
     click_on "Continue"
 
     # - Check your answers before sending your application

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -172,7 +172,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(session.reload.answers.payroll_gender).to eq("male")
 
     expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
-    fill_in :claim_teacher_reference_number, with: "1234567"
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
     click_on "Continue"
 
     expect(session.reload.answers.teacher_reference_number).to eql("1234567")


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1729
- Ultimate goal is to remove `module GovukFormHelper` which houses custom code for forms

# Changes

- Use `GOVUKDesignSystemFormBuilder::FormBuilder` for TRN form
- I've made the question size `l`, there use to be toggle depending on which journey the user was on but not sure why you would change the font size based off the question
- Use GOVUK components where applicable