### PR TITLE
CAPT 1689/irp/application route

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
@@ -1,0 +1,26 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class ApplicationRouteForm < Form
+      attribute :application_route, :string
+      validates :application_route,
+        inclusion: {
+          in: :available_options,
+          message: i18n_error_message(:inclusion)
+        }
+
+      def available_options
+        %w[teacher salaried_trainee other]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(
+          application_route: application_route
+        )
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -8,7 +8,9 @@ module Journeys
     I18N_NAMESPACE = "get_a_teacher_relocation_payment"
     POLICIES = [Policies::InternationalRelocationPayments]
     FORMS = {
-      "claims" => {}
+      "claims" => {
+        "application-route" => ApplicationRouteForm
+      }
     }
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -1,0 +1,23 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class AnswersPresenter < BaseAnswersPresenter
+      include ActionView::Helpers::TranslationHelper
+
+      def eligibility_answers
+        [].tap do |a|
+          a << application_route
+        end.compact
+      end
+
+      private
+
+      def application_route
+        [
+          t("get_a_teacher_relocation_payment.forms.application_route.question"),
+          t("get_a_teacher_relocation_payment.forms.application_route.answers.#{answers.application_route}.answer"),
+          "application-route"
+        ]
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -1,6 +1,7 @@
 module Journeys
   module GetATeacherRelocationPayment
     class SessionAnswers < Journeys::SessionAnswers
+      attribute :application_route, :string
     end
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -1,15 +1,16 @@
 module Journeys
   module GetATeacherRelocationPayment
     class SlugSequence
-      # FIXME RL due to how the page sequence works we need a minimum of 2
-      # slugs otherwise there's no next slug to go to. Once we have added
-      # another page remove the duplicate "check-your-answers" slug.
+      ELIGIBILITY_SLUGS = [
+        "application-route",
+        "check-your-answers-part-one"
+      ]
+
       RESULTS_SLUGS = [
-        "check-your-answers",
         "check-your-answers"
       ].freeze
 
-      SLUGS = RESULTS_SLUGS
+      SLUGS = ELIGIBILITY_SLUGS + RESULTS_SLUGS
 
       def self.start_page_url
         if Rails.env.production?

--- a/app/views/get_a_teacher_relocation_payment/claims/application_route.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/application_route.html.erb
@@ -1,0 +1,37 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.application_route.question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :application_route,
+        f.object.available_options,
+        -> (option) { option },
+        -> (option) { t("get_a_teacher_relocation_payment.forms.application_route.answers.#{option}.answer") },
+        -> (option) do
+          if I18n.exists?("get_a_teacher_relocation_payment.forms.application_route.answers.#{option}.hint")
+            t("get_a_teacher_relocation_payment.forms.application_route.answers.#{option}.hint")
+          end
+        end,
+        legend: { text: t("get_a_teacher_relocation_payment.forms.application_route.question") },
+        hint: { text: t("get_a_teacher_relocation_payment.forms.application_route.hint") }
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/get_a_teacher_relocation_payment/claims/check_your_answers_part_one.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/check_your_answers_part_one.html.erb
@@ -1,0 +1,29 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.check_your_answers.part_one.primary_heading"),
+    journey: current_journey_routing_name,
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t("get_a_teacher_relocation_payment.check_your_answers.part_one.primary_heading") %>
+    </h1>
+
+    <%= render(
+      partial: "claims/check_your_answers_section",
+      locals: {
+        heading: t("get_a_teacher_relocation_payment.check_your_answers.part_one.eligibility_details"),
+        answers: journey.answers_for_claim(journey_session).eligibility_answers,
+      }) %>
+
+    <%= button_to(
+      "Continue",
+      claim_path(current_journey_routing_name),
+      method: :patch,
+      class: "govuk-button"
+    ) %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -219,6 +219,7 @@ shared:
     - id
     - created_at
     - updated_at
+    - application_route
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -683,6 +683,26 @@ en:
     journey_name: "Get a teacher relocation payment"
     feedback_email: "teach.inengland@education.gov.uk"
     claim_description: "for a get a teacher relocation payment"
+    forms:
+      application_route:
+        question: "What is your employment status?"
+        hint: "Select one of the following options"
+        answers:
+          teacher:
+            answer: "I am employed as a teacher in a school in England"
+          salaried_trainee:
+            answer: "I am enrolled on a salaried teacher training course in England"
+            hint: "‘Salaried’ means a course where you are paid a wage to work while you train."
+          other:
+            answer: "Other"
+        errors:
+          inclusion: "Select the option that applies to you"
+    check_your_answers:
+      part_one:
+        primary_heading: "Check your answers"
+        eligibility_details: "Eligibility details"
+        confirmation_notice:
+          "By selecting continue you are confirming that, to the best of your knowledge, the details you are providing are correct."
 
   activerecord:
     errors:

--- a/db/migrate/20240620084630_add_application_route_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240620084630_add_application_route_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddApplicationRouteToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :application_route, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_18_143941) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_20_084630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -183,6 +183,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_18_143941) do
   create_table "international_relocation_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "application_route"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
       national_insurance_number { generate(:national_insurance_number) }
     end
 
+    trait :with_application_route do
+      application_route { "teacher" }
+    end
+
     trait :with_email_details do
       email_address { generate(:email_address) }
       email_verified { true }

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/session.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/session.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory(
+    :get_a_teacher_relocation_payment_session,
+    class: "Journeys::GetATeacherRelocationPayment::Session"
+  ) do
+    journey { "get-a-teacher-relocation-payment" }
+  end
+end

--- a/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "teacher route: completing the form" do
+describe "trainee route: completing the form" do
   include GetATeacherRelocationPayment::StepHelpers
 
   before do
@@ -11,7 +11,7 @@ describe "teacher route: completing the form" do
     it "submits an application" do
       when_i_start_the_form
       and_i_complete_application_route_question_with(
-        option: "I am employed as a teacher in a school in England"
+        option: "I am enrolled on a salaried teacher training course in England"
       )
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
@@ -25,7 +25,7 @@ describe "teacher route: completing the form" do
     assert_on_check_your_answers_part_one_page!
 
     expect(page).to have_text(
-      "What is your employment status? I am employed as a teacher in a school in England"
+      "What is your employment status? I am enrolled on a salaried teacher training course in England"
     )
   end
 end

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -59,11 +59,8 @@ RSpec.feature "Switching policies" do
 
       click_on "Submit"
 
-      # FIXME RL as of writing this test, the journey only has one page "check
-      # your answers", once the real first page of the journey is added this
-      # test will need to be updated to test for the content of that page
       expect(page.title).to include(
-        "Check your answers before sending your application — Get a teacher relocation payment"
+        "What is your employment status? — Get a teacher relocation payment"
       )
     end
 

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(claim: {application_route: option})
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    let(:option) { nil }
+
+    it do
+      is_expected.to(
+        validate_inclusion_of(:application_route)
+        .in_array(%w[teacher salaried_trainee other])
+        .with_message("Select the option that applies to you")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:option) { "teacher" }
+
+    it "udpates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.application_route }.to("teacher")
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
+  let(:journey_session) do
+    create(:get_a_teacher_relocation_payment_session, answers: answers)
+  end
+
+  let(:presenter) { described_class.new(journey_session) }
+
+  describe "#eligibility_answers" do
+    subject { presenter.eligibility_answers }
+
+    let(:answers) do
+      build(
+        :get_a_teacher_relocation_payment_answers,
+        :with_application_route
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "What is your employment status?",
+          "I am employed as a teacher in a school in England",
+          "application-route"
+        ]
+      )
+    end
+  end
+end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -1,0 +1,64 @@
+module GetATeacherRelocationPayment
+  module StepHelpers
+    def when_i_start_the_form
+      visit Journeys::GetATeacherRelocationPayment::SlugSequence.start_page_url
+
+      click_link("Start")
+    end
+
+    def and_i_submit_the_application
+      assert_on_check_your_answers_page!
+
+      click_button("Confirm and send")
+    end
+
+    # FIXME RL make sure to remove this step it's just a temporary hack until
+    # we've added the personal details pages. Really don't want to modify the db
+    # in a feature spec!
+    # Also we're only temporarily adding the teacher reference number, and
+    # payroll gender to get the test to pass as we're not asking for it on the
+    # IRP journey.
+    def and_the_personal_details_section_has_been_temporarily_stubbed
+      journey_session = Journeys::GetATeacherRelocationPayment::Session.last
+      journey_session.answers.assign_attributes(
+        attributes_for(
+          :get_a_teacher_relocation_payment_answers,
+          :submitable,
+          email_address: "test-irp-claim@example.com",
+          teacher_reference_number: "1234567",
+          payroll_gender: "male"
+        )
+      )
+      journey_session.save!
+    end
+
+    def and_i_complete_application_route_question_with(option: "teacher")
+      choose(option)
+
+      click_button("Continue")
+    end
+
+    def and_i_dont_change_my_answers
+      click_button("Continue")
+    end
+
+    def then_the_application_is_submitted_successfully
+      assert_application_is_submitted!
+    end
+
+    def assert_on_check_your_answers_part_one_page!
+      expect(page).to have_text("Check your answers")
+    end
+
+    def assert_on_check_your_answers_page!
+      expect(page).to have_text("Check your answers before sending your application")
+    end
+
+    def assert_application_is_submitted!
+      expect(page).to have_content("Claim submitted")
+      expect(page).to have_content(
+        "We have sent you a confirmation email to test-irp-claim@example.com"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Add application route

Adds the application route question on the irp journey and the check
your answers part one page.
We'll need to handle selecting the "other" option which makes the claim
ineligible but this will be addressed in a future commit.

## Walk though of IRP journey

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/acde6e57-291f-41d9-bcd0-d086e902e812

[follow up pr that adds eligibility checking](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2888)