### PR TITLE
Add maintenance window for DfE Analytics

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -52,6 +52,8 @@ DfE::Analytics.configure do |config|
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
 
-  # FIXME: remove this line once the window has passed
+  if Rails.env.development? && DateTime.now > DateTime.new(2024, 8, 9, 11, 0, 0)
+    fail "FIXME: remove the line below once the window has passed"
+  end
   config.bigquery_maintenance_window = "09-08-2024 10:00..09-08-2024 11:00"
 end

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -51,4 +51,7 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
+
+  # FIXME: remove this line once the window has passed
+  config.bigquery_maintenance_window = "09-08-2024 10:00..09-08-2024 11:00"
 end


### PR DESCRIPTION
Per @ericaporter:

> Hi Steve, would you be able to help me set a maintenance window on Claim so that we can do some CMEK encrypting of the Big Query production events table? This is part of the ongoing BQ assurance work, we were able to encrypt all other Claims tables week before last, but we want to stop events streaming to the production tables before we do those.