### PR TITLE
Update test hostname

### DIFF
--- a/terraform/application/config/test.tfvars.json
+++ b/terraform/application/config/test.tfvars.json
@@ -3,12 +3,12 @@
   "namespace": "srtl-test",
   "config": "test",
   "environment": "test",
-  "canonical_hostname": "claim-additional-payments-for-teaching-test-web.test.teacherservices.cloud",
+  "canonical_hostname": "test.claim-additional-teaching-payment.service.gov.uk",
   "web_replicas": 2,
   "startup_command": ["/bin/sh", "-c", "bin/rails server -b 0.0.0.0"],
   "worker_command": ["/bin/sh", "-c", "bin/bundle exec bin/delayed_job run -n 1"],
   "enable_monitoring": true,
   "statuscake_contact_groups": [195955, 282453],
-  "external_url": "https://claim-additional-payments-for-teaching-test-web.test.teacherservices.cloud/healthcheck",
+  "external_url": "https://test.claim-additional-teaching-payment.service.gov.uk/healthcheck",
   "enable_logit": true
 }


### PR DESCRIPTION
Part of the AKS migration, this sets the final public-facing URL for the test environment.