### PR TITLE
Fix missing translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -795,6 +795,8 @@ en:
         visa_type: "Visa type"
         date_of_entry: "Date of entry"
       task_questions:
+        matching_details:
+          title: "Is this claim still valid despite having matching details with other claims?"
         identity_confirmation:
           title: "Did %{claim_full_name} submit the claim?"
         visa:


### PR DESCRIPTION
We were missing a translation for the matching details task

<img width="1029" alt="before" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/4704d8a4-05a9-436c-bfd6-0b08c4b8de82">

<img width="852" alt="after" src="https://github.com/DFE-Digital/claim-additional-payments-for-teaching/assets/9936028/05184500-7071-40f9-9fbb-8fb30badb31d">