### PR TITLE
[LUPEYALPHA-583] FE claim confirmation page

### DIFF
--- a/app/views/further_education_payments/submissions/show.html.erb
+++ b/app/views/further_education_payments/submissions/show.html.erb
@@ -5,7 +5,7 @@
 
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title" id="submitted-title">
-        You applied for a further education financial incentive payment
+        You applied for a further education retention payment
       </h1>
 
       <div class="govuk-panel__body">
@@ -15,7 +15,42 @@
     </div>
 
     <p class="govuk-body">
-      FE CONFIRMATION PLACEHOLDER
+      We have sent you a confirmation email to <%= submitted_claim.email_address %>.
     </p>
+
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+
+    <p class="govuk-body">
+      Your application will be reviewed by the Department for Education. If it’s approved, you will receive the payment in one lump sum.
+    </p>
+
+    <p class="govuk-body">
+      Payments are given up to 20 weeks from applying. We will email you updates on the progress of your application.
+    </p>
+
+    <p class="govuk-body">
+      You will also receive emails to confirm:
+    </p>
+
+    <%= govuk_list [
+      "whether your application is accepted or rejected, usually within 14 weeks",
+      "when your payment has been made, with a full breakdown of how much you have received",
+    ], type: :bullet %>
+
+    <h2 class="govuk-heading-m">
+      Apply for a retention payment each academic year
+    </h2>
+
+    <p class="govuk-body">
+      As long as you continue to meet the <%= govuk_link_to "eligibility criteria", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers#eligibility" %>, you could claim a retention payment in future academic years.
+    </p>
+
+    <p class="govuk-body">
+      You can set a reminder so you know when you are able to apply next year. We cannot issue payments unless you apply.
+    </p>
+
+    <%= govuk_button_link_to "Set reminder", "#" %>
   </div>
 </div>

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     expect(page).to have_content("Check your answers before sending your application")
     click_on "Accept and send"
 
-    expect(page).to have_content("You applied for a further education financial incentive payment")
+    expect(page).to have_content("You applied for a further education retention payment")
   end
 
   def and_college_exists

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -173,7 +173,7 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Check your answers before sending your application")
     click_on "Accept and send"
 
-    expect(page).to have_content("You applied for a further education financial incentive payment")
+    expect(page).to have_content("You applied for a further education retention payment")
   end
 
   def and_college_exists


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-583
- Content for FE confirmation page as claim is submitted

# Review notes

- Reminder button is a placeholder and does not work as designed yet to be completed
- No email is sent yet as yet to be designed

# Screenshot

![Screenshot 2024-07-30 at 15 12 29](https://github.com/user-attachments/assets/eb7ac754-93d1-471e-870f-a7444e8e902b)