### PR TITLE
Fix visiting landing page for same journey

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -39,7 +39,11 @@ class ClaimsController < BasePublicController
   delegate :slugs, :current_slug, :previous_slug, :next_slug, :next_required_slug, to: :page_sequence
 
   def redirect_to_existing_claim_journey
-    new_journey = Journeys.for_routing_name(other_journey_sessions.first.journey)
+    # If other journey sessions is empty, then the claimant has hit the landing
+    # page for the journey they're already on, so we need to look at the
+    # existing session.
+    other_journey_session = other_journey_sessions.first || journey_session
+    new_journey = Journeys.for_routing_name(other_journey_session.journey)
 
     # Set the params[:journey] to the new journey routing name so things like
     # journey_session that rely on the journey param find the correct journey.

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -95,6 +95,36 @@ RSpec.feature "Switching policies" do
     end
   end
 
+  context "Switching to the same journey" do
+    scenario "a user can switch to the same journey after starting a claim on that journey" do
+      school = create(:school, :combined_journey_eligibile_for_all)
+
+      visit new_claim_path("additional-payments")
+
+      skip_tid
+
+      choose_school school
+
+      expect(page).to have_text(
+        "Are you currently teaching as a qualified teacher?"
+      )
+
+      visit new_claim_path("additional-payments")
+
+      expect(page).to(have_text(
+        "You have a claim in progress for an additional payment for teaching."
+      ))
+
+      choose "No, finish the claim I have in progress"
+
+      click_on "Submit"
+
+      expect(page).to have_text(
+        "Are you currently teaching as a qualified teacher?"
+      )
+    end
+  end
+
   scenario "a user does not select an option" do
     start_student_loans_claim
     visit new_claim_path("additional-payments")


### PR DESCRIPTION
Previously if a claimant started a journey then visited the landing page
for that journey and choose to continue with their existing session we'd
throw an error. The `other_journey_sessions` array contains the journey
sessions for the other journeys, which if you're still on the same
journey would be empty, so we need to check the current journey session
(the session for the journey we're currently on).

How we handle managing which journey you're on is subtle and spread
across many places in the controllers / concerns, the overall approach
likely needs revisiting.

## Before

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/2d71a455-5f6f-4f1b-9aca-6ec26d834659

## After

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/2a4fbf42-ae5d-43a4-b461-2c09c6862010


