### PR TITLE
Update production hostname

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -3,7 +3,7 @@
   "namespace": "srtl-production",
   "config": "production",
   "environment": "production",
-  "canonical_hostname": "claim-additional-payments-for-teaching-production-web.teacherservices.cloud",
+  "canonical_hostname": "www.claim-additional-teaching-payment.service.gov.uk",
   "web_replicas": 2,
   "worker_replicas": 2,
   "startup_command": ["/bin/sh", "-c", "bin/rails server -b 0.0.0.0"],
@@ -18,5 +18,5 @@
   },
   "enable_monitoring": true,
   "statuscake_contact_groups": [195955, 282453],
-  "external_url": "https://claim-additional-payments-for-teaching-production-web.teacherservices.cloud/healthcheck"
+  "external_url": "https://www.claim-additional-teaching-payment.service.gov.uk/healthcheck"
 }


### PR DESCRIPTION
Part of the AKS migration, this sets the final public-facing URL (we are migrating the current production domain).