### PR TITLE
ignore session answer attributes in the stored JSON that have not been defined on the SessionAnswers class

### DIFF
--- a/app/models/journeys/session_answers_type.rb
+++ b/app/models/journeys/session_answers_type.rb
@@ -12,7 +12,10 @@ module Journeys
         rescue
           nil
         end
-        answers_class.new(decoded) unless decoded.nil?
+        unless decoded.nil?
+          decoded_with_allowed_attributes = decoded.slice(*answers_class.attribute_names)
+          answers_class.new(decoded_with_allowed_attributes)
+        end
       when Hash
         answers_class.new(value)
       when answers_class

--- a/spec/models/journeys/session_answers_type_spec.rb
+++ b/spec/models/journeys/session_answers_type_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Journeys::SessionAnswersType do
+  describe "#cast_value" do
+    subject { described_class.new.cast_value(json) }
+
+    let(:json) { {"current_school_id" => current_school_id}.to_json }
+    let(:current_school_id) { "some-id" }
+
+    context "with a value that contains attributes that exist on the answers class" do
+      it "has the expected attributes" do
+        expect(subject.current_school_id).to eq current_school_id
+      end
+    end
+
+    context "with a value that contains attributes that no longer exist on the answers class" do
+      let(:json) { {"current_school_id" => "some-id", "attribute-that-no-longer-exists" => "some-value"}.to_json }
+
+      it "has the expected attributes" do
+        expect(subject.current_school_id).to eq current_school_id
+      end
+    end
+
+    context "with an empty string" do
+      let(:json) { "" }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Before this change, an `UnknownAttributeError` is raised on any page in the journey, hence breaking the app totally, in the following scenarios:
* we've added an attribute to `Journeys::SessionAnswers`, deployed it, but then want to roll back that deployment
* we want to remove an attribute from `Journeys::SessionAnswers` and deploy that
* for a developer running locally, and having completed journeys locally, switching between branches that have added new attributes

There is a workaround that doesn't involve this change - and that is to purge all journey sessions.
This change would mean that is no longer necessary.
