### PR TITLE
[LUPEYALPHA-615] FE journey handle ineligible as lack teaching

### DIFF
--- a/app/forms/journeys/further_education_payments/ineligible_form.rb
+++ b/app/forms/journeys/further_education_payments/ineligible_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    class IneligibleForm < Form
+      def journey_eligibility_checker
+        @journey_eligibility_checker ||= EligibilityChecker.new(journey_session:)
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -6,7 +6,7 @@ module Journeys
     ROUTING_NAME = "further-education-payments"
     VIEW_PATH = "further_education_payments"
     I18N_NAMESPACE = "further_education_payments"
-    POLICIES = []
+    POLICIES = [Policies::FurtherEducationPayments]
     FORMS = {
       "claims" => {
         "teaching-responsibilities" => TeachingResponsibilitiesForm,
@@ -17,7 +17,8 @@ module Journeys
         "further-education-teaching-start-year" => FurtherEducationTeachingStartYearForm,
         "subjects-taught" => SubjectsTaughtForm,
         "teaching-qualification" => TeachingQualificationForm,
-        "poor-performance" => PoorPerformanceForm
+        "poor-performance" => PoorPerformanceForm,
+        "ineligible" => IneligibleForm
       }
     }
   end

--- a/app/models/journeys/further_education_payments/eligibility_checker.rb
+++ b/app/models/journeys/further_education_payments/eligibility_checker.rb
@@ -1,9 +1,6 @@
 module Journeys
   module FurtherEducationPayments
     class EligibilityChecker < Journeys::EligibilityChecker
-      def ineligible?
-        false
-      end
     end
   end
 end

--- a/app/models/policies/further_education_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/further_education_payments/policy_eligibility_checker.rb
@@ -10,11 +10,19 @@ module Policies
       end
 
       def status
+        return :ineligible if ineligible?
+
         :eligible_now
       end
 
       def ineligible?
-        false
+        ineligibility_reason.present?
+      end
+
+      def ineligibility_reason
+        if answers.teaching_responsibilities == false
+          :lack_teaching_responsibilities
+        end
       end
     end
   end

--- a/app/views/further_education_payments/claims/_ineligible_lack_teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_lack_teaching_responsibilities.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      You are not eligible
+    </h1>
+
+    <p class="govuk-body">
+      In order to claim a levelling up premium payment, you must be employed as a member of staff with teaching responsibilities.
+    </p>
+
+    <p class="govuk-body">
+      For more information, check the eligibility criteria for <%= govuk_link_to "levelling up premium payments for early career further education teachers", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers", new_tab: true %>.
+    </p>
+
+    <p class="govuk-body">
+      The information entered is not stored. If you are unsure your information is correct, <%= govuk_link_to "start again", claim_path(current_journey_routing_name, "claim") %>.
+    </p>
+  </div>
+</div>

--- a/app/views/further_education_payments/claims/ineligible.html.erb
+++ b/app/views/further_education_payments/claims/ineligible.html.erb
@@ -1,1 +1,1 @@
-FE ineligible goes here
+<%= render "ineligible_#{@form.journey_eligibility_checker.ineligibility_reason}" %>

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments ineligible paths" do
+  scenario "when no teaching responsibilities" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    expect(page).to have_content("you must be employed as a member of staff with teaching responsibilities")
+  end
+
+  def when_further_education_payments_journey_configuration_exists
+    create(:journey_configuration, :further_education_payments)
+  end
+end

--- a/spec/models/policies/further_education_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/further_education_payments/policy_eligibility_checker_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Policies::FurtherEducationPayments::PolicyEligibilityChecker do
+  let(:answers) do
+    build(:further_education_payments_answers)
+  end
+
+  subject { described_class.new(answers: answers) }
+
+  describe "#status, #ineligible?, #ineligibility_reason" do
+    context "when ineligible as lacking teaching responsibility" do
+      let(:answers) do
+        build(:further_education_payments_answers, teaching_responsibilities: false)
+      end
+
+      it "is ineligble as :lack_teaching_responsibilities" do
+        expect(subject).to be_ineligible
+        expect(subject.status).to eql(:ineligible)
+        expect(subject.ineligibility_reason).to eql(:lack_teaching_responsibilities)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-615
- For FE journey add ineligible path when user lacks teaching responsibility

# Changes

- Added new ineligible page
- This is the first ineligible page for this journey so some plumbing was required to set everything up