### PR TITLE
[LUPEYALPHA-551] Add subject areas to FE journey

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -38,6 +38,10 @@ class Form
     I18n.t("#{i18n_namespace}.#{base_key}", default: base_key, **args)
   end
 
+  def t(key, args = {})
+    I18n.t(key, scope: "#{i18n_namespace}.forms.#{i18n_form_namespace}", **args)
+  end
+
   def permitted_params
     @permitted_params ||= params.fetch(model_name.param_key, {}).permit(*permitted_attributes)
   end
@@ -49,7 +53,16 @@ class Form
   private
 
   def permitted_attributes
-    attribute_names
+    attributes.keys.map do |key|
+      field = @attributes[key]
+
+      case field.value_before_type_cast
+      when []
+        {key => []}
+      else
+        key
+      end
+    end
   end
 
   def i18n_form_namespace
@@ -57,11 +70,11 @@ class Form
   end
 
   def attributes_with_current_value
-    attributes.each_with_object({}) do |(attribute, _), attributes|
-      attributes[attribute] = permitted_params[attribute]
-      next unless attributes[attribute].nil?
+    attributes.each_with_object({}) do |(attribute, _), hash|
+      hash[attribute] = permitted_params[attribute]
+      next unless hash[attribute].nil?
 
-      attributes[attribute] = load_current_value(attribute)
+      hash[attribute] = load_current_value(attribute)
     end
   end
 

--- a/app/forms/journeys/further_education_payments/subjects_taught_form.rb
+++ b/app/forms/journeys/further_education_payments/subjects_taught_form.rb
@@ -9,9 +9,9 @@ module Journeys
 
       validates :subjects_taught,
         presence: {message: i18n_error_message(:inclusion)},
-        inclusion: {in: ->(form) { form.radio_options.map(&:id) }, message: i18n_error_message(:inclusion)}
+        inclusion: {in: ->(form) { form.checkbox_options.map(&:id) }, message: i18n_error_message(:inclusion)}
 
-      def radio_options
+      def checkbox_options
         [
           OpenStruct.new(id: "building-and-construction", name: "Building and construction"),
           OpenStruct.new(id: "chemistry", name: "Chemistry"),

--- a/app/forms/journeys/further_education_payments/subjects_taught_form.rb
+++ b/app/forms/journeys/further_education_payments/subjects_taught_form.rb
@@ -1,0 +1,41 @@
+module Journeys
+  module FurtherEducationPayments
+    class SubjectsTaughtForm < Form
+      include ActiveModel::Validations::Callbacks
+
+      attribute :subjects_taught, default: []
+
+      before_validation :clean_subjects_taught
+
+      validates :subjects_taught,
+        presence: {message: i18n_error_message(:inclusion)},
+        inclusion: {in: ->(form) { form.radio_options.map(&:id) }, message: i18n_error_message(:inclusion)}
+
+      def radio_options
+        [
+          OpenStruct.new(id: "building-and-construction", name: "Building and construction"),
+          OpenStruct.new(id: "chemistry", name: "Chemistry"),
+          OpenStruct.new(id: "computing", name: "Computing, including digital and ICT"),
+          OpenStruct.new(id: "early-years", name: "Early years"),
+          OpenStruct.new(id: "engineering-and-manufacturing", name: "Engineering and manufacturing, including transport engineering and electronics"),
+          OpenStruct.new(id: "mathematics", name: "Mathematics"),
+          OpenStruct.new(id: "physics", name: "Physics"),
+          OpenStruct.new(id: "none", name: "I do not teach any of these subjects")
+        ]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(subjects_taught:)
+        journey_session.save!
+      end
+
+      private
+
+      def clean_subjects_taught
+        subjects_taught.reject!(&:blank?)
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -11,7 +11,8 @@ module Journeys
       "claims" => {
         "teaching-responsibilities" => TeachingResponsibilitiesForm,
         "further-education-provision-search" => FurtherEducationProvisionSearchForm,
-        "select-provision" => SelectProvisionForm
+        "select-provision" => SelectProvisionForm,
+        "subjects-taught" => SubjectsTaughtForm
       }
     }
   end

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -4,6 +4,7 @@ module Journeys
       attribute :teaching_responsibilities, :boolean
       attribute :provision_search, :string
       attribute :school_id, :string # GUID
+      attribute :subjects_taught, default: []
     end
   end
 end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -8,7 +8,7 @@ module Journeys
         contract-type
         teaching-hours-per-week
         academic-year-in-further-education
-        subject-areas
+        subjects-taught
         building-and-construction-courses
         teaching-courses
         half-teaching-hours

--- a/app/views/further_education_payments/claims/subject_areas.html.erb
+++ b/app/views/further_education_payments/claims/subject_areas.html.erb
@@ -1,7 +1,0 @@
-<p class="govuk-body">
-  FE subject areas goes here
-</p>
-
-<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
-  <%= f.govuk_submit %>
-<% end %>

--- a/app/views/further_education_payments/claims/subjects_taught.html.erb
+++ b/app/views/further_education_payments/claims/subjects_taught.html.erb
@@ -12,13 +12,13 @@
         hint: {
           text: @form.t(:hint)
         } do %>
-        <% @form.radio_options[0..-2].each do |option| %>
-          <%= f.govuk_check_box :subjects_taught, option.id, label: { text: option.name }, link_errors: @form.radio_options.first == option %>
+        <% @form.checkbox_options[0..-2].each do |option| %>
+          <%= f.govuk_check_box :subjects_taught, option.id, label: { text: option.name }, link_errors: @form.checkbox_options.first == option %>
         <% end %>
 
         <%= f.govuk_check_box_divider %>
 
-        <% option = @form.radio_options.last %>
+        <% option = @form.checkbox_options.last %>
         <%= f.govuk_check_box :subjects_taught, option.id, label: { text: option.name }, exclusive: true %>
       <% end %>
 

--- a/app/views/further_education_payments/claims/subjects_taught.html.erb
+++ b/app/views/further_education_payments/claims/subjects_taught.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_check_boxes_fieldset :subjects_taught,
+        legend: {
+          text: @form.t(:question),
+          tag: "h1",
+          size: "l"
+        },
+        hint: {
+          text: @form.t(:hint)
+        } do %>
+        <% @form.radio_options[0..-2].each do |option| %>
+          <%= f.govuk_check_box :subjects_taught, option.id, label: { text: option.name }, link_errors: @form.radio_options.first == option %>
+        <% end %>
+
+        <%= f.govuk_check_box_divider %>
+
+        <% option = @form.radio_options.last %>
+        <%= f.govuk_check_box :subjects_taught, option.id, label: { text: option.name }, exclusive: true %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -777,6 +777,11 @@ en:
       select_provision:
         errors:
           blank: Select the college you teach at
+      subjects_taught:
+        question: Which subject areas do you teach?
+        hint: Select all that apply
+        errors:
+          inclusion: Select the subject areas you teach in or select you do not teach any of the listed subject areas
   activerecord:
     errors:
       models:

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -35,7 +35,8 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_content("FE academic year in further education goes here")
     click_button "Continue"
 
-    expect(page).to have_content("FE subject areas goes here")
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
     click_button "Continue"
 
     expect(page).to have_content("FE building and construction courses goes here")

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -32,7 +32,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("FE academic year in further education goes here")
     click_button "Continue"
 
-    expect(page).to have_content("FE subject areas goes here")
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
     click_button "Continue"
 
     expect(page).to have_content("FE building and construction courses goes here")

--- a/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Journeys::FurtherEducationPayments::SubjectsTaughtForm, type: :model do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session) }
+  let(:subjects_taught) { [] }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        subjects_taught:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
+
+  describe "validations" do
+    context "when no option selected" do
+      let(:subjects_taught) { [] }
+
+      it do
+        is_expected.not_to(
+          allow_value([])
+          .for(:subjects_taught)
+          .with_message("Select the subject areas you teach in or select you do not teach any of the listed subject areas")
+        )
+      end
+    end
+
+    context "when non-existent injection option selected" do
+      let(:subjects_taught) { ["foo"] }
+
+      it do
+        is_expected.not_to(
+          allow_value(["foo"])
+          .for(:subjects_taught)
+          .with_message("Select the subject areas you teach in or select you do not teach any of the listed subject areas")
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:subjects_taught) { ["chemistry", "mathematics"] }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.subjects_taught }.to(["chemistry", "mathematics"])
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-551
- Add subject areas form to FE journey

# Changes

- Added subject areas form to FE journey
- Added `form#t` to aid in translations on forms
- From what I can tell this is actually the first use of checkboxes in any of the existing journeys and was not supported out of the box
- The issue was around strong parameters and how permitted attributes were whitelisted. In order to `permit` a collection it must be passed `attribute_name: []` and not just `attribute_name` which was the prior implementation
- A collection is discerned with the default value of `[]` which is probably sufficient for our current needs. If this needs to be more robust we'll need to register a custom type eg:
```
ActiveModel::Type::Collection # does not exist and we'd have to implement

class MyForm
  attribute :my_field, :collection
end
```