### PR TITLE
[LUPEYALPHA-546] Add FE contract type

### DIFF
--- a/app/forms/journeys/further_education_payments/contract_type_form.rb
+++ b/app/forms/journeys/further_education_payments/contract_type_form.rb
@@ -1,0 +1,36 @@
+module Journeys
+  module FurtherEducationPayments
+    class ContractTypeForm < Form
+      attribute :contract_type, :string
+
+      validates :contract_type,
+        inclusion: {in: ->(form) { form.radio_options.map(&:id) }, message: i18n_error_message(:inclusion)}
+
+      def radio_options
+        [
+          OpenStruct.new(
+            id: "permanent",
+            name: "Permanent contract",
+            hint: "This includes full-time and part-time contracts"
+          ),
+          OpenStruct.new(
+            id: "fixed-term",
+            name: "Fixed-term contract"
+          ),
+          OpenStruct.new(
+            id: "variable-hours",
+            name: "Variable hours contract",
+            hint: "This includes zero hours contract and hourly paid"
+          )
+        ]
+      end
+
+      def save
+        return if invalid?
+
+        journey_session.answers.assign_attributes(contract_type:)
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -12,6 +12,7 @@ module Journeys
         "teaching-responsibilities" => TeachingResponsibilitiesForm,
         "further-education-provision-search" => FurtherEducationProvisionSearchForm,
         "select-provision" => SelectProvisionForm,
+        "contract-type" => ContractTypeForm,
         "subjects-taught" => SubjectsTaughtForm
       }
     }

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -4,7 +4,12 @@ module Journeys
       attribute :teaching_responsibilities, :boolean
       attribute :provision_search, :string
       attribute :school_id, :string # GUID
+      attribute :contract_type, :string
       attribute :subjects_taught, default: []
+
+      def school
+        @school ||= School.find(school_id)
+      end
     end
   end
 end

--- a/app/views/further_education_payments/claims/contract_type.html.erb
+++ b/app/views/further_education_payments/claims/contract_type.html.erb
@@ -1,7 +1,12 @@
-<p class="govuk-body">
-  FE contract type goes here
-</p>
-
 <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons :contract_type, @form.radio_options, :id, :name, :hint,
+    legend: {
+      text: @form.t(:question, school_name: journey_session.answers.school.name),
+      tag: "h1",
+      size: "l"
+    } %>
+
   <%= f.govuk_submit %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -788,6 +788,10 @@ en:
       select_provision:
         errors:
           blank: Select the college you teach at
+      contract_type:
+        question: What type of contract do you have with %{school_name}?
+        errors:
+          inclusion: Select the contract type you have
       subjects_taught:
         question: Which subject areas do you teach?
         hint: Select all that apply

--- a/spec/factories/journeys/further_education_payments/session_answers.rb
+++ b/spec/factories/journeys/further_education_payments/session_answers.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :further_education_payments_answers, class: "Journeys::FurtherEducationPayments::SessionAnswers" do
+  end
+end

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_selector "input[type=radio][checked=checked][value='#{college.id}']", visible: false
     click_button "Continue"
 
-    expect(page).to have_content("FE contract type goes here")
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
     click_button "Continue"
 
     expect(page).to have_content("FE teaching hours per week goes here")

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -23,7 +23,8 @@ RSpec.feature "Further education payments" do
     choose college.name
     click_button "Continue"
 
-    expect(page).to have_content("FE contract type goes here")
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
     click_button "Continue"
 
     expect(page).to have_content("FE teaching hours per week goes here")

--- a/spec/forms/journeys/further_education_payments/contract_type_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/contract_type_form_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Journeys::FurtherEducationPayments::ContractTypeForm, type: :model do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, school_id: college.id) }
+  let(:college) { create(:school) }
+  let(:contract_type) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        contract_type:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
+
+  describe "validations" do
+    context "when no option selected" do
+      it do
+        is_expected.not_to(
+          allow_value(nil)
+          .for(:contract_type)
+          .with_message("Select the contract type you have")
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:contract_type) { %w[permanent fixed-term variable-hours].sample }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.contract_type }
+        .to(contract_type)
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-546
- Add contract type to FE journey

# Changes

- Added contract type form to FE journey handling happy path only
- I've tweaked the wire frames and moved some copy from radio labels to hint texts
- validation handled
- out of scope: eligibility and determine what the next page is

# Screenshots

![Screenshot 2024-06-26 at 09 38 38](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/3934260b-1713-4bc4-85b0-362ab0528195)

![Screenshot 2024-06-26 at 09 38 49](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/92580/d57d181e-b814-40b3-a768-a3cd0ad06127)