### PR TITLE
[LUPEYALPHA-557] Add eligible page to FE journey

### DIFF
--- a/app/forms/journeys/further_education_payments/check_your_answers_form.rb
+++ b/app/forms/journeys/further_education_payments/check_your_answers_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    class CheckYourAnswersForm < Form
+      def save
+        true
+      end
+    end
+  end
+end

--- a/app/forms/journeys/further_education_payments/eligible_form.rb
+++ b/app/forms/journeys/further_education_payments/eligible_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    class EligibleForm < Form
+      def save
+        true
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -18,6 +18,7 @@ module Journeys
         "subjects-taught" => SubjectsTaughtForm,
         "teaching-qualification" => TeachingQualificationForm,
         "poor-performance" => PoorPerformanceForm,
+        "check-your-answers" => CheckYourAnswersForm,
         "ineligible" => IneligibleForm
       }
     }

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -18,6 +18,7 @@ module Journeys
 
       RESULTS_SLUGS = %w[
         check-your-answers
+        eligible
         ineligible
       ].freeze
 

--- a/app/views/further_education_payments/claims/check_your_answers.html.erb
+++ b/app/views/further_education_payments/claims/check_your_answers.html.erb
@@ -1,3 +1,7 @@
 <p class="govuk-body">
   FE check your answers goes here
 </p>
+
+<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/further_education_payments/claims/eligible.html.erb
+++ b/app/views/further_education_payments/claims/eligible.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= govuk_panel(
+        title_text: "You’re eligible for a financial incentive payment",
+        html_attributes: {
+          class: "govuk-panel--informational"
+        }
+      ) %>
+
+      <div class="govuk-heading-m">
+        Based on what you’ve told us, you can apply for an early career further education financial incentive payment of:
+      </div>
+
+      <div class="govuk-heading-l">
+        £???
+      </div>
+
+      <div class="govuk-body">
+        For more information about why you are eligible, read about the <%= govuk_link_to "levelling up premium payments for early career further education teachers", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers", new_tab: true %>.
+      </div>
+
+      <%= f.govuk_submit "Apply now" %>
+    <% end %>
+  </div>
+</div>

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -66,6 +66,10 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     click_button "Continue"
 
     expect(page).to have_content("FE check your answers goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a financial incentive payment")
+    expect(page).to have_content("Apply now")
   end
 
   def when_further_education_payments_journey_configuration_exists

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -63,6 +63,10 @@ RSpec.feature "Further education payments" do
     click_button "Continue"
 
     expect(page).to have_content("FE check your answers goes here")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a financial incentive payment")
+    expect(page).to have_content("Apply now")
   end
 
   def when_further_education_payments_journey_configuration_exists


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-557
- Add eligible page to FE journey

# Changes

- Added eligible page to FE journey
- This page has a placeholder for the award amount which is yet to be implemented
- I had to add some placeholder code for the check your answers bit so able to get to the eligible page