### PR TITLE
Retry flaky test

### DIFF
--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -24,7 +24,7 @@ describe "teacher route: completing the form" do
     journey_configuration
   end
 
-  describe "navigating forward" do
+  describe "navigating forward", flaky: true do
     before do
       when_i_start_the_form
       and_i_complete_application_route_question_with(

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -103,6 +103,11 @@ module GetATeacherRelocationPayment
 
       click_button "Continue"
 
+      unless page.has_text?("Select your school from the search results")
+        # We've got stuck on the school search page, try again
+        click_button "Continue"
+      end
+
       choose school.name
 
       click_button "Continue"


### PR DESCRIPTION
This test regularly fails on the select school step, getting stuck on
the school search form. We've added a check to click the continue button
if we're still on the search form and a retry to the spec in case that
goes wrong too.
