### PR TITLE
CAPT-1762 Add database backup workflow

### DIFF
--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -3,8 +3,9 @@ concurrency: build_and_deploy_main
 
 on:
   workflow_dispatch:
-  schedule: # 03:00 UTC
-    - cron: "0 3 * * *"
+  # TODO: Uncomment after migration
+  # schedule: # 03:00 UTC
+  #   - cron: "0 3 * * *"
 
 jobs:
   backup:
@@ -23,5 +24,5 @@ jobs:
           resource-group: s189p01-capt-pd-rg
           app-name: claim-additional-payments-for-teaching-production
           cluster: production
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS}}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           backup-file: capt_prod_$(date +"%F").sql

--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Backup postgres
         uses: DFE-Digital/github-actions/backup-postgres@master
         with:

--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -1,0 +1,27 @@
+name: Backup Database to Azure Storage
+concurrency: build_and_deploy_main
+
+on:
+  workflow_dispatch:
+  schedule: # 03:00 UTC
+    - cron: "0 3 * * *"
+
+jobs:
+  backup:
+    name: Backup AKS Database (production)
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Backup postgres
+        uses: DFE-Digital/github-actions/backup-postgres@master
+        with:
+          storage-account: s189p01captdbbkppdsa
+          resource-group: s189p01-capt-pd-rg
+          app-name: claim-additional-payments-for-teaching-production
+          cluster: production
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS}}
+          backup-file: capt_prod_$(date +"%F").sql

--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   backup:
     name: Backup AKS Database (production)
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +21,7 @@ jobs:
         with:
           storage-account: s189p01captdbbkppdsa
           resource-group: s189p01-capt-pd-rg
-          app-name: claim-additional-payments-for-teaching-production
+          app-name: claim-additional-payments-for-teaching-production-web
           cluster: production
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           backup-file: capt_prod_$(date +"%F").sql


### PR DESCRIPTION
## Changes in this PR

- Add backup database workflow via GitHub Actions
- Uses this DfE GitHub Action: https://github.com/DFE-Digital/github-actions/blob/master/backup-postgres/README.md
- Schedule to run at 3am nightly (disabled until after migration), or via manual workflow dispatch