### PR TITLE
[LUPEYALPHA-606] GIAS import also stores UKPRN

### DIFF
--- a/app/models/school_data_importer.rb
+++ b/app/models/school_data_importer.rb
@@ -46,6 +46,7 @@ class SchoolDataImporter
     school.statutory_high_age = row.fetch("StatutoryHighAge")
     school.phone_number = row.fetch("TelephoneNum")
     school.open_date = row.fetch("OpenDate")
+    school.ukprn = row.fetch("UKPRN")
     school
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -221,6 +221,7 @@ shared:
     - statutory_high_age
     - phone_number
     - open_date
+    - ukprn
   :support_tickets:
     - id
     - url

--- a/db/migrate/20240627114644_add_ukprn_to_schools.rb
+++ b/db/migrate/20240627114644_add_ukprn_to_schools.rb
@@ -1,0 +1,7 @@
+class AddUkprnToSchools < ActiveRecord::Migration[7.0]
+  def change
+    add_column :schools, :ukprn, :text, null: true
+
+    add_index :schools, :ukprn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_25_135618) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_27_114644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -374,6 +374,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_25_135618) do
     t.string "phone_number", limit: 20
     t.date "open_date"
     t.string "postcode_sanitised"
+    t.text "ukprn"
     t.index ["close_date"], name: "index_schools_on_close_date"
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
@@ -381,6 +382,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_25_135618) do
     t.index ["name"], name: "index_schools_on_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["open_date"], name: "index_schools_on_open_date"
     t.index ["postcode_sanitised"], name: "index_schools_on_postcode_sanitised", opclass: :gin_trgm_ops, using: :gin
+    t.index ["ukprn"], name: "index_schools_on_ukprn"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 

--- a/spec/models/school_data_importer_spec.rb
+++ b/spec/models/school_data_importer_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe SchoolDataImporter do
         expect(imported_school.statutory_high_age).to eq(18)
         expect(imported_school.phone_number).to eq("01226762114")
         expect(imported_school.open_date).to be_nil
+        expect(imported_school.ukprn).to eql("10005034")
       end
 
       it "imports a closed school with the date it closed" do


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-606
- Store `UKPRN` when doing GIAS import so we can identify which schools/colleges are eligible for FELUP downstream

# Changes

- I've moved the location of the spec file to mirror the location of the actual file it tests against
- Added migration to hold `UKPRN` against `school`
- Updated `SchoolDataImporter` to now also store the UKPRN
- Update `dfe analytics` to support new db column