### PR TITLE
CAPT-1702 Add smoke test

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run smoke tests
         shell: bash
-        run: bin/smoke
+        run: bin/bundle exec rspec spec/smoke -t smoke:true -b
         env:
           RAILS_ENV: test
           SMOKE_TEST_APP_HOST: ${{ env.APP_URL }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -114,9 +114,15 @@ jobs:
           make ci test-aks get-cluster-credentials
           kubectl exec -n srtl-test deployment/claim-additional-payments-for-teaching-test-worker -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/prepare-database"
 
+      - name: Install Ruby 3.2.4
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.2.4
+
       - name: Run smoke tests
         shell: bash
-        run: bin/bundle exec rspec spec/smoke -t smoke:true -b
+        run: bundle exec rspec spec/smoke -t smoke:true -b
         env:
           RAILS_ENV: test
           SMOKE_TEST_APP_HOST: ${{ env.APP_URL }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -2,7 +2,7 @@ name: Build and deploy to AKS cluster
 
 on:
   push:
-    branches: [master]
+    branches: [CAPT-1702-smoke-test]
   pull_request:
     types: [labeled, opened, reopened, synchronize]
 
@@ -85,7 +85,7 @@ jobs:
     name: Deploy to test environment
     concurrency: deploy_test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/CAPT-1702-smoke-test' && github.event_name == 'push'
     needs: [build]
     environment:
       name: test-aks

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -114,7 +114,16 @@ jobs:
           make ci test-aks get-cluster-credentials
           kubectl exec -n srtl-test deployment/claim-additional-payments-for-teaching-test-worker -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/prepare-database"
 
-      - name: Slack notification
+      - name: Run smoke tests
+        shell: bash
+        run: bin/smoke
+        env:
+          RAILS_ENV: test
+          SMOKE_TEST_APP_HOST: ${{ env.APP_URL }}
+          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
+          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+
+      - name: Notify on failure
         if: failure()
         uses: rtCamp/action-slack-notify@master
         env:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -2,7 +2,7 @@ name: Build and deploy to AKS cluster
 
 on:
   push:
-    branches: [CAPT-1702-smoke-test]
+    branches: [master]
   pull_request:
     types: [labeled, opened, reopened, synchronize]
 
@@ -85,7 +85,7 @@ jobs:
     name: Deploy to test environment
     concurrency: deploy_test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/CAPT-1702-smoke-test' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: [build]
     environment:
       name: test-aks

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -129,11 +129,11 @@ jobs:
           BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
 
-      # - name: Notify on failure
-      #   if: failure()
-      #   uses: rtCamp/action-slack-notify@master
-      #   env:
-      #     SLACK_COLOR: failure
-      #     SLACK_TITLE: Failure deploying release to test
-      #     SLACK_MESSAGE: Failure deploying release to test - Docker tag ${{ needs.build.outputs.docker-image-tag }}
-      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Notify on failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_COLOR: failure
+          SLACK_TITLE: Failure deploying release to test
+          SLACK_MESSAGE: Failure deploying release to test - Docker tag ${{ needs.build.outputs.docker-image-tag }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -123,11 +123,11 @@ jobs:
           BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
 
-      - name: Notify on failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_COLOR: failure
-          SLACK_TITLE: Failure deploying release to test
-          SLACK_MESSAGE: Failure deploying release to test - Docker tag ${{ needs.build.outputs.docker-image-tag }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Notify on failure
+      #   if: failure()
+      #   uses: rtCamp/action-slack-notify@master
+      #   env:
+      #     SLACK_COLOR: failure
+      #     SLACK_TITLE: Failure deploying release to test
+      #     SLACK_MESSAGE: Failure deploying release to test - Docker tag ${{ needs.build.outputs.docker-image-tag }}
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,8 @@ group :test do
   gem "launchy"
   gem "rack_session_access"
   gem "simplecov", require: false
+  # Return null object for active record connection rather than raising error
+  gem "activerecord-nulldb-adapter"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
       activesupport (= 7.0.8.4)
     activerecord-copy (1.1.0)
       activerecord (>= 3.1)
+    activerecord-nulldb-adapter (1.0.1)
+      activerecord (>= 5.2.0, < 7.2)
     activestorage (7.0.8.4)
       actionpack (= 7.0.8.4)
       activejob (= 7.0.8.4)
@@ -544,6 +546,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-copy
+  activerecord-nulldb-adapter
   application_insights!
   bootsnap (>= 1.1.0)
   brakeman

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bin/rspec spec/smoke --tag smoke:true

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-bin/rspec spec/smoke --tag smoke:true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,12 +86,6 @@ RSpec.configure do |config|
     OmniAuth.config.mock_auth[:default] = nil
   end
 
-  config.around(:each, :smoke) do |example|
-    Capybara.app_host = ENV.fetch("SMOKE_TEST_APP_HOST")
-    example.run
-    Capybara.app_host = nil
-  end
-
   config.filter_run_excluding :smoke
   config.filter_run_excluding flaky: true unless ENV["RUN_FLAKY_SPECS"] == "true"
   config.filter_run_excluding js: true unless ENV["RUN_JS_SPECS"] == "true"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,13 @@ RSpec.configure do |config|
     OmniAuth.config.mock_auth[:default] = nil
   end
 
+  config.around(:each, :smoke) do |example|
+    Capybara.app_host = ENV.fetch("SMOKE_TEST_APP_HOST")
+    example.run
+    Capybara.app_host = nil
+  end
+
+  config.filter_run_excluding :smoke
   config.filter_run_excluding flaky: true unless ENV["RUN_FLAKY_SPECS"] == "true"
   config.filter_run_excluding js: true unless ENV["RUN_JS_SPECS"] == "true"
   config.filter_run_excluding slow: true unless ENV["RUN_SLOW_SPECS"] == "true"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,13 +22,17 @@ require "rspec/rails"
 #
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 
-# Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
+if ENV["SMOKE_TEST_APP_HOST"].present?
+  ActiveRecord::Base.establish_connection adapter: :nulldb
+else
+  # Checks for pending migrations and applies them before tests are run.
+  # If you are not using ActiveRecord, you can remove these lines.
+  begin
+    ActiveRecord::Migration.maintain_test_schema!
+  rescue ActiveRecord::PendingMigrationError => e
+    puts e.to_s.strip
+    exit 1
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/smoke/start_a_claim_spec.rb
+++ b/spec/smoke/start_a_claim_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Start a claim", :smoke, type: :feature do
+  # To test this locally you will need to add to your .env file:
+  #
+  # SMOKE_TEST_APP_HOST
+  # BASIC_AUTH_USERNAME
+  # BASIC_AUTH_PASSWORD
+
+  before do
+    create(:journey_configuration, :student_loans)
+  end
+
+  scenario "User starts a claim" do
+    visit url_with_basic_auth
+    expect(page).to have_text("Teachers: claim back your student loan repayments")
+  end
+
+  def url_with_basic_auth
+    uri = URI.parse(new_claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME))
+
+    uri.user = ENV.fetch("BASIC_AUTH_USERNAME", nil)
+    uri.password = ENV.fetch("BASIC_AUTH_PASSWORD", nil)
+    uri.to_s
+  end
+end

--- a/spec/smoke/start_a_claim_spec.rb
+++ b/spec/smoke/start_a_claim_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe "Start a claim", :smoke, type: :feature do
   end
 
   def url_with_basic_auth
-    uri = URI.parse(new_claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME))
+    host = ENV.fetch("SMOKE_TEST_APP_HOST")
+    path = new_claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME)
+    uri = URI.join(host, path)
 
     uri.user = ENV.fetch("BASIC_AUTH_USERNAME", nil)
     uri.password = ENV.fetch("BASIC_AUTH_PASSWORD", nil)

--- a/spec/smoke/start_a_claim_spec.rb
+++ b/spec/smoke/start_a_claim_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe "Start a claim", :smoke, type: :feature do
   # BASIC_AUTH_USERNAME
   # BASIC_AUTH_PASSWORD
 
-  before do
-    create(:journey_configuration, :student_loans)
-  end
-
   scenario "User starts a claim" do
     visit url_with_basic_auth
     expect(page).to have_text("Teachers: claim back your student loan repayments")

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -27,3 +27,13 @@ Capybara.configure do |config|
 end
 
 Capybara.automatic_label_click = true
+
+RSpec.configure do |config|
+  config.around(:each, :smoke) do |example|
+    Capybara.current_driver = Capybara.javascript_driver
+    Capybara.run_server = false
+    example.run
+    Capybara.run_server = true
+    Capybara.current_driver = Capybara.default_driver
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to run smoke tests on deployed environments.

## Changes proposed in this pull request

- Added job to `deploy-test` which runs tests in the spec/smoke folder, tagged with :smoke
- Added basic smoke test
- Excluded smoke tests from regular test runs

In the GitHub repo:
- Added repo secrets for SMOKE_TEST_APP_HOST, BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD

## Guidance to review

I tested the workflow by updating the branch conditions temporarily, this is the smoke test passing:

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/9596133206/job/26462471311?pr=2875


To run the smoke test locally, add SMOKE_TEST_APP_HOST, BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD to  your env and run `bundle exec rspec spec/smoke -t smoke:true`