### PR TITLE
CAPT 1689/irp/entry date

### DIFF
--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -14,7 +14,8 @@ module Journeys
         "contract-details" => ContractDetailsForm,
         "start-date" => StartDateForm,
         "subject" => SubjectForm,
-        "visa" => VisaForm
+        "visa" => VisaForm,
+        "entry-date" => EntryDateForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -11,6 +11,7 @@ module Journeys
           a << start_date_details
           a << subject_details
           a << visa_details
+          a << entry_date
         end.compact
       end
 
@@ -61,6 +62,14 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.visa.question"),
           answers.visa_type,
           "visa"
+        ]
+      end
+
+      def entry_date
+        [
+          t("get_a_teacher_relocation_payment.forms.entry_date.question"),
+          answers.date_of_entry.strftime("%d-%m-%Y"),
+          "entry-date"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -7,6 +7,7 @@ module Journeys
       attribute :start_date, :date
       attribute :subject, :string
       attribute :visa_type, :string
+      attribute :date_of_entry, :date
     end
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -8,6 +8,7 @@ module Journeys
         "start-date",
         "subject",
         "visa",
+        "entry-date",
         "check-your-answers-part-one"
       ]
 

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -35,9 +35,17 @@ module Policies
           "taught subject not accepted"
         in visa_type: "Other"
           "visa not accepted"
+        in date_of_entry: Date, start_date: Date unless date_of_entry_eligible?
+          "cannot enter the UK more than 3 months before your contract start date"
         else
           nil
         end
+      end
+
+      def date_of_entry_eligible?
+        return false unless answers.date_of_entry && answers.start_date
+
+        answers.date_of_entry >= answers.start_date - 3.months
       end
     end
   end

--- a/app/views/get_a_teacher_relocation_payment/claims/entry_date.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/entry_date.html.erb
@@ -1,0 +1,30 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.entry_date.question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <% if f.object.errors.any? %>
+        <%= render("shared/error_summary", instance: f.object) %>
+      <% end %>
+
+      <%= f.govuk_date_field(
+        :date_of_entry,
+        legend: {
+          text: t("get_a_teacher_relocation_payment.forms.entry_date.question")
+        },
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -198,6 +198,7 @@ shared:
     - start_date
     - subject
     - visa_type
+    - date_of_entry
   :schools:
     - id
     - urn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -735,6 +735,12 @@ en:
         question: "Select the visa you used to move to England"
         errors:
           inclusion: "Choose your visa type"
+      entry_date:
+        question: "Enter the date you moved to England to start your teaching job"
+        errors:
+          presence: "Enter your entry date"
+          date_not_in_future: "Date of entry cannot be in the future"
+
 
     check_your_answers:
       part_one:

--- a/db/migrate/20240621200501_add_date_of_entry_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240621200501_add_date_of_entry_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddDateOfEntryToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :date_of_entry, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_21_153517) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_21_200501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_21_153517) do
     t.date "start_date"
     t.string "subject"
     t.string "visa_type"
+    t.date "date_of_entry"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -35,6 +35,11 @@ FactoryBot.define do
       visa_type { "British National (Overseas) visa" }
     end
 
+    trait :with_entry_date do
+      with_start_date
+      date_of_entry { start_date - 1.week }
+    end
+
     trait :with_email_details do
       email_address { generate(:email_address) }
       email_verified { true }
@@ -59,6 +64,7 @@ FactoryBot.define do
       with_one_year_contract
       with_start_date
       with_visa
+      with_entry_date
     end
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -112,6 +112,24 @@ describe "ineligible route: completing the form" do
         then_i_see_the_ineligible_page
       end
     end
+
+    context "ineligible - entry date" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(
+          option: "I am employed as a teacher in a school in England"
+        )
+        and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_contract_details_step_with(option: "Yes")
+        and_i_complete_the_contract_start_date_step_with(
+          date: contract_start_date
+        )
+        and_i_complete_the_subject_step_with(option: "Physics")
+        and_i_complete_the_visa_screen_with(option: "British National (Overseas) visa")
+        and_i_complete_the_entry_date_page_with(date: contract_start_date - 4.months)
+        then_i_see_the_ineligible_page
+      end
+    end
   end
 
   def then_i_see_the_ineligible_page

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -11,6 +11,10 @@ describe "teacher route: completing the form" do
     Date.tomorrow
   end
 
+  let(:entry_date) do
+    contract_start_date - 1.week
+  end
+
   before do
     journey_configuration
   end
@@ -28,6 +32,7 @@ describe "teacher route: completing the form" do
       )
       and_i_complete_the_subject_step_with(option: "Physics")
       and_i_complete_the_visa_screen_with(option: "British National (Overseas) visa")
+      and_i_complete_the_entry_date_page_with(date: entry_date)
       then_the_check_your_answers_part_one_page_shows_my_answers
       and_i_dont_change_my_answers
       and_the_personal_details_section_has_been_temporarily_stubbed
@@ -61,6 +66,10 @@ describe "teacher route: completing the form" do
 
     expect(page).to have_text(
       "Select the visa you used to move to England British National (Overseas) visa"
+    )
+
+    expect(page).to have_text(
+      "Enter the date you moved to England to start your teaching job #{entry_date.strftime("%d-%m-%Y")}"
     )
   end
 end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/entry_date_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/entry_date_form_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::EntryDateForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: multi_part_date_parms(option)
+    )
+  end
+
+  let(:option) { nil }
+
+  def multi_part_date_parms(date)
+    return {} unless date.present?
+
+    {
+      "date_of_entry(1i)" => date.year.to_s,
+      "date_of_entry(2i)" => date.month.to_s,
+      "date_of_entry(3i)" => date.day.to_s
+    }
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    context "with an invalid date" do
+      it { is_expected.not_to be_valid }
+    end
+
+    context "with a date in the future" do
+      it do
+        is_expected.not_to(
+          allow_value(Date.tomorrow)
+          .for(:date_of_entry)
+          .with_message("Date of entry cannot be in the future")
+        )
+      end
+    end
+
+    context "with a date in the present" do
+      it { is_expected.to allow_value(Date.today).for(:date_of_entry) }
+    end
+
+    context "with a date in the past" do
+      it { is_expected.to allow_value(Date.yesterday).for(:date_of_entry) }
+    end
+  end
+
+  describe "#date_of_entry" do
+    subject { form.date_of_entry }
+
+    before do
+      journey_session.answers.assign_attributes(date_of_entry: Date.tomorrow)
+    end
+
+    context "when date is not present in the params" do
+      let(:option) { nil }
+
+      it { is_expected.to eq(journey_session.answers.date_of_entry) }
+    end
+
+    context "when date is persent in the params" do
+      let(:option) { Date.yesterday }
+
+      it { is_expected.to eq(option) }
+    end
+
+    context "when date is invalid" do
+      let(:params) do
+        ActionController::Parameters.new(
+          claim: {
+            "date_of_entry(1i)" => "01",
+            "date_of_entry(2i)" => "00",
+            "date_of_entry(3i)" => "2024"
+          }
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#save" do
+    let(:option) { Date.yesterday }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.date_of_entry }
+        .to(option)
+      )
+    end
+  end
+end

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/start_date_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/start_date_form_spec.rb
@@ -98,5 +98,34 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::StartDateForm, type: :mod
         .to(option)
       )
     end
+
+    describe "resetting depenent answers" do
+      before do
+        journey_session.answers.assign_attributes(date_of_entry: 1.year.ago)
+        journey_session.save!
+      end
+
+      context "when the start date is changed" do
+        it "resets the dependent answers" do
+          expect { form.save }.to(
+            change { journey_session.reload.answers.date_of_entry }
+            .to(nil)
+          )
+        end
+      end
+
+      context "when the start date is not changed" do
+        before do
+          journey_session.answers.assign_attributes(start_date: option)
+          journey_session.save!
+        end
+
+        it "does not reset the dependent answers" do
+          expect { form.save }.to(
+            not_change { journey_session.reload.answers.date_of_entry }
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
         :with_one_year_contract,
         :with_start_date,
         :with_subject,
-        :with_visa
+        :with_visa,
+        :with_entry_date
       )
     end
 
@@ -53,6 +54,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
           "Select the visa you used to move to England",
           "British National (Overseas) visa",
           "visa"
+        ],
+        [
+          "Enter the date you moved to England to start your teaching job",
+          answers.date_of_entry.strftime("%d-%m-%Y"),
+          "entry-date"
         ]
       )
     end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -83,6 +83,16 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
+    def and_i_complete_the_entry_date_page_with(date:)
+      assert_on_entry_date_page!
+
+      fill_in("Day", with: date.day)
+      fill_in("Month", with: date.month)
+      fill_in("Year", with: date.year)
+
+      click_button("Continue")
+    end
+
     def and_i_dont_change_my_answers
       click_button("Continue")
     end
@@ -121,6 +131,12 @@ module GetATeacherRelocationPayment
 
     def assert_on_visa_page!
       expect(page).to have_text("Select the visa you used to move to England")
+    end
+
+    def assert_on_entry_date_page!
+      expect(page).to have_text(
+        "Enter the date you moved to England to start your teaching job"
+      )
     end
 
     def assert_application_is_submitted!


### PR DESCRIPTION
Adds the entry date form

As in claim the entry date form writes to the date_of_entry attribute.
We also reset the date of entry if the start date changes as the
eligibility calculation for date of entry depends on the start date.

Of note there doesn't seem to be a validation in claim that the date of
entry isn't _after_ the start date of the contract. I'm not sure if
that's a business rule we want to enforce or not. There is a validation
that the date of entry isn't in the future.

