### PR TITLE
Purge unsubmitted journey sessions

### DIFF
--- a/app/jobs/purge_unsubmitted_claims_job.rb
+++ b/app/jobs/purge_unsubmitted_claims_job.rb
@@ -5,13 +5,13 @@ class PurgeUnsubmittedClaimsJob < CronJob
   self.cron_expression = "0 0 * * *"
 
   def perform
-    Rails.logger.info "Purging #{old_unsubmitted_claims.count} old and unsubmitted claims from the database"
-    old_unsubmitted_claims.destroy_all
+    Rails.logger.info "Purging #{old_unsubmitted_journeys.count} old and unsubmitted journeys from the database"
+    old_unsubmitted_journeys.destroy_all
   end
 
   private
 
-  def old_unsubmitted_claims
-    Claim.unsubmitted.where("updated_at < ?", 24.hours.ago)
+  def old_unsubmitted_journeys
+    Journeys::Session.purgeable
   end
 end

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -2,6 +2,8 @@ module Journeys
   class Session < ApplicationRecord
     self.abstract_class = true
 
+    self.table_name = "journeys_sessions"
+
     has_one :claim,
       dependent: :nullify,
       inverse_of: :journey_session,
@@ -10,6 +12,12 @@ module Journeys
     validates :journey,
       presence: true,
       inclusion: {in: Journeys.all_routing_names}
+
+    scope :unsubmitted, -> { where.missing(:claim) }
+
+    scope :purgeable, -> do
+      unsubmitted.where(journeys_sessions: {updated_at: ..24.hours.ago})
+    end
 
     def submitted?
       claim.present?


### PR DESCRIPTION
Now we only create a claim once the claimant has completed the journey
we need to update the purge job to work on journey sessions rather than
claims as all claims are submitted claims.

<!-- Do you need to update CHANGELOG.md? -->
