### PR TITLE
support validating OTP without a generated_at time and with a specified secret

### DIFF
--- a/lib/one_time_password/base.rb
+++ b/lib/one_time_password/base.rb
@@ -12,6 +12,10 @@ module OneTimePassword
 
     private
 
-    attr_reader :issuer
+    attr_reader :issuer, :secret
+
+    def encode_secret(secret)
+      ROTP::Base32.encode(secret) if secret
+    end
   end
 end

--- a/lib/one_time_password/generator.rb
+++ b/lib/one_time_password/generator.rb
@@ -1,11 +1,12 @@
 module OneTimePassword
   class Generator < Base
-    def initialize(issuer = nil)
+    def initialize(issuer = nil, secret: nil)
       @issuer = issuer || ISSUER
+      @secret = encode_secret(secret) || SECRET
     end
 
     def code
-      @code ||= rotp.new(SECRET, issuer: issuer).now
+      @code ||= rotp.new(secret, issuer: issuer).now
     end
   end
 end

--- a/lib/one_time_password/validator.rb
+++ b/lib/one_time_password/validator.rb
@@ -1,18 +1,19 @@
 module OneTimePassword
   class Validator < Base
-    def initialize(code, generated_at)
+    def initialize(code, generated_at = nil)
       @code = code
       @generated_at = generated_at
     end
 
     def valid?
-      code.present? && !wrong_length? && !expired? && !incorrect?
+      code.present? && !wrong_length? && (generated_at && !expired?) && !incorrect?
     end
 
     def warning
       return "Enter a passcode" if code.blank?
       return "Enter a valid passcode containing #{LENGTH} digits" if wrong_length?
-      return "Your passcode has expired, request a new one" if expired?
+      return "Your passcode has expired, request a new one" if generated_at && expired?
+      return "Your passcode is not valid or has expired" if !generated_at
       "Enter a valid passcode" if incorrect?
     end
 
@@ -23,7 +24,7 @@ module OneTimePassword
     def wrong_length?
       return @wrong_length if defined?(@wrong_length)
 
-      @wrong_length = code.gsub(/\D/, "").length != LENGTH
+      @wrong_length = code.length != LENGTH
     end
 
     def expired?

--- a/spec/lib/one_time_password/generator_spec.rb
+++ b/spec/lib/one_time_password/generator_spec.rb
@@ -1,14 +1,29 @@
 require "rails_helper"
 
 RSpec.describe OneTimePassword::Generator do
+  let(:totp) { instance_double ROTP::TOTP, now: one_time_passcode }
+  let(:one_time_passcode) { 123456 }
+
+  before do
+    allow(ROTP::TOTP).to receive(:new).and_return(totp)
+  end
+
   describe "#code" do
     subject { described_class.new.code }
 
-    let(:totp) { instance_double ROTP::TOTP, now: one_time_passcode }
-    let(:one_time_passcode) { 123456 }
+    it "generates a new code" do
+      expect(subject).to eq one_time_passcode
+    end
+  end
 
-    before do
-      allow(ROTP::TOTP).to receive(:new).and_return(totp)
+  context "specifying a secret" do
+    subject { described_class.new(secret: secret).code }
+
+    let(:secret) { "somesecret" }
+
+    it "uses the secret" do
+      expect(ROTP::TOTP).to receive(:new).with(ROTP::Base32.encode(secret), anything).and_return(totp)
+      subject
     end
 
     it "generates a new code" do

--- a/spec/lib/one_time_password/generator_spec.rb
+++ b/spec/lib/one_time_password/generator_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe OneTimePassword::Generator do
+  describe "#code" do
+    subject { described_class.new.code }
+
+    let(:totp) { instance_double ROTP::TOTP, now: one_time_passcode }
+    let(:one_time_passcode) { 123456 }
+
+    before do
+      allow(ROTP::TOTP).to receive(:new).and_return(totp)
+    end
+
+    it "generates a new code" do
+      expect(subject).to eq one_time_passcode
+    end
+  end
+end

--- a/spec/lib/one_time_password/validator_spec.rb
+++ b/spec/lib/one_time_password/validator_spec.rb
@@ -87,4 +87,31 @@ RSpec.describe OneTimePassword::Validator do
       end
     end
   end
+
+  context "not specifying generated_at" do
+    subject { described_class.new(one_time_passcode) }
+
+    context "with a valid code" do
+      it { is_expected.to be_valid }
+
+      it "has no warning" do
+        expect(subject.warning).to be_nil
+      end
+    end
+  end
+
+  context "specifying a secret" do
+    let!(:one_time_passcode) { OneTimePassword::Generator.new(secret: secret).code }
+    subject { described_class.new(one_time_passcode, secret: secret) }
+
+    let(:secret) { "somesecretstring" }
+
+    context "with a valid code" do
+      it { is_expected.to be_valid }
+
+      it "has no warning" do
+        expect(subject.warning).to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/one_time_password/validator_spec.rb
+++ b/spec/lib/one_time_password/validator_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe OneTimePassword::Validator do
+  subject { described_class.new(one_time_passcode, generated_at) }
+
+  let!(:one_time_passcode) { OneTimePassword::Generator.new.code }
+  let!(:generated_at) { Time.now }
+
+  context "with a valid code" do
+    it { is_expected.to be_valid }
+
+    it "has no warning" do
+      expect(subject.warning).to be_nil
+    end
+
+    context "memoization" do
+      before do
+        subject.warning
+        allow(ROTP::TOTP).to receive(:new) { rotp }
+      end
+
+      let(:rotp) { instance_double ROTP::TOTP }
+
+      it "memoizes the result of the passcode verification" do
+        expect(rotp).not_to receive(:verify)
+        subject.warning
+      end
+    end
+  end
+
+  context "with an empty code" do
+    let(:one_time_passcode) { "" }
+
+    it { is_expected.to_not be_valid }
+
+    it "has the correct warning" do
+      expect(subject.warning).to eq "Enter a passcode"
+    end
+  end
+
+  context "with a nil code" do
+    let(:one_time_passcode) { nil }
+
+    it { is_expected.to_not be_valid }
+
+    it "has the correct warning" do
+      expect(subject.warning).to eq "Enter a passcode"
+    end
+  end
+
+  context "with a code that is too short" do
+    let(:one_time_passcode) { "12345" }
+
+    it { is_expected.to_not be_valid }
+
+    it "has the correct warning" do
+      expect(subject.warning).to eq "Enter a valid passcode containing 6 digits"
+    end
+  end
+
+  context "with a code that is the correct length, but wrong" do
+    let(:one_time_passcode) { "000000" }
+
+    it { is_expected.to_not be_valid }
+
+    it "has the correct warning" do
+      expect(subject.warning).to eq "Enter a valid passcode"
+    end
+  end
+
+  context "with a code that has expired" do
+    before { travel 20.minutes }
+
+    it { is_expected.to_not be_valid }
+
+    it "has the correct warning" do
+      expect(subject.warning).to eq "Your passcode has expired, request a new one"
+    end
+
+    context "when generated_at is not specified" do
+      subject { described_class.new(one_time_passcode) }
+
+      it { is_expected.to_not be_valid }
+
+      it "has the correct warning" do
+        expect(subject.warning).to eq "Your passcode is not valid or has expired"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need 2 changes to the OTP code for the EY magic link:
* allow OTP code to be validated without having a `generated_at` time.
* allow OTP codes to be generated and verified using a specified secret (because we now are verifying codes generated in a separate session)
