### PR TITLE
Resolve deprecation warning

### DIFF
--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     end
     association(:payroll_run, factory: :payroll_run)
 
-    award_amount { claims.sum(&:award_amount) }
+    award_amount { claims.map(&:award_amount).compact.sum }
 
     trait :with_figures do
       # This is a rough approximation of the "grossing up" done by DfE Payroll. It


### PR DESCRIPTION
# Context 

- we have the following deprecation warning
```
DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument. (called from block (3 levels) in <top (required)> at /Volumes/git/claim-additional-payments-for-teaching/spec/factories/payments.rb:22)
```
- this change resolves the warning
- the change can be found here https://github.com/rails/rails/pull/42080/files