### PR TITLE
Upate DfE Sign-in redirect URL

### DIFF
--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -3,7 +3,7 @@ DFE_SIGN_IN_API_CLIENT_ID: teacherpayments
 DFE_SIGN_IN_API_ENDPOINT: https://api.signin.education.gov.uk
 DFE_SIGN_IN_IDENTIFIER: teacherpayments
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk:443
-DFE_SIGN_IN_REDIRECT_BASE_URL: https://claim-additional-teaching-payment.service.gov.uk
+DFE_SIGN_IN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 
 DQT_API_URL: https://teacher-qualifications-api.education.gov.uk/v1
 DQT_BASE_URL: https://api-customerengagement.platform.education.gov.uk/dqt-crm/v1/


### PR DESCRIPTION
## Changes in this PR

As part of the AKS migration, redirect production DfE Sign-in to www directly.