### PR TITLE
Authorisation spike

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -13,6 +13,7 @@ class ClaimsController < BasePublicController
 
   include FormSubmittable
   include ClaimsFormCallbacks
+  include AuthorisedSlugs
 
   def existing_session
     @existing_session = journey_sessions.first
@@ -68,7 +69,16 @@ class ClaimsController < BasePublicController
     # this session value.
     session[:current_journey_routing_name] = current_journey_routing_name
 
-    create_journey_session!
+    # Not happy about this!!
+    # The before new/create callback forces us to do this. Ideally the "Start
+    # now" button on each journey would have a corresponding form so we could
+    # set up the new journey with required attributes by `POST`ing to the
+    # `create` action, rather than when `GET`ting the `new` action.
+    # Also we should have some method for scoping the required params per
+    # journey TBBD.
+    create_journey_session!(
+      answers: params.fetch(:answers, {}).permit(:claim_id)
+    )
   end
 
   def check_page_is_in_sequence

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,6 +1,10 @@
 class ClaimsController < BasePublicController
   include PartOfClaimJourney
 
+  before_action do
+    puts "params slug #{params[:slug]}"
+  end
+
   skip_before_action :send_unstarted_claimants_to_the_start, only: [:new, :create]
   before_action :initialize_session_slug_history
   before_action :check_page_is_in_sequence, only: [:show, :update]
@@ -89,7 +93,7 @@ class ClaimsController < BasePublicController
 
     raise ActionController::RoutingError.new("Not Found for #{params[:slug]}") unless page_sequence.in_sequence?(params[:slug])
 
-    redirect_to claim_path(current_journey_routing_name, next_required_slug) unless page_sequence.has_completed_journey_until?(params[:slug])
+    claim_path(current_journey_routing_name, next_required_slug) unless page_sequence.has_completed_journey_until?(params[:slug])
   end
 
   def initialize_session_slug_history

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,10 +1,6 @@
 class ClaimsController < BasePublicController
   include PartOfClaimJourney
 
-  before_action do
-    puts "params slug #{params[:slug]}"
-  end
-
   skip_before_action :send_unstarted_claimants_to_the_start, only: [:new, :create]
   before_action :initialize_session_slug_history
   before_action :check_page_is_in_sequence, only: [:show, :update]

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -89,7 +89,7 @@ class ClaimsController < BasePublicController
 
     raise ActionController::RoutingError.new("Not Found for #{params[:slug]}") unless page_sequence.in_sequence?(params[:slug])
 
-    claim_path(current_journey_routing_name, next_required_slug) unless page_sequence.has_completed_journey_until?(params[:slug])
+    redirect_to claim_path(current_journey_routing_name, next_required_slug) unless page_sequence.has_completed_journey_until?(params[:slug])
   end
 
   def initialize_session_slug_history

--- a/app/controllers/concerns/authorised_slugs.rb
+++ b/app/controllers/concerns/authorised_slugs.rb
@@ -12,7 +12,14 @@ module AuthorisedSlugs
   end
 
   def authorised?
-    journey::Authorisation.new(journey_session.answers).authorised?(current_slug)
+    authorisation.authorised?
+  end
+
+  def authorisation
+    journey::Authorisation.new(
+      answers: journey_session.answers,
+      slug: current_slug
+    )
   end
 
   def current_slug_requires_authorisation?

--- a/app/controllers/concerns/authorised_slugs.rb
+++ b/app/controllers/concerns/authorised_slugs.rb
@@ -26,4 +26,3 @@ module AuthorisedSlugs
     page_sequence.requires_authorisation?(current_slug)
   end
 end
-

--- a/app/controllers/concerns/authorised_slugs.rb
+++ b/app/controllers/concerns/authorised_slugs.rb
@@ -1,0 +1,22 @@
+module AuthorisedSlugs
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorise_slug!
+  end
+
+  def authorise_slug!
+    if current_slug_requires_authorisation? && !authorised?
+      redirect_to_slug(page_sequence.authorisation_start(current_slug))
+    end
+  end
+
+  def authorised?
+    journey::Authorisation.new(journey_session.answers).authorised?(current_slug)
+  end
+
+  def current_slug_requires_authorisation?
+    page_sequence.requires_authorisation?(current_slug)
+  end
+end
+

--- a/app/controllers/concerns/journey_concern.rb
+++ b/app/controllers/concerns/journey_concern.rb
@@ -44,12 +44,12 @@ module JourneyConcern
     @journey_sessions = []
   end
 
-  def create_journey_session!
+  def create_journey_session!(answers: {})
     journey_session = journey::Session.create!(
       journey: current_journey_routing_name,
-      answers: {
+      answers: answers.to_h.reverse_merge(
         academic_year: journey_configuration.current_academic_year
-      }
+      )
     )
 
     session[journey_session_key] = journey_session.id

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -49,9 +49,27 @@ class OmniauthCallbacksController < ApplicationController
 
     # Yeah this should be a form object
 
-    redirect_to(
-      claim_path(journey: current_journey_routing_name, slug: "verify-claim")
+    authorisation = journey::Authorisation.new(
+      answers: journey_session.answers,
+      slug: "verify-claim"
     )
+
+    session[:slugs] << "sign-in"
+
+    if authorisation.authorised?
+      redirect_to(
+        claim_path(journey: current_journey_routing_name, slug: "verify-claim")
+      )
+    else
+      puts "in auth faliure"
+      redirect_to(
+        claim_path(
+          journey: current_journey_routing_name,
+          slug: "authorisation-failure",
+          reason: authorisation.failure_reason
+        )
+      )
+    end
 
     # FIXME handle errors, eg "omniauth hash not being present"
     # Think this should be handled by a form

--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -6,4 +6,3 @@ module Journeys
     end
   end
 end
-

--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class VerifyClaimForm < Form
+      end
+    end
+  end
+end
+

--- a/app/models/journeys.rb
+++ b/app/models/journeys.rb
@@ -10,6 +10,7 @@ module Journeys
     TeacherStudentLoanReimbursement,
     GetATeacherRelocationPayment,
     FurtherEducationPayments,
+    FurtherEducationPayments::Provider,
     EarlyYearsPayment::Provider
   ].freeze
 

--- a/app/models/journeys/further_education_payments/provider.rb
+++ b/app/models/journeys/further_education_payments/provider.rb
@@ -16,7 +16,7 @@ module Journeys
 
       FORMS = {
         "claims" => {
-          "verify-claim" => ClaimSubmissionForm,
+          "verify-claim" => VerifyClaimForm,
         }
       }
     end

--- a/app/models/journeys/further_education_payments/provider.rb
+++ b/app/models/journeys/further_education_payments/provider.rb
@@ -10,13 +10,12 @@ module Journeys
 
       POLICIES = []
 
-      # FIXME RL replace the one of these in the verification class
-      # with this
-      CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE = "fixme_rl"
+      # FIXME RL find out what this role should be
+      CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE = "FIXME_RL"
 
       FORMS = {
         "claims" => {
-          "verify-claim" => VerifyClaimForm,
+          "verify-claim" => VerifyClaimForm
         }
       }
     end

--- a/app/models/journeys/further_education_payments/provider.rb
+++ b/app/models/journeys/further_education_payments/provider.rb
@@ -1,0 +1,24 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      extend Base
+      extend self
+
+      ROUTING_NAME = "further-education-payments-provider"
+      VIEW_PATH = "further_education_payments/provider"
+      I18N_NAMESPACE = "further_education_payments_provider"
+
+      POLICIES = []
+
+      # FIXME RL replace the one of these in the verification class
+      # with this
+      CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE = "fixme_rl"
+
+      FORMS = {
+        "claims" => {
+          "verify-claim" => ClaimSubmissionForm,
+        }
+      }
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/provider/authorisation.rb
+++ b/app/models/journeys/further_education_payments/provider/authorisation.rb
@@ -1,0 +1,43 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class Authorisation
+        attr_reader :answers
+
+        def initialize(answers)
+          @answers = answers
+        end
+
+        def authorised?(slug)
+          return false if failure_reason(slug).present?
+
+          true
+        end
+
+        def failure_reason(slug)
+          return :not_signed_in unless signed_in?
+          return :no_service_access unless service_access?
+          return :organisation_mismatch unless organisation_matches?
+          # ...
+          nil
+        end
+
+        private
+
+        def signed_in?
+          answers.dfe_sign_in_uid.present?
+        end
+
+        def organisation_matches?
+          answers.dfe_sign_in_organisation_ukprn == answers.claim.school.ukprn
+        end
+
+        # FIXME RL: need to find out what the role codes should be
+        def service_access?
+          answers.dfe_sign_in_organisation_role_codes.include?("claim_verifier_access")
+        end
+      end
+    end
+  end
+end
+

--- a/app/models/journeys/further_education_payments/provider/authorisation.rb
+++ b/app/models/journeys/further_education_payments/provider/authorisation.rb
@@ -30,15 +30,19 @@ module Journeys
         end
 
         def organisation_matches?
+          # FIXME RL temp returning `true` until we've added school to the FE
+          # eligibility
+          return true
+
           answers.dfe_sign_in_organisation_ukprn == answers.claim.school.ukprn
         end
 
-        # FIXME RL: need to find out what the role codes should be
         def service_access?
-          answers.dfe_sign_in_organisation_role_codes.include?("claim_verifier_access")
+          answers.dfe_sign_in_organisation_role_codes.include?(
+            CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE
+          )
         end
       end
     end
   end
 end
-

--- a/app/models/journeys/further_education_payments/provider/authorisation.rb
+++ b/app/models/journeys/further_education_payments/provider/authorisation.rb
@@ -2,19 +2,18 @@ module Journeys
   module FurtherEducationPayments
     module Provider
       class Authorisation
-        attr_reader :answers
+        include ActiveModel::Model
 
-        def initialize(answers)
+        def initialize(answers:, slug:)
           @answers = answers
+          @slug = slug
         end
 
-        def authorised?(slug)
-          return false if failure_reason(slug).present?
-
-          true
+        def authorised?
+          failure_reason.nil?
         end
 
-        def failure_reason(slug)
+        def failure_reason
           return :not_signed_in unless signed_in?
           return :no_service_access unless service_access?
           return :organisation_mismatch unless organisation_matches?
@@ -23,6 +22,8 @@ module Journeys
         end
 
         private
+
+        attr_reader :answers, :slug
 
         def signed_in?
           answers.dfe_sign_in_uid.present?

--- a/app/models/journeys/further_education_payments/provider/eligibility_checker.rb
+++ b/app/models/journeys/further_education_payments/provider/eligibility_checker.rb
@@ -1,0 +1,8 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class EligibilityChecker < Journeys::EligibilityChecker
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/provider/session.rb
+++ b/app/models/journeys/further_education_payments/provider/session.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class Session < Journeys::Session
+        attribute :answers, SessionAnswersType.new
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/provider/session_answers.rb
+++ b/app/models/journeys/further_education_payments/provider/session_answers.rb
@@ -1,0 +1,18 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class SessionAnswers < Journeys::SessionAnswers
+        # There's a lot of shared answers this journey's answers doesn't need
+        # maybe split out another base class?
+        attribute :claim_id, :string # UUID id of claim we're verifying
+        attribute :dfe_sign_in_uid, :string
+        attribute :dfe_sign_in_organisation_ukprn, :string
+        attribute :dfe_sign_in_organisation_role_codes, default: []
+
+        def claim
+          @claim ||= Claim.includes(eligibility: :current_school).find(claim_id)
+        end
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/provider/session_answers_type.rb
+++ b/app/models/journeys/further_education_payments/provider/session_answers_type.rb
@@ -1,0 +1,7 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class SessionAnswersType < ::Journeys::SessionAnswersType; end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/provider/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/provider/slug_sequence.rb
@@ -5,10 +5,15 @@ module Journeys
         SLUGS = %w[
           sign-in
           verify-claim
+          authorisation-failure
         ]
 
         AUTHORISED_SLUGS = %w[
           verify-claim
+        ]
+
+        DEAD_END_SLUGS = %w[
+          authorisation-failure
         ]
 
         def self.verify_claim_url(claim)
@@ -33,10 +38,15 @@ module Journeys
 
         # May use different auth depending on slug
         def authorisation_start(slug)
+          "sign-in"
         end
 
         def requires_authorisation?(slug)
           AUTHORISED_SLUGS.include?(slug)
+        end
+
+        def dead_end_slugs
+          DEAD_END_SLUGS
         end
       end
     end

--- a/app/models/journeys/further_education_payments/provider/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/provider/slug_sequence.rb
@@ -1,0 +1,44 @@
+module Journeys
+  module FurtherEducationPayments
+    module Provider
+      class SlugSequence
+        SLUGS = %w[
+          sign-in
+          verify-claim
+        ]
+
+        AUTHORISED_SLUGS = %w[
+          verify-claim
+        ]
+
+        def self.verify_claim_url(claim)
+          Rails.application.routes.url_helpers.landing_page_path(
+            journey: module_parent::ROUTING_NAME,
+            claim_id: claim.id
+          )
+        end
+
+        # FIXME required but doesn't do any good without the claim
+        def self.start_page_url
+          Rails.application.routes.url_helpers.landing_page_path("further-education-payments-provider")
+        end
+
+        def initialize(journey_session)
+          @journey_session = journey_session
+        end
+
+        def slugs
+          SLUGS
+        end
+
+        # May use different auth depending on slug
+        def authorisation_start(slug)
+        end
+
+        def requires_authorisation?(slug)
+          AUTHORISED_SLUGS.include?(slug)
+        end
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/provider/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/provider/slug_sequence.rb
@@ -17,9 +17,11 @@ module Journeys
         ]
 
         def self.verify_claim_url(claim)
-          Rails.application.routes.url_helpers.landing_page_path(
-            journey: module_parent::ROUTING_NAME,
-            claim_id: claim.id
+          Rails.application.routes.url_helpers.new_claim_path(
+            module_parent::ROUTING_NAME,
+            answers: {
+              claim_id: claim.id
+            }
           )
         end
 

--- a/app/models/journeys/page_sequence.rb
+++ b/app/models/journeys/page_sequence.rb
@@ -5,6 +5,8 @@ module Journeys
   class PageSequence
     attr_reader :current_slug
 
+    delegate :requires_authorisation?, :authorisation_start, to: :@slug_sequence
+
     DEAD_END_SLUGS = %w[complete existing-session eligible-later future-eligibility ineligible]
     OPTIONAL_SLUGS = %w[postcode-search select-home-address reset-claim]
 

--- a/app/models/journeys/page_sequence.rb
+++ b/app/models/journeys/page_sequence.rb
@@ -48,7 +48,7 @@ module Journeys
     end
 
     def has_completed_journey_until?(slug)
-      return true if DEAD_END_SLUGS.include?(slug)
+      return true if dead_end_slugs.include?(slug)
       incomplete_slugs.empty?
     end
 
@@ -126,6 +126,10 @@ module Journeys
 
     def journey_ineligible?
       @journey_ineligible ||= journey::EligibilityChecker.new(journey_session: @journey_session).ineligible?
+    end
+
+    def dead_end_slugs
+      DEAD_END_SLUGS + @slug_sequence.dead_end_slugs
     end
   end
 end

--- a/app/views/further_education_payments/provider/claims/authorisation_failure.html.erb
+++ b/app/views/further_education_payments/provider/claims/authorisation_failure.html.erb
@@ -1,0 +1,6 @@
+<% case params[:reason] %>
+<% when "no_service_access" %>
+  You do not have access to verify claims for this organisation
+<% else %>
+  <% fail "unknown reason" %>
+<% end %>

--- a/app/views/further_education_payments/provider/claims/sign_in.html.erb
+++ b/app/views/further_education_payments/provider/claims/sign_in.html.erb
@@ -1,0 +1,1 @@
+<%= button_to "Sign in", "/further-education-payments-provider/auth/dfe_fe_provider" %>

--- a/app/views/further_education_payments/provider/claims/sign_in.html.erb
+++ b/app/views/further_education_payments/provider/claims/sign_in.html.erb
@@ -1,1 +1,1 @@
-<%= button_to "Sign in", "/further-education-payments-provider/auth/dfe_fe_provider" %>
+<%= button_to "Start now", "/further-education-payments-provider/auth/dfe_fe_provider" %>

--- a/app/views/further_education_payments/provider/claims/verify_claim.html.erb
+++ b/app/views/further_education_payments/provider/claims/verify_claim.html.erb
@@ -1,0 +1,1 @@
+Verifiy claim form

--- a/app/views/further_education_payments/provider/claims/verify_claim.html.erb
+++ b/app/views/further_education_payments/provider/claims/verify_claim.html.erb
@@ -1,1 +1,1 @@
-Verifiy claim form
+Verify claim form

--- a/app/views/further_education_payments/provider/landing_page.html.erb
+++ b/app/views/further_education_payments/provider/landing_page.html.erb
@@ -1,0 +1,4 @@
+<%= button_to(
+  "Start now",
+  claim_path(current_journey_routing_name, "claim", answers: { claim_id: params[:claim_id] })
+) %>

--- a/app/views/further_education_payments/provider/landing_page.html.erb
+++ b/app/views/further_education_payments/provider/landing_page.html.erb
@@ -1,4 +1,1 @@
-<%= button_to(
-  "Start now",
-  claim_path(current_journey_routing_name, "claim", answers: { claim_id: params[:claim_id] })
-) %>
+You need to use the link from the email

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -49,7 +49,7 @@ module ::OneLoginSignIn
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  if false && DfESignIn.bypass?
+  if DfESignIn.bypass?
     provider :developer
   else
     # FIXME RL: Check this doesn't allow FE providers to login

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1073,6 +1073,10 @@ en:
         By submitting this you are confirming that, to the best of your knowledge, the details you are providing are
         correct.
       btn_text: Accept and send
+  further_education_payments_provider:
+    journey_name: Claim incentive payments for further education teachers - provider
+    feedback_email: "FE-Levellingup.PremiumPayments@education.gov.uk"
+    support_email_address: "FE-Levellingup.PremiumPayments@education.gov.uk"
   early_years_payment_provider:
     claim_description: for an early years financial incentive payment
     journey_name: Claim an early years financial incentive payment - provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   root to: redirect(Rails.application.config.guidance_url)
 
   get "/claim/auth/tid/callback", to: "omniauth_callbacks#callback"
+  get "/further-education-payments-provider/auth/callback", to: "omniauth_callbacks#further_education_payments_provider"
   get "/auth/failure", to: "omniauth_callbacks#failure"
   get "/auth/onelogin", to: "omniauth_callbacks#onelogin"
   if OneLoginSignIn.bypass?

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       routing_name { Journeys::FurtherEducationPayments::ROUTING_NAME }
     end
 
+    trait :further_education_payments_provider do
+      routing_name { Journeys::FurtherEducationPayments::Provider::ROUTING_NAME }
+    end
+
     trait :early_years_payment_provider do
       routing_name { Journeys::EarlyYearsPayment::Provider::ROUTING_NAME }
     end

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -5,15 +5,9 @@ RSpec.feature "Provider verifying claims" do
     create(:journey_configuration, :further_education_payments_provider)
   end
 
-  xscenario "claim has already been approved"
-
-  xscenario "Problem with the service"
-
   scenario "Provider without access visits email link" do
-    # Given I have DSI permission to verify claims for "College A"
     fe_provider = create(:school, :further_education, name: "Springfield A&M")
 
-    # And there is a claim for "College A"
     claim = create(
       :claim,
       first_name: "Edna",
@@ -60,17 +54,9 @@ RSpec.feature "Provider verifying claims" do
     expect(page).to have_button("Sign in")
   end
 
-  xscenario "Provider with access to service but for the wrong organisation"
-
-  xscenario "User with no organisation in in FE provider group"
-
-  xscenario "DfE staff visits the approval link"
-
   scenario "provider approves the claim" do
-    # Given I have DSI permission to verify claims for "College A"
     fe_provider = create(:school, :further_education, name: "Springfield A&M")
 
-    # And there is a claim for "College A"
     claim = create(
       :claim,
       first_name: "Edna",
@@ -79,12 +65,6 @@ RSpec.feature "Provider verifying claims" do
       reference: "AB123456",
       created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
     )
-
-    # create(
-    #   :further_education_payments_eligibility,
-    #   current_school: fe_provider,
-    #   claim: claim
-    # )
 
     mock_dfe_sign_in_auth_session(
       provider: :dfe_fe_provider,
@@ -115,55 +95,6 @@ RSpec.feature "Provider verifying claims" do
 
     click_on "Sign in"
 
-    # When I complete the approval form
-    expect(page).to have_text("Claim reference AB123456")
-    expect(page).to have_text("Claimant name Edna Krabappel")
-    expect(page).to have_text("Claimant date of birth 3 July 1945")
-    expect(page).to have_text("Claimant teacher reference number (TRN) 1234567")
-    expect(page).to have_text("Claim date 1 August 2024")
-
-    choose(
-      "Yes",
-      from: "Does Edna Krabappel have a permanent contract of employment at Springfield A&M?"
-    )
-
-    choose(
-      "Yes",
-      from: "Is Edna Krabappel a member of staff with teaching responsibilities?"
-    )
-
-    choose(
-      "No",
-      from: "Is Edna Krabappel in the first 5 years of their further education teaching career in England?"
-    )
-
-    choose(
-      "Yes",
-      from: "Is Edna Krabappel timetabled to teach an average of 12 hours per week during the current term?"
-    )
-
-    choose(
-      "Yes",
-      from: "For at least half of their timetabled teaching hours, does Edna Krabappel teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
-    )
-
-    choose(
-      "Yes",
-      from: "For at least half of their timetabled teaching hours, does Edna Krabappel teach: qualifications approved for funding at level 3 and below in the engineering (opens in a new tab) sector subject area?"
-    )
-
-    check(
-      "To the best of my knowledge, I confirm that the information provided in this form is correct."
-    )
-
-    # Then I see a confirmation screen that the claim has been approved
-    expect(page).to have_text(
-      "Verification complete Claim reference number AB123456"
-    )
-
-    # And my FE provider receives an email confirming the claim has been approved
-    expect("???").to have_received_email(
-      "Verification form AB123456 has been submitted for Edna Krabappel"
-    )
+    expect(page).to have_text "Verify claim form"
   end
 end

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -44,14 +44,23 @@ RSpec.feature "Provider verifying claims" do
 
     click_on "Start now"
 
-    click_on "Sign in"
-
     expect(page).to have_text("You do not have access to verify claims for this organisation")
 
     # Attempt to skip to authorised page
     visit claim_path(journey: "further-education-payments-provider", slug: "verify-claim")
 
-    expect(page).to have_button("Sign in")
+    expect(page).to have_button("Start now")
+
+    # Sign in with access
+    stub_dfe_sign_in_user_info_request(
+      "11111",
+      "22222",
+      Journeys::FurtherEducationPayments::Provider::CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE
+    )
+
+    click_on "Start now"
+
+    expect(page).to have_text "Verify claim form"
   end
 
   scenario "provider approves the claim" do
@@ -92,8 +101,6 @@ RSpec.feature "Provider verifying claims" do
     visit claim_link
 
     click_on "Start now"
-
-    click_on "Sign in"
 
     expect(page).to have_text "Verify claim form"
   end

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.feature "Provider verifying claims" do
+  before do
+    create(:journey_configuration, :further_education_payments_provider)
+  end
+
+  xscenario "claim has already been approved"
+
+  xscenario "Problem with the service"
+
+  scenario "Provider skips a head" do
+    claim = create(
+      :claim,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+    )
+
+    claim_link = Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
+
+    visit claim_link
+
+    click_on "Start now"
+
+    expect(page).to have_button("Sign in")
+
+    # Attempt to skip signing in
+    visit claim_path(journey: "further-education-payments-provider", slug: "verify-claim")
+
+    expect(page).to have_button("Sign in")
+  end
+
+  scenario "Provider without access visits email link" do
+    # Given I have DSI permission to verify claims for "College A"
+    fe_provider = create(:school, :further_education, name: "Springfield A&M")
+
+    # And there is a claim for "College A"
+    claim = create(
+      :claim,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+    )
+
+    mock_dfe_sign_in_auth_session(
+      provider: :dfe_fe_provider,
+      auth_hash: {
+        uid: "11111",
+        extra: {
+          raw_info: {
+            organisation: {
+              id: "22222",
+              ukprn: fe_provider.ukprn
+            }
+          }
+        }
+      }
+    )
+
+    stub_dfe_sign_in_user_info_request(
+      "11111",
+      "22222",
+      "no-access-role-code"
+    )
+
+    claim_link = Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
+
+    visit claim_link
+
+    click_on "Start now"
+
+    click_on "Sign in"
+
+    expect(page).to have_text("You do not have access to verify claims for this organisation")
+  end
+
+  xscenario "Provider with access to service but for the wrong organisation"
+
+  xscenario "User with no organisation in in FE provider group"
+
+  xscenario "DfE staff visits the approval link"
+
+  scenario "provider approves the claim" do
+    # Given I have DSI permission to verify claims for "College A"
+    fe_provider = create(:school, :further_education, name: "Springfield A&M")
+
+    # And there is a claim for "College A"
+    claim = create(
+      :claim,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+    )
+
+    # create(
+    #   :further_education_payments_eligibility,
+    #   current_school: fe_provider,
+    #   claim: claim
+    # )
+
+    mock_dfe_sign_in_auth_session(
+      provider: :dfe_fe_provider,
+      auth_hash: {
+        uid: "11111",
+        extra: {
+          raw_info: {
+            organisation: {
+              id: "22222",
+              ukprn: fe_provider.ukprn
+            }
+          }
+        }
+      }
+    )
+
+    stub_dfe_sign_in_user_info_request(
+      "11111",
+      "22222",
+      Journeys::FurtherEducationPayments::Provider::CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE
+    )
+
+    claim_link = Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
+
+    visit claim_link
+
+    click_on "Start now"
+
+    click_on "Sign in"
+
+    # When I complete the approval form
+    expect(page).to have_text("Claim reference AB123456")
+    expect(page).to have_text("Claimant name Edna Krabappel")
+    expect(page).to have_text("Claimant date of birth 3 July 1945")
+    expect(page).to have_text("Claimant teacher reference number (TRN) 1234567")
+    expect(page).to have_text("Claim date 1 August 2024")
+
+    choose(
+      "Yes",
+      from: "Does Edna Krabappel have a permanent contract of employment at Springfield A&M?"
+    )
+
+    choose(
+      "Yes",
+      from: "Is Edna Krabappel a member of staff with teaching responsibilities?"
+    )
+
+    choose(
+      "No",
+      from: "Is Edna Krabappel in the first 5 years of their further education teaching career in England?"
+    )
+
+    choose(
+      "Yes",
+      from: "Is Edna Krabappel timetabled to teach an average of 12 hours per week during the current term?"
+    )
+
+    choose(
+      "Yes",
+      from: "For at least half of their timetabled teaching hours, does Edna Krabappel teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
+    )
+
+    choose(
+      "Yes",
+      from: "For at least half of their timetabled teaching hours, does Edna Krabappel teach: qualifications approved for funding at level 3 and below in the engineering (opens in a new tab) sector subject area?"
+    )
+
+    check(
+      "To the best of my knowledge, I confirm that the information provided in this form is correct."
+    )
+
+    # Then I see a confirmation screen that the claim has been approved
+    expect(page).to have_text(
+      "Verification complete Claim reference number AB123456"
+    )
+
+    # And my FE provider receives an email confirming the claim has been approved
+    expect("???").to have_received_email(
+      "Verification form AB123456 has been submitted for Edna Krabappel"
+    )
+  end
+end

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -9,30 +9,6 @@ RSpec.feature "Provider verifying claims" do
 
   xscenario "Problem with the service"
 
-  scenario "Provider skips a head" do
-    claim = create(
-      :claim,
-      first_name: "Edna",
-      surname: "Krabappel",
-      date_of_birth: Date.new(1945, 7, 3),
-      reference: "AB123456",
-      created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
-    )
-
-    claim_link = Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
-
-    visit claim_link
-
-    click_on "Start now"
-
-    expect(page).to have_button("Sign in")
-
-    # Attempt to skip signing in
-    visit claim_path(journey: "further-education-payments-provider", slug: "verify-claim")
-
-    expect(page).to have_button("Sign in")
-  end
-
   scenario "Provider without access visits email link" do
     # Given I have DSI permission to verify claims for "College A"
     fe_provider = create(:school, :further_education, name: "Springfield A&M")
@@ -77,6 +53,11 @@ RSpec.feature "Provider verifying claims" do
     click_on "Sign in"
 
     expect(page).to have_text("You do not have access to verify claims for this organisation")
+
+    # Attempt to skip to authorised page
+    visit claim_path(journey: "further-education-payments-provider", slug: "verify-claim")
+
+    expect(page).to have_button("Sign in")
   end
 
   xscenario "Provider with access to service but for the wrong organisation"

--- a/spec/lib/dfe_sign_in/authenticated_session_spec.rb
+++ b/spec/lib/dfe_sign_in/authenticated_session_spec.rb
@@ -6,7 +6,18 @@ RSpec.describe DfeSignIn::AuthenticatedSession do
   let(:role_codes) { ["role_code"] }
 
   describe "initialising with an auth hash" do
-    let(:auth_hash) { dfe_sign_in_auth_hash(user_id, organisation_id) }
+    let(:auth_hash) do
+      dfe_sign_in_auth_hash(
+        uid: user_id,
+        extra: {
+          raw_info: {
+            organisation: {
+              id: organisation_id
+            }
+          }
+        }
+      )
+    end
 
     subject(:authenticated_session) { DfeSignIn::AuthenticatedSession.from_auth_hash(auth_hash) }
 


### PR DESCRIPTION
# Attempt at introducing "authorised slugs" to the claims controller.
I wanted to get some example tests passing (see the specs in this pr) to make sure the api for authorised slugs actually worked so there's a bit of noise in this PR to set up the FE provider journey too.
(this is just a spike, the code in this pr needs a bunch of clean up!)

(alternative approach https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3074)

## General idea is
* Introduce a method on the slug sequence that determines if a given slug requires authorisation
* Introduce a `journey::Authorisation` class that takes the `SessionAnswers` and a `slug` and returns whether or not access to the slug is authorised.
* Introduce a method on the slug sequence for where to redirect the user for authorisation
* Introduce a call back on the claims controller that guards the "authorised slugs"

## Review notes
I'd start reviewing this feature in the `app/controllers/concerns/authorised_slugs.rb` concern. We have to call methods on the page sequence [¹](#one) as the slug_sequence isn't available in the controller, the page_sequence just delegates these methods to the slug_sequence (this is not ideal). For other omni auth style authentication this should work ok (send the user to a slug with a form that POSTs to the correct path to kick off the omni auth journey, see `app/views/further_education_payments/provider/claims/sign_in.html.erb`). For magic link based authentication I guess this slug could show a page to resend the verification email (if the user is already authorised before trying to visit an "authorised slug" they wouldn't hit this page).
There's also some tests (spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb) which check the happy and unhappy journeys.

## The general flow through the auth code for FE provider is
### Happy path
* Hit the landing page from the link in the email (app/views/further_education_payments/provider/landing_page.html.erb)
* POST to `ClaimsController#create` action [²](#two)
* Get redirected to the next_slug which in this case is "sign-in" (app/views/further_education_payments/provider/claims/sign_in.html.erb)
* "sign-in" POSTs to DfE Sign in
* Get redirected to the `OmniauthCallbacksController#futher_education_payments_provider` action (app/controllers/omniauth_callbacks_controller.rb)
* Get redirected to the `verify-claim` slug
* `ClaimsController#authorise_slug!` checks the `journey::Authorisation#authorised?` method which returns true
* `verify-claim` slug is rendered

### Unhappy path - skipping a head when unauthorised
* Hit the landing page from the link in the email (app/views/further_education_payments/provider/landing_page.html.erb)
* POST to `ClaimsController#create` action [²](#two)
* Get redirected to the next_slug which in this case is "sign-in" (app/views/further_education_payments/provider/claims/sign_in.html.erb)
* "sign-in" POSTs to DfE Sign in
* Get redirected to the `OmniauthCallbacksController#futher_education_payments_provider` action (app/controllers/omniauth_callbacks_controller.rb)
* Get redirected to the "authorisation-failure" slug with the failure reason as a param
* `"authorisation-failure"` is a "dead end slug" so we pass the `ClaimsController#check_page_is_in_sequence` check (app/models/journeys/page_sequence.rb)
* render the `authorisation-failure` page with the text for the failure reason
* If the user then tries to visit `verify-claim` directly
* `ClaimsController#authorise_slug!` checks the `journey::Authorisation#authorised?` method which returns false
* redirected to `page_sequence.authorisation_start` which returns `sign-in`


## Landing page issue
The approach in this PR introduces _two_ additional screens that are not in the prototype.
* Landing page
* Button to kick off the DSI journey

In the [prototype](https://fe-claim-lup-further-education-dc844b88474d.herokuapp.com) the claimant clicks the link from the email and starts their journey on the DSI page.
We can't redirect the user to DSI as we need to send a POST request to kick off the oauth flow so we need to introduce at minimum one screen that has a form on it (this could be the landing page screen).
There are a couple of approaches to set up the data we need to approve the claim (capture the claim id from the url) and send the user off to DSI.

### Approach taken in this PR
* Landing page captures the claim_id and POSTs the claim_id off to the `ClaimsController` where the journey session is created.
* First page of the journey is the `sign-in` page which shows a "sign in" `button_to` DSI

### Creating the session when the claimant submits the claim
* When the claimant submits the claim create the journey session for the verifier
* Email link contains the journey session id rather than the claim id
* Update the claims controller to allow finding the journey session from a url param
* Landing page redirect is skipped as we already have a journey session
* Only one additional page needed to POST the user to DSI

### Modifying the landing page controller
* Landing page controller creates the journey session with the claim id from the params
* Landing page shows a button to POST to DSI
* When coming back to claims controller landing page redirect is skipped as we already have a journey session

### Other
There's various other ways we could do this which would bigger changes to the claims controller or journey specific exemptions to the redirect to landing page logic or the creating a journey session logic.

```ruby
module Journeys
  module SomeJourney
    class ClaimsController < ClaimsController
      # journey specific stuff goes here
    end
  end
end
```
🤔 

## Thoughts
While this general approach is workable, and we will at some point need the idea of restricting journeys behind authorisation, I think the FE provider journey is more similar to an admin approving a claim than a claimant submitting a claim [3](#three). Another option I considered was introducing the concept of a "third party" verifier with it's own controller that looks up a verification form for a given journey, and a third party verifier session controller to handle authorising third party verifiers / approvers (could use different auth mechanism per journey). This would also allow us to support an "index" page of claims that a given verifier needs to approve, which could be linked off the DfE Sign In manage service url. This saves adding additional complexity to the claims controller, and while the approach in this pr seems to work for the FE provider journey we don't yet know exactly what we need for authorising slugs for other journeys.

---

<span id="one">1.)</span> We should consider refactoring how the slug redirection works, it's tricky to determine where you'll actually end up when visiting a given slug. Ideally there would just be one class that returns the slug the user should be one and we could remove the "authorised slugs" call back from the controller as this class would handle checking for authorised slugs.

<span id="two">2.)</span> JourneySessions are created in the `persist_claim` callback that runs before the `new` and `create` action. I think we could simplify the code quite a bit, and better support passing parameters to the new journey sessions, by changing the "Start now" buttons on the landing pages, to `POST` to the `ClaimsController#create` action, lose the `persist_claim` callback, and not have to create records with a `GET` request.

<span id="three">3.)</span> Like the admin claim tasks we need to authenticate a user, show them information about a claim and have them answer yes/no questions. There's a bunch of code the ClaimsController expects to be present when adding a journey that isn't really needed for the FE provider to review a claim, I don't think we really need the journey session, slug sequence, etc, we just need a verification form.