### PR TITLE
Add the payroll admin tasks for IRP

### DIFF
--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -12,8 +12,6 @@ class ClaimCheckingTasks
   delegate :policy, to: :claim
 
   def applicable_task_names
-    return %w[identity_confirmation visa arrival_date employment employment_contract employment_start subject] if policy.international_relocation_payments?
-
     @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
       task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
       task_names.delete("student_loan_amount") unless claim.policy == Policies::StudentLoans
@@ -21,11 +19,17 @@ class ClaimCheckingTasks
       task_names.delete("payroll_details") unless claim.must_manually_validate_bank_details?
       task_names.delete("matching_details") unless matching_claims.exists?
       task_names.delete("payroll_gender") unless claim.payroll_gender_missing? || task_names_for_claim.include?("payroll_gender")
-      task_names.delete("visa")
-      task_names.delete("arrival_date")
-      task_names.delete("employment_contract")
-      task_names.delete("employment_start")
-      task_names.delete("subject")
+      if claim.policy.international_relocation_payments?
+        task_names.delete("qualifications")
+        task_names.delete("census_subjects_taught")
+      end
+      unless claim.policy.international_relocation_payments?
+        task_names.delete("visa")
+        task_names.delete("arrival_date")
+        task_names.delete("employment_contract")
+        task_names.delete("employment_start")
+        task_names.delete("subject")
+      end
     end
   end
 

--- a/spec/factories/policies/international_relocation_payments/eligibilities.rb
+++ b/spec/factories/policies/international_relocation_payments/eligibilities.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :international_relocation_payments_eligibility, class: "Policies::InternationalRelocationPayments::Eligibility" do
     trait :eligible_home_office do
-      passport_number { "123456789" }
+      passport_number { Faker::Number.unique.number(digits: 9).to_s }
       nationality { "French" }
     end
 


### PR DESCRIPTION
We want to allow the existing payroll tasks to the IRP journeys in the
admin.

I opted to remove the early return for the IRP task list in order to
avoid duplicating logic around displaying the payroll tasks.

<!-- Do you need to update CHANGELOG.md? -->
