### PR TITLE
Initial IRP journey wire up

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form.rb
@@ -1,0 +1,21 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
+      private
+
+      def main_eligibility
+        @main_eligibility ||= eligibilities.first
+      end
+
+      def calculate_award_amount(eligibility)
+        # NOOP
+        # This is just for compatibility with the AdditionalPaymentsForTeaching
+        # claim submission form.
+      end
+
+      def generate_policy_options_provided
+        []
+      end
+    end
+  end
+end

--- a/app/models/journeys.rb
+++ b/app/models/journeys.rb
@@ -7,7 +7,8 @@ module Journeys
 
   JOURNEYS = [
     AdditionalPaymentsForTeaching,
-    TeacherStudentLoanReimbursement
+    TeacherStudentLoanReimbursement,
+    GetATeacherRelocationPayment
   ].freeze
 
   def all

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -1,0 +1,14 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    extend Base
+    extend self
+
+    ROUTING_NAME = "get-a-teacher-relocation-payment"
+    VIEW_PATH = "get_a_teacher_relocation_payment"
+    I18N_NAMESPACE = "get_a_teacher_relocation_payment"
+    POLICIES = [Policies::InternationalRelocationPayments]
+    FORMS = {
+      "claims" => {}
+    }
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/eligibility_checker.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/eligibility_checker.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class EligibilityChecker < Journeys::EligibilityChecker
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session.rb
@@ -1,0 +1,7 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class Session < Journeys::Session
+      attribute :answers, SessionAnswersType.new
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SessionAnswers < Journeys::SessionAnswers
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers_type.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers_type.rb
@@ -1,0 +1,5 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SessionAnswersType < ::Journeys::SessionAnswersType; end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -1,0 +1,35 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SlugSequence
+      # FIXME RL due to how the page sequence works we need a minimum of 2
+      # slugs otherwise there's no next slug to go to. Once we have added
+      # another page remove the duplicate "check-your-answers" slug.
+      RESULTS_SLUGS = [
+        "check-your-answers",
+        "check-your-answers"
+      ].freeze
+
+      SLUGS = RESULTS_SLUGS
+
+      def self.start_page_url
+        if Rails.env.production?
+          "https://www.gov.uk/government/publications/international-relocation-payments/international-relocation-payments"
+        else
+          Rails.application.routes.url_helpers.landing_page_path("get-a-teacher-relocation-payment")
+        end
+      end
+
+      attr_reader :journey_session
+
+      delegate :answers, to: :journey_session
+
+      def initialize(journey_session)
+        @journey_session = journey_session
+      end
+
+      def slugs
+        SLUGS
+      end
+    end
+  end
+end

--- a/app/models/policies/international_relocation_payments.rb
+++ b/app/models/policies/international_relocation_payments.rb
@@ -1,0 +1,4 @@
+module Policies
+  module InternationalRelocationPayments
+  end
+end

--- a/app/models/policies/international_relocation_payments/eligibility.rb
+++ b/app/models/policies/international_relocation_payments/eligibility.rb
@@ -1,0 +1,17 @@
+module Policies
+  module InternationalRelocationPayments
+    class Eligibility < ApplicationRecord
+      self.table_name = "international_relocation_payments_eligibilities"
+
+      has_one :claim, as: :eligibility, inverse_of: :eligibility
+
+      def ineligible?
+        false
+      end
+
+      def policy
+        Policies::InternationalRelocationPayments
+      end
+    end
+  end
+end

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -1,0 +1,21 @@
+module Policies
+  module InternationalRelocationPayments
+    class PolicyEligibilityChecker
+      attr_reader :answers
+
+      delegate_missing_to :answers
+
+      def initialize(answers:)
+        @answers = answers
+      end
+
+      def status
+        :eligible_now
+      end
+
+      def ineligible?
+        false
+      end
+    end
+  end
+end

--- a/app/views/get_a_teacher_relocation_payment/claims/check_your_answers.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/check_your_answers.html.erb
@@ -1,0 +1,27 @@
+<% content_for(
+  :page_title,
+  page_title(
+    "Check your answers before sending your application",
+    journey: current_journey_routing_name,
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Check your answers before sending your application
+    </h1>
+
+    <%= form_for @form, url: claim_submission_path, method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h2 class="govuk-heading-m"><%= t("check_your_answers.heading_send_application") %></h2>
+
+      <p class="govuk-body"><%= t("check_your_answers.statement") %></p>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_submit t("check_your_answers.btn_text") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
@@ -1,0 +1,120 @@
+<div class="govuk-grid-row">
+   <div class="govuk-grid-column-full">
+     <h1 class="govuk-heading-xl">Apply for the international relocation payment</h1>
+   </div>
+ </div>
+
+ <div class="govuk-grid-row">
+   <div class="govuk-grid-column-full">
+     <p class="govuk-body">
+       The international relocation payment (IRP) is a single payment of £10,000,
+       funded by the UK government, which is available to eligible non-UK trainees and teachers of:
+     </p>
+
+     <ul class="govuk-list govuk-list--bullet">
+       <li>languages</li>
+       <li>physics</li>
+       <li>general or combined science when that includes physics</li>
+     </ul>
+
+     <p class="govuk-body">
+       Only teachers and salaried trainees need to complete this form.
+     </p>
+
+     <p class="govuk-body">
+       Before starting your application, visit
+       <%= govuk_link_to(
+         "Get an international relocation payment",
+         "https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment",
+         target: "_blank"
+       ) %>
+       to check the criteria you must meet to receive the IRP. You need to have started your job or course before you can apply.
+     </p>
+
+     <p class="govuk-body">
+       You should also get your documents and information ready, as you will
+       not be able to save your entries and return to the form later. It should
+       take approximately 15 minutes to complete.
+     </p>
+
+
+     <h2 class="govuk-heading-l">Documents and information to get ready</h2>
+
+     <p class="govuk-body">
+       You will need:
+     </p>
+
+     <ul class="govuk-list govuk-list--bullet">
+       <li>
+         if you are a teacher, your teaching subject and the terms of your employment contract
+       </li>
+       <li>
+         if you are a salaried trainee, details of your teacher training course, including
+         teaching subject and start date
+       </li>
+       <li>
+         your visa type and when you entered the UK
+       </li>
+       <li>
+         your passport
+       </li>
+       <li>
+         your address in England
+       </li>
+       <li>
+         contact details for the school where you are employed as a teacher or trainee
+       </li>
+     </ul>
+
+     <p class="govuk-body">
+       <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+         Start
+         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+         </svg>
+       </a>
+     </p>
+
+     <h2 class="govuk-heading-l">Deadline for applications</h2>
+
+     <p class="govuk-body">
+       Applications for the international relocation payment (IRP) are open from:
+     </p>
+
+     <ul class="govuk-list govuk-list--bullet">
+       <li>2 April to 16 June 2024</li>
+     </ul>
+
+     <p class="govuk-body">
+       If you have started your teaching job or salaried teacher training
+       course, you should apply now. If you are eligible, you should receive
+       the money by 30 September 2024.
+     </p>
+
+     <p class="govuk-body">
+       To remain eligible for the IRP, you must apply in either the first or
+       second term of your employment as a teacher or salaried trainee.
+     </p>
+     <p class="govuk-body">
+       Applications will re-open later in 2024.
+     </p>
+
+     <h2 class="govuk-heading-l">Not ready to apply?</h2>
+     <p class="govuk-body">
+       If you have not started your job or course, please visit
+       <%= govuk_link_to(
+         "Get an international relocation payment",
+         "https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment",
+         target: "_blank"
+       ) %>
+       for information about future applications.
+     </p>
+
+     <h2 class="govuk-heading-m">Contact us</h2>
+
+     <p class="govuk-body">
+       For help, please email us at
+       <%= govuk_link_to("teach.inengland@education.gov.uk", "mailto:teach.inengland@education.gov.uk")%>.
+     </p>
+   </div>
+ </div>

--- a/app/views/get_a_teacher_relocation_payment/submissions/show.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/submissions/show.html.erb
@@ -1,0 +1,29 @@
+<% content_for(:page_title, page_title("Claim submitted", journey: current_journey_routing_name)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title" id="submitted-title">Claim submitted</h1>
+
+      <div class="govuk-panel__body">
+        Your reference number<br>
+        <strong><%= submitted_claim.reference %></strong>
+      </div>
+    </div>
+
+    <p class="govuk-body">
+      We have sent you a confirmation email to <%= submitted_claim.email_address %>.
+    </p>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+
+    <%= render partial: "submissions/confirmation" %>
+
+    <p class="govuk-body">
+      <%= link_to "What do you think of this service?", done_page_url, class: "govuk-link" %>
+      (takes 30 seconds)
+    </p>
+  </div>
+</div>
+

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -215,6 +215,10 @@ shared:
     - eligible_degree_subject
     - induction_completed
     - school_somewhere_else
+  :international_relocation_payments_eligibilities:
+    - id
+    - created_at
+    - updated_at
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -679,6 +679,11 @@ en:
     claim_amount_description: "Additional payment for teaching"
     support_email_address: "levellinguppremiumpayments@digital.education.gov.uk"
     information_provided_further_details_link_text: levelling up premium payment (opens in new tab)
+  get_a_teacher_relocation_payment:
+    journey_name: "Get a teacher relocation payment"
+    feedback_email: "teach.inengland@education.gov.uk"
+    claim_description: "for a get a teacher relocation payment"
+
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       resources :reminders, only: [:show, :update], param: :slug, constraints: {slug: %r{#{Journeys::AdditionalPaymentsForTeaching::SlugSequence::REMINDER_SLUGS.join("|")}}}, controller: "journeys/additional_payments_for_teaching/reminders"
     end
 
-    scope path: "/", constraints: {journey: /student-loans|additional-payments/} do
+    scope path: "/", constraints: {journey: /student-loans|additional-payments|get-a-teacher-relocation-payment/} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end
   end

--- a/db/migrate/20240618143941_create_policies_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240618143941_create_policies_relocation_payments_eligibilities.rb
@@ -1,0 +1,7 @@
+class CreatePoliciesRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :international_relocation_payments_eligibilities, id: :uuid do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_10_144004) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_18_143941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -176,6 +176,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_10_144004) do
   create_table "file_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "uploaded_by_id"
     t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "international_relocation_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@
 if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")
   Journeys::Configuration.create!(routing_name: Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, current_academic_year: AcademicYear.current)
   Journeys::Configuration.create!(routing_name: Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, current_academic_year: AcademicYear.current)
+  Journeys::Configuration.create!(routing_name: Journeys::GetATeacherRelocationPayment::ROUTING_NAME, current_academic_year: AcademicYear.current)
 
   ENV["FIXTURES_PATH"] = "spec/fixtures"
   ENV["FIXTURES"] = "local_authorities,local_authority_districts,schools"

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       routing_name { Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME }
     end
 
+    trait :get_a_teacher_relocation_payment do
+      routing_name { Journeys::GetATeacherRelocationPayment::ROUTING_NAME }
+    end
+
     trait :early_career_payments do
       additional_payments
     end

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -1,0 +1,35 @@
+FactoryBot.define do
+  factory :get_a_teacher_relocation_payment_answers, class: "Journeys::GetATeacherRelocationPayment::SessionAnswers" do
+    trait :with_personal_details do
+      first_name { "Jo" }
+      surname { "Bloggs" }
+      date_of_birth { 20.years.ago.to_date }
+      national_insurance_number { generate(:national_insurance_number) }
+    end
+
+    trait :with_email_details do
+      email_address { generate(:email_address) }
+      email_verified { true }
+    end
+
+    trait :with_mobile_details do
+      mobile_number { "07474000123" }
+      provide_mobile_number { true }
+      mobile_verified { true }
+    end
+
+    trait :with_bank_details do
+      bank_or_building_society { :personal_bank_account }
+      banking_name { "Jo Bloggs" }
+      bank_sort_code { rand(100000..999999) }
+      bank_account_number { rand(10000000..99999999) }
+    end
+
+    trait :submitable do
+      with_personal_details
+      with_email_details
+      with_mobile_details
+      with_bank_details
+    end
+  end
+end

--- a/spec/factories/policies/international_relocation_payments/eligibilities.rb
+++ b/spec/factories/policies/international_relocation_payments/eligibilities.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :international_relocation_payments_eligibility, class: "Policies::InternationalRelocationPayments::Eligibility" do
+  end
+end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe "teacher route: completing the form" do
+  before do
+    create(:journey_configuration, :get_a_teacher_relocation_payment)
+  end
+
+  describe "navigating forward" do
+    context "eligible users" do
+      it "submits an application" do
+        when_i_start_the_form
+        and_the_personal_details_section_has_been_temporarily_stubbed
+        and_i_submit_the_application
+        then_the_application_is_submitted_successfully
+      end
+    end
+  end
+
+  def when_i_start_the_form
+    visit Journeys::GetATeacherRelocationPayment::SlugSequence.start_page_url
+
+    click_link("Start")
+  end
+
+  def and_i_submit_the_application
+    assert_on_check_your_answers_page!
+
+    click_button("Confirm and send")
+  end
+
+  # FIXME RL make sure to remove this step it's just a temporary hack until
+  # we've added the personal details pages. Really don't want to modify the db
+  # in a feature spec!
+  # Also we're only temporarily adding the teacher reference number, and
+  # payroll gender to get the test to pass as we're not asking for it on the
+  # IRP journey.
+  def and_the_personal_details_section_has_been_temporarily_stubbed
+    journey_session = Journeys::GetATeacherRelocationPayment::Session.last
+    journey_session.answers.assign_attributes(
+      attributes_for(
+        :get_a_teacher_relocation_payment_answers,
+        :submitable,
+        email_address: "test-irp-claim@example.com",
+        teacher_reference_number: "1234567",
+        payroll_gender: "male"
+      )
+    )
+    journey_session.save!
+  end
+
+  def then_the_application_is_submitted_successfully
+    assert_application_is_submitted!
+  end
+
+  def assert_on_check_your_answers_page!
+    expect(page).to have_text("Check your answers before sending your application")
+  end
+
+  def assert_application_is_submitted!
+    expect(page).to have_content("Claim submitted")
+    expect(page).to have_content(
+      "We have sent you a confirmation email to test-irp-claim@example.com"
+    )
+  end
+end

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -6,29 +6,102 @@ RSpec.feature "Switching policies" do
   before do
     create(:journey_configuration, :student_loans)
     create(:journey_configuration, :early_career_payments)
-
-    start_student_loans_claim
-    visit new_claim_path("additional-payments")
+    create(:journey_configuration, :get_a_teacher_relocation_payment)
   end
 
-  scenario "a user can switch to a different policy after starting a claim on another" do
-    expect(page.title).to have_text(I18n.t("additional_payments.journey_name"))
-    expect(page.find("header")).to have_text(I18n.t("additional_payments.journey_name"))
+  context "swtiching from student loans to additional payments" do
+    before do
+      start_student_loans_claim
+      visit new_claim_path("additional-payments")
+    end
 
-    choose "Yes, start claim for an additional payment for teaching and lose my progress on my first claim"
-    click_on "Submit"
+    scenario "a user can switch to a different policy after starting a claim on another" do
+      expect(page.title).to have_text(I18n.t("additional_payments.journey_name"))
+      expect(page.find("header")).to have_text(I18n.t("additional_payments.journey_name"))
 
-    expect(page).to have_text("You can sign in or set up a DfE Identity account to make it easier to claim additional payments.")
+      choose "Yes, start claim for an additional payment for teaching and lose my progress on my first claim"
+      click_on "Submit"
+
+      expect(page).to have_text("You can sign in or set up a DfE Identity account to make it easier to claim additional payments.")
+    end
+
+    scenario "a user can choose to continue their claim" do
+      choose "No, finish the claim I have in progress"
+      click_on "Submit"
+
+      expect(page).to have_text(claim_school_question)
+    end
   end
 
-  scenario "a user can choose to continue their claim" do
-    choose "No, finish the claim I have in progress"
-    click_on "Submit"
+  context "switching from additional payments to get a teacher relocation payment" do
+    before do
+      school = create(:school, :combined_journey_eligibile_for_all)
 
-    expect(page).to have_text(claim_school_question)
+      visit new_claim_path("additional-payments")
+
+      skip_tid
+
+      choose_school school
+
+      visit new_claim_path("get-a-teacher-relocation-payment")
+    end
+
+    scenario "a user can switch to a different policy after starting a claim on another" do
+      expect(page.title).to have_text(
+        I18n.t("get_a_teacher_relocation_payment.journey_name")
+      )
+
+      expect(page.find("header")).to(
+        have_text(I18n.t("get_a_teacher_relocation_payment.journey_name"))
+      )
+
+      choose "Yes, start claim for a get a teacher relocation payment and lose my progress on my first claim"
+
+      click_on "Submit"
+
+      # FIXME RL as of writing this test, the journey only has one page "check
+      # your answers", once the real first page of the journey is added this
+      # test will need to be updated to test for the content of that page
+      expect(page.title).to include(
+        "Check your answers before sending your application — Get a teacher relocation payment"
+      )
+    end
+
+    scenario "a user can choose to continue their claim" do
+      choose "No, finish the claim I have in progress"
+      click_on "Submit"
+
+      expect(page.title).to include("Claim additional payments for teaching")
+    end
+  end
+
+  context "Switching from teacher relocation to additional payments" do
+    before do
+      visit new_claim_path("get-a-teacher-relocation-payment")
+
+      # FIXME RL as of writing this test, the journey only has one page "check
+      # your answers", once the real first page of the journey is added this
+      # test will need to be updated to select an option on that page
+      click_on "Continue"
+
+      visit new_claim_path("additional-payments")
+    end
+
+    scenario "a user can switch to a different policy after starting a claim on another" do
+      expect(page).to have_content "Are you sure you want to start a claim for an additional payment for teaching?"
+
+      expect(page).to have_content "You have a claim in progress for a get a teacher relocation payment"
+
+      choose "Yes, start claim for an additional payment for teaching and lose my progress on my first claim"
+
+      click_on "Submit"
+    end
   end
 
   scenario "a user does not select an option" do
+    start_student_loans_claim
+    visit new_claim_path("additional-payments")
+
     click_on "Submit"
 
     expect(page).to have_text("Select yes if you want to start a claim for an additional payment for teaching")

--- a/spec/models/journeys_spec.rb
+++ b/spec/models/journeys_spec.rb
@@ -5,13 +5,21 @@ require "rails_helper"
 RSpec.describe Journeys do
   describe ".all" do
     it "returns all the journeys" do
-      expect(described_class.all).to eq([Journeys::AdditionalPaymentsForTeaching, Journeys::TeacherStudentLoanReimbursement])
+      expect(described_class.all).to eq([
+        Journeys::AdditionalPaymentsForTeaching,
+        Journeys::TeacherStudentLoanReimbursement,
+        Journeys::GetATeacherRelocationPayment
+      ])
     end
   end
 
   describe ".all_routing_names" do
     it "returns all the journeys' routing names" do
-      expect(described_class.all_routing_names).to eq([Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME])
+      expect(described_class.all_routing_names).to eq([
+        Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME,
+        Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME,
+        Journeys::GetATeacherRelocationPayment::ROUTING_NAME
+      ])
     end
   end
 


### PR DESCRIPTION
This commit adds the initial set up for IRP along with a some feature
tests.
So far the IRP journey lets a user click "Start now" and then
shows the check your answers page where they can submit a claim.
The feature test has some temporary hacks, where we update the database
model, this is just required to get the answers in a state that passes
the validations on the claim. We'll be removing the
`teacher_reference_number` question and (probably) the `payroll_gender`
question from the IRP journey but they're currently required to submit a claim.

[follow up PR that adds the first form to the journey](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2886)