### PR TITLE
Enable log shipping to logit.io in production

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -18,5 +18,6 @@
   },
   "enable_monitoring": true,
   "statuscake_contact_groups": [195955, 282453],
-  "external_url": "https://www.claim-additional-teaching-payment.service.gov.uk/healthcheck"
+  "external_url": "https://www.claim-additional-teaching-payment.service.gov.uk/healthcheck",
+  "enable_logit": true
 }


### PR DESCRIPTION
Once we are happy with logging performance in review and test, enable shipping to production.