### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -114,11 +114,10 @@ jobs:
           make ci test-aks get-cluster-credentials
           kubectl exec -n srtl-test deployment/claim-additional-payments-for-teaching-test-worker -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/prepare-database"
 
-      - name: Install Ruby 3.2.4
+      - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.2.4
 
       - name: Run smoke tests
         shell: bash


### PR DESCRIPTION
## Changes in this PR

Stop specifying the ruby version in the deploy workflow. If it conflicts, it breaks the deploy.

The workflow should pick it up from `.ruby-version` file.

This is the same as in the ci workflow: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/.github/workflows/ci.yaml#L16-L19