### PR TITLE
Delete review apps if PR unlabelled

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -2,15 +2,16 @@ name: Delete review app on AKS
 
 on:
   pull_request:
-    types:
-      - closed
+    types: [closed, unlabeled]
 
 jobs:
   delete-review-app:
     name: Delete review app ${{ github.event.pull_request.number }}
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    if: >
+      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
     environment: review-aks
     steps:
       - name: Checkout


### PR DESCRIPTION
## Changes in this PR

We've noticed a lot of old review apps hanging around after PRs are closed/merged.

For all the ones I checked, it was because the 'deploy' label had been removed before closing.

This PR ensures that the review app is deleted if the label is removed.

## Guidance to review

Add and remove the 'deploy' label