### PR TITLE
[1914] Override backup file name in restore workflow

### DIFF
--- a/.github/workflows/database_restore.yml
+++ b/.github/workflows/database_restore.yml
@@ -12,14 +12,27 @@ on:
         options:
         - 'false'
         - 'true'
+      backup-file:
+        description: Name of the backup file in Azure storage. e.g. capt_prod_2024-07-15.sql.gz. The default value is today's backup.
+        type: string
 
 jobs:
   restore:
     name: Restore AKS Database (production)
+    if: inputs.confirm == 'true'
     runs-on: ubuntu-latest
     environment: production-aks
 
     steps:
+      - name: Set backup file
+        run: |
+          if [ "${{ inputs.backup-file }}" != "" ]; then
+            BACKUP_FILE=${{ inputs.backup-file }}
+          else
+            BACKUP_FILE=capt_prod_$(date +"%F").sql.gz
+          fi
+          echo "BACKUP_FILE=$BACKUP_FILE" >> $GITHUB_ENV
+
       - name: Restore postgres
         uses: DFE-Digital/github-actions/restore-postgres-backup@master
         with:
@@ -28,4 +41,4 @@ jobs:
           app-name: claim-additional-payments-for-teaching-production-web
           cluster: production
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          backup-file: capt_prod_$(date +"%F").sql.gz
+          backup-file: ${{ env.BACKUP_FILE }}


### PR DESCRIPTION
## Description
By default the workflow only uses today's backup. This change allows passing another file name as input

## Review
See successful run: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/9940315003