### PR TITLE
CAPT-1689 Add start date form

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
@@ -18,7 +18,8 @@ module Journeys
         if application_route_changed?
           journey_session.answers.assign_attributes(
             state_funded_secondary_school: nil,
-            one_year: nil
+            one_year: nil,
+            start_date: nil
           )
         end
 

--- a/app/forms/journeys/get_a_teacher_relocation_payment/start_date_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/start_date_form.rb
@@ -1,0 +1,33 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class StartDateForm < Form
+      include ActiveRecord::AttributeAssignment
+
+      validates :start_date,
+        presence: {
+          message: i18n_error_message(:presence)
+        }
+
+      attribute :start_date, :date
+
+      def initialize(journey_session:, journey:, params:)
+        super
+
+        # Handle setting date from multi part params see
+        # ActiveRecord::AttributeAssignment
+        _assign_attributes(permitted_params)
+      rescue ActiveRecord::MultiparameterAssignmentErrors
+        # Invalid date was entered
+        self.start_date = nil
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(start_date: start_date)
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -12,7 +12,8 @@ module Journeys
         "application-route" => ApplicationRouteForm,
         "state-funded-secondary-school" => StateFundedSecondarySchoolForm,
         "trainee-details" => TraineeDetailsForm,
-        "contract-details" => ContractDetailsForm
+        "contract-details" => ContractDetailsForm,
+        "start-date" => StartDateForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -12,6 +12,7 @@ module Journeys
             a << state_funded_secondary_school
             a << contract_details
           end
+          a << start_date_details
         end.compact
       end
 
@@ -46,6 +47,14 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.contract_details.question"),
           t("get_a_teacher_relocation_payment.forms.contract_details.answers.#{answers.one_year}.answer"),
           "contract-details"
+        ]
+      end
+
+      def start_date_details
+        [
+          t("get_a_teacher_relocation_payment.forms.start_date.question"),
+          answers.start_date.strftime("%d-%m-%Y"),
+          "start-date"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -4,6 +4,7 @@ module Journeys
       attribute :application_route, :string
       attribute :state_funded_secondary_school, :boolean
       attribute :one_year, :boolean
+      attribute :start_date, :date
 
       def trainee?
         application_route == "salaried_trainee"

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -6,6 +6,7 @@ module Journeys
         "state-funded-secondary-school",
         "trainee-details",
         "contract-details",
+        "start-date",
         "check-your-answers-part-one"
       ]
 

--- a/app/models/policies/international_relocation_payments/eligibility.rb
+++ b/app/models/policies/international_relocation_payments/eligibility.rb
@@ -12,6 +12,11 @@ module Policies
       def policy
         Policies::InternationalRelocationPayments
       end
+
+      def self.earliest_eligible_contract_start_date
+        # FIXME RL - waiting on policy to get back to us for what this should
+        # be
+      end
     end
   end
 end

--- a/app/views/get_a_teacher_relocation_payment/claims/start_date.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/start_date.html.erb
@@ -1,0 +1,28 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.start_date.question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_date_field(
+        :start_date,
+        legend: { text: t("get_a_teacher_relocation_payment.forms.start_date.question") },
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -222,6 +222,7 @@ shared:
     - application_route
     - state_funded_secondary_school
     - one_year
+    - start_date
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -734,6 +734,10 @@ en:
             answer: "No"
         errors:
           inclusion: "Select the option that applies to you"
+      start_date:
+        question: "Enter the start date of your contract"
+        errors:
+          presence: "Enter your contract start date"
 
     check_your_answers:
       part_one:

--- a/db/migrate/20240621152642_add_start_date_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240621152642_add_start_date_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddStartDateToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_20_124504) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_21_152642) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -191,6 +191,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_20_124504) do
     t.string "application_route"
     t.boolean "state_funded_secondary_school"
     t.boolean "one_year"
+    t.date "start_date"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
       one_year { true }
     end
 
+    trait :with_start_date do
+      start_date { Date.tomorrow }
+    end
+
     trait :with_email_details do
       email_address { generate(:email_address) }
       email_verified { true }
@@ -45,6 +49,7 @@ FactoryBot.define do
       with_teacher_application_route
       with_state_funded_secondary_school
       with_one_year_contract
+      with_start_date
     end
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -3,8 +3,20 @@ require "rails_helper"
 describe "ineligible route: completing the form" do
   include GetATeacherRelocationPayment::StepHelpers
 
-  before do
+  let(:journey_configuration) do
     create(:journey_configuration, :get_a_teacher_relocation_payment)
+  end
+
+  let(:contract_start_date) do
+    Date.new(
+      journey_configuration.current_academic_year.start_year,
+      1,
+      1
+    )
+  end
+
+  before do
+    journey_configuration
   end
 
   describe "navigating forward" do
@@ -47,6 +59,39 @@ describe "ineligible route: completing the form" do
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
         and_i_complete_the_contract_details_step_with(option: "No")
         then_i_see_the_ineligible_page
+      end
+    end
+
+    # FIXME RL waiting on feedback from policy team to determine what the cut
+    # off date is for contracts
+    xcontext "ineligible - contract start date" do
+      context "teacher" do
+        it "shows the ineligible page" do
+          when_i_start_the_form
+          and_i_complete_application_route_question_with(
+            option: "I am employed as a teacher in a school in England"
+          )
+          and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+          and_i_complete_the_contract_details_step_with(option: "Yes")
+          and_i_complete_the_contract_start_date_step_with(
+            date: Polices::InternationalRelocationPayments.earliest_eligible_contract_start_date - 1.day
+          )
+          then_i_see_the_ineligible_page
+        end
+      end
+
+      context "trainee" do
+        it "shows the ineligible page" do
+          when_i_start_the_form
+          and_i_complete_application_route_question_with(
+            option: "I am enrolled on a salaried teacher training course in England"
+          )
+          and_i_complete_the_trainee_details_step_with(option: "Yes")
+          and_i_complete_the_contract_start_date_step_with(
+            date: Polices::InternationalRelocationPayments.earliest_eligible_contract_start_date - 1.day
+          )
+          then_i_see_the_ineligible_page
+        end
       end
     end
   end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -3,8 +3,16 @@ require "rails_helper"
 describe "teacher route: completing the form" do
   include GetATeacherRelocationPayment::StepHelpers
 
-  before do
+  let(:journey_configuration) do
     create(:journey_configuration, :get_a_teacher_relocation_payment)
+  end
+
+  let(:contract_start_date) do
+    Date.tomorrow
+  end
+
+  before do
+    journey_configuration
   end
 
   describe "navigating forward" do
@@ -15,6 +23,9 @@ describe "teacher route: completing the form" do
       )
       and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
       and_i_complete_the_contract_details_step_with(option: "Yes")
+      and_i_complete_the_contract_start_date_step_with(
+        date: contract_start_date
+      )
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
@@ -29,11 +40,17 @@ describe "teacher route: completing the form" do
     expect(page).to have_text(
       "What is your employment status? I am employed as a teacher in a school in England"
     )
+
     expect(page).to have_text(
       "Are you employed by an English state secondary school? Yes"
     )
+
     expect(page).to have_text(
       "Are you employed on a contract lasting at least one year? Yes"
+    )
+
+    expect(page).to have_text(
+      "Enter the start date of your contract #{contract_start_date.strftime("%d-%m-%Y")}"
     )
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
@@ -3,8 +3,16 @@ require "rails_helper"
 describe "trainee route: completing the form" do
   include GetATeacherRelocationPayment::StepHelpers
 
-  before do
+  let(:journey_configuration) do
     create(:journey_configuration, :get_a_teacher_relocation_payment)
+  end
+
+  let(:contract_start_date) do
+    Date.tomorrow
+  end
+
+  before do
+    journey_configuration
   end
 
   describe "navigating forward" do
@@ -14,6 +22,9 @@ describe "trainee route: completing the form" do
         option: "I am enrolled on a salaried teacher training course in England"
       )
       and_i_complete_the_trainee_details_step_with(option: "Yes")
+      and_i_complete_the_contract_start_date_step_with(
+        date: contract_start_date
+      )
       then_the_check_your_answers_part_one_page_shows_my_answers
 
       and_i_dont_change_my_answers
@@ -32,6 +43,10 @@ describe "trainee route: completing the form" do
 
     expect(page).to have_text(
       "Are you on a teacher training course in England which meets the following conditions? Yes"
+    )
+
+    expect(page).to have_text(
+      "Enter the start date of your contract #{contract_start_date.strftime("%d-%m-%Y")}"
     )
   end
 end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
         journey_session.answers.assign_attributes(
           application_route: existing_option,
           state_funded_secondary_school: true,
-          one_year: true
+          one_year: true,
+          start_date: Date.new(2024, 1, 1)
         )
         journey_session.save!
       end
@@ -61,6 +62,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
               .from(true)
               .to(nil)
             )
+            .and(
+              change { journey_session.reload.answers.start_date }
+              .from(Date.new(2024, 1, 1))
+              .to(nil)
+            )
           )
         end
       end
@@ -72,6 +78,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
           expect { expect(form.save).to be(true) }.to(
             not_change { journey_session.reload.answers.state_funded_secondary_school }
             .and(not_change { journey_session.reload.answers.one_year })
+            .and(not_change { journey_session.reload.answers.start_date })
           )
         end
       end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/start_date_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/start_date_form_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::StartDateForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: multi_part_date_parms(option)
+    )
+  end
+
+  def multi_part_date_parms(date)
+    return {} unless date.present?
+
+    {
+      "start_date(1i)" => date.year.to_s,
+      "start_date(2i)" => date.month.to_s,
+      "start_date(3i)" => date.day.to_s
+    }
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    context "with an invalid date" do
+      let(:option) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "with a date in the future" do
+      let(:option) { Date.tomorrow }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with a date in the present" do
+      let(:option) { Date.today }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with a date in the past" do
+      let(:option) { Date.yesterday }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe "#start_date" do
+    subject { form.start_date }
+
+    before do
+      journey_session.answers.assign_attributes(start_date: Date.tomorrow)
+    end
+
+    context "when date is not present in the params" do
+      let(:option) { nil }
+
+      it { is_expected.to eq(journey_session.answers.start_date) }
+    end
+
+    context "when date is present in the params" do
+      let(:option) { Date.yesterday }
+
+      it { is_expected.to eq(option) }
+    end
+
+    context "when date is invalid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            "start_date(1i)" => "01",
+            "start_date(2i)" => "00",
+            "start_date(3i)" => "2024"
+          }
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#save" do
+    let(:option) { Date.tomorrow }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.start_date }
+        .to(option)
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
           :get_a_teacher_relocation_payment_answers,
           :with_teacher_application_route,
           :with_state_funded_secondary_school,
-          :with_one_year_contract
+          :with_one_year_contract,
+          :with_start_date
         )
       end
 
@@ -36,6 +37,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
             "Are you employed on a contract lasting at least one year?",
             "Yes",
             "contract-details"
+          ],
+          [
+            "Enter the start date of your contract",
+            answers.start_date.strftime("%d-%m-%Y"),
+            "start-date"
           ]
         )
       end
@@ -46,7 +52,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
         build(
           :get_a_teacher_relocation_payment_answers,
           :with_trainee_application_route,
-          :with_state_funded_secondary_school
+          :with_state_funded_secondary_school,
+          :with_start_date
         )
       end
 
@@ -61,6 +68,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
             "Are you on a teacher training course in England which meets the following conditions?",
             "Yes",
             "trainee-details"
+          ],
+          [
+            "Enter the start date of your contract",
+            answers.start_date.strftime("%d-%m-%Y"),
+            "start-date"
           ]
         )
       end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -65,6 +65,16 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
+    def and_i_complete_the_contract_start_date_step_with(date:)
+      assert_on_contract_start_date_page!
+
+      fill_in("Day", with: date.day)
+      fill_in("Month", with: date.month)
+      fill_in("Year", with: date.year)
+
+      click_button("Continue")
+    end
+
     def and_i_dont_change_my_answers
       click_button("Continue")
     end
@@ -95,6 +105,10 @@ module GetATeacherRelocationPayment
 
     def assert_on_contract_details_page!
       expect(page).to have_text("Are you employed on a contract lasting at least one year?")
+    end
+
+    def assert_on_contract_start_date_page!
+      expect(page).to have_text("Enter the start date of your contract")
     end
 
     def assert_application_is_submitted!


### PR DESCRIPTION
Adds the form to capture the start date. Of note is the use of `_assign_attributes`. ActiveModel doesn't support multi part parameters so we need to include `ActiveRecord::AttributeAssignment` to get them. This behaviour should probably be upstreamed We may want to upstream this behaviour into the base Form class though changing the attribute assignment in the base form to support this felt out of scope of this commit.

Also this commit doesn't add the eligibility checking for invalid contract dates. We're waiting on the product team to get back to us with what this should be. When they have we'll enable the feature tests for the ineligibility.


https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/26ac7c4f-885d-435b-b9e0-50d941d839e0

