### PR TITLE
Migration - Enable nightly db backups

### DIFF
--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -3,9 +3,8 @@ concurrency: build_and_deploy_main
 
 on:
   workflow_dispatch:
-  # TODO: Uncomment after migration
-  # schedule: # 03:00 UTC
-  #   - cron: "0 3 * * *"
+  schedule: # 03:00 UTC
+    - cron: "0 3 * * *"
 
 jobs:
   backup:


### PR DESCRIPTION
## Changes in this PR

Now that we're migrated the production database, run the database backup workflow nightly at 3:00 UTC.