### PR TITLE
CAPT 1689/irp/subject

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/application_route_form.rb
@@ -19,7 +19,8 @@ module Journeys
           journey_session.answers.assign_attributes(
             state_funded_secondary_school: nil,
             one_year: nil,
-            start_date: nil
+            start_date: nil,
+            subject: nil
           )
         end
 

--- a/app/forms/journeys/get_a_teacher_relocation_payment/subject_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/subject_form.rb
@@ -1,0 +1,30 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SubjectForm < Form
+      attribute :subject, :string
+
+      validates :subject, inclusion: {
+        in: :available_options,
+        message: i18n_error_message(:inclusion)
+      }
+
+      def available_options
+        if answers.trainee?
+          %w[physics languages other]
+        else
+          %w[physics combined_with_physics languages other]
+        end
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(subject: subject)
+
+        journey_session.save!
+
+        true
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -13,7 +13,8 @@ module Journeys
         "state-funded-secondary-school" => StateFundedSecondarySchoolForm,
         "trainee-details" => TraineeDetailsForm,
         "contract-details" => ContractDetailsForm,
-        "start-date" => StartDateForm
+        "start-date" => StartDateForm,
+        "subject" => SubjectForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -13,6 +13,7 @@ module Journeys
             a << contract_details
           end
           a << start_date_details
+          a << subject_details
         end.compact
       end
 
@@ -55,6 +56,14 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.start_date.question"),
           answers.start_date.strftime("%d-%m-%Y"),
           "start-date"
+        ]
+      end
+
+      def subject_details
+        [
+          t("get_a_teacher_relocation_payment.forms.subject.question.#{answers.application_route}"),
+          t("get_a_teacher_relocation_payment.forms.subject.answers.#{answers.subject}"),
+          "subject"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -5,6 +5,7 @@ module Journeys
       attribute :state_funded_secondary_school, :boolean
       attribute :one_year, :boolean
       attribute :start_date, :date
+      attribute :subject, :string
 
       def trainee?
         application_route == "salaried_trainee"

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -7,6 +7,7 @@ module Journeys
         "trainee-details",
         "contract-details",
         "start-date",
+        "subject",
         "check-your-answers-part-one"
       ]
 

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -29,6 +29,8 @@ module Policies
           "school not state funded"
         in application_route: "teacher", one_year: false
           "teacher contract duration of less than one year not accepted"
+        in subject: "other"
+          "taught subject not accepted"
         else
           nil
         end

--- a/app/views/get_a_teacher_relocation_payment/claims/subject.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/subject.html.erb
@@ -1,0 +1,32 @@
+<% content_for(
+  :page_title,
+  page_title(
+        t("get_a_teacher_relocation_payment.forms.subject.question.#{@form.answers.application_route}"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :subject,
+        f.object.available_options,
+        -> (option) { option },
+        -> (option) { t("get_a_teacher_relocation_payment.forms.subject.answers.#{option}") },
+        legend: { text: t("get_a_teacher_relocation_payment.forms.subject.question.#{f.object.answers.application_route}") },
+        hint: { text: t("get_a_teacher_relocation_payment.forms.subject.hint.#{f.object.answers.application_route}") }
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -223,6 +223,7 @@ shared:
     - state_funded_secondary_school
     - one_year
     - start_date
+    - subject
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -738,6 +738,20 @@ en:
         question: "Enter the start date of your contract"
         errors:
           presence: "Enter your contract start date"
+      subject:
+        question:
+          teacher: "What subject are you employed to teach at your school?"
+          salaried_trainee: "What subject are you training to teach?"
+        hint:
+          teacher: "Physics, general or combined science including physics, and languages can be combined with other subjects but must make up at least 50% of your time in the classroom."
+          salaried_trainee: "Physics or languages can be combined with other subjects but must make up at least 50% of your course content."
+        answers:
+          physics: "Physics"
+          combined_with_physics: "General or combined science, including physics"
+          languages: "Languages"
+          other: "Other"
+        errors:
+          inclusion: "Choose a subject"
 
     check_your_answers:
       part_one:

--- a/db/migrate/20240621152837_add_subject_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240621152837_add_subject_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddSubjectToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :subject, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_21_152642) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_21_152837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -192,6 +192,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_21_152642) do
     t.boolean "state_funded_secondary_school"
     t.boolean "one_year"
     t.date "start_date"
+    t.string "subject"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       start_date { Date.tomorrow }
     end
 
+    trait :with_subject do
+      subject { "physics" }
+    end
+
     trait :with_email_details do
       email_address { generate(:email_address) }
       email_verified { true }

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -65,7 +65,7 @@ describe "ineligible route: completing the form" do
     # FIXME RL waiting on feedback from policy team to determine what the cut
     # off date is for contracts
     xcontext "ineligible - contract start date" do
-      context "teacher" do
+      context "as a teacher" do
         it "shows the ineligible page" do
           when_i_start_the_form
           and_i_complete_application_route_question_with(
@@ -80,7 +80,7 @@ describe "ineligible route: completing the form" do
         end
       end
 
-      context "trainee" do
+      context "as a trainee" do
         it "shows the ineligible page" do
           when_i_start_the_form
           and_i_complete_application_route_question_with(
@@ -90,6 +90,39 @@ describe "ineligible route: completing the form" do
           and_i_complete_the_contract_start_date_step_with(
             date: Polices::InternationalRelocationPayments.earliest_eligible_contract_start_date - 1.day
           )
+          then_i_see_the_ineligible_page
+        end
+      end
+    end
+
+    context "ineligible - subject" do
+      context "as a teacher" do
+        it "shows the ineligible page" do
+          when_i_start_the_form
+          and_i_complete_application_route_question_with(
+            option: "I am employed as a teacher in a school in England"
+          )
+          and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+          and_i_complete_the_contract_details_step_with(option: "Yes")
+          and_i_complete_the_contract_start_date_step_with(
+            date: contract_start_date
+          )
+          and_i_complete_the_subject_step_with(option: "Other")
+          then_i_see_the_ineligible_page
+        end
+      end
+
+      context "as a trainee" do
+        it "shows the ineligible page" do
+          when_i_start_the_form
+          and_i_complete_application_route_question_with(
+            option: "I am enrolled on a salaried teacher training course in England"
+          )
+          and_i_complete_the_trainee_details_step_with(option: "Yes")
+          and_i_complete_the_contract_start_date_step_with(
+            date: contract_start_date
+          )
+          and_i_complete_the_subject_step_with(option: "Other", trainee: true)
           then_i_see_the_ineligible_page
         end
       end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -26,6 +26,7 @@ describe "teacher route: completing the form" do
       and_i_complete_the_contract_start_date_step_with(
         date: contract_start_date
       )
+      and_i_complete_the_subject_step_with(option: "Physics")
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
@@ -51,6 +52,10 @@ describe "teacher route: completing the form" do
 
     expect(page).to have_text(
       "Enter the start date of your contract #{contract_start_date.strftime("%d-%m-%Y")}"
+    )
+
+    expect(page).to have_text(
+      "What subject are you employed to teach at your school? Physics"
     )
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/trainee_route_completing_the_form_spec.rb
@@ -25,8 +25,8 @@ describe "trainee route: completing the form" do
       and_i_complete_the_contract_start_date_step_with(
         date: contract_start_date
       )
+      and_i_complete_the_subject_step_with(option: "Physics", trainee: true)
       then_the_check_your_answers_part_one_page_shows_my_answers
-
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
       and_i_submit_the_application
@@ -47,6 +47,10 @@ describe "trainee route: completing the form" do
 
     expect(page).to have_text(
       "Enter the start date of your contract #{contract_start_date.strftime("%d-%m-%Y")}"
+    )
+
+    expect(page).to have_text(
+      "What subject are you training to teach? Physics"
     )
   end
 end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/application_route_form_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
           application_route: existing_option,
           state_funded_secondary_school: true,
           one_year: true,
-          start_date: Date.new(2024, 1, 1)
+          start_date: Date.new(2024, 1, 1),
+          subject: "physics"
         )
         journey_session.save!
       end
@@ -67,6 +68,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
               .from(Date.new(2024, 1, 1))
               .to(nil)
             )
+            .and(
+              change { journey_session.reload.answers.subject }
+              .from("physics")
+              .to(nil)
+            )
           )
         end
       end
@@ -79,6 +85,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ApplicationRouteForm, typ
             not_change { journey_session.reload.answers.state_funded_secondary_school }
             .and(not_change { journey_session.reload.answers.one_year })
             .and(not_change { journey_session.reload.answers.start_date })
+            .and(not_change { journey_session.reload.answers.subject })
           )
         end
       end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/subject_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/subject_form_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::SubjectForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        subject: option
+      }
+    )
+  end
+
+  let(:option) { nil }
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    it do
+      is_expected.to(
+        validate_inclusion_of(:subject)
+        .in_array(%w[physics combined_with_physics languages other])
+        .with_message("Choose a subject")
+      )
+    end
+  end
+
+  describe "#available_options" do
+    subject { form.available_options }
+
+    context "when a teacher" do
+      before { journey_session.answers.application_route = "teacher" }
+
+      it do
+        is_expected.to(
+          match_array(%w[physics combined_with_physics languages other])
+        )
+      end
+    end
+
+    context "when a trainee" do
+      before { journey_session.answers.application_route = "salaried_trainee" }
+
+      it { is_expected.to(match_array(%w[physics languages other])) }
+    end
+  end
+
+  describe "#save" do
+    let(:option) { "physics" }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.subject }
+        .to("physics")
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
           :with_teacher_application_route,
           :with_state_funded_secondary_school,
           :with_one_year_contract,
-          :with_start_date
+          :with_start_date,
+          :with_subject
         )
       end
 
@@ -42,6 +43,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
             "Enter the start date of your contract",
             answers.start_date.strftime("%d-%m-%Y"),
             "start-date"
+          ],
+          [
+            "What subject are you employed to teach at your school?",
+            "Physics",
+            "subject"
           ]
         )
       end
@@ -53,7 +59,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
           :get_a_teacher_relocation_payment_answers,
           :with_trainee_application_route,
           :with_state_funded_secondary_school,
-          :with_start_date
+          :with_start_date,
+          :with_subject
         )
       end
 
@@ -73,6 +80,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
             "Enter the start date of your contract",
             answers.start_date.strftime("%d-%m-%Y"),
             "start-date"
+          ],
+          [
+            "What subject are you training to teach?",
+            "Physics",
+            "subject"
           ]
         )
       end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -75,6 +75,14 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
+    def and_i_complete_the_subject_step_with(option:, trainee: false)
+      assert_on_subject_page!(trainee)
+
+      choose(option)
+
+      click_button("Continue")
+    end
+
     def and_i_dont_change_my_answers
       click_button("Continue")
     end
@@ -109,6 +117,16 @@ module GetATeacherRelocationPayment
 
     def assert_on_contract_start_date_page!
       expect(page).to have_text("Enter the start date of your contract")
+    end
+
+    def assert_on_subject_page!(trainee)
+      if trainee
+        expect(page).to have_text("What subject are you training to teach?")
+      else
+        expect(page).to have_text(
+          "What subject are you employed to teach at your school?"
+        )
+      end
     end
 
     def assert_application_is_submitted!


### PR DESCRIPTION
Add subject form

Adds the subject form from IRP to the Claim.

## Walk through

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/e3f38aa8-0bf2-4d16-a255-b4331bc09e25

