### PR TITLE
Smoke tests - set smoke test host directly

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -113,7 +113,7 @@ jobs:
         run: bundle exec rspec spec/smoke -t smoke:true -b
         env:
           RAILS_ENV: test
-          SMOKE_TEST_APP_HOST: ${{ env.APP_URL }}
+          SMOKE_TEST_APP_HOST: ${{ vars.SMOKE_TEST_APP_HOST }}
           BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
 
@@ -123,5 +123,7 @@ jobs:
         env:
           SLACK_COLOR: failure
           SLACK_TITLE: Failure deploying release to ${{ matrix.environment }}
-          SLACK_MESSAGE: Failure deploying release to ${{ matrix.environment }} - Docker tag ${{ needs.build.outputs.docker-image-tag }}
+          SLACK_MESSAGE:
+            Failure deploying release to ${{ matrix.environment }} - Docker tag ${{ needs.build.outputs.docker-image-tag
+            }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Changes in this PR

Attempt smoke test fix.

Our smoke tests are failing in the test environment _we think_ because it hits a redirect and capybara is not passing through the basic auth creds.

```
SMOKE_TEST_APP_HOST="https://claim-additional-payments-for-teaching-test-web.test.teacherservices.cloud/" BASIC_AUTH_USERNAME={username} BASIC_AUTH_PASSWORD={password} bundle exec rspec spec/smoke -t smoke:true -b
..fails..

SMOKE_TEST_APP_HOST="https://test.claim-additional-teaching-payment.service.gov.uk/" BASIC_AUTH_USERNAME={username} BASIC_AUTH_PASSWORD={password} bundle exec rspec spec/smoke -t smoke:true -b
..passes..
```

In this PR we're pulling the `SMOKE_TEST_APP_HOST` from the github repo variables rather than using the output from terraform.