### PR TITLE
Bug - Improve name format regex

### DIFF
--- a/app/models/name_format_validator.rb
+++ b/app/models/name_format_validator.rb
@@ -1,5 +1,5 @@
 class NameFormatValidator < ActiveModel::EachValidator
-  NAME_REGEX_FILTER = /\A[^"=$%#&*+\/\\()@?!<>0-9]*\z/
+  NAME_REGEX_FILTER = /\A[^\[\]\^"=$%#&*+\/\\()@?!<>_`|{}~0-9]*\z/
 
   def validate_each(record, attribute, value)
     return unless value.present?

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/claimant_name_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/claimant_name_form_spec.rb
@@ -23,13 +23,15 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimantNam
     # First name validations
     it { should validate_presence_of(:first_name).with_message("Enter employee’s first name") }
     it { should validate_length_of(:first_name).is_at_most(100).with_message("Employee’s first name must be less than 100 characters") }
-    it { should_not allow_value("*").for(:first_name).with_message("Employee’s first name cannot contain special characters") }
     it { should allow_value("O'Brian").for(:first_name) }
+    %w[* | { ^ /].each do |char|
+      it { should_not allow_value(char).for(:first_name).with_message("Employee’s first name cannot contain special characters") }
+    end
 
     # Surname validations
     it { should validate_presence_of(:surname).with_message("Enter employee’s last name") }
     it { should validate_length_of(:surname).is_at_most(100).with_message("Employee’s last name must be less than 100 characters") }
-    it { should_not allow_value("$").for(:surname).with_message("Employee’s last name cannot contain special characters") }
+    it { should_not allow_value("5").for(:surname).with_message("Employee’s last name cannot contain special characters") }
     it { should allow_value("O'Brian").for(:surname) }
   end
 


### PR DESCRIPTION
## Context

As per this comment: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3092#discussion_r1716900855

We realised that the following special characters were still being allowed in name fields:

```
[]^_`|{}~
```

## Changes in this PR

Update the regex to exclude these characters too.

## Guidance to review

Business review - are any of these characters supposed to be allowed for any reason?