### PR TITLE
Add teaching hours task

### DIFF
--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -29,6 +29,7 @@ class ClaimCheckingTasks
         task_names.delete("employment_contract")
         task_names.delete("employment_start")
         task_names.delete("subject")
+        task_names.delete("teaching_hours")
       end
     end
   end

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -52,6 +52,14 @@ module Policies
         ]
       end
 
+      # We don't have a specific teaching hours question so we show the subject
+      # to admins
+      def teaching_hours
+        [
+          ["Subject", eligibility.subject.humanize]
+        ]
+      end
+
       private
 
       delegate :eligibility, to: :claim

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -20,6 +20,7 @@ class Task < ApplicationRecord
     subject
     student_loan_amount
     student_loan_plan
+    teaching_hours
     payroll_details
     matching_details
     payroll_gender

--- a/app/views/admin/tasks/teaching_hours.html.erb
+++ b/app/views/admin/tasks/teaching_hours.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} teaching_hours check for #{@claim.policy.short_name}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+  <%= render "claim_summary", claim: @claim, heading: "Subject check" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answers", answers: @tasks_presenter.teaching_hours %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@task.passed.nil? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= render "form", task_name: "teaching_hours", claim: @claim %>
+    <% end %>
+
+    <%= render partial: "admin/task_pagination" %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,6 +149,7 @@ en:
       employment_contract: "Check employment contract"
       employment_start: "Check employment start date"
       subject: "Check subject"
+      teaching_hours: "Check teaching hours"
     undo_decision:
       approved: "Undo approval"
       rejected: "Undo rejection"
@@ -818,6 +819,8 @@ en:
           title: "Does the claimant’s employment start date match the above information from their claim?"
         subject:
           title: "Does the claimant’s subject match the above information from their claim?"
+        teaching_hours:
+          title: "Does the teacher meet the minimum 50% teaching time requirement in their role?"
   further_education_payments:
     landing_page: Find out if you are eligible for any incentive payments for further education teachers
     claim_description: for further education payments

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -179,7 +179,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Employment start", "Subject", "Decision"]
+      ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Employment start", "Subject", "Teaching hours", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
IRP requires we check with the school how much time the claimant spends
teaching specific subjects. We don't ask this question in the
eligibility, so in the admin presenter we reshow the teaching subject
for this task.
