### PR TITLE
[1750] DNS configuration for test and production domains

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -11,7 +11,11 @@
         "/assets/*"
       ],
       "environment_short": "pd",
-      "origin_hostname": "s118p01-app-as.azurewebsites.net"
+      "origin_hostname": "s118p01-app-as.azurewebsites.net",
+      "redirect_rules": [{
+        "from-domain": "apex",
+        "to-domain": "www.claim-additional-teaching-payment.service.gov.uk"
+      }]
     }
   }
 }

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "claim-additional-teaching-payment.service.gov.uk": {
+      "front_door_name": "s189p01-capt-dom-fd",
+      "resource_group_name": "s189p01-capt-dom-rg",
+      "domains": [
+        "apex",
+        "www"
+      ],
+      "cached_paths": [
+        "/assets/*"
+      ],
+      "environment_short": "pd",
+      "origin_hostname": "s118p01-app-as.azurewebsites.net"
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/production_Terrafile
+++ b/terraform/domains/environment_domains/config/production_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -1,0 +1,16 @@
+{
+  "hosted_zone": {
+    "claim-additional-teaching-payment.service.gov.uk": {
+      "front_door_name": "s189p01-capt-dom-fd",
+      "resource_group_name": "s189p01-capt-dom-rg",
+      "domains": [
+        "test"
+      ],
+      "cached_paths": [
+        "/assets/*"
+      ],
+      "environment_short": "ts",
+      "origin_hostname": "s118t01-app-as.azurewebsites.net"
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/test_Terrafile
+++ b/terraform/domains/environment_domains/config/test_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -1,0 +1,12 @@
+# Used to create domains to be managed by front door.
+module "domains" {
+  for_each            = var.hosted_zone
+  source              = "./vendor/modules/domains//domains/environment_domains"
+  zone                = each.key
+  front_door_name     = each.value.front_door_name
+  resource_group_name = each.value.resource_group_name
+  domains             = each.value.domains
+  environment         = each.value.environment_short
+  host_name           = each.value.origin_hostname
+  cached_paths        = try(each.value.cached_paths, [])
+}

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -9,4 +9,5 @@ module "domains" {
   environment         = each.value.environment_short
   host_name           = each.value.origin_hostname
   cached_paths        = try(each.value.cached_paths, [])
+  redirect_rules      = try(each.value.redirect_rules, null)
 }

--- a/terraform/domains/environment_domains/terraform.tf
+++ b/terraform/domains/environment_domains/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+
+  required_version = "= 1.8.4"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.104.2"
+    }
+  }
+  backend "azurerm" {
+    container_name = "terraform-state"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -1,0 +1,4 @@
+variable "hosted_zone" {
+  type    = map(any)
+  default = {}
+}


### PR DESCRIPTION
## Description
Terraform code and configuration for the test and production domains

## How to review
Check both domains:
- https://claim-additional-teaching-payment.service.gov.uk/
- https://test.claim-additional-teaching-payment.service.gov.uk/

Check DNS zone claim-additional-teaching-payment.service.gov.uk and front door s189p01-capt-dom-fd

Check https://claim-additional-teaching-payment.service.gov.uk/admin/ redirects to
https://www.claim-additional-teaching-payment.service.gov.uk/admin/ using front door (HTTP 308)