### PR TITLE
CAPT-1777 Validate format of banking name

### DIFF
--- a/app/forms/bank_details_form.rb
+++ b/app/forms/bank_details_form.rb
@@ -1,6 +1,7 @@
 class BankDetailsForm < Form
   # Only validate against HMRC API if number of attempts is below threshold
   MAX_HMRC_API_VALIDATION_ATTEMPTS = 3
+  BANKING_NAME_REGEX_FILTER = /\A[0-9A-Za-z .\/&-]*\z/
 
   attribute :hmrc_validation_attempt_count, :integer
   attribute :banking_name, :string
@@ -11,6 +12,7 @@ class BankDetailsForm < Form
   attr_reader :hmrc_api_validation_attempted, :hmrc_api_validation_succeeded, :hmrc_api_response_error
 
   validates :banking_name, presence: {message: i18n_error_message(:enter_banking_name)}
+  validates :banking_name, format: {with: BANKING_NAME_REGEX_FILTER, message: i18n_error_message(:invalid_banking_name)}, if: -> { banking_name.present? }
   validates :bank_sort_code, presence: {message: i18n_error_message(:enter_sort_code)}
   validates :bank_account_number, presence: {message: i18n_error_message(:enter_account_number)}
   validates :building_society_roll_number, presence: {message: i18n_error_message(:enter_roll_number)}, if: -> { answers.building_society? }

--- a/spec/forms/bank_details_form_spec.rb
+++ b/spec/forms/bank_details_form_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe BankDetailsForm do
     let(:hmrc_validation_attempt_count) { 0 }
 
     describe "#valid?" do
+      context "banking name with invalid characters" do
+        let(:banking_name) { "John=Doe" }
+
+        it { is_expected.not_to be_valid }
+
+        it do
+          form.valid?
+          expect(form.errors[:banking_name]).to contain_exactly("Enter a valid name on the account")
+        end
+      end
+
+      context "banking name with valid characters" do
+        let(:valid_characters) { "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ./&-".chars }
+        let(:banking_name) { Array.new(15) { valid_characters.sample }.join }
+
+        it { is_expected.to be_valid }
+      end
+
       context "with 200 code HMRC API response", :with_stubbed_hmrc_client do
         context "with valid account number" do
           let(:bank_account_number) { "12-34-56-78" }


### PR DESCRIPTION
Restrict the name on account field to certain allowed characters.

![Screenshot 2024-08-05 at 15 41 50](https://github.com/user-attachments/assets/7acc03a1-feeb-4a08-823b-debdd8e301e1)
