### PR TITLE
[1881] Ship production logs to Logit.io

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -18,5 +18,6 @@
   },
   "enable_monitoring": true,
   "statuscake_contact_groups": [195955, 282453],
-  "external_url": "https://www.claim-additional-teaching-payment.service.gov.uk/healthcheck"
+  "external_url": "https://www.claim-additional-teaching-payment.service.gov.uk/healthcheck",
+  "enable_logit": true
 }


### PR DESCRIPTION
Non prod environment logs are already in Logit.io. They have been validated and we can now ship production logs.

