### PR TITLE
[LUPEYALPHA-842] EY send another link

### DIFF
--- a/app/controllers/claims_form_callbacks.rb
+++ b/app/controllers/claims_form_callbacks.rb
@@ -64,6 +64,11 @@ module ClaimsFormCallbacks
     end
   end
 
+  def check_your_email_after_form_save_success
+    @email_resent = true
+    render("check_your_email")
+  end
+
   private
 
   def set_backlink_override_to_current_slug

--- a/app/models/journeys/early_years_payment/provider/start.rb
+++ b/app/models/journeys/early_years_payment/provider/start.rb
@@ -11,7 +11,8 @@ module Journeys
         POLICIES = [Policies::EarlyYearsPayments]
         FORMS = {
           "claims" => {
-            "email-address" => EmailAddressForm
+            "email-address" => EmailAddressForm,
+            "check-your-email" => EmailAddressForm
           }
         }
       end

--- a/app/models/journeys/page_sequence.rb
+++ b/app/models/journeys/page_sequence.rb
@@ -5,7 +5,7 @@ module Journeys
   class PageSequence
     attr_reader :current_slug
 
-    DEAD_END_SLUGS = %w[complete existing-session eligible-later future-eligibility ineligible]
+    DEAD_END_SLUGS = %w[complete existing-session eligible-later future-eligibility ineligible check-your-email]
     OPTIONAL_SLUGS = %w[postcode-search select-home-address reset-claim]
 
     def initialize(slug_sequence, completed_slugs, current_slug, journey_session)

--- a/app/views/early_years_payment/provider/start/claims/check_your_email.html.erb
+++ b/app/views/early_years_payment/provider/start/claims/check_your_email.html.erb
@@ -1,10 +1,13 @@
 <% content_for(:page_title, page_title(t("early_years_payment_provider_start.check_your_email_page.title"), journey: current_journey_routing_name)) %>
 
-<div class="govuk-grid-row">
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb|
-        nb.with_heading(text: "Email sent to #{journey_session.answers.email_address}")
-      end %>
+<% @backlink_path = claim_path(current_journey_routing_name, "email-address") %>
 
+<div class="govuk-grid-row">
+  <% if @email_resent %>
+    <%= govuk_notification_banner(title_text: "Success", success: true) do |nb|
+          nb.with_heading(text: "Email sent to #{journey_session.answers.email_address}")
+        end %>
+  <% end %>
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       Check your email
@@ -20,7 +23,7 @@
 
     <p class="govuk-body">
       If you do not receive the email, check your spam or junk folder.
-      If you cannot find the email, <%= govuk_link_to "send another link", "" %> or <%= govuk_link_to "enter another email address", @backlink_path %>.
+      If you cannot find the email, <%= govuk_link_to "send another link", method: :patch %> or <%= govuk_link_to "enter another email address", @backlink_path %>.
     </p>
   </div>
 </div>

--- a/spec/features/early_years_payment/provider/start/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/start/happy_path_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature "Early years payment provider" do
   let(:mail) { ActionMailer::Base.deliveries.last }
   let(:magic_link) { mail[:personalisation].unparsed_value[:magic_link] }
 
+  def number_of_emails_sent
+    ActionMailer::Base.deliveries.count { |mail| mail.to == ["johndoe@example.com"] }
+  end
+
   scenario "start - enter email, get magic link" do
     when_early_years_payment_provider_start_journey_configuration_exists
     when_eligible_ey_provider_exists
@@ -18,11 +22,9 @@ RSpec.feature "Early years payment provider" do
     click_on "Submit"
 
     expect(page.title).to have_text("Check your email")
-    within ".govuk-notification-banner--success" do
-      expect(page).to have_content("Email sent to johndoe@example.com")
-    end
     expect(page).to have_content("Check your email")
     expect(page).to have_content("We have sent an email to johndoe@example.com")
+    expect(page).not_to have_css ".govuk-notification-banner--success"
 
     expect(mail.to).to eq ["johndoe@example.com"]
     expect(magic_link).to match(/\?code=\d{6}&/)
@@ -45,5 +47,36 @@ RSpec.feature "Early years payment provider" do
     expect(page).to have_content("We have sent an email to janedoe@example.com")
 
     expect(mail.to).to eq ["janedoe@example.com"]
+  end
+
+  scenario "send another link" do
+    when_early_years_payment_provider_start_journey_configuration_exists
+    when_eligible_ey_provider_exists
+
+    visit landing_page_path(Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME)
+    click_link "Start now"
+
+    fill_in "Email address", with: "johndoe@example.com"
+    click_on "Submit"
+    click_link "send another link"
+
+    within ".govuk-notification-banner--success" do
+      expect(page).to have_content("Email sent to johndoe@example.com")
+    end
+
+    expect(number_of_emails_sent).to eq 2
+
+    click_link "send another link"
+
+    within ".govuk-notification-banner--success" do
+      expect(page).to have_content("Email sent to johndoe@example.com")
+    end
+    expect(number_of_emails_sent).to eq 3
+
+    visit claim_path(Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME, :claim)
+    choose "Continue with the eligibility check that you have already started"
+    click_on "Continue"
+    expect(page.title).to have_text("Check your email")
+    expect(page).to have_content("Check your email")
   end
 end


### PR DESCRIPTION
<!-- Do you need to update CHANGELOG.md? -->
The notification banner does not show in the normal flow (enter email -> check your email page),
but if the user clicks 'send another link', then the banner shows.