### PR TITLE
Add an employment start date task

### DIFF
--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ class ClaimCheckingTasks
   delegate :policy, to: :claim
 
   def applicable_task_names
-    return %w[identity_confirmation visa arrival_date employment employment_contract] if policy.international_relocation_payments?
+    return %w[identity_confirmation visa arrival_date employment employment_contract employment_start] if policy.international_relocation_payments?
 
     @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
       task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
@@ -24,6 +24,7 @@ class ClaimCheckingTasks
       task_names.delete("visa") unless claim.policy.international_relocation_payments?
       task_names.delete("arrival_date") unless claim.policy.international_relocation_payments?
       task_names.delete("employment_contract") unless claim.policy.international_relocation_payments?
+      task_names.delete("employment_start") unless claim.policy.international_relocation_payments?
     end
   end
 

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -27,6 +27,12 @@ module Policies
         ]
       end
 
+      def employment_start
+        [
+          ["Employment start date", eligibility.start_date&.to_fs(:govuk_date)]
+        ]
+      end
+
       def identity_confirmation
         [
           ["Nationality", eligibility.nationality],

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -20,6 +20,7 @@ class Task < ApplicationRecord
     payroll_gender
     arrival_date
     employment_contract
+    employment_start
     visa
   ].freeze
 

--- a/app/views/admin/tasks/employment_start.html.erb
+++ b/app/views/admin/tasks/employment_start.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} employment start date check for #{@claim.policy.short_name}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+  <%= render "claim_summary", claim: @claim, heading: "Employment start date check" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answers", answers: @tasks_presenter.employment_start %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@task.passed.nil? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= render "form", task_name: "employment_start", claim: @claim %>
+    <% end %>
+
+    <%= render partial: "admin/task_pagination" %>
+  </div>
+</div>
+
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
       visa: "Check visa"
       arrival_date: "Check arrival date"
       employment_contract: "Check employment contract"
+      employment_start: "Check employment start date"
     undo_decision:
       approved: "Undo approval"
       rejected: "Undo rejection"
@@ -792,6 +793,8 @@ en:
           title: "Does the claimant’s current school match the above information from their claim?"
         employment_contract:
           title: "Does the claimant’s employment contract match the above information from their claim?"
+        employment_start:
+          title: "Does the claimant’s employment start date match the above information from their claim?"
 
   further_education_payments:
     landing_page: Find out if you are eligible for any incentive payments for further education teachers

--- a/spec/factories/policies/international_relocation_payments/eligibilities.rb
+++ b/spec/factories/policies/international_relocation_payments/eligibilities.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :eligible_contract do
       one_year { true }
     end
+
+    trait :eligible_start_date do
+      start_date { 1.month.ago }
+    end
   end
 end

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -179,7 +179,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Decision"]
+      ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Employment start", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
THe IRP journey collects a claimant's employment start date.

We want an admin task to verify the answer provided.

<img width="974" alt="Screenshot 2024-07-03 at 8 39 14 am" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/3126/1287a19d-7c39-4075-8243-5353bf97bcec">

<!-- Do you need to update CHANGELOG.md? -->
