### PR TITLE
Enqueue school import job when seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,10 @@ if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")
   Rake::Task["db:fixtures:load"].invoke
 end
 
+if ENV["ENVIRONMENT_NAME"].start_with?("review")
+  SchoolDataImporterJob.perform_later if School.count < 100
+end
+
 if Rails.env.development?
   require "./lib/factory_helpers"
 


### PR DESCRIPTION
# Context

- Originally https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2988 but made a new PR has review app failed plus changes deploy mechanism meant a different approach has been taken
- When review apps are created we currently do not import schools from GIAS
- Importing schools from GIAS aids in the review process with less managing of custom seeds especially for FE journey where specific colleges will be eligible

# Changes

- When a review app spins up as part of the seeding process also enqueue `SchoolDataImporterJob` which the worker will pick up to import schools from GIAS
- Tested on the deployed review app