### PR TITLE
[LUPEYALPHA-787] Add back links to FE inelgible screens

### DIFF
--- a/app/views/further_education_payments/claims/ineligible.html.erb
+++ b/app/views/further_education_payments/claims/ineligible.html.erb
@@ -1,3 +1,5 @@
 <% content_for(:page_title, page_title(@form.t("#{@form.journey_eligibility_checker.ineligibility_reason}.heading"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
+<% @backlink_path = claim_path(current_journey_routing_name, session[:slugs].last) %>
+
 <%= render "ineligible_#{@form.journey_eligibility_checker.ineligibility_reason}" %>

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -19,6 +19,9 @@ RSpec.feature "Further education payments ineligible paths" do
 
     expect(page).to have_content("You are not eligible")
     expect(page).to have_content("you must be employed as a member of staff with teaching responsibilities")
+    click_link "Back"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
   end
 
   scenario "when ineligible FE provider is selected" do


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-787

# Changes

- Add missing back links to ineligible screens in FE journey

# Screenshots

![Screenshot 2024-07-25 at 11 46 44](https://github.com/user-attachments/assets/99bac571-dd97-4769-8ff9-376d79ed8900)