### PR TITLE
[LUPEYALPHA-778] FE journey: add ineligible state when under hours teaching courses

### DIFF
--- a/app/forms/form_helpers.rb
+++ b/app/forms/form_helpers.rb
@@ -9,9 +9,16 @@ module FormHelpers
   end
 
   def t(key, args = {})
+    key_string = case key
+    when Array
+      key.join(".")
+    else
+      key
+    end
+
     i18n_form_namespace_dup = args.delete(:i18n_form_namespace) || i18n_form_namespace
 
-    base_key = :"forms.#{i18n_form_namespace_dup}.#{key}"
+    base_key = :"forms.#{i18n_form_namespace_dup}.#{key_string}"
     I18n.t("#{i18n_namespace}.#{base_key}", default: base_key, **args)
   end
 

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -105,6 +105,20 @@ module Journeys
 
         school.closed?
       end
+
+      def all_selected_courses_ineligible?
+        groups = subjects_taught.reject { |e| e == "none" }
+
+        return if groups.empty?
+
+        groups.all? do |subject|
+          public_send(:"#{subject}_courses").include?("none")
+        end
+      end
+
+      def less_than_half_hours_teaching_eligible_courses?
+        hours_teaching_eligible_subjects == false
+      end
     end
   end
 end

--- a/app/models/policies/further_education_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/further_education_payments/policy_eligibility_checker.rb
@@ -40,20 +40,10 @@ module Policies
           :must_at_least_half_hours_teaching_fe
         elsif answers.subjects_taught.include? "none"
           :subject
-        elsif all_selected_courses_ineligible?
+        elsif answers.all_selected_courses_ineligible?
           :courses
-        end
-      end
-
-      private
-
-      def all_selected_courses_ineligible?
-        groups = answers.subjects_taught.reject { |e| e == "none" }
-
-        return if groups.empty?
-
-        groups.all? do |subject|
-          answers.public_send(:"#{subject}_courses").include?("none")
+        elsif answers.less_than_half_hours_teaching_eligible_courses?
+          :less_than_half_hours_teaching_eligible_courses
         end
       end
     end

--- a/app/views/further_education_payments/claims/_ineligible_courses.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_courses.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_fe_provider.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_fe_provider.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      The further education (FE) provider you have entered is not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_lack_teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_lack_teaching_responsibilities.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_lacks_teacher_qualification_or_enrolment.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_lacks_teacher_qualification_or_enrolment.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_less_than_half_hours_teaching_eligible_courses.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_less_than_half_hours_teaching_eligible_courses.html.erb
@@ -5,13 +5,8 @@
     </h1>
 
     <p class="govuk-body">
-      In order to claim a financial incentive payment, half of your timetabled teaching hours must include:
+      In order to claim a financial incentive payment, at least half of your timetabled teaching hours should be spent teaching an <%= govuk_link_to "eligible FE course", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers#eligible-fe-courses", new_tab: true %>.
     </p>
-
-    <%= govuk_list [
-      "a student aged 16 to 19",
-      "a person up to age 25 with an Education, Health and Care Plan (EHCP)",
-    ], type: :bullet %>
 
     <p class="govuk-body">
       For more information, check the eligibility criteria for <%= govuk_link_to "levelling up premium payments for early career further education teachers", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers", new_tab: true %>.

--- a/app/views/further_education_payments/claims/_ineligible_must_be_recent_further_education_teacher.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_must_be_recent_further_education_teacher.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_must_teach_at_least_one_term.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_must_teach_at_least_one_term.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible for a financial incentive payment yet
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_subject.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_subject.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_subject_to_problematic_actions.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_subject_to_problematic_actions.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5_next_term.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5_next_term.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= @form.t("#{@form.journey_eligibility_checker.ineligibility_reason}.heading") %>
+      <%= @form.t([@form.journey_eligibility_checker.ineligibility_reason, "heading"]) %>
     </h1>
 
     <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -813,12 +813,18 @@ en:
           heading: You are not eligible for a financial incentive payment yet
         subject_to_problematic_actions:
           heading: You are not eligible
-        ineligible_teaching_less_than_2_5:
+        teaching_less_than_2_5:
           heading: You are not eligible
         teaching_less_than_2_5_next_term:
           heading: You are not eligible
         fe_provider:
           heading: The further education (FE) provider you have entered is not eligible
+        less_than_half_hours_teaching_eligible_courses:
+          heading: You are not eligible
+        subject:
+          heading: You are not eligible
+
+
       teaching_responsibilities:
         question: Are you a member of staff with teaching responsibilities?
         errors:

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -283,6 +283,54 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_content("you must teach an eligible FE course")
   end
 
+  scenario "when teacher spends less than half hours teaching eligible courses" do
+    when_further_education_payments_journey_configuration_exists
+    and_eligible_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: eligible_college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select the college you teach at")
+    choose eligible_college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{eligible_college.name}?")
+    choose "Permanent contract"
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week")
+    choose "More than 12 hours per week"
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose "September 2023 to August 2024"
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check "Building and construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in onsite construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    expect(page).to have_content("In order to claim a financial incentive payment, at least half of your timetabled teaching hours should be spent teaching an")
+  end
+
   scenario "when not a recent FE teacher" do
     when_further_education_payments_journey_configuration_exists
     and_eligible_college_exists


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-778
- Add ineligible state for when teaching under half hours on eligible courses

# Changes

- Tweaked `Form#t` to now accept an array as a key, this just get converted internally to `whatever.the.key.is` which makes the api a bit nicer
- Moved some code from eligibility checker to session answers, which is where i think it belongs better
- Use i18n for the ineligible screens. Could probably extract to reusable wrapper partial but not really much gain for the effort
