### PR TITLE
[LUPEYALPHA-545] FE journey school search only returns FE bodies

### DIFF
--- a/app/assets/javascripts/components/college_search.js.erb
+++ b/app/assets/javascripts/components/college_search.js.erb
@@ -7,6 +7,8 @@ document.addEventListener("DOMContentLoaded", function () {
     return;
   }
 
+  var feOnly = form.dataset.feOnly || false;
+
   var searchInputContainer = form.querySelector("#autocomplete-container");
 
   if (!searchInputContainer) {
@@ -57,7 +59,7 @@ document.addEventListener("DOMContentLoaded", function () {
       Rails.ajax({
         type: "post",
         url: "<%= Rails.application.routes.url_helpers.school_search_index_path %>",
-        data: "query=" + query,
+        data: "query=" + query + "&fe_only=" + feOnly.toString(),
         success: handleResponse,
         error: handleResponse
       });

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -15,10 +15,11 @@ class SchoolSearchController < ApplicationController
       return
     end
 
+    fe_only = ActiveModel::Type::Boolean.new.cast(params[:fe_only])
     schools = ActiveModel::Type::Boolean.new.cast(params[:exclude_closed]) ? School.open : School
 
     begin
-      @schools = schools.search(params[:query])
+      @schools = schools.search(params[:query], fe_only:)
     rescue ArgumentError => e
       raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 

--- a/app/forms/journeys/further_education_payments/select_provision_form.rb
+++ b/app/forms/journeys/further_education_payments/select_provision_form.rb
@@ -22,9 +22,9 @@ module Journeys
 
       def results
         @results ||= if journey_session.answers.school_id.present?
-          School.open.where(id: school_id)
+          School.open.fe_only.where(id: school_id)
         else
-          School.open.search(provision_search)
+          School.open.fe_only.search(provision_search)
         end
       end
 

--- a/app/views/further_education_payments/claims/further_education_provision_search.html.erb
+++ b/app/views/further_education_payments/claims/further_education_provision_search.html.erb
@@ -5,6 +5,7 @@
       method: :patch,
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       id: "further-education-provision-search-form",
+      data: { "fe-only" => true },
       html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/further_education_payments/claims/further_education_provision_search.html.erb
+++ b/app/views/further_education_payments/claims/further_education_provision_search.html.erb
@@ -26,7 +26,7 @@
         type: :bullet %>
 
       <p class="govuk-body">
-        If you are unsure if your FE provider is eligible, you can refer to the full list of eligible FE providers for more information.
+        If you are unsure if your FE provider is eligible, you can refer to the <%= govuk_link_to "full list of eligible FE providers", "https://assets.publishing.service.gov.uk/media/667300fe64e554df3bd0db92/List_of_eligible_FE_providers_and_payment_value_for_levelling_up_premium.xlsx" %> for more information.
       </p>
 
       <div id="autocomplete-container" class="govuk-!-margin-bottom-9">

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -133,5 +133,9 @@ FactoryBot.define do
       open_date { 10.days.ago }
       close_date { nil }
     end
+
+    trait :further_education do
+      phase { 6 }
+    end
   end
 end

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Further education payments", js: true, flaky: true do
-  let(:college) { create(:school) }
+  let(:college) { create(:school, :further_education) }
 
   scenario "happy js path" do
     when_further_education_payments_journey_configuration_exists

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Further education payments" do
-  let(:college) { create(:school) }
+  let(:college) { create(:school, :further_education) }
 
   scenario "happy path claim" do
     when_further_education_payments_journey_configuration_exists

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe School, type: :model do
   describe ".search" do
     let!(:first_school) { create(:school, name: "Community School London", postcode: "SW1P 3BT") }
     let!(:second_school) { create(:school, name: "Unity School London", postcode: "SW1P 3BT") }
-    let!(:third_school) { create(:school, name: "The Unity College Manchester", postcode: "M1 2WD") }
+    let!(:third_school) { create(:school, :further_education, name: "The Unity College Manchester", postcode: "M1 2WD") }
 
     it "returns schools with a name matching the search term" do
       expect(School.search("School")).to match_array([first_school, second_school])
@@ -37,6 +37,12 @@ RSpec.describe School, type: :model do
 
     it "orders the results by similarity" do
       expect(School.search("Unity School")).to eq([second_school, first_school])
+    end
+
+    context "when searching for FE only" do
+      it "only returns FE bodies" do
+        expect(School.search("Unity", fe_only: true)).to eq([third_school])
+      end
     end
   end
 

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -75,5 +75,21 @@ RSpec.describe "School search", type: :request do
         expect(response.body).to include(other_school_similar_name.name)
       end
     end
+
+    context "when searching for FE only" do
+      let!(:school_3) { create(:school, :further_education, name: "some college") }
+
+      before do
+        school_1.update(name: "some school")
+        school_2.update(name: "some school")
+      end
+
+      it "only returns FE bodies" do
+        post school_search_index_path, params: {query: "some", fe_only: true}
+
+        expect(JSON.parse(response.body)["data"].size).to eql(1)
+        expect(response.body).to include("some college")
+      end
+    end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-545
- Missing part of FE journey where school search should only return FE bodies

# Changes

- School search backend now capable of returning FE bodies only
- This is based of `PhaseOfEducation` is `16 plus` this is encoded as `6` 
- Wired up FE journey to this so only return FE bodies