### PR TITLE
Add eligibility check for contract start date

### DIFF
--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -15,6 +15,9 @@ class AcademicYear
 
   ACADEMIC_YEAR_REGEXP = /\A20\d{2}\/20\d{2}\z/
 
+  AUTUMN_TERM_START_MONTH = 9
+  AUTUMN_TERM_START_DAY = 1
+
   attr_reader :start_year, :end_year
 
   # Defines a custom ActiveRecord::Type for AcademicYear that means we can
@@ -52,7 +55,12 @@ class AcademicYear
     def for(date)
       return if date.nil?
 
-      start_of_autumn_term = Date.new(date.year, 9, 1)
+      start_of_autumn_term = Date.new(
+        date.year,
+        AUTUMN_TERM_START_MONTH,
+        AUTUMN_TERM_START_DAY
+      )
+
       if date < start_of_autumn_term
         new(date.year - 1)
       else
@@ -131,5 +139,9 @@ class AcademicYear
 
   def +(other)
     AcademicYear.new(start_year + other)
+  end
+
+  def start_of_autumn_term
+    Date.new(start_year, AUTUMN_TERM_START_MONTH, AUTUMN_TERM_START_DAY)
   end
 end

--- a/app/models/policies/international_relocation_payments/eligibility.rb
+++ b/app/models/policies/international_relocation_payments/eligibility.rb
@@ -3,6 +3,15 @@ module Policies
     class Eligibility < ApplicationRecord
       self.table_name = "international_relocation_payments_eligibilities"
 
+      PRE_ACADEMIC_YEAR_WINDOW_LIMIT = 6.months
+
+      def self.earliest_eligible_contract_start_date
+        Journeys::GetATeacherRelocationPayment
+          .configuration
+          .current_academic_year
+          .start_of_autumn_term - PRE_ACADEMIC_YEAR_WINDOW_LIMIT
+      end
+
       has_one :claim, as: :eligibility, inverse_of: :eligibility
 
       def ineligible?
@@ -11,11 +20,6 @@ module Policies
 
       def policy
         Policies::InternationalRelocationPayments
-      end
-
-      def self.earliest_eligible_contract_start_date
-        # FIXME RL - waiting on policy to get back to us for what this should
-        # be
       end
     end
   end

--- a/app/models/policies/international_relocation_payments/eligibility.rb
+++ b/app/models/policies/international_relocation_payments/eligibility.rb
@@ -3,15 +3,6 @@ module Policies
     class Eligibility < ApplicationRecord
       self.table_name = "international_relocation_payments_eligibilities"
 
-      PRE_ACADEMIC_YEAR_WINDOW_LIMIT = 6.months
-
-      def self.earliest_eligible_contract_start_date
-        Journeys::GetATeacherRelocationPayment
-          .configuration
-          .current_academic_year
-          .start_of_autumn_term - PRE_ACADEMIC_YEAR_WINDOW_LIMIT
-      end
-
       has_one :claim, as: :eligibility, inverse_of: :eligibility
 
       def ineligible?

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -35,11 +35,23 @@ module Policies
           "taught subject not accepted"
         in visa_type: "Other"
           "visa not accepted"
+        in start_date: Date unless contract_start_date_eligible?
+          "contract start date must be after #{earliest_eligible_contract_start_date}"
         in date_of_entry: Date, start_date: Date unless date_of_entry_eligible?
           "cannot enter the UK more than 3 months before your contract start date"
         else
           nil
         end
+      end
+
+      def contract_start_date_eligible?
+        return false unless answers.start_date
+
+        answers.start_date >= earliest_eligible_contract_start_date
+      end
+
+      def earliest_eligible_contract_start_date
+        Eligibility.earliest_eligible_contract_start_date
       end
 
       def date_of_entry_eligible?

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -1,9 +1,20 @@
 module Policies
   module InternationalRelocationPayments
     class PolicyEligibilityChecker
+      PRE_ACADEMIC_YEAR_WINDOW_LIMIT = 6.months
+
+      def self.earliest_eligible_contract_start_date
+        Journeys::GetATeacherRelocationPayment
+          .configuration
+          .current_academic_year
+          .start_of_autumn_term - PRE_ACADEMIC_YEAR_WINDOW_LIMIT
+      end
+
       attr_reader :answers
 
       delegate_missing_to :answers
+
+      delegate :earliest_eligible_contract_start_date, to: :class
 
       def initialize(answers:)
         @answers = answers
@@ -48,10 +59,6 @@ module Policies
         return false unless answers.start_date
 
         answers.start_date >= earliest_eligible_contract_start_date
-      end
-
-      def earliest_eligible_contract_start_date
-        Eligibility.earliest_eligible_contract_start_date
       end
 
       def date_of_entry_eligible?

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -8,7 +8,7 @@ describe "ineligible route: completing the form" do
   end
 
   let(:contract_start_date) do
-    Policies::InternationalRelocationPayments::Eligibility
+    Policies::InternationalRelocationPayments::PolicyEligibilityChecker
       .earliest_eligible_contract_start_date
   end
 
@@ -69,7 +69,7 @@ describe "ineligible route: completing the form" do
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
         and_i_complete_the_contract_details_step_with(option: "Yes")
         and_i_complete_the_contract_start_date_step_with(
-          date: Policies::InternationalRelocationPayments::Eligibility
+          date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker
           .earliest_eligible_contract_start_date - 1.day
         )
         then_i_see_the_ineligible_page

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -8,11 +8,8 @@ describe "ineligible route: completing the form" do
   end
 
   let(:contract_start_date) do
-    Date.new(
-      journey_configuration.current_academic_year.start_year,
-      1,
-      1
-    )
+    Policies::InternationalRelocationPayments::Eligibility
+      .earliest_eligible_contract_start_date
   end
 
   before do
@@ -63,9 +60,7 @@ describe "ineligible route: completing the form" do
       end
     end
 
-    # FIXME RL waiting on feedback from policy team to determine what the cut
-    # off date is for contracts
-    xcontext "ineligible - contract start date" do
+    context "ineligible - contract start date" do
       it "shows the ineligible page" do
         when_i_start_the_form
         and_i_complete_application_route_question_with(
@@ -74,7 +69,8 @@ describe "ineligible route: completing the form" do
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
         and_i_complete_the_contract_details_step_with(option: "Yes")
         and_i_complete_the_contract_start_date_step_with(
-          date: Polices::InternationalRelocationPayments.earliest_eligible_contract_start_date - 1.day
+          date: Policies::InternationalRelocationPayments::Eligibility
+          .earliest_eligible_contract_start_date - 1.day
         )
         then_i_see_the_ineligible_page
       end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -8,7 +8,7 @@ describe "teacher route: completing the form" do
   end
 
   let(:contract_start_date) do
-    Policies::InternationalRelocationPayments::Eligibility
+    Policies::InternationalRelocationPayments::PolicyEligibilityChecker
       .earliest_eligible_contract_start_date
   end
 

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -8,7 +8,8 @@ describe "teacher route: completing the form" do
   end
 
   let(:contract_start_date) do
-    Date.yesterday
+    Policies::InternationalRelocationPayments::Eligibility
+      .earliest_eligible_contract_start_date
   end
 
   let(:entry_date) do

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -186,4 +186,10 @@ RSpec.describe AcademicYear do
       expect(AcademicYear.new(2014).hash).not_to eql 2014.hash
     end
   end
+
+  describe "#start_of_autumn_term" do
+    it "returns September 1st of the start year" do
+      expect(AcademicYear.new(2014).start_of_autumn_term).to eq Date.new(2014, 9, 1)
+    end
+  end
 end

--- a/spec/models/policies/international_relocation_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/international_relocation_payments/policy_eligibility_checker_spec.rb
@@ -139,7 +139,7 @@ describe Policies::InternationalRelocationPayments::PolicyEligibilityChecker do
           one_year: true,
           subject: "physics",
           visa_type: "British National (Overseas) visa",
-          start_date: Policies::InternationalRelocationPayments::Eligibility.earliest_eligible_contract_start_date - 1.day
+          start_date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 1.day
         }
       end
 
@@ -154,8 +154,8 @@ describe Policies::InternationalRelocationPayments::PolicyEligibilityChecker do
           one_year: true,
           subject: "physics",
           visa_type: "British National (Overseas) visa",
-          start_date: Policies::InternationalRelocationPayments::Eligibility.earliest_eligible_contract_start_date,
-          date_of_entry: Policies::InternationalRelocationPayments::Eligibility.earliest_eligible_contract_start_date - 4.months
+          start_date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date,
+          date_of_entry: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 4.months
         }
       end
 
@@ -170,8 +170,8 @@ describe Policies::InternationalRelocationPayments::PolicyEligibilityChecker do
           one_year: true,
           subject: "physics",
           visa_type: "British National (Overseas) visa",
-          start_date: Policies::InternationalRelocationPayments::Eligibility.earliest_eligible_contract_start_date,
-          date_of_entry: Policies::InternationalRelocationPayments::Eligibility.earliest_eligible_contract_start_date - 1.week
+          start_date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date,
+          date_of_entry: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 1.week
         }
       end
 


### PR DESCRIPTION
We want to reject claimants if their contract start date is earlier than
6 months before the autumn term. This commit updates the eligibility
checker to do so and also adds some missing tests.

## Walk through

https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/2ac61505-a9a7-4d84-9990-403650dc26ec


