### PR TITLE
BUGFIX Show the correct name for the previous journey

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -18,6 +18,7 @@ class ClaimsController < BasePublicController
   end
 
   def existing_session
+    @existing_session = journey_sessions.first
   end
 
   def start_new

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -11,7 +11,7 @@
             </legend>
 
           <h2 class="govuk-heading-m">
-            You have a claim in progress <%= journey_description(current_journey_routing_name) %>.
+            You have a claim in progress <%= journey_description(@existing_session.journey) %>.
           </h2>
 
           <h2 class="govuk-heading-m">


### PR DESCRIPTION
Noticed this one while checking switching journey to / from IRP

The `current_journey_routing` name shows the name of the journey we're
switching to. We need to take a look at the journey the user came from
which will be the `first` journey session.

Due to how we clear the session when the user starts a new journey there
will only ever be two journey sessions in the `journey_sessions`
collection. In this specific case, on the existing session page, there is
only one journey session in the journey_sessions collection (as the
session for the journey we're considering switching too hasn't been
created, and as such `journey_session` is `nil`)

Looking at the git history I think this has been an issue for a while. As part
of the IRP work I'm adding some regression tests that will catch this but
didn't want to block this bug fix on that work.

If we do decide to support multiple inflight journeys this whole "existing
session" handling code can be removed and the claims controller can be
simplified quite a bit.


## Before
![Screenshot 2024-06-19 at 10 16 09](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/777d9380-f84c-4d62-ba2d-17c2b7bacb7b)

## After
![Screenshot 2024-06-19 at 10 16 44](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/c98ba0d8-79c8-4c1d-875b-e6fbd093d581)
