### PR TITLE
[LUPEYALPHA-763] EY Declaration of consent page

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/claim_submission_form.rb
@@ -1,0 +1,23 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
+        private
+
+        def main_eligibility
+          @main_eligibility ||= Policies::EarlyYearsPayment::Eligibility.new
+        end
+
+        def calculate_award_amount(eligibility)
+          # NOOP
+          # This is just for compatibility with the AdditionalPaymentsForTeaching
+          # claim submission form.
+        end
+
+        def generate_policy_options_provided
+          []
+        end
+      end
+    end
+  end
+end

--- a/app/forms/journeys/early_years_payment/provider/consent_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/consent_form.rb
@@ -1,0 +1,19 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      class ConsentForm < Form
+        attribute :consent_given, :boolean
+
+        validates :consent_given,
+          presence: {message: i18n_error_message(:presence)}
+
+        def save
+          return false if invalid?
+
+          journey_session.answers.assign_attributes(consent_given:)
+          journey_session.save!
+        end
+      end
+    end
+  end
+end

--- a/app/models/journeys/early_years_payment/provider.rb
+++ b/app/models/journeys/early_years_payment/provider.rb
@@ -9,7 +9,9 @@ module Journeys
       I18N_NAMESPACE = "early_years_payment_provider"
       POLICIES = [Policies::EarlyYearsPayment]
       FORMS = {
-        "claims" => {}
+        "claims" => {
+          "consent" => ConsentForm
+        }
       }
     end
   end

--- a/app/models/journeys/early_years_payment/provider/session_answers.rb
+++ b/app/models/journeys/early_years_payment/provider/session_answers.rb
@@ -2,6 +2,8 @@ module Journeys
   module EarlyYearsPayment
     module Provider
       class SessionAnswers < Journeys::SessionAnswers
+        attribute :consent_given, :boolean
+
         def policy
           Policies::EarlyYearsPayment
         end

--- a/app/models/journeys/early_years_payment/provider/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/slug_sequence.rb
@@ -2,7 +2,10 @@ module Journeys
   module EarlyYearsPayment
     module Provider
       class SlugSequence
-        SLUGS = %w[].freeze
+        SLUGS = %w[
+          consent
+          current-nursery
+        ].freeze
 
         def self.start_page_url
           Rails.application.routes.url_helpers.landing_page_path("early-years-payment-provider")

--- a/app/views/early_years_payment/provider/claims/consent.html.erb
+++ b/app/views/early_years_payment/provider/claims/consent.html.erb
@@ -1,0 +1,52 @@
+<% content_for(:page_title, page_title(@form.t(:question), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+
+      <%= f.govuk_check_boxes_fieldset :consent_given, multiple: false, legend: nil do %>
+        <h1 class="govuk-heading-l">
+          <%= @form.t(:question) %>
+        </h1>
+
+        <p class="govuk-body">
+          You need to confirm that you’ve got consent from your employee before
+          you can continue with a claim.
+        </p>
+
+        <p class="govuk-body">
+          By continuing you’re confirming that you’ve:
+        </p>
+
+        <%= govuk_list [
+          "obtained written consent from your employee to share their personal information (full name, start date, email address)",
+          "provided your employee with a privacy notice that explains what information will be collected, why it is being collected and who it will be shared with"
+        ], type: :bullet %>
+
+        <p class="govuk-body">
+          You do not need to send us the consent forms, but you should keep them
+          for your records.
+        </p>
+
+        <p class="govuk-body">
+          If you have any questions, or need further guidance, contact our support
+          team at
+          <%= govuk_link_to t("early_years_payment_provider.feedback_email"), "mailto:#{t("early_years_payment_provider.feedback_email")}", no_visited_state: true %>.
+        </p>
+
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            By ticking this box, you confirm that you have obtained consent from
+            your employee.
+          </strong>
+        </div>
+
+        <%= f.govuk_check_box :consent_given, 1, 0, multiple: false, link_errors: true, label: { text: @form.t(:option) } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/early_years_payment/provider/claims/consent.html.erb
+++ b/app/views/early_years_payment/provider/claims/consent.html.erb
@@ -4,11 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
 
-      <%= f.govuk_check_boxes_fieldset :consent_given, multiple: false, legend: nil do %>
-        <h1 class="govuk-heading-l">
-          <%= @form.t(:question) %>
-        </h1>
-
+      <%= f.govuk_check_boxes_fieldset :consent_given, multiple: false, legend: { text: @form.t(:question), tag: "h1", size: "l" }, hint: -> do %>
         <p class="govuk-body">
           You need to confirm that you’ve got consent from your employee before
           you can continue with a claim.
@@ -42,6 +38,7 @@
             your employee.
           </strong>
         </div>
+        <% end do %>
 
         <%= f.govuk_check_box :consent_given, 1, 0, multiple: false, link_errors: true, label: { text: @form.t(:option) } %>
       <% end %>

--- a/app/views/early_years_payment/provider/landing_page.html.erb
+++ b/app/views/early_years_payment/provider/landing_page.html.erb
@@ -133,7 +133,7 @@
     </p>
 
     <% if @journey_open %>
-      <%= govuk_start_button(text: "Start now", href: "#") %>
+      <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1072,6 +1072,14 @@ en:
     landing_page:
       title: Claim an early years financial incentive payment
     feedback_email: "help@opsteam.education.gov.uk"
+    forms:
+      consent:
+        question: Declaration of Employee Consent
+        option:
+          I confirm that I have obtained consent from my employee and have provided them with the relevant privacy
+          notice.
+        errors:
+          presence: You must be able to confirm this information to continue
   activerecord:
     errors:
       models:

--- a/spec/factories/journeys/early_years_payment/provider/session.rb
+++ b/spec/factories/journeys/early_years_payment/provider/session.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :early_years_payment_provider_session, class: "Journeys::EarlyYearsPayment::Provider::Session" do
+    journey { Journeys::EarlyYearsPayment::Provider::ROUTING_NAME }
+  end
+end

--- a/spec/features/early_years_payment/provider/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/happy_path_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature "Early years payment provider" do
     when_early_years_payment_provider_journey_configuration_exists
 
     visit landing_page_path(Journeys::EarlyYearsPayment::Provider::ROUTING_NAME)
-    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Declaration of Employee Consent")
+    check "I confirm that I have obtained consent from my employee and have provided them with the relevant privacy notice."
+    click_button "Continue"
   end
 end

--- a/spec/forms/journeys/early_years_payment/provider/consent_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/consent_form_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Provider::ConsentForm, type: :model do
+  let(:journey) { Journeys::EarlyYearsPayment::Provider }
+  let(:journey_session) { create(:early_years_payment_provider_session) }
+  let(:consent_given) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        consent_given:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(journey_session:, journey:, params:)
+  end
+
+  describe "validations" do
+    it do
+      is_expected.not_to(
+        allow_value(consent_given)
+        .for(:consent_given)
+        .with_message("You must be able to confirm this information to continue")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:consent_given) { true }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.consent_given }.to(true)
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- New `ConsentForm` with presence validation on `:consent_given` attribute
- Form spec and extension of happy path feature test
- Basic `ClaimSubmissionForm` which is required for the page sequence to work - it checks `claim_submittable?`

## Notes

- We've skipped the email address form for now until we finish the whitelisting work

## Guidance to review

- Head to the EY landing page (link in review app comment below)
- Click 'Start now'
- Check the declaration of consent page against [the prototype](https://claim-additi-main-9yrds6vyxcsd.herokuapp.com/consent)
- Click 'Continue' with the checkbox unchecked
- Check that you get the correct error message
- Check the checkbox and press 'Continue'
- Check that you progress to the 'current-nursery' page (currently empty) 

<img width="913" alt="Screenshot 2024-07-31 at 13 53 48" src="https://github.com/user-attachments/assets/8775c258-b86e-4b7c-bc6c-941ddbbe90fc">
<img width="913" alt="Screenshot 2024-07-31 at 13 53 50" src="https://github.com/user-attachments/assets/045b3451-1fd3-4562-b6ad-37ac4fc25a74">
