### PR TITLE
CAPT 1689/irp/contract details

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
@@ -17,7 +17,8 @@ module Journeys
 
         if application_route_changed?
           journey_session.answers.assign_attributes(
-            state_funded_secondary_school: nil
+            state_funded_secondary_school: nil,
+            one_year: nil
           )
         end
 

--- a/app/forms/journeys/get_a_teacher_relocation_payment/contract_details_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/contract_details_form.rb
@@ -1,0 +1,25 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class ContractDetailsForm < Form
+      attribute :one_year, :boolean
+
+      validates :one_year,
+        inclusion: {
+          in: [true, false],
+          message: i18n_error_message(:inclusion)
+        }
+
+      def available_options
+        [true, false]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(one_year: one_year)
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -11,7 +11,8 @@ module Journeys
       "claims" => {
         "application-route" => ApplicationRouteForm,
         "state-funded-secondary-school" => StateFundedSecondarySchoolForm,
-        "trainee-details" => TraineeDetailsForm
+        "trainee-details" => TraineeDetailsForm,
+        "contract-details" => ContractDetailsForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -6,10 +6,11 @@ module Journeys
       def eligibility_answers
         [].tap do |a|
           a << application_route
-          a << if answers.trainee?
-            trainee_details
+          if answers.trainee?
+            a << trainee_details
           else
-            state_funded_secondary_school
+            a << state_funded_secondary_school
+            a << contract_details
           end
         end.compact
       end
@@ -37,6 +38,14 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.trainee_details.question"),
           t("get_a_teacher_relocation_payment.forms.trainee_details.answers.#{answers.state_funded_secondary_school}.answer"),
           "trainee-details"
+        ]
+      end
+
+      def contract_details
+        [
+          t("get_a_teacher_relocation_payment.forms.contract_details.question"),
+          t("get_a_teacher_relocation_payment.forms.contract_details.answers.#{answers.one_year}.answer"),
+          "contract-details"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -3,6 +3,7 @@ module Journeys
     class SessionAnswers < Journeys::SessionAnswers
       attribute :application_route, :string
       attribute :state_funded_secondary_school, :boolean
+      attribute :one_year, :boolean
 
       def trainee?
         application_route == "salaried_trainee"

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -5,6 +5,7 @@ module Journeys
         "application-route",
         "state-funded-secondary-school",
         "trainee-details",
+        "contract-details",
         "check-your-answers-part-one"
       ]
 
@@ -35,6 +36,7 @@ module Journeys
         SLUGS.dup.tap do |sequence|
           if answers.trainee?
             sequence.delete("state-funded-secondary-school")
+            sequence.delete("contract-details")
           else
             sequence.delete("trainee-details")
           end

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -27,6 +27,8 @@ module Policies
           "application route other not accecpted"
         in state_funded_secondary_school: false
           "school not state funded"
+        in application_route: "teacher", one_year: false
+          "teacher contract duration of less than one year not accepted"
         else
           nil
         end

--- a/app/views/get_a_teacher_relocation_payment/claims/contract_details.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/contract_details.html.erb
@@ -1,0 +1,34 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.contract_details.question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :one_year,
+        f.object.available_options,
+        -> (option) { option },
+        -> (option) { t("get_a_teacher_relocation_payment.forms.contract_details.answers.#{option}.answer") },
+        legend: { text: t("get_a_teacher_relocation_payment.forms.contract_details.question") },
+        hint: { text: t("get_a_teacher_relocation_payment.forms.contract_details.hint") }
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -221,6 +221,7 @@ shared:
     - updated_at
     - application_route
     - state_funded_secondary_school
+    - one_year
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,6 +724,16 @@ en:
             answer: "No"
         errors:
           inclusion: "Select the option that applies to you"
+      contract_details:
+        question: "Are you employed on a contract lasting at least one year?"
+        hint: "Your contract can also be ongoing or permanent."
+        answers:
+          true:
+            answer: "Yes"
+          false:
+            answer: "No"
+        errors:
+          inclusion: "Select the option that applies to you"
 
     check_your_answers:
       part_one:

--- a/db/migrate/20240620124504_add_one_year_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240620124504_add_one_year_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddOneYearToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :one_year, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_20_085756) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_20_124504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -185,6 +185,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_20_085756) do
     t.datetime "updated_at", null: false
     t.string "application_route"
     t.boolean "state_funded_secondary_school"
+    t.boolean "one_year"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       state_funded_secondary_school { true }
     end
 
+    trait :with_one_year_contract do
+      one_year { true }
+    end
+
     trait :with_email_details do
       email_address { generate(:email_address) }
       email_verified { true }
@@ -40,6 +44,7 @@ FactoryBot.define do
     trait :eligible_teacher do
       with_teacher_application_route
       with_state_funded_secondary_school
+      with_one_year_contract
     end
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -37,6 +37,18 @@ describe "ineligible route: completing the form" do
         then_i_see_the_ineligible_page
       end
     end
+
+    context "ineligible - contract details" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(
+          option: "I am employed as a teacher in a school in England"
+        )
+        and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_contract_details_step_with(option: "No")
+        then_i_see_the_ineligible_page
+      end
+    end
   end
 
   def then_i_see_the_ineligible_page

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -14,6 +14,7 @@ describe "teacher route: completing the form" do
         option: "I am employed as a teacher in a school in England"
       )
       and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+      and_i_complete_the_contract_details_step_with(option: "Yes")
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
@@ -30,6 +31,9 @@ describe "teacher route: completing the form" do
     )
     expect(page).to have_text(
       "Are you employed by an English state secondary school? Yes"
+    )
+    expect(page).to have_text(
+      "Are you employed on a contract lasting at least one year? Yes"
     )
   end
 end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
       before do
         journey_session.answers.assign_attributes(
           application_route: existing_option,
-          state_funded_secondary_school: true
+          state_funded_secondary_school: true,
+          one_year: true
         )
         journey_session.save!
       end
@@ -55,6 +56,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
             change { journey_session.reload.answers.state_funded_secondary_school }
             .from(true)
             .to(nil)
+            .and(
+              change { journey_session.reload.answers.one_year }
+              .from(true)
+              .to(nil)
+            )
           )
         end
       end
@@ -63,8 +69,9 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
         let(:existing_option) { option }
 
         it "doesn't reset dependent answers if the value hasn't changed" do
-          expect { expect(form.save).to be(true) }.not_to(
-            change { journey_session.reload.answers.state_funded_secondary_school }
+          expect { expect(form.save).to be(true) }.to(
+            not_change { journey_session.reload.answers.state_funded_secondary_school }
+            .and(not_change { journey_session.reload.answers.one_year })
           )
         end
       end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/contract_details_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/contract_details_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::ContractDetailsForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        one_year: option
+      }
+    )
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    let(:option) { nil }
+
+    it do
+      is_expected.not_to(
+        allow_value(nil)
+        .for(:one_year)
+        .with_message("Select the option that applies to you")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:option) { true }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.one_year }
+        .to(true)
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
         build(
           :get_a_teacher_relocation_payment_answers,
           :with_teacher_application_route,
-          :with_state_funded_secondary_school
+          :with_state_funded_secondary_school,
+          :with_one_year_contract
         )
       end
 
@@ -30,6 +31,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
             "Are you employed by an English state secondary school?",
             "Yes",
             "state-funded-secondary-school"
+          ],
+          [
+            "Are you employed on a contract lasting at least one year?",
+            "Yes",
+            "contract-details"
           ]
         )
       end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -57,6 +57,14 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
+    def and_i_complete_the_contract_details_step_with(option:)
+      assert_on_contract_details_page!
+
+      choose(option)
+
+      click_button("Continue")
+    end
+
     def and_i_dont_change_my_answers
       click_button("Continue")
     end
@@ -83,6 +91,10 @@ module GetATeacherRelocationPayment
 
     def assert_on_check_your_answers_page!
       expect(page).to have_text("Check your answers before sending your application")
+    end
+
+    def assert_on_contract_details_page!
+      expect(page).to have_text("Are you employed on a contract lasting at least one year?")
     end
 
     def assert_application_is_submitted!


### PR DESCRIPTION
Adds the contract details page

The contract details page in IRP write to the `one_year` attribute, so
that's what we've done too.

## Walk through

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/2558c37a-87b4-4049-8ef6-4beb1ff14739


