### PR TITLE
LUPEYALPHA-786 - add courses to check your answers part one

### DIFF
--- a/app/models/journeys/further_education_payments/answers_presenter.rb
+++ b/app/models/journeys/further_education_payments/answers_presenter.rb
@@ -2,6 +2,7 @@ module Journeys
   module FurtherEducationPayments
     class AnswersPresenter < BaseAnswersPresenter
       include ActionView::Helpers::TranslationHelper
+      include CoursesHelper
 
       # Formats the eligibility as a list of questions and answers, each
       # accompanied by a slug for changing the answer. Suitable for playback to
@@ -20,6 +21,13 @@ module Journeys
           a << teaching_hours_per_week
           a << further_education_teaching_start_year
           a << subjects_taught
+          a << building_construction_courses
+          a << chemistry_courses
+          a << computing_courses
+          a << early_years_courses
+          a << engineering_manufacturing_courses
+          a << maths_courses
+          a << physics_courses
           a << hours_teaching_eligible_subjects
           a << half_teaching_hours
           a << teaching_qualification
@@ -41,7 +49,7 @@ module Journeys
       def teaching_responsibilities
         [
           t("further_education_payments.forms.teaching_responsibilities.question"),
-          (journey_session.answers.teaching_responsibilities? ? "Yes" : "No"),
+          (answers.teaching_responsibilities? ? "Yes" : "No"),
           "teaching-responsibilities"
         ]
       end
@@ -49,23 +57,23 @@ module Journeys
       def school
         [
           t("further_education_payments.forms.further_education_provision_search.question"),
-          journey_session.answers.school.name,
+          answers.school.name,
           "further-education-provision-search"
         ]
       end
 
       def contract_type
         [
-          t("further_education_payments.forms.contract_type.question", school_name: journey_session.answers.school.name),
-          t(journey_session.answers.contract_type, scope: "further_education_payments.forms.contract_type.options"),
+          t("further_education_payments.forms.contract_type.question", school_name: answers.school.name),
+          t(answers.contract_type, scope: "further_education_payments.forms.contract_type.options"),
           "contract-type"
         ]
       end
 
       def teaching_hours_per_week
         [
-          t("further_education_payments.forms.teaching_hours_per_week.question", school_name: journey_session.answers.school.name),
-          t(journey_session.answers.teaching_hours_per_week, scope: "further_education_payments.forms.teaching_hours_per_week.options"),
+          t("further_education_payments.forms.teaching_hours_per_week.question", school_name: answers.school.name),
+          t(answers.teaching_hours_per_week, scope: "further_education_payments.forms.teaching_hours_per_week.options"),
           "teaching-hours-per-week"
         ]
       end
@@ -73,17 +81,17 @@ module Journeys
       def hours_teaching_eligible_subjects
         [
           t("further_education_payments.forms.hours_teaching_eligible_subjects.question"),
-          (journey_session.answers.hours_teaching_eligible_subjects? ? "Yes" : "No"),
+          (answers.hours_teaching_eligible_subjects? ? "Yes" : "No"),
           "hours-teaching-eligible-subjects"
         ]
       end
 
       def further_education_teaching_start_year
         # TODO: pre-xxxx is an ineligible state so this conditional can be removed when the eligility checking is added, it won't be used
-        answer = if journey_session.answers.further_education_teaching_start_year =~ /pre-(\d{4})/
+        answer = if answers.further_education_teaching_start_year =~ /pre-(\d{4})/
           t("further_education_payments.forms.further_education_teaching_start_year.options.before_date", year: $1)
         else
-          start_year = journey_session.answers.further_education_teaching_start_year.to_i
+          start_year = answers.further_education_teaching_start_year.to_i
           end_year = start_year + 1
 
           t("further_education_payments.forms.further_education_teaching_start_year.options.between_dates", start_year: start_year, end_year: end_year)
@@ -97,13 +105,13 @@ module Journeys
       end
 
       def subjects_taught
-        answers = journey_session.answers.subjects_taught.map { |subject_taught|
+        subjects_list = answers.subjects_taught.map { |subject_taught|
           content_tag(:p, t(subject_taught, scope: "further_education_payments.forms.subjects_taught.options"), class: "govuk-body")
         }.join("").html_safe
 
         [
           t("further_education_payments.forms.subjects_taught.question"),
-          answers,
+          subjects_list,
           "subjects-taught"
         ]
       end
@@ -111,7 +119,7 @@ module Journeys
       def half_teaching_hours
         [
           t("further_education_payments.forms.half_teaching_hours.question"),
-          (journey_session.answers.half_teaching_hours? ? "Yes" : "No"),
+          (answers.half_teaching_hours? ? "Yes" : "No"),
           "half-teaching-hours"
         ]
       end
@@ -119,7 +127,7 @@ module Journeys
       def teaching_qualification
         [
           t("further_education_payments.forms.teaching_qualification.question"),
-          t(journey_session.answers.teaching_qualification, scope: "further_education_payments.forms.teaching_qualification.options"),
+          t(answers.teaching_qualification, scope: "further_education_payments.forms.teaching_qualification.options"),
           "teaching-qualification"
         ]
       end
@@ -127,7 +135,7 @@ module Journeys
       def subject_to_formal_performance_action
         [
           t("further_education_payments.forms.poor_performance.questions.performance.question"),
-          (journey_session.answers.subject_to_formal_performance_action? ? "Yes" : "No"),
+          (answers.subject_to_formal_performance_action? ? "Yes" : "No"),
           "poor-performance"
         ]
       end
@@ -135,8 +143,53 @@ module Journeys
       def subject_to_disciplinary_action
         [
           t("further_education_payments.forms.poor_performance.questions.disciplinary.question"),
-          (journey_session.answers.subject_to_disciplinary_action? ? "Yes" : "No"),
+          (answers.subject_to_disciplinary_action? ? "Yes" : "No"),
           "poor-performance"
+        ]
+      end
+
+      def building_construction_courses
+        courses_for_course_field(:building_construction_courses)
+      end
+
+      def chemistry_courses
+        courses_for_course_field(:chemistry_courses)
+      end
+
+      def computing_courses
+        courses_for_course_field(:computing_courses)
+      end
+
+      def early_years_courses
+        courses_for_course_field(:early_years_courses)
+      end
+
+      def engineering_manufacturing_courses
+        courses_for_course_field(:engineering_manufacturing_courses)
+      end
+
+      def maths_courses
+        courses_for_course_field(:maths_courses)
+      end
+
+      def physics_courses
+        courses_for_course_field(:physics_courses)
+      end
+
+      def courses_for_course_field(course_field)
+        scope = "further_education_payments.forms.#{course_field}"
+
+        courses_list = answers.public_send(course_field).map { |course|
+          body = t("options.#{course}", scope: scope, link: link_for_course(course_field, course, link: false))
+          content_tag(:p, body, class: "govuk-body")
+        }.join("").html_safe
+
+        return nil if courses_list.empty?
+
+        [
+          t("further_education_payments.forms.#{course_field}.question_check_your_answers"),
+          courses_list,
+          course_field.to_s.tr("_", "-")
         ]
       end
     end

--- a/app/models/journeys/further_education_payments/courses_helper.rb
+++ b/app/models/journeys/further_education_payments/courses_helper.rb
@@ -78,14 +78,28 @@ module Journeys
         }
       }.freeze
 
+      # Some radio button options have a link in the description
       def course_option_description(course, opts = {})
         course_field = opts.key?(:i18n_form_namespace) ? opts[:i18n_form_namespace] : i18n_form_namespace
-        args = {i18n_form_namespace: course_field}
+
+        args = {
+          i18n_form_namespace: course_field,
+          link: link_for_course(course_field, course)
+        }
+
+        # NOTE: This is expecting FormHelpers mixin if used for a specific `t()`
+        t("options.#{course}", args)
+      end
+
+      # If there is a link for course - generate one
+      # Pass in {link: false} to return just the text and not a link
+      def link_for_course(course_field, course, opts = {})
+        dont_link = opts[:link] == false
 
         text, url = COURSE_DESCRIPTIONS_WITH_INLINE_LINKS.dig(course_field.to_sym, course.to_sym)
-        args[:link] = govuk_link_to(text, url, new_tab: true) if text.present? && url.present?
-
-        t("options.#{course}", args)
+        if text.present? && url.present?
+          dont_link ? text : govuk_link_to(text, url, new_tab: true)
+        end
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -936,6 +936,7 @@ en:
       building_construction_courses:
         <<: *courses
         question: Which building and construction courses do you teach?
+        question_check_your_answers: Building and construction courses
         options:
           esfa_buildingconstruction: ESFA-funded qualifications at level 3 and below in the %{link} sector subject area
           tlevel_building: T Level in building services engineering for construction
@@ -946,6 +947,7 @@ en:
       chemistry_courses:
         <<: *courses
         question: Which chemistry courses do you teach?
+        question_check_your_answers: Chemistry courses
         options:
           alevel_chemistry: A or AS level chemistry
           gcse_chemistry: GCSE chemistry
@@ -954,6 +956,7 @@ en:
       computing_courses:
         <<: *courses
         question: Which computing courses do you teach?
+        question_check_your_answers: Computing courses
         options:
           esfa_digitalpractitioners: ESFA-funded qualifications at level 3 and below in the %{link} sector subject area
           esfa_digitalusers: ESFA-funded qualifications at level 3 and below in the %{link} sector subject area
@@ -967,6 +970,7 @@ en:
       early_years_courses:
         <<: *courses
         question: Which early years courses do you teach?
+        question_check_your_answers: Early years courses
         options:
           eylevel2: Early years practitioner (level 2) apprenticeship
           eylevel3: Early years educator (level 3) apprenticeship
@@ -977,6 +981,7 @@ en:
       engineering_manufacturing_courses:
         <<: *courses
         question: Which engineering and manufacturing courses do you teach?
+        question_check_your_answers: Engineering and manufacturing courses
         options:
           esfa_engineering: ESFA-funded qualifications at level 3 and below in the %{link} sector subject area
           esfa_manufacturing: ESFA-funded qualifications at level 3 and below in the %{link} sector subject area
@@ -989,6 +994,7 @@ en:
       maths_courses:
         <<: *courses
         question: Which maths courses do you teach?
+        question_check_your_answers: Maths courses
         options:
           esfa: ESFA-funded qualifications at level 3 and below in the %{link} sector subject area
           gcse_maths:
@@ -998,6 +1004,7 @@ en:
       physics_courses:
         <<: *courses
         question: Which physics courses do you teach?
+        question_check_your_answers: Physics courses
         options:
           alevel_physics: A or AS level physics
           gcse_physics: GCSE physics

--- a/spec/models/journeys/further_education_payments/answers_presenter_spec.rb
+++ b/spec/models/journeys/further_education_payments/answers_presenter_spec.rb
@@ -20,6 +20,73 @@ RSpec.describe Journeys::FurtherEducationPayments::AnswersPresenter do
     let(:subject_to_formal_performance_action) { false }
     let(:subject_to_disciplinary_action) { false }
 
+    let(:building_construction_courses) {
+      %w[
+        esfa_buildingconstruction
+        tlevel_building
+        tlevel_onsiteconstruction
+        tlevel_design_surveying
+        level2_3_apprenticeship
+      ]
+    }
+
+    let(:chemistry_courses) {
+      %w[
+        alevel_chemistry
+        gcse_chemistry
+        ib_certificate_chemistry
+      ]
+    }
+
+    let(:computing_courses) {
+      %w[
+        esfa_digitalpractitioners
+        esfa_digitalusers
+        digitalskills_quals
+        tlevel_digitalsupport
+        tlevel_digitalbusiness
+        tlevel_digitalproduction
+        ib_certificate_compsci
+        level2_3_apprenticeship
+      ]
+    }
+
+    let(:early_years_courses) {
+      %w[
+        eylevel2
+        eylevel3
+        eytlevel
+        coursetoeyq
+      ]
+    }
+
+    let(:engineering_manufacturing_courses) {
+      %w[
+        esfa_engineering
+        esfa_manufacturing
+        esfa_transportation
+        tlevel_design
+        tlevel_maintenance
+        tlevel_engineering
+        level2_3_apprenticeship
+      ]
+    }
+
+    let(:maths_courses) {
+      %w[
+        esfa
+        gcse_maths
+      ]
+    }
+
+    let(:physics_courses) {
+      %w[
+        alevel_physics
+        gcse_physics
+        ib_certificate_physics
+      ]
+    }
+
     let(:answers) {
       build(
         :further_education_payments_answers,
@@ -33,7 +100,14 @@ RSpec.describe Journeys::FurtherEducationPayments::AnswersPresenter do
         half_teaching_hours: half_teaching_hours,
         teaching_qualification: teaching_qualification,
         subject_to_formal_performance_action: subject_to_formal_performance_action,
-        subject_to_disciplinary_action: subject_to_disciplinary_action
+        subject_to_disciplinary_action: subject_to_disciplinary_action,
+        building_construction_courses: building_construction_courses,
+        chemistry_courses: chemistry_courses,
+        computing_courses: computing_courses,
+        early_years_courses: early_years_courses,
+        engineering_manufacturing_courses: engineering_manufacturing_courses,
+        maths_courses: maths_courses,
+        physics_courses: physics_courses
       )
     }
 
@@ -46,6 +120,13 @@ RSpec.describe Journeys::FurtherEducationPayments::AnswersPresenter do
           ["On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?", "More than 12 hours per week", "teaching-hours-per-week"],
           ["Which academic year did you start teaching in further education (FE) in England?", "September 2023 to August 2024", "further-education-teaching-start-year"],
           ["Which subject areas do you teach?", "<p class=\"govuk-body\">Chemistry</p><p class=\"govuk-body\">Maths</p>", "subjects-taught"],
+          ["Building and construction courses", "<p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the building and construction sector subject area</p><p class=\"govuk-body\">T Level in building services engineering for construction</p><p class=\"govuk-body\">T Level in onsite construction</p><p class=\"govuk-body\">T Level in design, surveying and planning for construction</p><p class=\"govuk-body\">Level 2 or level 3 apprenticeships in the construction and the built environment occupational route</p>", "building-construction-courses"],
+          ["Chemistry courses", "<p class=\"govuk-body\">A or AS level chemistry</p><p class=\"govuk-body\">GCSE chemistry</p><p class=\"govuk-body\">International baccalaureate middle years programme or certificate in chemistry</p>", "chemistry-courses"],
+          ["Computing courses", "<p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the digital technology for practitioners sector subject area</p><p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the digital technology for users sector subject area</p><p class=\"govuk-body\">Digital functional skills qualifications and essential digital skills qualifications</p><p class=\"govuk-body\">T Level in digital support services</p><p class=\"govuk-body\">T Level in digital business services</p><p class=\"govuk-body\">T Level in digital production, design and development</p><p class=\"govuk-body\">International baccalaureate certificate in computer science</p><p class=\"govuk-body\">Level 2 or level 3 apprenticeships in the digital occupational route</p>", "computing-courses"],
+          ["Early years courses", "<p class=\"govuk-body\">Early years practitioner (level 2) apprenticeship</p><p class=\"govuk-body\">Early years educator (level 3) apprenticeship</p><p class=\"govuk-body\">T Level in education and early years (early years educator)</p><p class=\"govuk-body\">A course that leads to an early years qualification which enables providers to count the recipient in staff:child ratios</p>", "early-years-courses"],
+          ["Engineering and manufacturing courses", "<p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the engineering sector subject area</p><p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the manufacturing technologies sector subject area</p><p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the transportation operations and maintenance sector subject area</p><p class=\"govuk-body\">T Level in design and development for engineering and manufacturing</p><p class=\"govuk-body\">T Level in maintenance, installation and repair for engineering and manufacturing</p><p class=\"govuk-body\">T Level in engineering, manufacturing, processing and control</p><p class=\"govuk-body\">Level 2 or level 3 apprenticeships in the engineering and manufacturing occupational route</p>", "engineering-manufacturing-courses"],
+          ["Maths courses", "<p class=\"govuk-body\">ESFA-funded qualifications at level 3 and below in the mathematics and statistics sector subject area</p><p class=\"govuk-body\">Maths GCSE, functional skills qualifications and other maths qualifications approved for teaching to 16 to 19-year-olds who meet the condition of funding</p>", "maths-courses"],
+          ["Physics courses", "<p class=\"govuk-body\">A or AS level physics</p><p class=\"govuk-body\">GCSE physics</p><p class=\"govuk-body\">International baccalaureate middle years programme or certificate in physics</p>", "physics-courses"],
           ["Do you spend at least half of your timetabled teaching hours teaching these eligible courses?", "Yes", "hours-teaching-eligible-subjects"],
           ["Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?", "Yes", "half-teaching-hours"],
           ["Do you have a teaching qualification?", "Yes", "teaching-qualification"],
@@ -89,6 +170,28 @@ RSpec.describe Journeys::FurtherEducationPayments::AnswersPresenter do
           "subjects-taught"
         ])
       }
+    end
+
+    context "courses" do
+      context "course field has no answers" do
+        let(:maths_courses) { [] }
+
+        it do
+          questions = subject.map { |question, answers, slug| question }
+
+          expect(questions).to_not include("Maths courses")
+        end
+      end
+
+      context "course field has none selected - still show none option" do
+        let(:maths_courses) { ["none"] }
+
+        it do
+          questions = subject.map { |question, answers, slug| question }
+
+          expect(questions).to include("Maths courses")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* Displays all the courses selected
* Hyperlinks in the courses descriptions are not shown like they are in the initial radio buttons or course list playback 
* If "I do not teach any of these courses" was selected for a course field, that will show the question, to give opportunity to go back and change
* If a subject/course field was NOT selected meaning the question was NOT asked the question is NOT shown as there is no page to go back to