### PR TITLE
CAPT-1766 one login bypass

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,6 +11,7 @@ ADMIN_ALLOWED_IPS=::1,127.0.0.1
 ENVIRONMENT_NAME=local
 
 BYPASS_DFE_SIGN_IN=true
+BYPASS_ONELOGIN_SIGN_IN=true
 SUPPRESS_DFE_ANALYTICS_INIT=true
 
 HMRC_API_BASE_URL=https://test-api.service.hmrc.gov.uk
@@ -21,3 +22,5 @@ TID_SIGN_IN_API_ENDPOINT=https://preprod.teaching-identity.education.gov.uk:433
 TID_BASE_URL=https://localhost:3000
 TID_SIGN_IN_CLIENT_ID=claim
 
+ONELOGIN_SIGN_IN_ISSUER=https://oidc.integration.account.gov.uk/
+ONELOGIN_REDIRECT_BASE_URL=http://localhost:3000

--- a/.env.test
+++ b/.env.test
@@ -37,3 +37,4 @@ TID_SIGN_IN_ISSUER=https://preprod.teaching-identity.education.gov.uk/
 TID_SIGN_IN_API_ENDPOINT=https://preprod.teaching-identity.education.gov.uk:433
 TID_SIGN_IN_CLIENT_ID=claim
 
+BYPASS_ONELOGIN_SIGN_IN=true

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,6 +1,8 @@
 class OmniauthCallbacksController < ApplicationController
   include JourneyConcern
 
+  ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY = "https://vocab.account.gov.uk/v1/coreIdentityJWT".freeze
+
   def callback
     auth = request.env["omniauth.auth"]
 
@@ -25,6 +27,20 @@ class OmniauthCallbacksController < ApplicationController
     render layout: false
   end
 
+  def onelogin
+    auth = if OneLoginSignIn.bypass?
+      test_user_auth_hash
+    else
+      request.env["omniauth.auth"]
+    end
+
+    core_identity_jwt = auth.extra.raw_info[ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY]
+    return process_one_login_identity_verification_callback(core_identity_jwt) if core_identity_jwt
+    process_one_login_authentication_callback(auth)
+  rescue Rack::OAuth2::Client::Error => e
+    render plain: e.message
+  end
+
   private
 
   def current_journey_routing_name
@@ -34,6 +50,62 @@ class OmniauthCallbacksController < ApplicationController
       # If for some reason the session is empty, redirect the user to the first
       # available user journey
       Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME
+    end
+  end
+
+  def process_one_login_authentication_callback(auth)
+    onelogin_user_info_attributes = auth.info.to_h.slice(
+      *SignInForm::OneloginUserInfoForm::ONELOGIN_USER_INFO_ATTRIBUTES.map(&:to_s)
+    )
+
+    journey_session.answers.assign_attributes(onelogin_user_info: onelogin_user_info_attributes)
+    journey_session.save!
+
+    redirect_to(
+      claim_path(
+        journey: current_journey_routing_name,
+        slug: "sign-in",
+        claim: {
+          logged_in_with_onelogin: true
+        }
+      )
+    )
+  end
+
+  def process_one_login_identity_verification_callback(core_identity_jwt)
+    first_name, surname = extract_name_from_jwt(core_identity_jwt)
+    redirect_to(
+      claim_path(
+        journey: current_journey_routing_name,
+        slug: "sign-in",
+        claim: {
+          identity_confirmed_with_onelogin: true,
+          first_name: first_name,
+          surname: surname
+        }
+      )
+    )
+  end
+
+  def extract_name_from_jwt(jwt)
+    if OneLoginSignIn.bypass?
+      first_name = "TEST"
+      surname = "USER"
+    else
+      identity_jwt_public_key = OpenSSL::PKey::EC.new(Base64.decode64(ENV["ONELOGIN_IDENTITY_JWT_PUBLIC_KEY_BASE64"]))
+      decoded_jwt = JSON::JWT.decode(jwt, identity_jwt_public_key)
+      name_parts = decoded_jwt["vc"]["credentialSubject"]["name"][0]["nameParts"]
+      first_name = name_parts.find { |part| part["type"] == "GivenName" }["value"]
+      surname = name_parts.find { |part| part["type"] == "FamilyName" }["value"]
+    end
+    [first_name, surname]
+  end
+
+  def test_user_auth_hash
+    if request.path == "/auth/onelogin"
+      OmniAuth::AuthHash.new(info: {email: "test@example.com"}, extra: {raw_info: {}})
+    elsif request.path == "/auth/onelogin_identity"
+      OmniAuth::AuthHash.new(info: {email: ""}, extra: {raw_info: {ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY => "test"}})
     end
   end
 end

--- a/app/forms/sign_in_form.rb
+++ b/app/forms/sign_in_form.rb
@@ -1,0 +1,48 @@
+class SignInForm < Form
+  class OneloginUserInfoForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    ONELOGIN_USER_INFO_ATTRIBUTES = %i[
+      email
+      phone
+    ]
+
+    ONELOGIN_USER_INFO_ATTRIBUTES.each do |attribute_name|
+      attribute attribute_name
+    end
+  end
+
+  attribute :logged_in_with_onelogin, :boolean, default: false
+  attribute :identity_confirmed_with_onelogin, :boolean, default: false
+  attribute :onelogin_user_info_attributes
+  attribute :first_name
+  attribute :surname
+
+  def onelogin_user_info_attributes=(attributes)
+    onelogin_user_info.assign_attributes(
+      journey_session.answers.onelogin_user_info
+    )
+  end
+
+  def onelogin_user_info
+    @onelogin_user_info ||= OneloginUserInfoForm.new
+  end
+
+  def save
+    journey_session.answers.assign_attributes(
+      onelogin_user_info: onelogin_user_info.attributes,
+      first_name: first_name,
+      surname: surname
+    )
+    journey_session.save!
+  end
+
+  private
+
+  def permitted_attributes
+    super + [
+      onelogin_user_info_attributes: OneloginUserInfoForm::ONELOGIN_USER_INFO_ATTRIBUTES
+    ]
+  end
+end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -2,6 +2,7 @@ module Journeys
   module Base
     SHARED_FORMS = {
       "claims" => {
+        "sign-in" => SignInForm,
         "sign-in-or-continue" => SignInOrContinueForm,
         "current-school" => CurrentSchoolForm,
         "gender" => GenderForm,

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -2,6 +2,7 @@ module Journeys
   module FurtherEducationPayments
     class SlugSequence
       ELIGIBILITY_SLUGS = %w[
+        sign-in
         teaching-responsibilities
         further-education-provision-search
         select-provision

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -2,7 +2,6 @@ module Journeys
   module FurtherEducationPayments
     class SlugSequence
       ELIGIBILITY_SLUGS = %w[
-        sign-in
         teaching-responsibilities
         further-education-provision-search
         select-provision
@@ -29,7 +28,7 @@ module Journeys
       ]
 
       PERSONAL_DETAILS_SLUGS = %w[
-        one-login-placeholder
+        sign-in
         information-provided
         personal-details
         postcode-search

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -32,8 +32,10 @@ module Journeys
     attribute :hmrc_bank_validation_succeeded, :boolean
     attribute :hmrc_bank_validation_responses, default: []
     attribute :logged_in_with_tid, :boolean
+    attribute :logged_in_with_onelogin, :boolean
     attribute :details_check, :boolean
     attribute :teacher_id_user_info, default: {}
+    attribute :onelogin_user_info, default: {}
     attribute :email_address_check, :boolean
     attribute :mobile_check, :string
     attribute :qualifications_details_check, :boolean

--- a/app/views/claims/_sign_in.html.erb
+++ b/app/views/claims/_sign_in.html.erb
@@ -4,7 +4,7 @@
 <% elsif @form.identity_confirmed_with_onelogin %>
   You've successfully proved your identity with GOV.UK One Login
 <% else %>
-  Sign in with GOV.UK One Login
+  You're now going to GOV.UK One Login
 <% end %>
 </h1>
 

--- a/app/views/claims/_sign_in.html.erb
+++ b/app/views/claims/_sign_in.html.erb
@@ -1,0 +1,49 @@
+<h1 class="govuk-heading-l">
+<% if @form.logged_in_with_onelogin %>
+  You've successfully signed in to GOV.UK One Login
+<% elsif @form.identity_confirmed_with_onelogin %>
+  You've successfully proved your identity with GOV.UK One Login
+<% else %>
+  Sign in with GOV.UK One Login
+<% end %>
+</h1>
+
+<% if @form.logged_in_with_onelogin %>
+  <p>
+    Before you can continue your application, you'll need to prove your identity through GOV.UK One Login.
+  </p>
+  <p>
+    When you've proved your identity through GOV.UK One Login, you'll return to this service to complete your applciation.
+  </p>
+<% elsif @form.identity_confirmed_with_onelogin %>
+  <p>
+    You can now continue your application
+  </p>
+<% else %>
+  <p>
+  To continue your application, you'll need to create a GOV.UK One Login or sign in.
+  </p>
+  <p>
+    When you've signed in through GOV.UK One Login, your progress will be saved
+    and you'll be able to return to complete your application.
+  </p>
+<% end %>
+
+<div class="govuk-button-group">
+  <% if @form.logged_in_with_onelogin %>
+    <%= button_to "Continue", "/auth/onelogin_identity", class: "govuk-button", method: :post %>
+  <% elsif @form.identity_confirmed_with_onelogin %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+      <%= f.fields_for :onelogin_user_info do |ff| %>
+        <% ff.object.attribute_names.each do |attribute| %>
+          <%= ff.hidden_field attribute %>
+        <% end %>
+      <% end %>
+      <%= f.hidden_field :first_name %>
+      <%= f.hidden_field :surname %>
+      <%= f.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  <% else %>
+    <%= button_to "Continue", "/auth/onelogin", class: "govuk-button", method: :post %>
+  <% end %>
+</div>

--- a/app/views/claims/sign_in.html.erb
+++ b/app/views/claims/sign_in.html.erb
@@ -1,0 +1,18 @@
+<% @backlink_path = landing_page_path %>
+
+<% if @form.errors.any? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render(
+        "shared/error_summary",
+        instance: @form,
+        errored_field_id_overrides: { details_check: "claim_details_check_true" }) %>
+    </div>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <%= render partial: "sign_in" %>
+  </div>
+</div>

--- a/app/views/claims/sign_in.html.erb
+++ b/app/views/claims/sign_in.html.erb
@@ -1,5 +1,3 @@
-<% @backlink_path = landing_page_path %>
-
 <% if @form.errors.any? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/further_education_payments/claims/one_login_placeholder.html.erb
+++ b/app/views/further_education_payments/claims/one_login_placeholder.html.erb
@@ -1,7 +1,0 @@
-<p class="govuk-body">
-  FE ONE LOGIN PLACEHOLDER
-</p>
-
-<%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
-  <%= f.govuk_submit %>
-<% end %>

--- a/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
@@ -7,18 +7,22 @@
  <div class="govuk-grid-row">
    <div class="govuk-grid-column-full">
      <p class="govuk-body">
-       The international relocation payment (IRP) is a single payment of £10,000,
-       funded by the UK government, which is available to eligible non-UK trainees and teachers of:
+       The international relocation payment (IRP) is a payment of up to
+       £10,000, funded by the UK government, which is available to eligible
+       non-UK teachers of:
      </p>
 
-     <ul class="govuk-list govuk-list--bullet">
-       <li>languages</li>
-       <li>physics</li>
-       <li>general or combined science when that includes physics</li>
-     </ul>
+     <%= govuk_list [
+       "languages",
+       "physics",
+       "general or combined science when that includes physics"
+     ], type: :bullet %>
 
      <p class="govuk-body">
-       Only teachers and salaried trainees need to complete this form.
+      Eligible teachers will receive their IRP in 2 instalments of £5,000
+      spread over 2 years. Teachers must make separate applications for each
+      eligible year showing they meet the eligibility requirements to receive
+      each instalment.
      </p>
 
      <p class="govuk-body">
@@ -44,27 +48,15 @@
        You will need:
      </p>
 
-     <ul class="govuk-list govuk-list--bullet">
-       <li>
-         if you are a teacher, your teaching subject and the terms of your employment contract
-       </li>
-       <li>
-         if you are a salaried trainee, details of your teacher training course, including
-         teaching subject and start date
-       </li>
-       <li>
-         your visa type and when you entered the UK
-       </li>
-       <li>
-         your passport
-       </li>
-       <li>
-         your address in England
-       </li>
-       <li>
-         contact details for the school where you are employed as a teacher or trainee
-       </li>
-     </ul>
+     <%= govuk_list [
+       "your teaching subject and the terms of your employment contract",
+       "your visa type and when you entered the UK",
+       "your passport",
+       "your address in England",
+       "your national insurance number",
+       "your UK bank account details",
+       "contact details for the school where you are employed"
+     ], type: :bullet %>
 
      <p class="govuk-body">
        <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
@@ -82,32 +74,31 @@
      </p>
 
      <ul class="govuk-list govuk-list--bullet">
-       <li>2 April to 16 June 2024</li>
+       <li>30 September 2024 to the end March 2025</li>
      </ul>
 
      <p class="govuk-body">
-       If you have started your teaching job or salaried teacher training
-       course, you should apply now. If you are eligible, you should receive
-       the money by 30 September 2024.
+       If you start your teaching job between 1 March 2024 and 28 February 2025
+       you should apply now. If you are eligible, you should receive the money
+       following successful completion of our eligibility checks. You must
+       apply before the end March 2025 to remain eligible.
      </p>
 
      <p class="govuk-body">
-       To remain eligible for the IRP, you must apply in either the first or
-       second term of your employment as a teacher or salaried trainee.
-     </p>
-     <p class="govuk-body">
-       Applications will re-open later in 2024.
+       If you start your teaching job between the 1 April 2025 and 31 May 2025
+       you can apply when applications re-open in September 2025.
      </p>
 
-     <h2 class="govuk-heading-l">Not ready to apply?</h2>
      <p class="govuk-body">
-       If you have not started your job or course, please visit
-       <%= govuk_link_to(
-         "Get an international relocation payment",
-         "https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment",
-         target: "_blank"
-       ) %>
-       for information about future applications.
+       If you start your teaching job in March 2025 you can either apply before
+       applications close at the end of March 2025 or when they open again in
+       September 2025.
+     </p>
+
+     <p class="govuk-body">
+       Late applications for the IRP will not be accepted. If you fail to apply
+       during the correct window, we will be unable to process your
+       application.
      </p>
 
      <h2 class="govuk-heading-m">Contact us</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,11 @@ Rails.application.routes.draw do
 
   get "/claim/auth/tid/callback", to: "omniauth_callbacks#callback"
   get "/auth/failure", to: "omniauth_callbacks#failure"
+  get "/auth/onelogin", to: "omniauth_callbacks#onelogin"
+  if OneLoginSignIn.bypass?
+    post "/auth/onelogin", to: "omniauth_callbacks#onelogin"
+    post "/auth/onelogin_identity", to: "omniauth_callbacks#onelogin"
+  end
 
   # /early-career-payments is now /additional-payments - redirect old urls to a gov page
   get "early-career-payments(/*anything)", to: redirect("https://www.gov.uk/government/collections/additional-payments-for-teaching-eligibility-and-payment-details")

--- a/spec/factories/journeys/further_education_payments/further_education_payments_answers.rb
+++ b/spec/factories/journeys/further_education_payments/further_education_payments_answers.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :further_education_payments_answers, class: "Journeys::FurtherEducationPayments::SessionAnswers" do
+    trait :with_details_from_onelogin do
+      first_name { "Jo" }
+      surname { "Bloggs" }
+      onelogin_user_info { {email: "jo.bloggs@example.com"} }
+    end
   end
 end

--- a/spec/features/further_education_payments/college_not_found_spec.rb
+++ b/spec/features/further_education_payments/college_not_found_spec.rb
@@ -8,8 +8,6 @@ RSpec.feature "Further education payments" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -28,8 +26,6 @@ RSpec.feature "Further education payments" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
-
-    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"

--- a/spec/features/further_education_payments/college_not_found_spec.rb
+++ b/spec/features/further_education_payments/college_not_found_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -26,6 +28,8 @@ RSpec.feature "Further education payments" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
+
+    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -11,6 +11,8 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -11,8 +11,6 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -79,8 +77,7 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_content("Apply now")
     click_button "Apply now"
 
-    expect(page).to have_content("FE ONE LOGIN PLACEHOLDER")
-    click_button "Continue"
+    sign_in_with_one_login
 
     expect(page).to have_content("How we will use the information you provide in your application")
     click_button "Continue"

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -14,8 +14,6 @@ RSpec.feature "Further education payments" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -115,8 +113,7 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Apply now")
     click_button "Apply now"
 
-    expect(page).to have_content("FE ONE LOGIN PLACEHOLDER")
-    click_button "Continue"
+    sign_in_with_one_login
 
     expect(page).to have_content("How we will use the information you provide in your application")
     click_button "Continue"

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -13,6 +13,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "No"
     click_button "Continue"
@@ -141,6 +143,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -175,6 +179,8 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
+
+    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -216,6 +222,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -246,6 +254,8 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
+
+    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -339,6 +349,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -374,6 +386,8 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
+
+    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -441,6 +455,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -507,6 +523,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -563,6 +581,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -594,6 +614,8 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
+
+    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -635,6 +657,8 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
+    sign_in_with_one_login
+
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -674,6 +698,8 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
+
+    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -13,8 +13,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "No"
     click_button "Continue"
@@ -143,8 +141,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -179,8 +175,6 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
-
-    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -222,8 +216,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -254,8 +246,6 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
-
-    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -349,8 +339,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -386,8 +374,6 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
-
-    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -455,8 +441,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -523,8 +507,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -581,8 +563,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -614,8 +594,6 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
-
-    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
@@ -657,8 +635,6 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_link("Start now")
     click_link "Start now"
 
-    sign_in_with_one_login
-
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"
     click_button "Continue"
@@ -698,8 +674,6 @@ RSpec.feature "Further education payments ineligible paths" do
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
     expect(page).to have_link("Start now")
     click_link "Start now"
-
-    sign_in_with_one_login
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
     choose "Yes"

--- a/spec/forms/sign_in_form_spec.rb
+++ b/spec/forms/sign_in_form_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe SignInForm do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) do
+    build(
+      :"#{journey::I18N_NAMESPACE}_session",
+      answers: attributes_for(
+        :"#{journey::I18N_NAMESPACE}_answers",
+        :with_details_from_onelogin
+      )
+    )
+  end
+
+  let(:onelogin_user_info) do
+    {email: "jo.bloggs@example.com", phone: nil}
+  end
+
+  let(:form) do
+    described_class.new(
+      journey: journey,
+      journey_session: journey_session,
+      params: params
+    )
+  end
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        # logged_in_with_tid: true
+      }
+    )
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    it "keeps the details from onelogin_user_info" do
+      expect(
+        journey_session.answers.onelogin_user_info.symbolize_keys
+      ).to(eq(onelogin_user_info))
+    end
+
+    it "keeps the first name" do
+      expect(journey_session.answers.first_name).to eq "Jo"
+    end
+
+    it "keeps the surname" do
+      expect(journey_session.answers.surname).to eq "Bloggs"
+    end
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -135,7 +135,7 @@ module FeatureHelpers
   end
 
   def sign_in_with_one_login
-    expect(page).to have_content("Sign in with GOV.UK One Login")
+    expect(page).to have_content("You're now going to GOV.UK One Login")
     click_button "Continue"
 
     expect(page).to have_content("You've successfully signed in to GOV.UK One Login")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -133,4 +133,15 @@ module FeatureHelpers
 
     page.set_rack_session(slugs: visited_slugs)
   end
+
+  def sign_in_with_one_login
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("You've successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("You've successfully proved your identity with GOV.UK One Login")
+    click_button "Continue"
+  end
 end

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -5,6 +5,7 @@ DFE_SIGN_IN_IDENTIFIER: teacherpayments
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk:443
 DFE_SIGN_IN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 
+BYPASS_ONELOGIN_SIGN_IN: true
 ONELOGIN_SIGN_IN_ISSUER=https://oidc.integration.account.gov.uk/
 ONELOGIN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -5,6 +5,9 @@ DFE_SIGN_IN_IDENTIFIER: teacherpayments
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk:443
 DFE_SIGN_IN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 
+ONELOGIN_SIGN_IN_ISSUER=https://oidc.integration.account.gov.uk/
+ONELOGIN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
+
 DQT_API_URL: https://teacher-qualifications-api.education.gov.uk/v1
 DQT_BASE_URL: https://api-customerengagement.platform.education.gov.uk/dqt-crm/v1/
 

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -1,5 +1,6 @@
 ---
 BYPASS_DFE_SIGN_IN: true
+BYPASS_ONELOGIN_SIGN_IN: true
 
 DFE_SIGN_IN_API_CLIENT_ID: teacherpayments
 DFE_SIGN_IN_API_ENDPOINT: https://pp-api.signin.education.gov.uk

--- a/terraform/application/config/test_app_env.yml
+++ b/terraform/application/config/test_app_env.yml
@@ -5,6 +5,9 @@ DFE_SIGN_IN_IDENTIFIER: teacherpayments
 DFE_SIGN_IN_ISSUER: https://test-oidc.signin.education.gov.uk:443
 DFE_SIGN_IN_REDIRECT_BASE_URL: https://test.claim-additional-teaching-payment.service.gov.uk
 
+ONELOGIN_SIGN_IN_ISSUER: https://oidc.integration.account.gov.uk/
+ONELOGIN_REDIRECT_BASE_URL: https://test.claim-additional-teaching-payment.service.gov.uk
+
 DQT_API_URL: https://test.teacher-qualifications-api.education.gov.uk/v1
 DQT_BASE_URL: https://test-api-customerengagement.platform.education.gov.uk/dqt-crm/v1/
 


### PR DESCRIPTION
The env var `BYPASS_ONELOGIN_SIGN_IN` is set to`true`,
which means the user will be logged in with email: `user@example.com` and name: `TEST USER`.
(note: the name from One Login currently comes back all capitalised).

This branch is built on top of the changes from https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3001