### PR TITLE
Add the Home Office identity confirmation task

### DIFF
--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ class ClaimCheckingTasks
   delegate :policy, to: :claim
 
   def applicable_task_names
-    return [] if policy.international_relocation_payments?
+    return ["identity_confirmation"] if policy.international_relocation_payments?
 
     @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
       task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -8,6 +8,17 @@ module Policies
       def initialize(claim)
         @claim = claim
       end
+
+      def identity_confirmation
+        [
+          ["Nationality", eligibility.nationality],
+          ["Passport number", eligibility.passport_number]
+        ]
+      end
+
+      private
+
+      delegate :eligibility, to: :claim
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,8 @@ en:
     claim_route: "Claim route"
     claim_route_not_tid: "Not signed in with DfE Identity"
     claim_route_with_tid: "Signed in with DfE Identity"
+    passport_number: "Passport number"
+    nationality: "Nationality"
     decision:
       created_at: "Created at"
       result: "Result"
@@ -772,6 +774,10 @@ en:
     <<: *get_a_teacher_relocation_payment
     policy_short_name: "International Relocation Payments"
     policy_acronym: "IRP"
+    admin:
+      task_questions:
+        identity_confirmation:
+          title: "Did %{claim_full_name} submit the claim?"
 
   further_education_payments:
     landing_page: Find out if you are eligible for any incentive payments for further education teachers

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe "Admin tasks", type: :request do
         end
       end
     end
+
+    context "with an International Relocation Payments claim" do
+      let(:claim) { create(:claim, :submitted, policy: Policies::InternationalRelocationPayments) }
+
+      describe "tasks#show" do
+        it "renders the requested page" do
+          get admin_claim_task_path(claim, "identity_confirmation")
+          expect(response.body).to include(I18n.t("admin.nationality"))
+          expect(response.body).to include(I18n.t("admin.passport_number"))
+        end
+      end
+    end
   end
 
   context "when signed in as a payroll operator or a support agent" do

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -179,7 +179,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["Decision"]
+      ["Identity confirmation", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
The first admin task for the IRP journey is verifying the Home Office
identity check.

We request the nationality and passport number for the individual
submitting the claim and present that as the check for the admin task.

| Header | Header |
|--------|--------|
| Claim view | <img width="1038" alt="Screenshot 2024-07-01 at 7 41 36 am" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/3126/e1e24c2d-c18a-4bf2-8f42-84308dca85f4"> |
| Task view | <img width="1055" alt="Screenshot 2024-07-01 at 7 41 48 am" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/3126/ba4b759d-3f73-47c4-a2d0-7fe782173b2b"> |
| Confirmed | <img width="1104" alt="Screenshot 2024-07-01 at 7 42 12 am" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/3126/5fb112a7-7960-48ce-912d-23eb2470475a"> |
