### PR TITLE
Add a visa check task for IRP

### DIFF
--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ class ClaimCheckingTasks
   delegate :policy, to: :claim
 
   def applicable_task_names
-    return ["identity_confirmation"] if policy.international_relocation_payments?
+    return ["identity_confirmation", "visa"] if policy.international_relocation_payments?
 
     @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
       task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
@@ -21,6 +21,7 @@ class ClaimCheckingTasks
       task_names.delete("payroll_details") unless claim.must_manually_validate_bank_details?
       task_names.delete("matching_details") unless matching_claims.exists?
       task_names.delete("payroll_gender") unless claim.payroll_gender_missing? || task_names_for_claim.include?("payroll_gender")
+      task_names.delete("visa") unless claim.policy.international_relocation_payments?
     end
   end
 

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -16,6 +16,12 @@ module Policies
         ]
       end
 
+      def visa
+        [
+          ["Visa type", eligibility.visa_type]
+        ]
+      end
+
       private
 
       delegate :eligibility, to: :claim

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -18,6 +18,7 @@ class Task < ApplicationRecord
     payroll_details
     matching_details
     payroll_gender
+    visa
   ].freeze
 
   belongs_to :claim

--- a/app/views/admin/tasks/visa.html.erb
+++ b/app/views/admin/tasks/visa.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} visa check for #{@claim.policy.short_name}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+  <%= render "claim_summary", claim: @claim, heading: "Visa check" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answers", answers: @tasks_presenter.visa %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@task.passed.nil? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= render "form", task_name: "visa", claim: @claim %>
+    <% end %>
+
+    <%= render partial: "admin/task_pagination" %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,7 @@ en:
       student_loan_plan: "Check student loan plan"
       payroll_details: "Check bank/building society account details"
       census_subjects_taught: "Check eligible subjects are taught"
+      visa: "Check visa"
     undo_decision:
       approved: "Undo approval"
       rejected: "Undo rejection"
@@ -780,6 +781,8 @@ en:
       task_questions:
         identity_confirmation:
           title: "Did %{claim_full_name} submit the claim?"
+        visa:
+          title: "Is the claimant’s visa type eligible for a claim?"
 
   further_education_payments:
     landing_page: Find out if you are eligible for any incentive payments for further education teachers

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -179,7 +179,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["Identity confirmation", "Decision"]
+      ["Identity confirmation", "Visa", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
For the international relocation payments journey we want to add a new
admin task for checking the visa type provided.

We collect the visa type as part of the journey, so we want an admin
task to confirm this.

<img width="1066" alt="Screenshot 2024-07-02 at 10 02 53 am" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/3126/33da2708-f3f3-4391-95f1-731b385ba2c3">

<!-- Do you need to update CHANGELOG.md? -->
