### PR TITLE
import schools on seeding review apps

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,8 @@ if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")
   ENV["FIXTURES_PATH"] = "spec/fixtures"
   ENV["FIXTURES"] = "local_authorities,local_authority_districts,schools"
   Rake::Task["db:fixtures:load"].invoke
+
+  SchoolDataImporterJob.perform_later if School.count < 100
 end
 
 if Rails.env.development?


### PR DESCRIPTION
# Context

- When review apps are created we currently do not import schools from GIAS
- Importing schools from GIAS aids in the review process with less managing of custom seeds

# Changes

- When a review app spins up as part of the seeding process also enqueue `SchoolDataImporterJob` which the worker will pick up to import schools from GIAS