### PR TITLE
[LUPEYALPHA-550] Add academic start year form for FE journey

### DIFF
--- a/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
@@ -1,0 +1,37 @@
+module Journeys
+  module FurtherEducationPayments
+    class FurtherEducationTeachingStartYearForm < Form
+      attribute :further_education_teaching_start_year, :string
+
+      validates :further_education_teaching_start_year,
+        presence: {message: i18n_error_message(:blank)}
+
+      def radio_options
+        years_before = -4
+
+        array = (years_before..0).map do |delta|
+          academic_year = AcademicYear.current + delta
+          OpenStruct.new(
+            id: academic_year.start_year.to_s,
+            name: "September #{academic_year.start_year} to August #{academic_year.end_year}"
+          )
+        end
+
+        academic_year = AcademicYear.current + years_before
+        array << OpenStruct.new(
+          id: "pre-#{academic_year.start_year}",
+          name: "I started before September #{academic_year.start_year}"
+        )
+
+        array
+      end
+
+      def save
+        return false if invalid?
+
+        journey_session.answers.assign_attributes(further_education_teaching_start_year:)
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -13,6 +13,7 @@ module Journeys
         "further-education-provision-search" => FurtherEducationProvisionSearchForm,
         "select-provision" => SelectProvisionForm,
         "contract-type" => ContractTypeForm,
+        "further-education-teaching-start-year" => FurtherEducationTeachingStartYearForm,
         "subjects-taught" => SubjectsTaughtForm
       }
     }

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -5,6 +5,7 @@ module Journeys
       attribute :provision_search, :string
       attribute :school_id, :string # GUID
       attribute :contract_type, :string
+      attribute :further_education_teaching_start_year, :string
       attribute :subjects_taught, default: []
 
       def school

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -7,7 +7,7 @@ module Journeys
         select-provision
         contract-type
         teaching-hours-per-week
-        academic-year-in-further-education
+        further-education-teaching-start-year
         subjects-taught
         building-and-construction-courses
         teaching-courses

--- a/app/views/further_education_payments/claims/academic_year_in_further_education.html.erb
+++ b/app/views/further_education_payments/claims/academic_year_in_further_education.html.erb
@@ -1,7 +1,0 @@
-<p class="govuk-body">
-  FE academic year in further education goes here
-</p>
-
-<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
-  <%= f.govuk_submit %>
-<% end %>

--- a/app/views/further_education_payments/claims/further_education_teaching_start_year.html.erb
+++ b/app/views/further_education_payments/claims/further_education_teaching_start_year.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :further_education_teaching_start_year,
+        legend: {
+          text: "Which academic year did you start teaching in further education (FE) in England?",
+          tag: "h1",
+          size: "l"
+        } do %>
+        <% @form.radio_options[0..-2].each do |option| %>
+          <%= f.govuk_radio_button :further_education_teaching_start_year, option.id,
+            label: { text: option.name },
+            link_errors: @form.radio_options.first == option %>
+        <% end %>
+
+        <%= f.govuk_radio_divider %>
+
+        <% option = @form.radio_options.last %>
+        <%= f.govuk_radio_button :further_education_teaching_start_year, option.id,
+          label: { text: option.name } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -800,6 +800,9 @@ en:
         question: What type of contract do you have with %{school_name}?
         errors:
           inclusion: Select the contract type you have
+      further_education_teaching_start_year:
+        errors:
+          blank: Select which academic year you started teaching in further education in England
       subjects_taught:
         question: Which subject areas do you teach?
         hint: Select all that apply

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_content("FE teaching hours per week goes here")
     click_button "Continue"
 
-    expect(page).to have_content("FE academic year in further education goes here")
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
     click_button "Continue"
 
     expect(page).to have_content("Which subject areas do you teach?")

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -30,7 +30,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("FE teaching hours per week goes here")
     click_button "Continue"
 
-    expect(page).to have_content("FE academic year in further education goes here")
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
     click_button "Continue"
 
     expect(page).to have_content("Which subject areas do you teach?")

--- a/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationTeachingStartYearForm, type: :model do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session) }
+  let(:further_education_teaching_start_year) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        further_education_teaching_start_year:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
+
+  describe "#radio_options" do
+    it "returns 6 options" do
+      expect(subject.radio_options.size).to eql(6)
+    end
+
+    it "returns expected data" do
+      travel_to Time.zone.local(2024, 12, 1) do
+        expected = [
+          OpenStruct.new(id: "2020", name: "September 2020 to August 2021"),
+          OpenStruct.new(id: "2021", name: "September 2021 to August 2022"),
+          OpenStruct.new(id: "2022", name: "September 2022 to August 2023"),
+          OpenStruct.new(id: "2023", name: "September 2023 to August 2024"),
+          OpenStruct.new(id: "2024", name: "September 2024 to August 2025"),
+          OpenStruct.new(id: "pre-2020", name: "I started before September 2020")
+        ]
+
+        expect(subject.radio_options).to eql(expected)
+      end
+    end
+  end
+
+  describe "validations" do
+    let(:further_education_teaching_start_year) { nil }
+
+    it do
+      is_expected.not_to(
+        allow_value(further_education_teaching_start_year)
+        .for(:further_education_teaching_start_year)
+        .with_message("Select which academic year you started teaching in further education in England")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:further_education_teaching_start_year) { AcademicYear.current.start_year.to_s }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.further_education_teaching_start_year }.to(further_education_teaching_start_year)
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-550
- Added academic start year for FE journey

# Changes

- Added which academic year started teaching FE in FE journey
- I've tweaked the slug so it is more descriptive