### PR TITLE
LUPEYALPHA-543 - First pass of FE landing-page

### DIFF
--- a/app/views/further_education_payments/landing_page.html.erb
+++ b/app/views/further_education_payments/landing_page.html.erb
@@ -1,5 +1,110 @@
-<p class="govuk-body">
-  further education landing page goes here
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("further_education_payments.landing_page") %></h1>
 
-<%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>
+    <p class="govuk-body">
+      Use this service to check your eligibility for an incentive payment before you apply.
+    </p>
+
+    <p class="govuk-body">
+      Before starting your application, it may be useful to have the following information to hand:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><span class="govuk-body">your contract or written statement of employment</span></li>
+      <li><span class="govuk-body">your teaching timetable</span></li>
+      <li><span class="govuk-body">the name of your college or sixth-form group, if your further education (FE) provider is part of one</span></li>
+    </ul>
+
+    <p class="govuk-body">
+      Answering questions about eligibility takes [TBC] minutes and applying for the payment takes another [TBC] minutes.
+    </p>
+
+    <div class="govuk-inset-text">
+      <p>
+        You’ll need a GOV.UK One Login account to apply for a further education financial incentive payment. If you don’t have an account yet, we’ll help you create one.
+      </p>
+
+      <p>To create a GOV.UK One Login, you’ll need:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li><span class="govuk-body">an email address</span></li>
+        <li><span class="govuk-body">a way to get security codes - this can be a mobile phone number or an authenticator app</span></li>
+      </ul>
+    </div>
+
+    <%# TODO: There isn't any journey closed content, for now hide the button %>
+    <% if @journey_open %>
+      <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>
+    <% end %>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Continue an existing application</h2>
+
+    <p class="govuk-body">
+      If you have already started an application, you can <%= govuk_link_to "continue it [TBC]" %>. You will be asked to sign in to GOV.UK One Login if you are not signed in already.
+    </p>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Eligibility criteria</h2>
+
+    <p class="govuk-body">
+      Eligible early career FE teachers can claim an annual incentive payment to encourage them to continue teaching.
+    </p>
+
+    <p class="govuk-body">
+      Claimants should be in the first 5 years of their teaching career in England and teach specific courses in the following subject areas:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><span class="govuk-body"></span>building and construction</li>
+      <li><span class="govuk-body"></span>chemistry</li>
+      <li><span class="govuk-body"></span>computing, including digital and ICT</li>
+      <li><span class="govuk-body"></span>early years</li>
+      <li><span class="govuk-body"></span>engineering and manufacturing, including transport engineering and electronics</li>
+      <li><span class="govuk-body"></span>maths</li>
+      <li><span class="govuk-body"></span>physics</li>
+    </ul>
+
+    <p class="govuk-body">
+      Further information about the eligibility criteria can be found in the <%= govuk_link_to "levelling up premium payments for FE teachers guidance", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers", target: "_blank" %>.
+    </p>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Payments and deductions</h2>
+
+    <p class="govuk-body">
+      If you meet the eligibility criteria, you could be eligible for between £2,000 and £6,000. The amount you are eligible for depends on:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><span class="govuk-body"></span><%= govuk_link_to "the FE provider you teach in [TBC]" %></li>
+      <li><span class="govuk-body"></span>the number of hours you teach</li>
+    </ul>
+
+    <p class="govuk-body">
+      The incentive payment is taxable income, so the amount you receive may be lower following tax deductions. If you are currently paying off a student loan, a deduction from your payment will also go towards repaying it.
+    </p>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Further information</h2>
+
+    <p class="govuk-body">
+      You must apply between [MONTH TBC] <%= @academic_year.start_year.to_s %> and March <%= @academic_year.end_year.to_s %>.
+    </p>
+
+    <p class="govuk-body">
+      If you are eligible for an incentive payment, we will collect personal information to verify your claim and process your payment.
+    </p>
+
+    <p class="govuk-body">
+      Payments are given up to [TBC] weeks from applying. You will receive an approval email with further information on your application.
+    </p>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Contact</h2>
+
+    <p class="govuk-body">
+      For further support, email
+      <br />
+      <%= govuk_link_to "FE-Levellingup.PremiumPayments@education.gov.uk", "mailto:FE-Levellingup.PremiumPayments@education.gov.uk", no_visited_state: true %>.
+    </p>
+
+    <p class="govuk-body">You should receive a reply within [TBC] working days.</p>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -764,6 +764,7 @@ en:
         confirmation_notice:
           "By selecting continue you are confirming that, to the best of your knowledge, the details you are providing are correct."
   further_education_payments:
+    landing_page: Find out if you are eligible for any incentive payments for further education teachers
     claim_description: for further education payments
     journey_name: Claim incentive payments for further education teachers
     feedback_email: "fe-levellingup.premiumpayments@education.gov.uk"


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/LUPEYALPHA-543

Not addressed in this PR, suggested in ticket to create new tickets for when those requirements are ready:

* A few TBC values need to be added, but for another ticket
* Journey closed content not present, so just hide the button
* OneLogin continue application link is a placeholder until OL works is started

Notes:

* Enabled `raise_on_missing_translations=true` for development env

