### PR TITLE
CAPT 1753/only show state secondary schools

### DIFF
--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -7,6 +7,7 @@ module Journeys
         [].tap do |a|
           a << application_route
           a << state_funded_secondary_school
+          a << current_school
           a << contract_details
           a << start_date_details
           a << subject_details
@@ -24,7 +25,6 @@ module Journeys
 
       def employment_answers
         [].tap do |a|
-          a << current_school
           a << school_headteacher_name
         end
       end

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -4,6 +4,7 @@ module Journeys
       ELIGIBILITY_SLUGS = [
         "application-route",
         "state-funded-secondary-school",
+        "current-school",
         "contract-details",
         "start-date",
         "subject",
@@ -15,7 +16,6 @@ module Journeys
       PERSONAL_DETAILS_SLUGS = [
         "nationality",
         "passport-number",
-        "current-school",
         "headteacher-details",
         "personal-details",
         "postcode-search",

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -50,6 +50,8 @@ module Policies
           "contract start date must be after #{earliest_eligible_contract_start_date}"
         in date_of_entry: Date, start_date: Date unless date_of_entry_eligible?
           "cannot enter the UK more than 3 months before your contract start date"
+        in current_school_id: String unless current_school_eligible?
+          "school not eligible"
         else
           nil
         end
@@ -65,6 +67,12 @@ module Policies
         return false unless answers.date_of_entry && answers.start_date
 
         answers.date_of_entry >= answers.start_date - 3.months
+      end
+
+      def current_school_eligible?
+        return false unless answers.current_school
+
+        answers.current_school.secondary_or_equivalent? && answers.current_school.state_funded?
       end
     end
   end

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       state_funded_secondary_school { true }
     end
 
+    trait :with_current_school do
+      current_school_id { create(:school).id }
+    end
+
     trait :with_one_year_contract do
       one_year { true }
     end
@@ -67,13 +71,13 @@ FactoryBot.define do
     end
 
     trait :with_employment_details do
-      current_school_id { create(:school).id }
       school_headteacher_name { "Seymour Skinner" }
     end
 
     trait :eligible_teacher do
       with_teacher_application_route
       with_state_funded_secondary_school
+      with_current_school
       with_one_year_contract
       with_start_date
       with_visa

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -48,6 +48,18 @@ describe "ineligible route: completing the form" do
       end
     end
 
+    context "ineligible - school-choice" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(
+          option: "I am employed as a teacher in a school in England"
+        )
+        and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_current_school_step(create(:school, phase: :primary))
+        then_i_see_the_ineligible_page
+      end
+    end
+
     context "ineligible - contract details" do
       it "shows the ineligible page" do
         when_i_start_the_form
@@ -55,6 +67,7 @@ describe "ineligible route: completing the form" do
           option: "I am employed as a teacher in a school in England"
         )
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_current_school_step(create(:school, phase: :secondary))
         and_i_complete_the_contract_details_step_with(option: "No")
         then_i_see_the_ineligible_page
       end
@@ -67,6 +80,7 @@ describe "ineligible route: completing the form" do
           option: "I am employed as a teacher in a school in England"
         )
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_current_school_step(create(:school, phase: :secondary))
         and_i_complete_the_contract_details_step_with(option: "Yes")
         and_i_complete_the_contract_start_date_step_with(
           date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker
@@ -83,6 +97,7 @@ describe "ineligible route: completing the form" do
           option: "I am employed as a teacher in a school in England"
         )
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_current_school_step(create(:school, phase: :secondary))
         and_i_complete_the_contract_details_step_with(option: "Yes")
         and_i_complete_the_contract_start_date_step_with(
           date: contract_start_date
@@ -99,6 +114,7 @@ describe "ineligible route: completing the form" do
           option: "I am employed as a teacher in a school in England"
         )
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_current_school_step(create(:school, phase: :secondary))
         and_i_complete_the_contract_details_step_with(option: "Yes")
         and_i_complete_the_contract_start_date_step_with(
           date: contract_start_date
@@ -116,6 +132,7 @@ describe "ineligible route: completing the form" do
           option: "I am employed as a teacher in a school in England"
         )
         and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_current_school_step(create(:school, phase: :secondary))
         and_i_complete_the_contract_details_step_with(option: "Yes")
         and_i_complete_the_contract_start_date_step_with(
           date: contract_start_date
@@ -123,28 +140,6 @@ describe "ineligible route: completing the form" do
         and_i_complete_the_subject_step_with(option: "Physics")
         and_i_complete_the_visa_screen_with(option: "British National (Overseas) visa")
         and_i_complete_the_entry_date_page_with(date: contract_start_date - 4.months)
-        then_i_see_the_ineligible_page
-      end
-    end
-
-    context "ineligible - school-choice" do
-      it "shows the ineligible page" do
-        when_i_start_the_form
-        and_i_complete_application_route_question_with(
-          option: "I am employed as a teacher in a school in England"
-        )
-        and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
-        and_i_complete_the_contract_details_step_with(option: "Yes")
-        and_i_complete_the_contract_start_date_step_with(
-          date: contract_start_date
-        )
-        and_i_complete_the_subject_step_with(option: "Physics")
-        and_i_complete_the_visa_screen_with(option: "British National (Overseas) visa")
-        and_i_complete_the_entry_date_page_with(date: contract_start_date)
-        and_i_dont_change_my_answers
-        and_i_complete_the_nationality_step_with(option: "Australian")
-        and_i_complete_the_passport_number_step_with(options: "123456789")
-        and_i_complete_the_current_school_step(create(:school, phase: :primary))
         then_i_see_the_ineligible_page
       end
     end

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -126,6 +126,28 @@ describe "ineligible route: completing the form" do
         then_i_see_the_ineligible_page
       end
     end
+
+    context "ineligible - school-choice" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(
+          option: "I am employed as a teacher in a school in England"
+        )
+        and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+        and_i_complete_the_contract_details_step_with(option: "Yes")
+        and_i_complete_the_contract_start_date_step_with(
+          date: contract_start_date
+        )
+        and_i_complete_the_subject_step_with(option: "Physics")
+        and_i_complete_the_visa_screen_with(option: "British National (Overseas) visa")
+        and_i_complete_the_entry_date_page_with(date: contract_start_date)
+        and_i_dont_change_my_answers
+        and_i_complete_the_nationality_step_with(option: "Australian")
+        and_i_complete_the_passport_number_step_with(options: "123456789")
+        and_i_complete_the_current_school_step(create(:school, phase: :primary))
+        then_i_see_the_ineligible_page
+      end
+    end
   end
 
   def then_i_see_the_ineligible_page

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -31,6 +31,7 @@ describe "teacher route: completing the form" do
         option: "I am employed as a teacher in a school in England"
       )
       and_i_complete_the_state_funded_secondary_school_step_with(option: "Yes")
+      and_i_complete_the_current_school_step(school)
       and_i_complete_the_contract_details_step_with(option: "Yes")
       and_i_complete_the_contract_start_date_step_with(
         date: contract_start_date
@@ -46,7 +47,6 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
-        and_i_complete_the_current_school_step(school)
         and_i_complete_the_headteacher_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_postcode_step
@@ -64,7 +64,6 @@ describe "teacher route: completing the form" do
       it "submits an application", js: true do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
-        and_i_complete_the_current_school_step(school)
         and_i_complete_the_headteacher_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_manual_address_step
@@ -82,7 +81,6 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
-        and_i_complete_the_current_school_step(school)
         and_i_complete_the_headteacher_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_manual_address_step
@@ -100,7 +98,6 @@ describe "teacher route: completing the form" do
       it "submits an application" do
         and_i_complete_the_nationality_step_with(option: "Australian")
         and_i_complete_the_passport_number_step_with(options: "123456789")
-        and_i_complete_the_current_school_step(school)
         and_i_complete_the_headteacher_step
         and_i_complete_the_personal_details_step
         and_i_complete_the_manual_address_step
@@ -128,6 +125,10 @@ describe "teacher route: completing the form" do
 
     expect(page).to have_text(
       "Are you employed by an English state secondary school? Yes"
+    )
+
+    expect(page).to have_text(
+      "Which school are you currently employed to teach at? #{school.name}"
     )
 
     expect(page).to have_text(
@@ -180,10 +181,6 @@ describe "teacher route: completing the form" do
 
     expect(page).to have_text(
       "Enter the name of the headteacher of the school where you are employed as a teacher Seymour Skinner"
-    )
-
-    expect(page).to have_text(
-      "Which school are you currently employed to teach at? #{school.name}"
     )
 
     if mobile_number

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
         :get_a_teacher_relocation_payment_answers,
         :with_teacher_application_route,
         :with_state_funded_secondary_school,
+        :with_current_school,
         :with_one_year_contract,
         :with_start_date,
         :with_subject,
@@ -30,6 +31,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
           "What is your employment status?",
           "I am employed as a teacher in a school in England",
           "application-route"
+        ],
+        [
+          "Which school are you currently employed to teach at?",
+          answers.current_school.name,
+          "current-school"
         ],
         [
           "Are you employed by an English state secondary school?",
@@ -104,11 +110,6 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
 
     it do
       is_expected.to include(
-        [
-          "Which school are you currently employed to teach at?",
-          answers.current_school.name,
-          "current-school"
-        ],
         [
           "Enter the name of the headteacher of the school where you are employed as a teacher",
           "Seymour Skinner",

--- a/spec/models/policies/international_relocation_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/international_relocation_payments/policy_eligibility_checker_spec.rb
@@ -162,6 +162,40 @@ describe Policies::InternationalRelocationPayments::PolicyEligibilityChecker do
       it { is_expected.to eq(true) }
     end
 
+    context "with a non secondary school" do
+      let(:attributes) do
+        {
+          application_route: "teacher",
+          state_funded_secondary_school: true,
+          one_year: true,
+          subject: "physics",
+          visa_type: "British National (Overseas) visa",
+          start_date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date,
+          date_of_entry: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 1.week,
+          current_school_id: create(:school, school_type_group: "la_maintained", phase: :primary).id
+        }
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a non state funded secondary school" do
+      let(:attributes) do
+        {
+          application_route: "teacher",
+          state_funded_secondary_school: true,
+          one_year: true,
+          subject: "physics",
+          visa_type: "British National (Overseas) visa",
+          start_date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date,
+          date_of_entry: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 1.week,
+          current_school_id: create(:school, school_type_group: "independent_schools", phase: :secondary).id
+        }
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
     context "with an eligible application" do
       let(:attributes) do
         {
@@ -171,7 +205,8 @@ describe Policies::InternationalRelocationPayments::PolicyEligibilityChecker do
           subject: "physics",
           visa_type: "British National (Overseas) visa",
           start_date: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date,
-          date_of_entry: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 1.week
+          date_of_entry: Policies::InternationalRelocationPayments::PolicyEligibilityChecker.earliest_eligible_contract_start_date - 1.week,
+          current_school_id: create(:school, school_type_group: "la_maintained", phase: :secondary).id
         }
       end
 


### PR DESCRIPTION
Only treat state funded secondary schools as eligible.

IRPs is only available for state funded secondary schools.

The first commit in this PR updates the eligibility check to look at the type
of school the claimant has selected.
The second commit moves the school select page into the eligibility section of
the journey.
