### PR TITLE
[LUPEYALPHA-559] Introduce further education payments

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -75,11 +75,12 @@ jobs:
           message: |
             ### Deployments
 
-            | Journey             | URL                                  |
-            | ------------------- | ------------------------------------ |
-            | Additional Payments | <${{ env.APP_URL }}/additional-payments/claim> |
-            | Student Loans       | <${{ env.APP_URL }}/student-loans/claim>       |
-            | Admin               | <${{ env.APP_URL }}/admin>                     |
+            | Journey             | URL                                                          |
+            | ------------------- | ------------------------------------------------------------ |
+            | Additional Payments | <${{ env.APP_URL }}/additional-payments/claim>               |
+            | Student Loans       | <${{ env.APP_URL }}/student-loans/claim>                     |
+            | Further Education   | <${{ env.APP_URL }}/further-education-payments/landing-page> |
+            | Admin               | <${{ env.APP_URL }}/admin>                                   |
 
   deploy_test:
     name: Deploy to test environment

--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -1,0 +1,21 @@
+module Journeys
+  module FurtherEducationPayments
+    class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
+      private
+
+      def main_eligibility
+        @main_eligibility ||= Policies::FurtherEducationPayments::Eligibility.new
+      end
+
+      def calculate_award_amount(eligibility)
+        # NOOP
+        # This is just for compatibility with the AdditionalPaymentsForTeaching
+        # claim submission form.
+      end
+
+      def generate_policy_options_provided
+        []
+      end
+    end
+  end
+end

--- a/app/models/journeys.rb
+++ b/app/models/journeys.rb
@@ -8,7 +8,8 @@ module Journeys
   JOURNEYS = [
     AdditionalPaymentsForTeaching,
     TeacherStudentLoanReimbursement,
-    GetATeacherRelocationPayment
+    GetATeacherRelocationPayment,
+    FurtherEducationPayments
   ].freeze
 
   def all

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -1,0 +1,14 @@
+module Journeys
+  module FurtherEducationPayments
+    extend Base
+    extend self
+
+    ROUTING_NAME = "further-education-payments"
+    VIEW_PATH = "further_education_payments"
+    I18N_NAMESPACE = "further_education_payments"
+    POLICIES = []
+    FORMS = {
+      "claims" => {}
+    }
+  end
+end

--- a/app/models/journeys/further_education_payments/eligibility_checker.rb
+++ b/app/models/journeys/further_education_payments/eligibility_checker.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    class EligibilityChecker < Journeys::EligibilityChecker
+      def ineligible?
+        false
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/session.rb
+++ b/app/models/journeys/further_education_payments/session.rb
@@ -1,0 +1,7 @@
+module Journeys
+  module FurtherEducationPayments
+    class Session < Journeys::Session
+      attribute :answers, SessionAnswersType.new
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module FurtherEducationPayments
+    class SessionAnswers < Journeys::SessionAnswers
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/session_answers_type.rb
+++ b/app/models/journeys/further_education_payments/session_answers_type.rb
@@ -1,0 +1,5 @@
+module Journeys
+  module FurtherEducationPayments
+    class SessionAnswersType < ::Journeys::SessionAnswersType; end
+  end
+end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -1,0 +1,46 @@
+module Journeys
+  module FurtherEducationPayments
+    class SlugSequence
+      ELIGIBILITY_SLUGS = %w[
+        teaching-responsibilities
+        further-education-provision-search
+        contract-type
+        teaching-hours-per-week
+        academic-year-in-further-education
+        subject-areas
+        building-and-construction-courses
+        teaching-courses
+        half-teaching-hours
+        qualification
+        poor-performance
+      ]
+
+      RESULTS_SLUGS = %w[
+        check-your-answers
+        ineligible
+      ].freeze
+
+      SLUGS = ELIGIBILITY_SLUGS + RESULTS_SLUGS
+
+      def self.start_page_url
+        if Rails.env.production?
+          "https://www.example.com" # TODO: update to correct guidance
+        else
+          Rails.application.routes.url_helpers.landing_page_path("further-education-payments")
+        end
+      end
+
+      attr_reader :journey_session
+
+      delegate :answers, to: :journey_session
+
+      def initialize(journey_session)
+        @journey_session = journey_session
+      end
+
+      def slugs
+        SLUGS
+      end
+    end
+  end
+end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -1,0 +1,4 @@
+module Policies
+  module FurtherEducationPayments
+  end
+end

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -1,0 +1,17 @@
+module Policies
+  module FurtherEducationPayments
+    class Eligibility < ApplicationRecord
+      self.table_name = "further_education_payments_eligibilities"
+
+      has_one :claim, as: :eligibility, inverse_of: :eligibility
+
+      def policy
+        Policies::FurtherEducationPayments
+      end
+
+      def ineligible?
+        false
+      end
+    end
+  end
+end

--- a/app/models/policies/further_education_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/further_education_payments/policy_eligibility_checker.rb
@@ -1,0 +1,21 @@
+module Policies
+  module FurtherEducationPayments
+    class PolicyEligibilityChecker
+      attr_reader :answers
+
+      delegate_missing_to :answers
+
+      def initialize(answers:)
+        @answers = answers
+      end
+
+      def status
+        :eligible_now
+      end
+
+      def ineligible?
+        false
+      end
+    end
+  end
+end

--- a/app/views/further_education_payments/claims/academic_year_in_further_education.html.erb
+++ b/app/views/further_education_payments/claims/academic_year_in_further_education.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE academic year in further education goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/building_and_construction_courses.html.erb
+++ b/app/views/further_education_payments/claims/building_and_construction_courses.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE building and construction courses goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/check_your_answers.html.erb
+++ b/app/views/further_education_payments/claims/check_your_answers.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  FE check your answers goes here
+</p>

--- a/app/views/further_education_payments/claims/contract_type.html.erb
+++ b/app/views/further_education_payments/claims/contract_type.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE contract type goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/further_education_provision_search.html.erb
+++ b/app/views/further_education_payments/claims/further_education_provision_search.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE provision search goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/half_teaching_hours.html.erb
+++ b/app/views/further_education_payments/claims/half_teaching_hours.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE half teaching hours goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/ineligible.html.erb
+++ b/app/views/further_education_payments/claims/ineligible.html.erb
@@ -1,0 +1,1 @@
+FE ineligible goes here

--- a/app/views/further_education_payments/claims/poor_performance.html.erb
+++ b/app/views/further_education_payments/claims/poor_performance.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE poor performance goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/qualification.html.erb
+++ b/app/views/further_education_payments/claims/qualification.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE qualification goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/subject_areas.html.erb
+++ b/app/views/further_education_payments/claims/subject_areas.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE subject areas goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/teaching_courses.html.erb
+++ b/app/views/further_education_payments/claims/teaching_courses.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE teaching courses goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/teaching_hours_per_week.html.erb
+++ b/app/views/further_education_payments/claims/teaching_hours_per_week.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  FE teaching hours per week goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/claims/teaching_responsibilities.html.erb
@@ -1,0 +1,9 @@
+<% @backlink_path = landing_page_path %>
+
+<p class="govuk-body">
+  FE teaching responsibilities goes here
+</p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/landing_page.html.erb
+++ b/app/views/further_education_payments/landing_page.html.erb
@@ -1,0 +1,5 @@
+<p class="govuk-body">
+  further education landing page goes here
+</p>
+
+<%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -310,3 +310,7 @@ shared:
     - journey
     - created_at
     - updated_at
+  :further_education_payments_eligibilities:
+    - id
+    - created_at
+    - updated_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,7 +741,11 @@ en:
         eligibility_details: "Eligibility details"
         confirmation_notice:
           "By selecting continue you are confirming that, to the best of your knowledge, the details you are providing are correct."
-
+  further_education_payments:
+    claim_description: for further education payments
+    journey_name: Claim further education payments
+    feedback_email: "fe-levellingup.premiumpayments@education.gov.uk"
+    support_email_address: "fe-levellingup.premiumpayments@education.gov.uk"
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       resources :reminders, only: [:show, :update], param: :slug, constraints: {slug: %r{#{Journeys::AdditionalPaymentsForTeaching::SlugSequence::REMINDER_SLUGS.join("|")}}}, controller: "journeys/additional_payments_for_teaching/reminders"
     end
 
-    scope path: "/", constraints: {journey: /student-loans|additional-payments|get-a-teacher-relocation-payment/} do
+    scope path: "/", constraints: {journey: Regexp.new(Journeys.all_routing_names.join("|"))} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end
   end

--- a/db/migrate/20240620102034_create_further_education_payments_eligibilities.rb
+++ b/db/migrate/20240620102034_create_further_education_payments_eligibilities.rb
@@ -1,0 +1,7 @@
+class CreateFurtherEducationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :further_education_payments_eligibilities, id: :uuid do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -180,6 +180,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_20_124504) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "further_education_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "international_relocation_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")
   Journeys::Configuration.create!(routing_name: Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, current_academic_year: AcademicYear.current)
   Journeys::Configuration.create!(routing_name: Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, current_academic_year: AcademicYear.current)
   Journeys::Configuration.create!(routing_name: Journeys::GetATeacherRelocationPayment::ROUTING_NAME, current_academic_year: AcademicYear.current)
+  Journeys::Configuration.create!(routing_name: Journeys::FurtherEducationPayments::ROUTING_NAME, current_academic_year: AcademicYear.current)
 
   ENV["FIXTURES_PATH"] = "spec/fixtures"
   ENV["FIXTURES"] = "local_authorities,local_authority_districts,schools"

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
       additional_payments
     end
 
+    trait :further_education_payments do
+      routing_name { Journeys::FurtherEducationPayments::ROUTING_NAME }
+    end
+
     trait :closed do
       open_for_submissions { false }
     end

--- a/spec/features/further_education_payments/happy_claim_spec.rb
+++ b/spec/features/further_education_payments/happy_claim_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments" do
+  scenario "happy path claim" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("FE teaching responsibilities goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE provision search goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE contract type goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE teaching hours per week goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE academic year in further education goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE subject areas goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE building and construction courses goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE teaching courses goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE half teaching hours goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE qualification goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE poor performance goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("FE check your answers goes here")
+  end
+
+  def when_further_education_payments_journey_configuration_exists
+    create(:journey_configuration, :further_education_payments)
+  end
+end

--- a/spec/models/journeys_spec.rb
+++ b/spec/models/journeys_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Journeys do
       expect(described_class.all).to eq([
         Journeys::AdditionalPaymentsForTeaching,
         Journeys::TeacherStudentLoanReimbursement,
-        Journeys::GetATeacherRelocationPayment
+        Journeys::GetATeacherRelocationPayment,
+        Journeys::FurtherEducationPayments
       ])
     end
   end
@@ -18,7 +19,8 @@ RSpec.describe Journeys do
       expect(described_class.all_routing_names).to eq([
         Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME,
         Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME,
-        Journeys::GetATeacherRelocationPayment::ROUTING_NAME
+        Journeys::GetATeacherRelocationPayment::ROUTING_NAME,
+        Journeys::FurtherEducationPayments::ROUTING_NAME
       ])
     end
   end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net.mcas.ms/browse/LUPEYALPHA-559
- Introduce further education payments journey into the application
- We want to add scaffolding for this journey to unblock developers so they can start working in parallel  

# Changes

- Added lots of boilerplate to enable new FE payments journey
- Simple test to go through happy path journey pages
- Added lots of place holder pages with blank content to be added later

# Known issues

- There are multiple issues with this PR but have left out of scope of this PR
- Only added single happy path, many branching pages will be missing
- There is no form submission at the end and will still need implementing
- Not 100% on slugs these can be corrected at a later stage
- Missing lots of translation strings