### PR TITLE
[LUPEYALPHA-639] Add unhappy teaching hours paths to FE journey

### DIFF
--- a/app/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form.rb
@@ -1,0 +1,36 @@
+module Journeys
+  module FurtherEducationPayments
+    class TeachingHoursPerWeekNextTermForm < Form
+      attribute :teaching_hours_per_week_next_term, :string
+
+      validates :teaching_hours_per_week_next_term,
+        inclusion: {in: ->(form) { form.radio_options.map(&:id) }, message: i18n_error_message(:inclusion)}
+
+      def radio_options
+        @radio_options ||= [
+          OpenStruct.new(
+            id: "at_least_2_5",
+            name: t("options.at_least_2_5", school_name: school.name)
+          ),
+          OpenStruct.new(
+            id: "less_than_2_5",
+            name: t("options.less_than_2_5", school_name: school.name)
+          )
+        ]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(teaching_hours_per_week_next_term:)
+        journey_session.save!
+      end
+
+      private
+
+      def school
+        journey_session.answers.school
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -16,6 +16,7 @@ module Journeys
         "fixed-term-contract" => FixedTermContractForm,
         "taught-at-least-one-term" => TaughtAtLeastOneTermForm,
         "teaching-hours-per-week" => TeachingHoursPerWeekForm,
+        "teaching-hours-per-week-next-term" => TeachingHoursPerWeekNextTermForm,
         "further-education-teaching-start-year" => FurtherEducationTeachingStartYearForm,
         "subjects-taught" => SubjectsTaughtForm,
         "teaching-qualification" => TeachingQualificationForm,

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -8,6 +8,7 @@ module Journeys
       attribute :fixed_term_full_year, :boolean
       attribute :taught_at_least_one_term, :boolean
       attribute :teaching_hours_per_week, :string
+      attribute :teaching_hours_per_week_next_term, :string
       attribute :further_education_teaching_start_year, :string
       attribute :subjects_taught, default: []
       attribute :teaching_qualification, :string
@@ -37,6 +38,14 @@ module Journeys
 
       def recent_further_education_teacher?
         !further_education_teaching_start_year&.start_with?("pre-")
+      end
+
+      def teaching_less_than_2_5_hours_per_week?
+        teaching_hours_per_week == "less_than_2_5"
+      end
+
+      def teaching_less_than_2_5_hours_per_week_next_term?
+        teaching_hours_per_week_next_term == "less_than_2_5"
       end
     end
   end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -9,6 +9,7 @@ module Journeys
         fixed-term-contract
         taught-at-least-one-term
         teaching-hours-per-week
+        teaching-hours-per-week-next-term
         further-education-teaching-start-year
         subjects-taught
         building-and-construction-courses
@@ -48,6 +49,7 @@ module Journeys
           if answers.contract_type == "permanent"
             sequence.delete("fixed-term-contract")
             sequence.delete("taught-at-least-one-term")
+            sequence.delete("teaching-hours-per-week-next-term")
           end
 
           if answers.contract_type == "variable_hours"

--- a/app/models/policies/further_education_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/further_education_payments/policy_eligibility_checker.rb
@@ -26,6 +26,10 @@ module Policies
           :must_teach_at_least_one_term
         elsif !answers.recent_further_education_teacher?
           :must_be_recent_further_education_teacher
+        elsif answers.teaching_less_than_2_5_hours_per_week?
+          :teaching_less_than_2_5
+        elsif answers.teaching_less_than_2_5_hours_per_week_next_term?
+          :teaching_less_than_2_5_next_term
         end
       end
     end

--- a/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body">
-      In order to claim a levelling up premium payment, you must be employed as a member of staff with teaching responsibilities.
+      In order to claim an incentive payment, you must be timetabled to teach at least 2.5 hours per week in the current term.
     </p>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5_next_term.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5_next_term.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body">
-      In order to claim a levelling up premium payment, you must be employed as a member of staff with teaching responsibilities.
+      In order to claim an incentive payment, you must have an ongoing commitment to teach at least 2.5 hours per week next term.
     </p>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/teaching_hours_per_week_next_term.html.erb
+++ b/app/views/further_education_payments/claims/teaching_hours_per_week_next_term.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_radio_buttons :teaching_hours_per_week_next_term, @form.radio_options, :id, :name,
+        legend: {
+          text: @form.t(:question, school_name: journey_session.answers.school.name),
+          tag: "h1",
+          size: "l"
+        },
+        hint: { text: @form.t(:hint) } %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -861,6 +861,14 @@ en:
           less_than_2_5: Less than 2.5 hours per week
         errors:
           inclusion: Select how many hours per week you are timetabled to teach during the current term
+      teaching_hours_per_week_next_term:
+        question: Are you timetabled to teach at least 2.5 hours per week at %{school_name} next term?
+        hint: If you are unsure, you should speak to HR or apply when you know your arrangements for next term.
+        options:
+          at_least_2_5: Yes, I am timetabled to teach at least 2.5 hours at %{school_name} next term
+          less_than_2_5: No, I’m not timetabled to teach at least 2.5 hours at %{school_name} next term
+        errors:
+          inclusion: Select yes if you are timetabled to teach at least 2.5 hours next term otherwise select you are not
       further_education_teaching_start_year:
         question: Which academic year did you start teaching in further education (FE) in England?
         options:

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -24,15 +24,7 @@ RSpec.feature "Further education payments" do
     click_button "Continue"
 
     expect(page).to have_content("What type of contract do you have with #{college.name}?")
-    choose("Fixed-term contract")
-    click_button "Continue"
-
-    expect(page).to have_content("Does your fixed-term contract cover the full #{AcademicYear.current.to_s(:long)} academic year?")
-    choose("No")
-    click_button "Continue"
-
-    expect(page).to have_content("Have you taught at #{college.name} for at least one academic term?")
-    choose("Yes, I have taught at #{college.name} for at least one academic term")
+    choose("Permanent contract")
     click_button "Continue"
 
     expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -109,6 +109,7 @@ RSpec.feature "Further education payments ineligible paths" do
     click_button "Continue"
 
     expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+
     choose("More than 12 hours per week")
     click_button "Continue"
 
@@ -118,6 +119,115 @@ RSpec.feature "Further education payments ineligible paths" do
 
     expect(page).to have_content("You are not eligible")
     expect(page).to have_content("you must be in the first 5 years of")
+  end
+
+  scenario "when permanent contract and not enough hours" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select the college you teach at")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("Less than 2.5 hours per week")
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    expect(page).to have_content("teach at least 2.5 hours per week")
+  end
+
+  scenario "when fixed-term contract and not enough hours" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select the college you teach at")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Fixed-term contract")
+    click_button "Continue"
+
+    expect(page).to have_content("Does your fixed-term contract cover the full #{current_academic_year.to_s(:long)} academic year?")
+    choose("Yes, it covers the full #{current_academic_year.to_s(:long)} academic year")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("More than 12 hours per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{college.name} next term?")
+    choose("No, I’m not timetabled to teach at least 2.5 hours at #{college.name} next term")
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    expect(page).to have_content("teach at least 2.5 hours per week")
+  end
+
+  scenario "when variable contract and not enough hours" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select the college you teach at")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Variable hours contract")
+    click_button "Continue"
+
+    expect(page).to have_content("Have you taught at #{college.name} for at least one academic term?")
+    choose("Yes, I have taught at #{college.name} for at least one academic term")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("More than 12 hours per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{college.name} next term?")
+    choose("No, I’m not timetabled to teach at least 2.5 hours at #{college.name} next term")
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    expect(page).to have_content("teach at least 2.5 hours per week")
   end
 
   def when_further_education_payments_journey_configuration_exists

--- a/spec/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Journeys::FurtherEducationPayments::TeachingHoursPerWeekNextTermForm, type: :model do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:college) { create(:school) }
+  let(:answers_hash) do
+    {school_id: college.id}
+  end
+  let(:teaching_hours_per_week_next_term) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        teaching_hours_per_week_next_term:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
+
+  describe "validations" do
+    it do
+      is_expected.not_to(
+        allow_value(nil)
+        .for(:teaching_hours_per_week_next_term)
+        .with_message("Select yes if you are timetabled to teach at least 2.5 hours next term otherwise select you are not")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:teaching_hours_per_week_next_term) { "at_least_2_5" }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.teaching_hours_per_week_next_term }.to(teaching_hours_per_week_next_term)
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-639
- Handle unhappy paths for teaching hour pages for FE journey

# Changes

- Added new page to capture teaching hours for next term if user is not on a permanent contract
- Although technically you could store as a boolean due the way the question is structured i think storing as a string is far more flexible should they decide to change the question from a simple yes/no answer