### PR TITLE
Authorisation spike 2

### DIFF
--- a/app/controllers/concerns/third_party_authorised.rb
+++ b/app/controllers/concerns/third_party_authorised.rb
@@ -1,0 +1,33 @@
+module ThirdPartyAuthorised
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!
+    before_action :authorise_user!
+
+    def authenticate_user!
+      return if third_party_session.signed_in?
+
+      session[:after_sign_in_path] = request.path
+
+      redirect_to new_third_parties_session_path(journey: params[:journey])
+    end
+
+    def authorise_user!
+      return if authorisation.authorised?
+
+      redirect_to third_parties_authorisation_failure_path(
+        authorisation.failure_reason,
+        journey: params[:journey]
+      )
+    end
+
+    def authorisation
+      @authorisation ||= journey::ThirdPartyAuthorisation.new(
+        user: third_party_session,
+        record: claim
+      )
+    end
+  end
+end
+

--- a/app/controllers/concerns/third_party_authorised.rb
+++ b/app/controllers/concerns/third_party_authorised.rb
@@ -1,3 +1,20 @@
+# Expects a journey two define two classes
+# `SomeJourney::ThirdPartySession`
+#    This class needs to implement a class method `.from_session`
+#    which will be passed the contents of the controller session,
+#    a `to_h` instance method which returns a hash of what to store in the
+#    session, and a `signed_in?` instance method which returns a boolean.
+#
+# `SomeJourney::ThirdPartyAuthorisation`
+#    This class is passed `SomeJourney::ThirdPartySession` and the current
+#    record to authorised.
+#    It should implement an instance method `authorised?` which returns a
+#    boolean and `failure_reason` which returns the reason for authorisation
+#    failure.
+#
+#    The including controller needs to implement a `record_to_authorise` method
+#    The return value from this method will be passed to the
+#    `ThirdPartyAuthorisation` class
 module ThirdPartyAuthorised
   extend ActiveSupport::Concern
 
@@ -25,7 +42,7 @@ module ThirdPartyAuthorised
     def authorisation
       @authorisation ||= journey::ThirdPartyAuthorisation.new(
         user: third_party_session,
-        record: claim
+        record: record_to_authorise
       )
     end
   end

--- a/app/controllers/third_parties/authorisation_failures_controller.rb
+++ b/app/controllers/third_parties/authorisation_failures_controller.rb
@@ -1,0 +1,29 @@
+module ThirdParties
+  class AuthorisationFailuresController < ApplicationController
+    include DfE::Analytics::Requests
+    include HttpAuthConcern
+
+    before_action :add_view_paths
+
+    def show
+      @reason = params[:reason]
+    end
+
+    private
+
+    def journey
+      @journey ||= Journeys.for_routing_name(params[:journey])
+    end
+
+    def add_view_paths
+      prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
+    end
+
+    def current_journey_routing_name
+      journey::ROUTING_NAME
+    end
+
+    helper_method :current_journey_routing_name
+  end
+end
+

--- a/app/controllers/third_parties/authorisation_failures_controller.rb
+++ b/app/controllers/third_parties/authorisation_failures_controller.rb
@@ -1,29 +1,8 @@
 module ThirdParties
-  class AuthorisationFailuresController < ApplicationController
-    include DfE::Analytics::Requests
-    include HttpAuthConcern
-
-    before_action :add_view_paths
-
+  class AuthorisationFailuresController < BaseController
     def show
       @reason = params[:reason]
     end
-
-    private
-
-    def journey
-      @journey ||= Journeys.for_routing_name(params[:journey])
-    end
-
-    def add_view_paths
-      prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
-    end
-
-    def current_journey_routing_name
-      journey::ROUTING_NAME
-    end
-
-    helper_method :current_journey_routing_name
   end
 end
 

--- a/app/controllers/third_parties/base_controller.rb
+++ b/app/controllers/third_parties/base_controller.rb
@@ -1,0 +1,30 @@
+module ThirdParties
+  class BaseController < ApplicationController
+    include DfE::Analytics::Requests
+    include HttpAuthConcern
+
+    before_action :add_view_paths
+
+    private
+
+    def third_party_session
+      @third_party_session ||= journey::ThirdPartySession.from_session(
+        session[journey::ThirdPartySession.session_key] || {}
+      )
+    end
+
+    def journey
+      @journey ||= Journeys.for_routing_name(params[:journey])
+    end
+
+    def add_view_paths
+      prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
+    end
+
+    def current_journey_routing_name
+      journey::ROUTING_NAME
+    end
+
+    helper_method :current_journey_routing_name
+  end
+end

--- a/app/controllers/third_parties/claims/verifications_controller.rb
+++ b/app/controllers/third_parties/claims/verifications_controller.rb
@@ -38,6 +38,10 @@ module ThirdParties
       def claim
         @claim ||= Claim.find(params[:claim_id])
       end
+
+      def record_to_authorise
+        claim
+      end
     end
   end
 end

--- a/app/controllers/third_parties/claims/verifications_controller.rb
+++ b/app/controllers/third_parties/claims/verifications_controller.rb
@@ -1,12 +1,8 @@
 module ThirdParties
   module Claims
-    class VerificationsController < ApplicationController
-      include DfE::Analytics::Requests
-      include HttpAuthConcern
+    class VerificationsController < BaseController
+      include ThirdPartyAuthorised
 
-      before_action :add_view_paths
-      before_action :authenticate_user!
-      before_action :authorise_user!
       before_action :setup_form
 
       def show
@@ -32,36 +28,6 @@ module ThirdParties
 
       private
 
-      def authenticate_user!
-        return if third_party_session.signed_in?
-
-        session[:after_sign_in_path] = request.path
-
-        redirect_to new_third_parties_session_path(journey: params[:journey])
-      end
-
-      def authorise_user!
-        return if authorisation.authorised?
-
-        redirect_to third_parties_authorisation_failure_path(
-          authorisation.failure_reason,
-          journey: params[:journey]
-        )
-      end
-
-      def authorisation
-        @authorisation ||= journey::ThirdPartyAuthorisation.new(
-          user: third_party_session,
-          record: claim
-        )
-      end
-
-      def third_party_session
-        @third_party_session ||= journey::ThirdPartySession.from_session(
-          session[journey::ThirdPartySession.session_key] || {}
-        )
-      end
-
       def setup_form
         @form = journey::ThirdPartyVerificationForm.new(
           claim: claim,
@@ -72,20 +38,6 @@ module ThirdParties
       def claim
         @claim ||= Claim.find(params[:claim_id])
       end
-
-      def journey
-        @journey ||= Journeys.for_routing_name(params[:journey])
-      end
-
-      def add_view_paths
-        prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
-      end
-
-      def current_journey_routing_name
-        journey::ROUTING_NAME
-      end
-
-      helper_method :current_journey_routing_name
     end
   end
 end

--- a/app/controllers/third_parties/claims/verifications_controller.rb
+++ b/app/controllers/third_parties/claims/verifications_controller.rb
@@ -1,0 +1,92 @@
+module ThirdParties
+  module Claims
+    class VerificationsController < ApplicationController
+      include DfE::Analytics::Requests
+      include HttpAuthConcern
+
+      before_action :add_view_paths
+      before_action :authenticate_user!
+      before_action :authorise_user!
+      before_action :setup_form
+
+      def show
+        # render success page
+      end
+
+      def new
+        # render form to verify the claim
+      end
+
+      def create
+        if @form.save
+          redirect_to(
+            third_parties_claims_verification_path(
+              claim_id: claim.id,
+              journey: params[:journey]
+            )
+          )
+        else
+          render :new
+        end
+      end
+
+      private
+
+      def authenticate_user!
+        return if third_party_session.signed_in?
+
+        session[:after_sign_in_path] = request.path
+
+        redirect_to new_third_parties_session_path(journey: params[:journey])
+      end
+
+      def authorise_user!
+        return if authorisation.authorised?
+
+        redirect_to third_parties_authorisation_failure_path(
+          authorisation.failure_reason,
+          journey: params[:journey]
+        )
+      end
+
+      def authorisation
+        @authorisation ||= journey::ThirdPartyAuthorisation.new(
+          user: third_party_session,
+          record: claim
+        )
+      end
+
+      def third_party_session
+        @third_party_session ||= journey::ThirdPartySession.from_session(
+          session[journey::ThirdPartySession.session_key] || {}
+        )
+      end
+
+      def setup_form
+        @form = journey::ThirdPartyVerificationForm.new(
+          claim: claim,
+          params: params
+        )
+      end
+
+      def claim
+        @claim ||= Claim.find(params[:claim_id])
+      end
+
+      def journey
+        @journey ||= Journeys.for_routing_name(params[:journey])
+      end
+
+      def add_view_paths
+        prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
+      end
+
+      def current_journey_routing_name
+        journey::ROUTING_NAME
+      end
+
+      helper_method :current_journey_routing_name
+    end
+  end
+end
+

--- a/app/controllers/third_parties/sessions_controller.rb
+++ b/app/controllers/third_parties/sessions_controller.rb
@@ -1,10 +1,5 @@
 module ThirdParties
-  class SessionsController < ApplicationController
-    include DfE::Analytics::Requests
-    include HttpAuthConcern
-
-    before_action :add_view_paths
-
+  class SessionsController < BaseController
     def new
     end
 
@@ -19,22 +14,6 @@ module ThirdParties
 
       redirect_to session.delete(:after_sign_in_path)
     end
-
-    private
-
-    def journey
-      @journey ||= Journeys.for_routing_name(params[:journey])
-    end
-
-    def add_view_paths
-      prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
-    end
-
-    def current_journey_routing_name
-      journey::ROUTING_NAME
-    end
-
-    helper_method :current_journey_routing_name
   end
 end
 

--- a/app/controllers/third_parties/sessions_controller.rb
+++ b/app/controllers/third_parties/sessions_controller.rb
@@ -1,0 +1,40 @@
+module ThirdParties
+  class SessionsController < ApplicationController
+    include DfE::Analytics::Requests
+    include HttpAuthConcern
+
+    before_action :add_view_paths
+
+    def new
+    end
+
+    def callback
+      third_party_session = journey::ThirdPartySession.from_omniauth(
+        request.env["omniauth.auth"]
+      )
+
+      # Ideally we'd have a record in the db but can get away without one
+      # so long as we're not storing too much in the session.
+      session[journey::ThirdPartySession.session_key] = third_party_session.to_h
+
+      redirect_to session.delete(:after_sign_in_path)
+    end
+
+    private
+
+    def journey
+      @journey ||= Journeys.for_routing_name(params[:journey])
+    end
+
+    def add_view_paths
+      prepend_view_path(Rails.root.join("app", "views", journey::VIEW_PATH))
+    end
+
+    def current_journey_routing_name
+      journey::ROUTING_NAME
+    end
+
+    helper_method :current_journey_routing_name
+  end
+end
+

--- a/app/forms/journeys/further_education_payments/third_party_verification_form.rb
+++ b/app/forms/journeys/further_education_payments/third_party_verification_form.rb
@@ -1,0 +1,18 @@
+module Journeys
+  module FurtherEducationPayments
+    class ThirdPartyVerificationForm
+      include ActiveModel::Model
+
+      def initialize(claim:, params:)
+        @claim = claim
+
+        # super(permitted_params(params)) # permitting params TBD
+        super()
+      end
+
+      def save
+        # ...
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/third_party_authorisation.rb
+++ b/app/models/journeys/further_education_payments/third_party_authorisation.rb
@@ -1,0 +1,43 @@
+module Journeys
+  module FurtherEducationPayments
+    class ThirdPartyAuthorisation
+      def initialize(user:, record:)
+        @user = user
+        @claim = record
+      end
+
+      def authorised?
+        failure_reason.nil?
+      end
+
+      def failure_reason
+        return :no_service_access unless service_access?
+        return :organisation_mismatch unless organisation_matches?
+        nil
+      end
+
+      private
+
+      attr_reader :user, :claim
+
+      def service_access?
+        dfe_sign_in_user.has_role?("claim-verifier")
+      end
+
+      def organisation_matches?
+        # Temp early return until fe claims have a school
+        return true
+
+        claim.school.ukprn == dfe_sign_in_user.organisation_ukprn
+      end
+
+      def dfe_sign_in_user
+        @dfe_sign_in_user ||= DfeSignIn::Api::User.new(
+          organisation_id: user.organisation_id,
+          organisation_ukprn: user.organisation_ukprn,
+          user_id: user.uid
+        )
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/third_party_session.rb
+++ b/app/models/journeys/further_education_payments/third_party_session.rb
@@ -1,0 +1,45 @@
+module Journeys
+  module FurtherEducationPayments
+    class ThirdPartySession
+      def self.session_key
+        "further_education_payments_third_party_session"
+      end
+
+      def self.from_omniauth(auth_hash)
+        new(
+          organisation_id: auth_hash.extra.raw_info.organisation.id,
+          organisation_ukprn: auth_hash.extra.raw_info.organisation.ukprn,
+          uid: auth_hash.uid
+        )
+      end
+
+      def self.from_session(hash)
+        new(
+          organisation_id: hash["organisation_id"],
+          organisation_ukprn: hash["organisation_ukprn"],
+          uid: hash["uid"]
+        )
+      end
+
+      attr_reader :organisation_id, :organisation_ukprn, :uid
+
+      def initialize(organisation_id:, organisation_ukprn:, uid:)
+        @organisation_id = organisation_id
+        @organisation_ukprn = organisation_ukprn
+        @uid = uid
+      end
+
+      def to_h
+        {
+          organisation_id: organisation_id,
+          organisation_ukprn: organisation_ukprn,
+          uid: uid
+        }
+      end
+
+      def signed_in?
+        uid.present?
+      end
+    end
+  end
+end

--- a/app/views/further_education_payments/third_parties/authorisation_failures/show.html.erb
+++ b/app/views/further_education_payments/third_parties/authorisation_failures/show.html.erb
@@ -1,0 +1,6 @@
+<% case @reason %>
+<% when %>
+  <%# use reason to look up i18n key %>
+  You do not have access to verify claims for this organisation
+<% else %>
+<% end %>

--- a/app/views/further_education_payments/third_parties/claims/verifications/new.html.erb
+++ b/app/views/further_education_payments/third_parties/claims/verifications/new.html.erb
@@ -1,0 +1,1 @@
+Verify claim form goes here

--- a/app/views/further_education_payments/third_parties/sessions/new.html.erb
+++ b/app/views/further_education_payments/third_parties/sessions/new.html.erb
@@ -1,0 +1,1 @@
+<%= button_to "Start now", "/further-education-payments/third-parties/sessions/auth/dfe_fe_provider" %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -13,6 +13,8 @@ dfe_sign_in_issuer_uri = ENV["DFE_SIGN_IN_ISSUER"].present? ? URI(ENV["DFE_SIGN_
 
 if ENV["DFE_SIGN_IN_REDIRECT_BASE_URL"].present?
   dfe_sign_in_redirect_uri = URI.join(ENV["DFE_SIGN_IN_REDIRECT_BASE_URL"], "/admin/auth/callback")
+
+  dfe_sign_in_fe_provider_redirect_uri = URI.join(ENV["DFE_SIGN_IN_REDIRECT_BASE_URL"], "/further-education-payments/third-parties/sessions/callback")
 end
 
 tid_sign_in_endpoint_uri = ENV["TID_SIGN_IN_API_ENDPOINT"].present? ? URI(ENV["TID_SIGN_IN_API_ENDPOINT"]) : nil
@@ -50,6 +52,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   if DfESignIn.bypass?
     provider :developer
   else
+    # FIXME RL: Check this doesn't allow FE providers to login
     provider :openid_connect, {
       name: :dfe,
       discovery: true,
@@ -64,6 +67,26 @@ Rails.application.config.middleware.use OmniAuth::Builder do
         identifier: ENV["DFE_SIGN_IN_IDENTIFIER"],
         secret: ENV["DFE_SIGN_IN_SECRET"],
         redirect_uri: dfe_sign_in_redirect_uri&.to_s
+      },
+      issuer:
+        ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)
+    }
+
+    # FIXME RL Need to handle sign out depending on the journey the user is on
+    provider :openid_connect, {
+      name: :dfe_fe_provider,
+      discovery: true,
+      response_type: :code,
+      scope: %i[openid email organisation],
+      callback_path: "/further-education-payments/third-parties/sessions/callback",
+      path_prefix:  "/further-education-payments/third-parties/sessions/auth",
+      client_options: {
+        port: dfe_sign_in_issuer_uri&.port,
+        scheme: dfe_sign_in_issuer_uri&.scheme,
+        host: dfe_sign_in_issuer_uri&.host,
+        identifier: ENV["DFE_SIGN_IN_IDENTIFIER"],
+        secret: ENV["DFE_SIGN_IN_SECRET"],
+        redirect_uri: dfe_sign_in_fe_provider_redirect_uri&.to_s
       },
       issuer:
         ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,19 @@ Rails.application.routes.draw do
       resources :reminders, only: [:show, :update], param: :slug, constraints: {slug: %r{#{Journeys::AdditionalPaymentsForTeaching::SlugSequence::REMINDER_SLUGS.join("|")}}}, controller: "journeys/additional_payments_for_teaching/reminders"
     end
 
+    scope constraints: {journey: "further-education-payments"} do
+      namespace :third_parties, only: [] do
+        resources :sessions, only: [:new, :create]
+        resources :authorisation_failures, only: [:show], param: :reason
+        resources :claims, only: [] do
+          resources :verifications, only: [:show, :new, :create], module: "claims"
+        end
+      end
+
+      get "verify-claim/:claim_id", to: "third_parties/claims/verifications#new"
+      get "third-parties/sessions/callback", to: "third_parties/sessions#callback"
+    end
+
     scope path: "/", constraints: {journey: Regexp.new(Journeys.all_routing_names.join("|"))} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end

--- a/lib/dfe_sign_in/api/user.rb
+++ b/lib/dfe_sign_in/api/user.rb
@@ -7,6 +7,7 @@ module DfeSignIn
       attr_accessor :organisation_id,
         :user_id,
         :organisation_name,
+        :organisation_ukprn,
         :given_name,
         :family_name,
         :email
@@ -47,6 +48,7 @@ module DfeSignIn
       def initialize(attrs)
         self.organisation_id = attrs[:organisation_id]
         self.organisation_name = attrs[:organisation_name]
+        self.organisation_ukprn = attrs[:organisation_ukprn]
         self.user_id = attrs[:user_id]
         self.given_name = attrs[:given_name]
         self.family_name = attrs[:family_name]

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       routing_name { Journeys::FurtherEducationPayments::ROUTING_NAME }
     end
 
+    trait :further_education_payments_provider do
+      routing_name { Journeys::FurtherEducationPayments::Provider::ROUTING_NAME }
+    end
+
     trait :early_years_payment_provider do
       routing_name { Journeys::EarlyYearsPayment::Provider::ROUTING_NAME }
     end

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.feature "Provider verifying claims" do
+  before do
+    #create(:journey_configuration, :further_education_payments_provider)
+  end
+
+  scenario "Provider without access visits email link" do
+    fe_provider = create(:school, :further_education, name: "Springfield A&M")
+
+    claim = create(
+      :claim,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+    )
+
+    mock_dfe_sign_in_auth_session(
+      provider: :dfe_fe_provider,
+      auth_hash: {
+        uid: "11111",
+        extra: {
+          raw_info: {
+            organisation: {
+              id: "22222",
+              ukprn: fe_provider.ukprn
+            }
+          }
+        }
+      }
+    )
+
+    stub_dfe_sign_in_user_info_request(
+      "11111",
+      "22222",
+      "no-access-role-code"
+    )
+
+    claim_link = "/further-education-payments/verify-claim/#{claim.id}"
+
+    visit claim_link
+
+    click_on "Start now"
+
+    expect(page).to have_text("You do not have access to verify claims for this organisation")
+
+    # Attempt to skip to authorised page
+    visit "/further-education-payments/third_parties/claims/#{claim.id}/verifications/new"
+
+    expect(page).to have_text("You do not have access to verify claims for this organisation")
+  end
+
+  scenario "provider approves the claim" do
+    fe_provider = create(:school, :further_education, name: "Springfield A&M")
+
+    claim = create(
+      :claim,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+    )
+
+    mock_dfe_sign_in_auth_session(
+      provider: :dfe_fe_provider,
+      auth_hash: {
+        uid: "11111",
+        extra: {
+          raw_info: {
+            organisation: {
+              id: "22222",
+              ukprn: fe_provider.ukprn
+            }
+          }
+        }
+      }
+    )
+
+    stub_dfe_sign_in_user_info_request(
+      "11111",
+      "22222",
+      "claim-verifier"
+    )
+
+    claim_link = "/further-education-payments/verify-claim/#{claim.id}"
+
+    visit claim_link
+
+    click_on "Start now"
+
+    expect(page).to have_text "Verify claim form"
+  end
+end

--- a/spec/lib/dfe_sign_in/authenticated_session_spec.rb
+++ b/spec/lib/dfe_sign_in/authenticated_session_spec.rb
@@ -6,7 +6,18 @@ RSpec.describe DfeSignIn::AuthenticatedSession do
   let(:role_codes) { ["role_code"] }
 
   describe "initialising with an auth hash" do
-    let(:auth_hash) { dfe_sign_in_auth_hash(user_id, organisation_id) }
+    let(:auth_hash) do
+      dfe_sign_in_auth_hash(
+        uid: user_id,
+        extra: {
+          raw_info: {
+            organisation: {
+              id: organisation_id
+            }
+          }
+        }
+      )
+    end
 
     subject(:authenticated_session) { DfeSignIn::AuthenticatedSession.from_auth_hash(auth_hash) }
 


### PR DESCRIPTION
# An alternative approach from [this pr](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3070) for third parties to verify claims

(this is just a spike, I think some of the name spacing could be improved, and I'm not sold on "third parties" as the name for external approvers, and there's a bunch of shared code we could clean up.

## Reasoning
Third parties verifying claims feels quite a lot like the admin approving claims feature. We present a page of questions about an existing claim to a user, who we need to authenticate.
This pr proposes an new concept of a "third party verifier" to approve claims for journeys that require it.

We introduce three new controllers
* third_parties/claims/verifications - for handling the actual approval of a claim
* third_parties/sessions - for authenticating the third party
* third_parties/authorisation_failures - for displaying the reason authentication failed

Each journey will define it's own logic for
* verification views
* authentication views
* authorisation failure views
* serialising / deserialising the third party "user" from the session
* verification form
* authorisation logic

## Notes for review
Best to start reviewing in the third_parties/claims/verifications_controller#new action as that's where the journey kicks off. The two tests in this pr `spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb` pass so you can pull this code down and drop some `binding.pry`s in to get a feel for how this works.

## Happy path
* user visits the link to verify a form
* they land on the Claims::VerificationsController
* they're not signed in so they're kicked to the session controller's new action
* for FE SessionController#new renders a form to post to DfE Sign in
* user is redirected to SessionController#callback
* we capture details from oauth into the session
* we redirect the user back to the Claims::VerificationsController
* we check the user's authorisation
* we render the form for them to approve the claim

## Notes
We've namespaced verifications under claims as there needs to be a claim for them to verify, sessions aren't namespaces under claims as they're not specific to verifying a claim, and we may in future want to support other third party use cases, eg a controller that shows claims awaiting verification. A bunch of shared logic around what journey we're on can be pulled out into a shared controller. We should name space the models better eg `Journeys::FurtherEducationPayments::ThirdParties::Claims::VerificationForm` rather than `Journeys::FurtherEducationPayments:: ThirdPartyVerificationForm` (I was doing this quickly!)

*Note* we're relying on the session being tamper proof!
