### PR TITLE
CAPT 1742/dont allow future start dates

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/start_date_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/start_date_form.rb
@@ -3,12 +3,18 @@ module Journeys
     class StartDateForm < Form
       include ActiveRecord::AttributeAssignment
 
+      attribute :start_date, :date
+
       validates :start_date,
         presence: {
           message: i18n_error_message(:presence)
         }
 
-      attribute :start_date, :date
+      validates :start_date,
+        comparison: {
+          less_than: ->(_) { Date.tomorrow },
+          message: i18n_error_message(:date_not_in_future)
+        }, if: :start_date
 
       def initialize(journey_session:, journey:, params:)
         super

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -723,6 +723,7 @@ en:
         question: "Enter the start date of your contract"
         errors:
           presence: "Enter your contract start date"
+          date_not_in_future: "Start date cannot be in the future"
       subject:
         question: "What subject are you employed to teach at your school?"
         hint: "Physics, general or combined science including physics, and languages can be combined with other subjects but must make up at least 50% of your time in the classroom."

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -8,7 +8,7 @@ describe "teacher route: completing the form" do
   end
 
   let(:contract_start_date) do
-    Date.tomorrow
+    Date.yesterday
   end
 
   let(:entry_date) do

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/start_date_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/start_date_form_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::StartDateForm, type: :mod
     )
   end
 
+  let(:option) { nil }
+
   def multi_part_date_parms(date)
     return {} unless date.present?
 
@@ -31,27 +33,25 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::StartDateForm, type: :mod
     subject { form }
 
     context "with an invalid date" do
-      let(:option) { nil }
-
       it { is_expected.not_to be_valid }
     end
 
     context "with a date in the future" do
-      let(:option) { Date.tomorrow }
-
-      it { is_expected.to be_valid }
+      it do
+        is_expected.not_to(
+          allow_value(Date.tomorrow)
+          .for(:start_date)
+          .with_message("Start date cannot be in the future")
+        )
+      end
     end
 
     context "with a date in the present" do
-      let(:option) { Date.today }
-
-      it { is_expected.to be_valid }
+      it { is_expected.to allow_value(Date.today).for(:start_date) }
     end
 
     context "with a date in the past" do
-      let(:option) { Date.yesterday }
-
-      it { is_expected.to be_valid }
+      it { is_expected.to allow_value(Date.yesterday).for(:start_date) }
     end
   end
 
@@ -90,7 +90,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::StartDateForm, type: :mod
   end
 
   describe "#save" do
-    let(:option) { Date.tomorrow }
+    let(:option) { Date.yesterday }
 
     it "updates the journey session" do
       expect { expect(form.save).to be(true) }.to(


### PR DESCRIPTION
Don't allow future dates for start date

IRP feedback from Richard Forrest

>  I am able to enter a contract start date in the future although I can't
>  enter a travel date in the future. Can both these fields only accept
>  dates in the past?

Updates the start date form to not permit dates in the future.

