### PR TITLE
CAPT 1689/irp/employment information

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/employment_details_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/employment_details_form.rb
@@ -1,0 +1,62 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class EmploymentDetailsForm < Form
+      attribute :school_headteacher_name, :string
+      attribute :school_name, :string
+      attribute :school_address_line_1, :string
+      attribute :school_address_line_2, :string
+      attribute :school_city, :string
+      attribute :school_postcode, :string
+
+      validates :school_headteacher_name,
+        presence: {
+          message: i18n_error_message(:school_headteacher_name)
+        }
+
+      validates :school_name,
+        presence: {
+          message: i18n_error_message(:school_name)
+        }
+
+      validates :school_address_line_1,
+        presence: {
+          message: i18n_error_message(:school_address_line_1)
+        }
+
+      validates :school_city,
+        presence: {
+          message: i18n_error_message(:school_city)
+        }
+
+      validates :school_postcode,
+        presence: {
+          message: i18n_error_message(:school_postcode)
+        }
+
+      validate :school_postcode_is_valid, if: -> { school_postcode.present? }
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(
+          school_headteacher_name: school_headteacher_name,
+          school_name: school_name,
+          school_address_line_1: school_address_line_1,
+          school_address_line_2: school_address_line_2,
+          school_city: school_city,
+          school_postcode: school_postcode
+        )
+
+        journey_session.save!
+      end
+
+      private
+
+      def school_postcode_is_valid
+        unless UKPostcode.parse(school_postcode).full_valid?
+          errors.add(:school_postcode, i18n_errors_path(:school_postcode))
+        end
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -17,7 +17,8 @@ module Journeys
         "visa" => VisaForm,
         "entry-date" => EntryDateForm,
         "nationality" => NationalityForm,
-        "passport-number" => PassportNumberForm
+        "passport-number" => PassportNumberForm,
+        "employment-details" => EmploymentDetailsForm
       }
     }
   end

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -22,6 +22,17 @@ module Journeys
         end
       end
 
+      def employment_answers
+        [].tap do |a|
+          a << school_headteacher_name
+          a << school_name
+          a << school_address_line_1
+          a << school_address_line_2 if answers.school_address_line_2.present?
+          a << school_city
+          a << school_postcode
+        end
+      end
+
       private
 
       def application_route
@@ -93,6 +104,54 @@ module Journeys
           t("get_a_teacher_relocation_payment.forms.passport_number.question"),
           answers.passport_number,
           "passport-number"
+        ]
+      end
+
+      def school_headteacher_name
+        [
+          t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_headteacher_name"),
+          answers.school_headteacher_name,
+          "employment-details"
+        ]
+      end
+
+      def school_name
+        [
+          t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_name"),
+          answers.school_name,
+          "employment-details"
+        ]
+      end
+
+      def school_address_line_1
+        [
+          t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_address_line_1"),
+          answers.school_address_line_1,
+          "employment-details"
+        ]
+      end
+
+      def school_address_line_2
+        [
+          t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_address_line_2"),
+          answers.school_address_line_2,
+          "employment-details"
+        ]
+      end
+
+      def school_city
+        [
+          t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_city"),
+          answers.school_city,
+          "employment-details"
+        ]
+      end
+
+      def school_postcode
+        [
+          t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_postcode"),
+          answers.school_postcode,
+          "employment-details"
         ]
       end
     end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -10,6 +10,12 @@ module Journeys
       attribute :date_of_entry, :date
       attribute :nationality, :string
       attribute :passport_number, :string
+      attribute :school_headteacher_name, :string
+      attribute :school_name, :string
+      attribute :school_address_line_1, :string
+      attribute :school_address_line_2, :string
+      attribute :school_city, :string
+      attribute :school_postcode, :string
 
       def policy
         Policies::InternationalRelocationPayments

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -15,6 +15,7 @@ module Journeys
       PERSONAL_DETAILS_SLUGS = [
         "nationality",
         "passport-number",
+        "employment-details",
         "personal-details",
         "postcode-search",
         "select-home-address",

--- a/app/views/get_a_teacher_relocation_payment/claims/check_your_answers.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/check_your_answers.html.erb
@@ -26,6 +26,14 @@
       <%= render(
         partial: "claims/check_your_answers_section",
         locals: {
+          heading: "Employment information",
+          answers: journey.answers_for_claim(@form.journey_session).employment_answers
+        }
+      ) %>
+
+      <%= render(
+        partial: "claims/check_your_answers_section",
+        locals: {
           heading: "Payment details",
           answers: journey.answers_for_claim(@form.journey_session).payment_answers
         }

--- a/app/views/get_a_teacher_relocation_payment/claims/employment_details.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/employment_details.html.erb
@@ -1,0 +1,73 @@
+<% content_for(
+  :page_title,
+  page_title(
+    t("get_a_teacher_relocation_payment.forms.employment_details.title"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t("get_a_teacher_relocation_payment.forms.employment_details.title") %>
+    </h1>
+
+    <%= form_for(
+      @form,
+      url: claim_path(current_journey_routing_name),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field(
+        :school_headteacher_name,
+        label: {
+          text: t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_headteacher_name"),
+        },
+      ) %>
+
+      <%= f.govuk_text_field(
+        :school_name,
+        label: {
+          text: t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_name"),
+        },
+      ) %>
+
+      <%= f.govuk_fieldset(
+        legend: {
+          text: t("get_a_teacher_relocation_payment.forms.employment_details.school_address_legend"),
+        },
+      ) do %>
+        <%= f.govuk_text_field(
+          :school_address_line_1,
+          label: {
+            text: t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_address_line_1"),
+          },
+        ) %>
+
+        <%= f.govuk_text_field(
+          :school_address_line_2,
+          label: {
+            text: t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_address_line_2"),
+          },
+        ) %>
+
+        <%= f.govuk_text_field(
+          :school_city,
+          label: {
+            text: t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_city"),
+          },
+        ) %>
+
+        <%= f.govuk_text_field(
+          :school_postcode,
+          label: {
+            text: t("get_a_teacher_relocation_payment.forms.employment_details.questions.school_postcode"),
+          },
+        ) %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -98,6 +98,12 @@
   - gender_digit
   :international_relocation_payments_eligibilities:
   - passport_number
+  - school_headteacher_name
+  - school_name
+  - school_address_line_1
+  - school_address_line_2
+  - school_city
+  - school_postcode
   :levelling_up_premium_payments_eligibilities:
   - teacher_reference_number
   :early_career_payments_eligibilities:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,23 @@ en:
         errors:
           presence: "Enter your passport number"
           invalid: "Invalid passport number"
+      employment_details:
+        title: "Employment information"
+        school_address_legend: "Enter the school address"
+        questions:
+          school_headteacher_name: "Enter the name of the headteacher of the school where you are employed as a teacher"
+          school_name: "Enter the name of the school"
+          school_address_line_1: "Address line 1"
+          school_address_line_2: "Address line 2"
+          school_city: "Town or city"
+          school_postcode: "Postcode"
+        errors:
+          school_headteacher_name: "Enter the headteacher's name"
+          school_name: "Enter the school name"
+          school_address_line_1: "Enter your school's address"
+          school_city: "Enter your school's city"
+          school_postcode: "Enter a valid postcode (for example, BN1 1AA)"
+
     check_your_answers:
       part_one:
         primary_heading: "Check your answers"

--- a/db/migrate/20240625135618_add_employment_details_to_international_relocation_payments_eligibilities.rb
+++ b/db/migrate/20240625135618_add_employment_details_to_international_relocation_payments_eligibilities.rb
@@ -1,0 +1,10 @@
+class AddEmploymentDetailsToInternationalRelocationPaymentsEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :international_relocation_payments_eligibilities, :school_headteacher_name, :string
+    add_column :international_relocation_payments_eligibilities, :school_name, :string
+    add_column :international_relocation_payments_eligibilities, :school_address_line_1, :string
+    add_column :international_relocation_payments_eligibilities, :school_address_line_2, :string
+    add_column :international_relocation_payments_eligibilities, :school_city, :string
+    add_column :international_relocation_payments_eligibilities, :school_postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_24_105924) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_25_135618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -199,6 +199,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_24_105924) do
     t.date "date_of_entry"
     t.string "nationality"
     t.string "passport_number"
+    t.string "school_headteacher_name"
+    t.string "school_name"
+    t.string "school_address_line_1"
+    t.string "school_address_line_2"
+    t.string "school_city"
+    t.string "school_postcode"
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -66,6 +66,15 @@ FactoryBot.define do
       bank_account_number { rand(10000000..99999999) }
     end
 
+    trait :with_employment_details do
+      school_headteacher_name { "Seymour Skinner" }
+      school_name { "Springfield Elementary School" }
+      school_address_line_1 { "Springfield Elementary School" }
+      school_address_line_2 { "Plympton Street" }
+      school_city { "Springfield" }
+      school_postcode { "TE57 1NG" }
+    end
+
     trait :eligible_teacher do
       with_teacher_application_route
       with_state_funded_secondary_school

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -41,6 +41,7 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
+        and_i_complete_the_employment_details_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_postcode_step
         and_i_complete_the_email_address_step
@@ -58,6 +59,7 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
+        and_i_complete_the_employment_details_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_manual_address_step
         and_i_complete_the_email_address_step
@@ -75,6 +77,7 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
+        and_i_complete_the_employment_details_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_manual_address_step
         and_i_complete_the_email_address_step
@@ -92,6 +95,7 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
+        and_i_complete_the_employment_details_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_manual_address_step
         and_i_complete_the_email_address_step
@@ -167,6 +171,22 @@ describe "teacher route: completing the form" do
     expect(page).to have_text(
       "Enter your passport number, as it appears on your passport 123456789"
     )
+
+    expect(page).to have_text(
+      "Enter the name of the headteacher of the school where you are employed as a teacher Seymour Skinner"
+    )
+
+    expect(page).to have_text(
+      "Enter the name of the school Springfield Elementary School"
+    )
+
+    expect(page).to have_text("Address line 1 Springfield Elementary School")
+
+    expect(page).to have_text("Address line 2 Plympton Street")
+
+    expect(page).to have_text("Town or city Springfield")
+
+    expect(page).to have_text("Postcode TE57 1NG")
 
     if mobile_number
       expect(page).to have_text("Mobile number 01234567890")

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/employment_details_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/employment_details_form_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::EmploymentDetailsForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) { ActionController::Parameters.new(claim: {}) }
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+
+    it do
+      is_expected.to(
+        validate_presence_of(:school_headteacher_name)
+        .with_message("Enter the headteacher's name")
+      )
+    end
+
+    it do
+      is_expected.to(
+        validate_presence_of(:school_name)
+        .with_message("Enter the school name")
+      )
+    end
+
+    it do
+      is_expected.to(
+        validate_presence_of(:school_address_line_1)
+        .with_message("Enter your school's address")
+      )
+    end
+
+    it do
+      is_expected.to(
+        validate_presence_of(:school_city)
+        .with_message("Enter your school's city")
+      )
+    end
+
+    it do
+      is_expected.not_to(
+        allow_value(nil)
+        .for(:school_postcode)
+        .with_message("Enter a valid postcode (for example, BN1 1AA)")
+      )
+    end
+
+    it do
+      is_expected.not_to(
+        allow_value("fff fff")
+        .for(:school_postcode)
+        .with_message("Enter a valid postcode (for example, BN1 1AA)")
+      )
+    end
+
+    it { is_expected.to(allow_value("BN1 1AA").for(:school_postcode)) }
+  end
+
+  describe "#save" do
+    let(:params) do
+      ActionController::Parameters.new(claim: {
+        school_headteacher_name: "Seymour Skinner",
+        school_name: "Springfield Elementary School",
+        school_address_line_1: "19",
+        school_address_line_2: "Plympton Street",
+        school_city: "Springfield",
+        school_postcode: "TE57 1NG"
+      })
+    end
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change { journey_session.reload.answers.school_headteacher_name }
+        .to("Seymour Skinner")
+        .and(
+          change { journey_session.reload.answers.school_name }
+          .to("Springfield Elementary School")
+        ).and(
+          change { journey_session.reload.answers.school_address_line_1 }
+          .to("19")
+        ).and(
+          change { journey_session.reload.answers.school_address_line_2 }
+          .to("Plympton Street")
+        ).and(
+          change { journey_session.reload.answers.school_city }
+          .to("Springfield")
+        ).and(
+          change { journey_session.reload.answers.school_postcode }
+          .to("TE57 1NG")
+        )
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -91,4 +91,50 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
       )
     end
   end
+
+  describe "#employment_answers" do
+    subject { presenter.employment_answers }
+
+    let(:answers) do
+      build(
+        :get_a_teacher_relocation_payment_answers,
+        :with_employment_details
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "Enter the name of the headteacher of the school where you are employed as a teacher",
+          "Seymour Skinner",
+          "employment-details"
+        ],
+        [
+          "Enter the name of the school",
+          "Springfield Elementary School",
+          "employment-details"
+        ],
+        [
+          "Address line 1",
+          "Springfield Elementary School",
+          "employment-details"
+        ],
+        [
+          "Address line 2",
+          "Plympton Street",
+          "employment-details"
+        ],
+        [
+          "Town or city",
+          "Springfield",
+          "employment-details"
+        ],
+        [
+          "Postcode",
+          "TE57 1NG",
+          "employment-details"
+        ]
+      )
+    end
+  end
 end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -93,6 +93,30 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
+    def and_i_complete_the_employment_details_step
+      assert_on_employment_details_page!
+
+      fill_in(
+        "Enter the name of the headteacher of the school where you are employed as a teacher",
+        with: "Seymour Skinner"
+      )
+
+      fill_in(
+        "Enter the name of the school",
+        with: "Springfield Elementary School"
+      )
+
+      fill_in("Address line 1", with: "Springfield Elementary School")
+
+      fill_in("Address line 2", with: "Plympton Street")
+
+      fill_in("Town or city", with: "Springfield")
+
+      fill_in("Postcode", with: "TE57 1NG")
+
+      click_button("Continue")
+    end
+
     def and_i_complete_the_personal_details_step
       assert_on_personal_details_page!
 
@@ -297,6 +321,10 @@ module GetATeacherRelocationPayment
       expect(page).to have_text(
         "Enter your passport number, as it appears on your passport"
       )
+    end
+
+    def assert_on_employment_details_page!
+      expect(page).to have_text("Employment information")
     end
 
     def assert_on_personal_details_page!


### PR DESCRIPTION
Add employment details form

Adds the employment details page as per IRP. We've named the fields the
same as in IRP. We could probably provide a school search box for this
but that's something for a future iteration.
Have also added the school details to the PII section to be on the safe
side as they might be enough to identify an claimant in combination with
some of the other non pii answers.

