### PR TITLE
Add an IRP task to check the subject

### DIFF
--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ class ClaimCheckingTasks
   delegate :policy, to: :claim
 
   def applicable_task_names
-    return %w[identity_confirmation visa arrival_date employment employment_contract employment_start] if policy.international_relocation_payments?
+    return %w[identity_confirmation visa arrival_date employment employment_contract employment_start subject] if policy.international_relocation_payments?
 
     @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
       task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
@@ -21,10 +21,11 @@ class ClaimCheckingTasks
       task_names.delete("payroll_details") unless claim.must_manually_validate_bank_details?
       task_names.delete("matching_details") unless matching_claims.exists?
       task_names.delete("payroll_gender") unless claim.payroll_gender_missing? || task_names_for_claim.include?("payroll_gender")
-      task_names.delete("visa") unless claim.policy.international_relocation_payments?
-      task_names.delete("arrival_date") unless claim.policy.international_relocation_payments?
-      task_names.delete("employment_contract") unless claim.policy.international_relocation_payments?
-      task_names.delete("employment_start") unless claim.policy.international_relocation_payments?
+      task_names.delete("visa")
+      task_names.delete("arrival_date")
+      task_names.delete("employment_contract")
+      task_names.delete("employment_start")
+      task_names.delete("subject")
     end
   end
 

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -40,6 +40,12 @@ module Policies
         ]
       end
 
+      def subject
+        [
+          ["Subject employed to teach", eligibility.subject.humanize]
+        ]
+      end
+
       def visa
         [
           ["Visa type", eligibility.visa_type]

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,19 +9,20 @@
 class Task < ApplicationRecord
   NAMES = %w[
     identity_confirmation
+    visa
+    arrival_date
     qualifications
     induction_confirmation
     census_subjects_taught
     employment
+    employment_contract
+    employment_start
+    subject
     student_loan_amount
     student_loan_plan
     payroll_details
     matching_details
     payroll_gender
-    arrival_date
-    employment_contract
-    employment_start
-    visa
   ].freeze
 
   belongs_to :claim

--- a/app/views/admin/tasks/subject.html.erb
+++ b/app/views/admin/tasks/subject.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} subject check for #{@claim.policy.short_name}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+  <%= render "claim_summary", claim: @claim, heading: "Subject check" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answers", answers: @tasks_presenter.subject %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@task.passed.nil? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= render "form", task_name: "subject", claim: @claim %>
+    <% end %>
+
+    <%= render partial: "admin/task_pagination" %>
+  </div>
+</div>
+
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,7 @@ en:
       arrival_date: "Check arrival date"
       employment_contract: "Check employment contract"
       employment_start: "Check employment start date"
+      subject: "Check subject"
     undo_decision:
       approved: "Undo approval"
       rejected: "Undo rejection"
@@ -799,6 +800,8 @@ en:
           title: "Does the claimant’s employment contract match the above information from their claim?"
         employment_start:
           title: "Does the claimant’s employment start date match the above information from their claim?"
+        subject:
+          title: "Does the claimant’s subject match the above information from their claim?"
 
   further_education_payments:
     landing_page: Find out if you are eligible for any incentive payments for further education teachers

--- a/spec/factories/policies/international_relocation_payments/eligibilities.rb
+++ b/spec/factories/policies/international_relocation_payments/eligibilities.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
       eligible_date_of_entry
       eligible_home_office
       eligible_school
+      eligible_subject
     end
 
     trait :eligible_school do
@@ -26,6 +27,10 @@ FactoryBot.define do
 
     trait :eligible_start_date do
       start_date { 1.month.ago }
+    end
+
+    trait :eligible_subject do
+      subject { "physics" }
     end
   end
 end

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -179,7 +179,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Employment start", "Decision"]
+      ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Employment start", "Subject", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
As part of the IRP journey, we ask for the claimant's teaching subject.

This change introduces an admin task to check that answer.

<img width="987" alt="Screenshot 2024-07-03 at 4 24 35 pm" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/3126/f562f3d1-98ca-4a02-9616-2bac9a22131a">

<!-- Do you need to update CHANGELOG.md? -->
