### PR TITLE
CAPT 1740/remove trn from irp

### DIFF
--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -35,6 +35,10 @@ module Journeys
 
       private
 
+      def show_trn?
+        false
+      end
+
       def application_route
         [
           t("get_a_teacher_relocation_payment.forms.application_route.question"),

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -31,8 +31,7 @@ module Journeys
         "bank-or-building-society",
         "personal-bank-account",
         "building-society-account",
-        "gender",
-        "teacher-reference-number"
+        "gender"
       ].freeze
 
       RESULTS_SLUGS = [

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -48,7 +48,6 @@ describe "teacher route: completing the form" do
         and_i_dont_provide_my_mobile_number
         and_i_provide_my_personal_bank_details
         and_i_complete_the_payroll_gender_step
-        and_i_complete_the_trn_step
         then_the_check_your_answers_part_page_shows_my_answers
         and_i_submit_the_application
         then_the_application_is_submitted_successfully
@@ -66,7 +65,6 @@ describe "teacher route: completing the form" do
         and_i_dont_provide_my_mobile_number
         and_i_provide_my_personal_bank_details
         and_i_complete_the_payroll_gender_step
-        and_i_complete_the_trn_step
         then_the_check_your_answers_part_page_shows_my_answers
         and_i_submit_the_application
         then_the_application_is_submitted_successfully
@@ -84,7 +82,6 @@ describe "teacher route: completing the form" do
         and_i_provide_my_mobile_number
         and_i_provide_my_personal_bank_details
         and_i_complete_the_payroll_gender_step
-        and_i_complete_the_trn_step
         then_the_check_your_answers_part_page_shows_my_answers(mobile_number: true)
         and_i_submit_the_application
         then_the_application_is_submitted_successfully
@@ -102,7 +99,6 @@ describe "teacher route: completing the form" do
         and_i_provide_my_mobile_number
         and_i_provide_my_building_society_details
         and_i_complete_the_payroll_gender_step
-        and_i_complete_the_trn_step
         then_the_check_your_answers_part_page_shows_my_answers(
           mobile_number: true,
           building_society: true

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::ClaimSubmissionForm do
+  let(:journey_configuration) do
+    create(:journey_configuration, :get_a_teacher_relocation_payment)
+  end
+
+  let(:claim_answers) do
+    {
+      address_line_1: "330",
+      address_line_2: "Pikeland Ave",
+      address_line_3: "Springfield",
+      address_line_4: "Oregon",
+      postcode: "TE57 1NG",
+      date_of_birth: Date.new(1944, 7, 12),
+      national_insurance_number: "AB123456C",
+      email_address: "seymour-skinner@springfield-elementy.edu",
+      bank_sort_code: "123456",
+      bank_account_number: "12345678",
+      details_check: true,
+      payroll_gender: "male",
+      first_name: "Seymour",
+      middle_name: "Walter",
+      surname: "Skinner",
+      banking_name: "Seymour W Skinner",
+      building_society_roll_number: "12345678",
+      academic_year: journey_configuration.current_academic_year.to_s,
+      bank_or_building_society: "personal_bank_account",
+      provide_mobile_number: true,
+      mobile_number: "07123456789",
+      email_verified: true,
+      mobile_verified: true,
+      hmrc_bank_validation_succeeded: true,
+      hmrc_bank_validation_responses: {}
+    }
+  end
+
+  let(:start_date) { Date.tomorrow }
+
+  let(:eligibility_answers) do
+    {
+      application_route: "teacher",
+      state_funded_secondary_school: true,
+      one_year: true,
+      start_date: start_date,
+      subject: "physics",
+      visa_type: "British National (Overseas) visa",
+      date_of_entry: start_date - 1.week,
+      nationality: "Australian",
+      passport_number: "1234567890123456789A",
+      school_headteacher_name: "Seymour Skinner",
+      school_name: "Springfield Elementary School",
+      school_address_line_1: "Springfield Elementary School",
+      school_address_line_2: "Plympton Street",
+      school_city: "Springfield",
+      school_postcode: "TE57 1NG"
+    }
+  end
+
+  let(:journey_session) do
+    create(
+      :get_a_teacher_relocation_payment_session,
+      answers: answers
+    )
+  end
+
+  let(:form) { described_class.new(journey_session: journey_session) }
+
+  describe "#save" do
+    let(:answers) do
+      build(
+        :get_a_teacher_relocation_payment_answers,
+        **claim_answers.merge(eligibility_answers)
+      )
+    end
+
+    before { form.save }
+
+    it "sets the expect attributes on the claim" do
+      claim = form.claim
+
+      eligibility = claim.eligibility
+
+      claim_answers.each do |attribute, value|
+        expect(claim.public_send(attribute)).to eq(value)
+      end
+
+      expect(claim.submitted_at).to be_present
+
+      expect(claim.reference).to be_present
+
+      eligibility_answers.each do |attribute, value|
+        expect(eligibility.public_send(attribute)).to eq(value)
+      end
+    end
+  end
+end

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -263,14 +263,6 @@ module GetATeacherRelocationPayment
       click_button("Continue")
     end
 
-    # FIXME RL: Once https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1625
-    # remove this step. We don't want to capture a TRN on the IRP journey.
-    def and_i_complete_the_trn_step
-      fill_in("What is your teacher reference number (TRN)?", with: "1234567")
-
-      click_button("Continue")
-    end
-
     def then_the_application_is_submitted_successfully
       assert_application_is_submitted!
     end


### PR DESCRIPTION
Remove TRN step

We don't want to ask for a TRN on the IRP journey. We previously asked
for it as it was required to submit a claim. Now TRN is no longer a
required field on the claim we can drop the TRN step from the IRP
journey.

