### PR TITLE
Remove debug rescue

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -37,8 +37,6 @@ class OmniauthCallbacksController < ApplicationController
     core_identity_jwt = auth.extra.raw_info[ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY]
     return process_one_login_identity_verification_callback(core_identity_jwt) if core_identity_jwt
     process_one_login_authentication_callback(auth)
-  rescue Rack::OAuth2::Client::Error => e
-    render plain: e.message
   end
 
   private


### PR DESCRIPTION
# Context

- We are silently catching an exception and displaying it back to the user
- This was likely debug code and don't want this to happen under normal circumstances
- We want this exception to bubble up and be caught thru usual means
