### PR TITLE
CAPT 1689/irp/school details

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
@@ -15,11 +15,23 @@ module Journeys
       def save
         return false unless valid?
 
+        if application_route_changed?
+          journey_session.answers.assign_attributes(
+            state_funded_secondary_school: nil
+          )
+        end
+
         journey_session.answers.assign_attributes(
           application_route: application_route
         )
 
         journey_session.save!
+      end
+
+      private
+
+      def application_route_changed?
+        journey_session.answers.application_route != application_route
       end
     end
   end

--- a/app/forms/journeys/get_a_teacher_relocation_payment/state_funded_secondary_school_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/state_funded_secondary_school_form.rb
@@ -1,0 +1,27 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class StateFundedSecondarySchoolForm < Form
+      attribute :state_funded_secondary_school, :boolean
+
+      validates :state_funded_secondary_school,
+        inclusion: {
+          in: [true, false],
+          message: i18n_error_message(:inclusion)
+        }
+
+      def available_options
+        [true, false]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(
+          state_funded_secondary_school: state_funded_secondary_school
+        )
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/forms/journeys/get_a_teacher_relocation_payment/trainee_details_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/trainee_details_form.rb
@@ -1,0 +1,27 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class TraineeDetailsForm < Form
+      attribute :state_funded_secondary_school, :boolean
+
+      validates :state_funded_secondary_school,
+        inclusion: {
+          in: [true, false],
+          message: i18n_error_message(:inclusion)
+        }
+
+      def available_options
+        [true, false]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(
+          state_funded_secondary_school: state_funded_secondary_school
+        )
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -9,7 +9,8 @@ module Journeys
     POLICIES = [Policies::InternationalRelocationPayments]
     FORMS = {
       "claims" => {
-        "application-route" => ApplicationRouteForm
+        "application-route" => ApplicationRouteForm,
+        "state-funded-secondary-school" => StateFundedSecondarySchoolForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -10,7 +10,8 @@ module Journeys
     FORMS = {
       "claims" => {
         "application-route" => ApplicationRouteForm,
-        "state-funded-secondary-school" => StateFundedSecondarySchoolForm
+        "state-funded-secondary-school" => StateFundedSecondarySchoolForm,
+        "trainee-details" => TraineeDetailsForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -6,6 +6,7 @@ module Journeys
       def eligibility_answers
         [].tap do |a|
           a << application_route
+          a << state_funded_secondary_school
         end.compact
       end
 
@@ -16,6 +17,14 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.application_route.question"),
           t("get_a_teacher_relocation_payment.forms.application_route.answers.#{answers.application_route}.answer"),
           "application-route"
+        ]
+      end
+
+      def state_funded_secondary_school
+        [
+          t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.question"),
+          t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.answers.#{answers.state_funded_secondary_school}.answer"),
+          "state-funded-secondary-school"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -6,7 +6,11 @@ module Journeys
       def eligibility_answers
         [].tap do |a|
           a << application_route
-          a << state_funded_secondary_school
+          a << if answers.trainee?
+            trainee_details
+          else
+            state_funded_secondary_school
+          end
         end.compact
       end
 
@@ -25,6 +29,14 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.question"),
           t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.answers.#{answers.state_funded_secondary_school}.answer"),
           "state-funded-secondary-school"
+        ]
+      end
+
+      def trainee_details
+        [
+          t("get_a_teacher_relocation_payment.forms.trainee_details.question"),
+          t("get_a_teacher_relocation_payment.forms.trainee_details.answers.#{answers.state_funded_secondary_school}.answer"),
+          "trainee-details"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -3,6 +3,10 @@ module Journeys
     class SessionAnswers < Journeys::SessionAnswers
       attribute :application_route, :string
       attribute :state_funded_secondary_school, :boolean
+
+      def trainee?
+        application_route == "salaried_trainee"
+      end
     end
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -2,6 +2,7 @@ module Journeys
   module GetATeacherRelocationPayment
     class SessionAnswers < Journeys::SessionAnswers
       attribute :application_route, :string
+      attribute :state_funded_secondary_school, :boolean
     end
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -3,6 +3,7 @@ module Journeys
     class SlugSequence
       ELIGIBILITY_SLUGS = [
         "application-route",
+        "state-funded-secondary-school",
         "check-your-answers-part-one"
       ]
 

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -4,6 +4,7 @@ module Journeys
       ELIGIBILITY_SLUGS = [
         "application-route",
         "state-funded-secondary-school",
+        "trainee-details",
         "check-your-answers-part-one"
       ]
 
@@ -31,7 +32,13 @@ module Journeys
       end
 
       def slugs
-        SLUGS
+        SLUGS.dup.tap do |sequence|
+          if answers.trainee?
+            sequence.delete("state-funded-secondary-school")
+          else
+            sequence.delete("trainee-details")
+          end
+        end
       end
     end
   end

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -25,6 +25,8 @@ module Policies
         case answers.attributes.symbolize_keys
         in application_route: "other"
           "application route other not accecpted"
+        in state_funded_secondary_school: false
+          "school not state funded"
         else
           nil
         end

--- a/app/views/get_a_teacher_relocation_payment/claims/state_funded_secondary_school.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/state_funded_secondary_school.html.erb
@@ -1,0 +1,33 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :state_funded_secondary_school,
+        f.object.available_options,
+        -> (option) { option },
+        -> (option) { t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.answers.#{option}.answer") },
+        legend: { text: t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.question") },
+        hint: { text: t("get_a_teacher_relocation_payment.forms.state_funded_secondary_school.hint") }
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/get_a_teacher_relocation_payment/claims/trainee_details.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/trainee_details.html.erb
@@ -1,0 +1,34 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.trainee_details.question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :state_funded_secondary_school,
+        f.object.available_options,
+        -> (option) { option },
+        -> (option) { t("get_a_teacher_relocation_payment.forms.trainee_details.answers.#{option}.answer") },
+        legend: { text: t("get_a_teacher_relocation_payment.forms.trainee_details.question") },
+        hint: { html: t("get_a_teacher_relocation_payment.forms.trainee_details.hint_html") }
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+

--- a/app/views/get_a_teacher_relocation_payment/claims/trainee_details.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/trainee_details.html.erb
@@ -23,7 +23,7 @@
         -> (option) { option },
         -> (option) { t("get_a_teacher_relocation_payment.forms.trainee_details.answers.#{option}.answer") },
         legend: { text: t("get_a_teacher_relocation_payment.forms.trainee_details.question") },
-        hint: { html: t("get_a_teacher_relocation_payment.forms.trainee_details.hint_html") }
+        hint: { text: t("get_a_teacher_relocation_payment.forms.trainee_details.hint_html") }
       ) %>
 
       <%= f.govuk_submit %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -220,6 +220,7 @@ shared:
     - created_at
     - updated_at
     - application_route
+    - state_funded_secondary_school
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -707,6 +707,24 @@ en:
             answer: "No"
         errors:
           inclusion: "Select the option that applies to you"
+      trainee_details:
+        question: "Are you on a teacher training course in England which meets the following conditions?"
+        hint_html: >
+          The course must:
+          <ul>
+            <li>pay a salary</li>
+            <li>lead to qualified teacher status (QTS)</li>
+            <li>be accredited by the UK government</li>
+          </ul>
+          Check with your training provider if you're not sure.
+        answers:
+          true:
+            answer: "Yes"
+          false:
+            answer: "No"
+        errors:
+          inclusion: "Select the option that applies to you"
+
     check_your_answers:
       part_one:
         primary_heading: "Check your answers"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -697,6 +697,16 @@ en:
             answer: "Other"
         errors:
           inclusion: "Select the option that applies to you"
+      state_funded_secondary_school:
+        question: "Are you employed by an English state secondary school?"
+        hint: "State schools receive funding from the UK government. Secondary schools teach children aged 11 to 16, or 11 to 18."
+        answers:
+          true:
+            answer: "Yes"
+          false:
+            answer: "No"
+        errors:
+          inclusion: "Select the option that applies to you"
     check_your_answers:
       part_one:
         primary_heading: "Check your answers"

--- a/db/migrate/20240620085756_add_state_funded_secondary_school_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240620085756_add_state_funded_secondary_school_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddStateFundedSecondarySchoolToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :state_funded_secondary_school, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_20_084630) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_20_085756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -184,6 +184,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_20_084630) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "application_route"
+    t.boolean "state_funded_secondary_school"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -7,8 +7,12 @@ FactoryBot.define do
       national_insurance_number { generate(:national_insurance_number) }
     end
 
-    trait :with_application_route do
+    trait :with_teacher_application_route do
       application_route { "teacher" }
+    end
+
+    trait :with_trainee_application_route do
+      application_route { "salaried_trainee" }
     end
 
     trait :with_state_funded_secondary_school do
@@ -34,16 +38,8 @@ FactoryBot.define do
     end
 
     trait :eligible_teacher do
-      with_application_route
+      with_teacher_application_route
       with_state_funded_secondary_school
-    end
-
-    trait :submitable do
-      eligible_teacher
-      with_personal_details
-      with_email_details
-      with_mobile_details
-      with_bank_details
     end
   end
 end

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       application_route { "teacher" }
     end
 
+    trait :with_state_funded_secondary_school do
+      state_funded_secondary_school { true }
+    end
+
     trait :with_email_details do
       email_address { generate(:email_address) }
       email_verified { true }
@@ -29,7 +33,13 @@ FactoryBot.define do
       bank_account_number { rand(10000000..99999999) }
     end
 
+    trait :eligible_teacher do
+      with_application_route
+      with_state_funded_secondary_school
+    end
+
     trait :submitable do
+      eligible_teacher
       with_personal_details
       with_email_details
       with_mobile_details

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -8,10 +8,21 @@ describe "ineligible route: completing the form" do
   end
 
   describe "navigating forward" do
-    context "ineligible application route" do
+    context "ineligible - application route" do
       it "shows the ineligible page" do
         when_i_start_the_form
         and_i_complete_application_route_question_with(option: "Other")
+        then_i_see_the_ineligible_page
+      end
+    end
+
+    context "ineligible - non state funded school" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(
+          option: "I am employed as a teacher in a school in England"
+        )
+        and_i_complete_the_state_funded_secondary_school_step_with(option: "No")
         then_i_see_the_ineligible_page
       end
     end

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -26,6 +26,17 @@ describe "ineligible route: completing the form" do
         then_i_see_the_ineligible_page
       end
     end
+
+    context "ineligible - trainee details" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(
+          option: "I am enrolled on a salaried teacher training course in England"
+        )
+        and_i_complete_the_trainee_details_step_with(option: "No")
+        then_i_see_the_ineligible_page
+      end
+    end
   end
 
   def then_i_see_the_ineligible_page

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -13,6 +13,7 @@ describe "teacher route: completing the form" do
       and_i_complete_application_route_question_with(
         option: "I am employed as a teacher in a school in England"
       )
+      and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
@@ -26,6 +27,9 @@ describe "teacher route: completing the form" do
 
     expect(page).to have_text(
       "What is your employment status? I am employed as a teacher in a school in England"
+    )
+    expect(page).to have_text(
+      "Are you employed by an English state secondary school? Yes"
     )
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
@@ -7,12 +7,15 @@ describe "trainee route: completing the form" do
     create(:journey_configuration, :get_a_teacher_relocation_payment)
   end
 
-  describe "navigating forward" do
+  # FIXME RL temp disabling this form as the teacher journey has a different
+  # second page
+  xdescribe "navigating forward" do
     it "submits an application" do
       when_i_start_the_form
       and_i_complete_application_route_question_with(
         option: "I am enrolled on a salaried teacher training course in England"
       )
+      # TODO RL: this journey has a different second page
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed

--- a/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
@@ -7,16 +7,15 @@ describe "trainee route: completing the form" do
     create(:journey_configuration, :get_a_teacher_relocation_payment)
   end
 
-  # FIXME RL temp disabling this form as the teacher journey has a different
-  # second page
-  xdescribe "navigating forward" do
+  describe "navigating forward" do
     it "submits an application" do
       when_i_start_the_form
       and_i_complete_application_route_question_with(
         option: "I am enrolled on a salaried teacher training course in England"
       )
-      # TODO RL: this journey has a different second page
+      and_i_complete_the_trainee_details_step_with(option: "Yes")
       then_the_check_your_answers_part_one_page_shows_my_answers
+
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
       and_i_submit_the_application
@@ -29,6 +28,10 @@ describe "trainee route: completing the form" do
 
     expect(page).to have_text(
       "What is your employment status? I am enrolled on a salaried teacher training course in England"
+    )
+
+    expect(page).to have_text(
+      "Are you on a teacher training course in England which meets the following conditions? Yes"
     )
   end
 end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
@@ -37,5 +37,37 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
         change { journey_session.reload.answers.application_route }.to("teacher")
       )
     end
+
+    describe "reseting dependent answers" do
+      before do
+        journey_session.answers.assign_attributes(
+          application_route: existing_option,
+          state_funded_secondary_school: true
+        )
+        journey_session.save!
+      end
+
+      context "when the value has changed" do
+        let(:existing_option) { "salaried_trainee" }
+
+        it "resets dependent answers" do
+          expect { expect(form.save).to be(true) }.to(
+            change { journey_session.reload.answers.state_funded_secondary_school }
+            .from(true)
+            .to(nil)
+          )
+        end
+      end
+
+      context "when the value hasn't changed" do
+        let(:existing_option) { option }
+
+        it "doesn't reset dependent answers if the value hasn't changed" do
+          expect { expect(form.save).to be(true) }.not_to(
+            change { journey_session.reload.answers.state_funded_secondary_school }
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/state_funded_secondary_school_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/state_funded_secondary_school_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::StateFundedSecondarySchoolForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        state_funded_secondary_school: option
+      }
+    )
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    let(:option) { nil }
+
+    it do
+      is_expected.not_to(
+        allow_value(nil)
+        .for(:state_funded_secondary_school)
+        .with_message("Select the option that applies to you")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:option) { true }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.state_funded_secondary_school }
+        .to(true)
+      )
+    end
+  end
+end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/trainee_details_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/trainee_details_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::TraineeDetailsForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        state_funded_secondary_school: option
+      }
+    )
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    let(:option) { nil }
+
+    it do
+      is_expected.not_to(
+        allow_value(nil)
+        .for(:state_funded_secondary_school)
+        .with_message("Select the option that applies to you")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:option) { true }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.state_funded_secondary_school }
+        .to(true)
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -10,27 +10,54 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
   describe "#eligibility_answers" do
     subject { presenter.eligibility_answers }
 
-    let(:answers) do
-      build(
-        :get_a_teacher_relocation_payment_answers,
-        :with_application_route,
-        :with_state_funded_secondary_school
-      )
+    context "when a teacher application" do
+      let(:answers) do
+        build(
+          :get_a_teacher_relocation_payment_answers,
+          :with_teacher_application_route,
+          :with_state_funded_secondary_school
+        )
+      end
+
+      it do
+        is_expected.to include(
+          [
+            "What is your employment status?",
+            "I am employed as a teacher in a school in England",
+            "application-route"
+          ],
+          [
+            "Are you employed by an English state secondary school?",
+            "Yes",
+            "state-funded-secondary-school"
+          ]
+        )
+      end
     end
 
-    it do
-      is_expected.to include(
-        [
-          "What is your employment status?",
-          "I am employed as a teacher in a school in England",
-          "application-route"
-        ],
-        [
-          "Are you employed by an English state secondary school?",
-          "Yes",
-          "state-funded-secondary-school"
-        ]
-      )
+    context "when a trainee application" do
+      let(:answers) do
+        build(
+          :get_a_teacher_relocation_payment_answers,
+          :with_trainee_application_route,
+          :with_state_funded_secondary_school
+        )
+      end
+
+      it do
+        is_expected.to include(
+          [
+            "What is your employment status?",
+            "I am enrolled on a salaried teacher training course in England",
+            "application-route"
+          ],
+          [
+            "Are you on a teacher training course in England which meets the following conditions?",
+            "Yes",
+            "trainee-details"
+          ]
+        )
+      end
     end
   end
 end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
     let(:answers) do
       build(
         :get_a_teacher_relocation_payment_answers,
-        :with_application_route
+        :with_application_route,
+        :with_state_funded_secondary_school
       )
     end
 
@@ -23,6 +24,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
           "What is your employment status?",
           "I am employed as a teacher in a school in England",
           "application-route"
+        ],
+        [
+          "Are you employed by an English state secondary school?",
+          "Yes",
+          "state-funded-secondary-school"
         ]
       )
     end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -32,7 +32,15 @@ module GetATeacherRelocationPayment
       journey_session.save!
     end
 
-    def and_i_complete_application_route_question_with(option: "teacher")
+    def and_i_complete_application_route_question_with(option:)
+      choose(option)
+
+      click_button("Continue")
+    end
+
+    def and_i_complete_the_state_funded_secondary_school_step_with(option:)
+      assert_on_state_funded_secondary_school_page!
+
       choose(option)
 
       click_button("Continue")
@@ -44,6 +52,12 @@ module GetATeacherRelocationPayment
 
     def then_the_application_is_submitted_successfully
       assert_application_is_submitted!
+    end
+
+    def assert_on_state_funded_secondary_school_page!
+      expect(page).to have_text(
+        "Are you employed by an English state secondary school?"
+      )
     end
 
     def assert_on_check_your_answers_part_one_page!

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -23,7 +23,10 @@ module GetATeacherRelocationPayment
       journey_session.answers.assign_attributes(
         attributes_for(
           :get_a_teacher_relocation_payment_answers,
-          :submitable,
+          :with_personal_details,
+          :with_email_details,
+          :with_mobile_details,
+          :with_bank_details,
           email_address: "test-irp-claim@example.com",
           teacher_reference_number: "1234567",
           payroll_gender: "male"
@@ -46,6 +49,14 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
+    def and_i_complete_the_trainee_details_step_with(option:)
+      assert_on_trainee_details_page!
+
+      choose(option)
+
+      click_button("Continue")
+    end
+
     def and_i_dont_change_my_answers
       click_button("Continue")
     end
@@ -57,6 +68,12 @@ module GetATeacherRelocationPayment
     def assert_on_state_funded_secondary_school_page!
       expect(page).to have_text(
         "Are you employed by an English state secondary school?"
+      )
+    end
+
+    def assert_on_trainee_details_page!
+      expect(page).to have_text(
+        "Are you on a teacher training course in England which meets the following conditions?"
       )
     end
 


### PR DESCRIPTION
Adds the next two forms in the IRP journey.

Depending on the application route the user can see two different forms, each
form writes to the same attribute as this is how it's implemented in the IRP
app.

This pr is split into 3 commits, might be easier to review each commit
separately.

## Walk through

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/3a73da0c-0973-42bb-8a39-7c84433b709f


