### PR TITLE
Setup the admin to display IRP claims

### DIFF
--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -46,4 +46,8 @@ module BasePolicy
 
     self::SEARCHABLE_ELIGIBILITY_ATTRIBUTES
   end
+
+  def international_relocation_payments?
+    to_s == "InternationalRelocationPayments"
+  end
 end

--- a/app/models/claim/claims_preventing_payment_finder.rb
+++ b/app/models/claim/claims_preventing_payment_finder.rb
@@ -25,6 +25,8 @@ class Claim
     private
 
     def find_claims_preventing_payment
+      return [] if claim.policy == Policies::InternationalRelocationPayments
+
       eligibility_ids = claim.policy.policies_claimable.map { |policy|
         policy::Eligibility.where(teacher_reference_number: claim.eligibility.teacher_reference_number)
       }.flatten.map(&:id)

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -9,7 +9,11 @@ class ClaimCheckingTasks
     @claim = claim
   end
 
+  delegate :policy, to: :claim
+
   def applicable_task_names
+    return [] if policy.international_relocation_payments?
+
     @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
       task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
       task_names.delete("student_loan_amount") unless claim.policy == Policies::StudentLoans

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -2,7 +2,8 @@ module Policies
   POLICIES = [
     StudentLoans,
     EarlyCareerPayments,
-    LevellingUpPremiumPayments
+    LevellingUpPremiumPayments,
+    InternationalRelocationPayments
   ].freeze
 
   AMENDABLE_ELIGIBILITY_ATTRIBUTES = POLICIES.map do |policy|

--- a/app/models/policies/international_relocation_payments.rb
+++ b/app/models/policies/international_relocation_payments.rb
@@ -3,6 +3,9 @@ module Policies
     include BasePolicy
     extend self
 
+    ELIGIBILITY_MATCHING_ATTRIBUTES = [["passport_number"]].freeze
+    OTHER_CLAIMABLE_POLICIES = []
+
     # NOTE RL: currently IRP only has a single reply to address, so notify
     # doesn't show the address id
     def notify_reply_to_id

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -1,0 +1,13 @@
+module Policies
+  module InternationalRelocationPayments
+    class AdminTasksPresenter
+      include Admin::PresenterMethods
+
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+    end
+  end
+end

--- a/app/models/policies/international_relocation_payments/eligibility.rb
+++ b/app/models/policies/international_relocation_payments/eligibility.rb
@@ -3,7 +3,16 @@ module Policies
     class Eligibility < ApplicationRecord
       self.table_name = "international_relocation_payments_eligibilities"
 
+      AMENDABLE_ATTRIBUTES = %i[].freeze
+
       has_one :claim, as: :eligibility, inverse_of: :eligibility
+      belongs_to :current_school, class_name: "School"
+
+      attr_accessor :teacher_reference_number
+
+      def award_amount
+        0
+      end
 
       def ineligible?
         false

--- a/app/models/policies/international_relocation_payments/eligibility_admin_answers_presenter.rb
+++ b/app/models/policies/international_relocation_payments/eligibility_admin_answers_presenter.rb
@@ -1,0 +1,28 @@
+module Policies
+  module InternationalRelocationPayments
+    class EligibilityAdminAnswersPresenter
+      include Admin::PresenterMethods
+
+      attr_reader :eligibility
+
+      def initialize(eligibility)
+        @eligibility = eligibility
+      end
+
+      def answers
+        [].tap do |a|
+          a << current_school
+        end
+      end
+
+      private
+
+      def current_school
+        [
+          translate("admin.current_school"),
+          display_school(eligibility.current_school)
+        ]
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -770,6 +770,8 @@ en:
           "By selecting continue you are confirming that, to the best of your knowledge, the details you are providing are correct."
   international_relocation_payments:
     <<: *get_a_teacher_relocation_payment
+    policy_short_name: "International Relocation Payments"
+    policy_acronym: "IRP"
 
   further_education_payments:
     landing_page: Find out if you are eligible for any incentive payments for further education teachers

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       routing_name { Journeys::GetATeacherRelocationPayment::ROUTING_NAME }
     end
 
+    trait :international_relocation_payments do
+      routing_name { Journeys::GetATeacherRelocationPayment::ROUTING_NAME }
+    end
+
     trait :early_career_payments do
       additional_payments
     end

--- a/spec/factories/policies/international_relocation_payments/eligibilities.rb
+++ b/spec/factories/policies/international_relocation_payments/eligibilities.rb
@@ -1,4 +1,17 @@
 FactoryBot.define do
   factory :international_relocation_payments_eligibility, class: "Policies::InternationalRelocationPayments::Eligibility" do
+    trait :eligible_home_office do
+      passport_number { "123456789" }
+      nationality { "French" }
+    end
+
+    trait :eligible do
+      eligible_home_office
+      eligible_school
+    end
+
+    trait :eligible_school do
+      association :current_school, factory: :school
+    end
   end
 end

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         it "sets the GOV.UK Notify reply_to_id according to the policy" do
-          expect(mail["reply_to_id"].first.value).to eql(policy.notify_reply_to_id)
+          expect(mail["reply_to_id"]&.first&.value).to eql(policy.notify_reply_to_id)
         end
 
         it "mentions the type of claim in the subject" do

--- a/spec/models/policies/international_relocation_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/international_relocation_payments/admin_tasks_presenter_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Policies::InternationalRelocationPayments::AdminTasksPresenter, type: :model do
+  subject { presenter }
+
+  let(:claim) { build(:claim, policy: Policies::InternationalRelocationPayments) }
+  let(:eligibility) { claim.eligibility }
+  let(:presenter) { described_class.new(claim) }
+
+  describe "#claim" do
+    subject { presenter.claim }
+
+    it { is_expected.to eq claim }
+  end
+end

--- a/spec/models/policies/international_relocation_payments/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/policies/international_relocation_payments/eligibility_admin_answers_presenter_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Policies::InternationalRelocationPayments::EligibilityAdminAnswersPresenter, type: :model do
+  let(:claim) { build(:claim, :submittable, policy: Policies::InternationalRelocationPayments, academic_year: "2021/2022") }
+
+  subject(:presenter) { described_class.new(claim.eligibility) }
+
+  describe "#answers" do
+    it "returns an array of questions and answers for displaying to service operator" do
+      expect(presenter.answers).to eq [[I18n.t("admin.current_school"), presenter.display_school(claim.eligibility.current_school)]]
+    end
+  end
+end

--- a/spec/models/policies_spec.rb
+++ b/spec/models/policies_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Policies, type: :model do
       expect(described_class::POLICIES).to eq([
         Policies::StudentLoans,
         Policies::EarlyCareerPayments,
-        Policies::LevellingUpPremiumPayments
+        Policies::LevellingUpPremiumPayments,
+        Policies::InternationalRelocationPayments
       ])
     end
   end
@@ -30,7 +31,8 @@ RSpec.describe Policies, type: :model do
       expect(described_class.options_for_select).to eq([
         ["Student Loans", "student-loans"],
         ["Early-Career Payments", "early-career-payments"],
-        ["Levelling Up Premium Payments", "levelling-up-premium-payments"]
+        ["Levelling Up Premium Payments", "levelling-up-premium-payments"],
+        ["International Relocation Payments", "international-relocation-payments"]
       ])
     end
   end

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -34,7 +34,12 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
   }
 
   let!(:similar_claim) {
-    eligibility = create(:"#{policy.to_s.underscore}_eligibility", :eligible, teacher_reference_number: multiple_claim.eligibility.teacher_reference_number)
+    duplicate_attribute = if policy == Policies::InternationalRelocationPayments
+      {passport_number: multiple_claim.eligibility.passport_number}
+    else
+      {teacher_reference_number: multiple_claim.eligibility.teacher_reference_number}
+    end
+    eligibility = create(:"#{policy.to_s.underscore}_eligibility", :eligible, duplicate_attribute)
     create(
       :claim,
       :submitted,
@@ -173,6 +178,8 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       ["Identity confirmation", "Qualifications", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
+    when Policies::InternationalRelocationPayments
+      ["Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
In order to be able to display the IRP claims in the admin, there are some basic methods that need to be available.

This change ensures the minimum implementation for displaying claims without being concerned about the correctness of the required methods. Specifically the `award_amount` is a placeholder.

In order to ensure we can successfully check for duplicate claims, I
made an assumption that we would use passport number rather than teacher
reference number as a unique identifier.

I don't think claimants for IRP will have TRNs, therefore we need some
other way of matching.

We can change this assumption easily in the future but for now this
allows us to ship the admin changes and keep moving forward.

<!-- Do you need to update CHANGELOG.md? -->
