### PR TITLE
Persist TRN on eligibility for FE journey

### DIFF
--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -4,7 +4,9 @@ module Journeys
       private
 
       def main_eligibility
-        @main_eligibility ||= Policies::FurtherEducationPayments::Eligibility.new
+        @main_eligibility ||= Policies::FurtherEducationPayments::Eligibility.new(
+          teacher_reference_number: @journey_session.answers.teacher_reference_number
+        )
       end
 
       def calculate_award_amount(eligibility)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -115,5 +115,7 @@
   - teacher_reference_number
   :student_loans_eligibilities:
   - teacher_reference_number
+  :further_education_payments_eligibilities:
+  - teacher_reference_number
   :journeys_sessions:
   - answers

--- a/db/migrate/20240812123209_add_trn_to_fe_eligibilities.rb
+++ b/db/migrate/20240812123209_add_trn_to_fe_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddTrnToFeEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :further_education_payments_eligibilities, :teacher_reference_number, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_08_153424) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_12_123209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -217,6 +217,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_08_153424) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "award_amount", precision: 7, scale: 2
+    t.text "teacher_reference_number"
   end
 
   create_table "international_relocation_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -172,7 +172,20 @@ RSpec.feature "Further education payments" do
     click_on "Continue"
 
     expect(page).to have_content("Check your answers before sending your application")
-    click_on "Accept and send"
+
+    expect do
+      click_on "Accept and send"
+    end.to change { Claim.count }.by(1)
+      .and change { Policies::FurtherEducationPayments::Eligibility.count }.by(1)
+
+    claim = Claim.last
+
+    expect(claim.first_name).to eql("John")
+    expect(claim.surname).to eql("Doe")
+
+    eligibility = Policies::FurtherEducationPayments::Eligibility.last
+
+    expect(eligibility.teacher_reference_number).to eql("1234567")
 
     expect(page).to have_content("You applied for a further education retention payment")
   end


### PR DESCRIPTION
# Context

- For FE journey when claim is submitted we need to store optional TRN on the `Policies::FurtherEducationPayments::Eligibility` record