### PR TITLE
Pass parameters to sesson creation

### DIFF
--- a/app/controllers/concerns/journey_concern.rb
+++ b/app/controllers/concerns/journey_concern.rb
@@ -45,12 +45,7 @@ module JourneyConcern
   end
 
   def create_journey_session!
-    journey_session = journey::Session.create!(
-      journey: current_journey_routing_name,
-      answers: {
-        academic_year: journey_configuration.current_academic_year
-      }
-    )
+    journey_session = journey::SessionForm.create!(params)
 
     session[journey_session_key] = journey_session.id
 

--- a/app/forms/journeys/additional_payments_for_teaching/session_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/session_form.rb
@@ -1,0 +1,5 @@
+module Journeys
+  module AdditionalPaymentsForTeaching
+    class SessionForm < Journeys::SessionForm; end
+  end
+end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/session_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/session_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      module Authenticated
+        class SessionForm < Journeys::SessionForm; end
+      end
+    end
+  end
+end

--- a/app/forms/journeys/early_years_payment/provider/start/session_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/start/session_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      module Start
+        class SessionForm < Journeys::SessionForm; end
+      end
+    end
+  end
+end

--- a/app/forms/journeys/further_education_payments/session_form.rb
+++ b/app/forms/journeys/further_education_payments/session_form.rb
@@ -1,0 +1,5 @@
+module Journeys
+  module FurtherEducationPayments
+    class SessionForm < Journeys::SessionForm; end
+  end
+end

--- a/app/forms/journeys/get_a_teacher_relocation_payment/session_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/session_form.rb
@@ -1,0 +1,5 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class SessionForm < Journeys::SessionForm; end
+  end
+end

--- a/app/forms/journeys/session_form.rb
+++ b/app/forms/journeys/session_form.rb
@@ -1,0 +1,43 @@
+module Journeys
+  class SessionForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    def self.create!(params)
+      new(params).tap(&:save!).journey_session
+    end
+
+    attr_reader :journey_session
+
+    def initialize(params)
+      super(permitted_params(params))
+    end
+
+    def save!
+      @journey_session = journey::Session.create!(
+        journey: journey::ROUTING_NAME,
+        answers: answers.reverse_merge(
+          academic_year: journey.configuration.current_academic_year
+        )
+      )
+
+      true
+    end
+
+    private
+
+    def journey
+      self.class.module_parent
+    end
+
+    def answers
+      attributes.to_h
+    end
+
+    def permitted_params(params)
+      params.fetch(:answers, {})
+        .slice(*self.class.attribute_names)
+        .permit(*self.class.attribute_names)
+    end
+  end
+end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/session_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/session_form.rb
@@ -1,0 +1,5 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class SessionForm < Journeys::SessionForm; end
+  end
+end


### PR DESCRIPTION
On some journeys we'll want to be able to set answers based on url
parameters when starting a journey. This commit adds support for setting
answers when creating a session introducing a journey session form. The
session form is passed the parameters and subclasses of the form permit
various parameters based on their attributes.

---

In the specific case of the further education payments provider journey, the provider starts the journey by following a link with the claim id in it, we need to capture this claim id in the journey session when we create it.
For reference here is the session form for the FE provider journey:

```ruby
module Journeys
  module FurtherEducationPayments
    module Provider
      class SessionForm < Journeys::SessionForm
        attribute :claim_id, :string
      end
    end
  end
end
```

---

Currently `create_journey_session!` is called by a call back before the `ClaimsController#new` action runs. Ideally we'd update the landing pages for each journey to `POST` to the `ClaimsController#create` action and create the journey session there or, better still, have a separate `JourneysController` which handles all the setup actions for a journey and the `ClaimsController` can always assume one exists. Something for the backlog.