### PR TITLE
[LUPEYALPHA-851] One login DID

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -24,6 +24,7 @@ TID_SIGN_IN_CLIENT_ID=claim
 
 ONELOGIN_SIGN_IN_ISSUER=https://oidc.integration.account.gov.uk/
 ONELOGIN_REDIRECT_BASE_URL=http://localhost:3000
+ONELOGIN_DID_URL=https://identity.integration.account.gov.uk/.well-known/did.json
 
 CANONICAL_HOSTNAME=localhost:3000
 EY_MAGIC_LINK_SECRET=some-secret-for-ey-magic-link

--- a/.env.test
+++ b/.env.test
@@ -39,6 +39,7 @@ TID_SIGN_IN_CLIENT_ID=claim
 
 BYPASS_ONELOGIN_SIGN_IN=true
 ONELOGIN_SIGN_IN_ISSUER=https://oidc.integration.account.gov.uk/
+ONELOGIN_DID_URL=https://identity.integration.account.gov.uk/.well-known/did.json
 
 CANONICAL_HOSTNAME=www.example.com
 

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -93,9 +93,8 @@ class OmniauthCallbacksController < ApplicationController
       first_name = "TEST"
       surname = "USER"
     else
-      identity_jwt_public_key = OpenSSL::PKey::EC.new(Base64.decode64(ENV["ONELOGIN_IDENTITY_JWT_PUBLIC_KEY_BASE64"]))
-      decoded_jwt = JSON::JWT.decode(jwt, identity_jwt_public_key)
-      name_parts = decoded_jwt["vc"]["credentialSubject"]["name"][0]["nameParts"]
+      decoded_jwt = OneLogin::CoreIdentityValidator.new(jwt:).call
+      name_parts = decoded_jwt[0]["vc"]["credentialSubject"]["name"][0]["nameParts"]
       first_name = name_parts.find { |part| part["type"] == "GivenName" }["value"]
       surname = name_parts.find { |part| part["type"] == "FamilyName" }["value"]
     end

--- a/app/models/one_login/core_identity_validator.rb
+++ b/app/models/one_login/core_identity_validator.rb
@@ -1,0 +1,21 @@
+class OneLogin::CoreIdentityValidator
+  attr_reader :jwt
+
+  def initialize(jwt:)
+    @jwt = jwt
+  end
+
+  def call
+    JWT.decode(jwt, nil, true, algorithms:, jwks:)
+  end
+
+  private
+
+  def algorithms
+    OneLogin::DidCache.document.algorithms
+  end
+
+  def jwks
+    OneLogin::DidCache.document.jwks
+  end
+end

--- a/app/models/one_login/did.rb
+++ b/app/models/one_login/did.rb
@@ -1,0 +1,19 @@
+class OneLogin::Did
+  attr_reader :document_hash
+
+  def initialize(document_hash:)
+    @document_hash = document_hash
+  end
+
+  def context
+    document_hash["@context"]
+  end
+
+  def id
+    document_hash["id"]
+  end
+
+  def assertion_methods
+    document_hash["assertionMethod"]
+  end
+end

--- a/app/models/one_login/did_cache.rb
+++ b/app/models/one_login/did_cache.rb
@@ -1,0 +1,102 @@
+require "json"
+require "net/http"
+
+class OneLogin::DidCache
+  # public api to use document
+  # if document not present it will fetch
+  # if it determines document has expired it will first refresh the document
+  def self.document
+    @cache ||= new
+
+    @cache.document
+  end
+
+  def self.clear_cache!
+    @cache ||= new
+    @cache.clear_cache!
+  end
+
+  def self.cache
+    @cache
+  end
+
+  attr_reader :document_object, :expires_at
+
+  def initialize(document_object: nil, expires_at: nil)
+    @document_object = document_object
+    @expires_at = expires_at
+  end
+
+  def expired?
+    return true if expires_at.nil?
+
+    Time.now > expires_at
+  end
+
+  def clear_cache!
+    @document_object = nil
+  end
+
+  def document
+    if document_object.nil?
+      refresh_document
+    end
+
+    if expired?
+      refresh_document
+    end
+
+    document_object
+  end
+
+  private
+
+  def did_uri
+    URI(ENV["ONELOGIN_DID_URL"])
+  end
+
+  # explicitly read the cached document
+  def cached_document
+    @document_object
+  end
+
+  def refresh_document
+    response = Net::HTTP.get_response(did_uri)
+
+    if response.is_a?(Net::HTTPSuccess)
+      new_doc = OneLogin::Did.new(document_hash: JSON.parse(response.body))
+      set_expiry_from_response(response)
+      @document_object = new_doc
+    else
+      increment_expiry
+    end
+  end
+
+  def increment_expiry
+    current_expiry = expires_at || Time.now
+    new_expiry = current_expiry + 1.hour
+
+    @expires_at = new_expiry
+  end
+
+  def set_expiry_from_response(response)
+    new_expiry = Time.now + cache_control_max_age(response).seconds
+
+    @expires_at = new_expiry
+  end
+
+  # seconds
+  def cache_control_max_age(response)
+    if response["Cache-Control"]
+      matches = response["Cache-Control"].match(/max-age=(?<max_age>\d+)/)
+      matches[:max_age].to_i
+    else
+      default_cache_control_max_age
+    end
+  end
+
+  # seconds
+  def default_cache_control_max_age
+    3600
+  end
+end

--- a/spec/models/one_login/core_identity_validator_spec.rb
+++ b/spec/models/one_login/core_identity_validator_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe OneLogin::CoreIdentityValidator do
+  before do
+    OneLogin::DidCache.clear_cache!
+  end
+
+  let(:jwt) do
+    "eyJraWQiOiJkaWQ6d2ViOmlkZW50aXR5LmludGVncmF0aW9uLmFjY291bnQuZ292LnVrI2M5ZjhkYTFjODc1MjViYjQxNjUzNTgzYzJkMDUyNzRlODU4MDVhYjdkMGFiYzU4Mzc2YzcxMjgxMjlkYWE5MzYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOmVOaEd2dWFtZXZYUXVGcVVSdDdPTjZsZHZMQU5SSExqZS1hU2lUWWtRUVUiLCJhdWQiOiJQU1RSRG1QRXFtTkhWalZHV0d3OTk0bk4xY0EiLCJuYmYiOjE3MjM1NDg3NTEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE3MjM1NTA1NTEsImlhdCI6MTcyMzU0ODc1MSwidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJLRU5ORVRIIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJERUNFUlFVRUlSQSIsInR5cGUiOiJGYW1pbHlOYW1lIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTY1LTA3LTA4In1dfX0sInZ0bSI6Imh0dHBzOi8vb2lkYy5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsifQ.mKZ4BK01BZn1I6ziPB4zdF0o0yIKUC6hU4k8R-qp6khcTXKMgxrPbWRD7CzLae-bst9cp3bFGtbpHzDpX72W3Q"
+  end
+
+  subject { described_class.new(jwt:) }
+
+  describe "#call" do
+    context "when valid" do
+      before do
+        stub_normal_did
+      end
+
+      it "decodes payload corectly" do
+        travel_to(Time.at(1723548751)) do
+          expect(subject.call[0]["vc"]["credentialSubject"]["name"][0]["nameParts"][0]["value"]).to eql("KENNETH")
+        end
+      end
+    end
+
+    context "when bad public key" do
+      before do
+        stub_bad_did
+      end
+
+      it do
+        travel_to(Time.at(1723548751)) do
+          expect { subject.call }.to raise_error(JWT::VerificationError)
+        end
+      end
+    end
+  end
+
+  let(:stub_normal_did) do
+    return_headers = {
+      "Cache-Control" => "max-age=3600, private"
+    }
+
+    return_body = '{
+  "@context" : [ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" ],
+  "id" : "did:web:identity.integration.account.gov.uk",
+  "assertionMethod" : [ {
+    "type" : "JsonWebKey",
+    "id" : "did:web:identity.integration.account.gov.uk#c9f8da1c87525bb41653583c2d05274e85805ab7d0abc58376c7128129daa936",
+    "controller" : "did:web:identity.integration.account.gov.uk",
+    "publicKeyJwk" : {
+      "kty" : "EC",
+      "crv" : "P-256",
+      "x" : "NPGA7cyIKtH1nz2CJIH14s9_CtC93NwdCQcEi-ADvxg",
+      "y" : "2cTdmHAmZjighly34lXcxEw50cbKFV7FTOdZKhOG7ps",
+      "alg" : "ES256"
+    }
+  } ]
+}'
+
+    stub_request(:get, "https://identity.integration.account.gov.uk/.well-known/did.json")
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "identity.integration.account.gov.uk",
+          "User-Agent" => "Ruby"
+        }
+      )
+      .to_return(status: 200, body: return_body, headers: return_headers)
+  end
+
+  let(:stub_bad_did) do
+    return_headers = {
+      "Cache-Control" => "max-age=3600, private"
+    }
+
+    return_body = '{
+  "@context" : [ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" ],
+  "id" : "did:web:identity.integration.account.gov.uk",
+  "assertionMethod" : [ {
+    "type" : "JsonWebKey",
+    "id" : "did:web:identity.integration.account.gov.uk#c9f8da1c87525bb41653583c2d05274e85805ab7d0abc58376c7128129daa936",
+    "controller" : "did:web:identity.integration.account.gov.uk",
+    "publicKeyJwk" : {
+      "kty" : "EC",
+      "crv" : "P-256",
+      "x": "Vm7_Vhz07e9UoblDw1rmd29bV6ykcut4npLnqhhQlVk",
+      "y": "uISs1AK-TVo0duSg3AvFuBNgBPp7ex4dWmYvkFN8uRk",
+      "alg" : "ES256"
+    }
+  } ]
+}'
+
+    stub_request(:get, "https://identity.integration.account.gov.uk/.well-known/did.json")
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "identity.integration.account.gov.uk",
+          "User-Agent" => "Ruby"
+        }
+      )
+      .to_return(status: 200, body: return_body, headers: return_headers)
+  end
+end

--- a/spec/models/one_login/did_cache_spec.rb
+++ b/spec/models/one_login/did_cache_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe OneLogin::DidCache do
+  before do
+    described_class.clear_cache!
+  end
+
+  describe "::document" do
+    context "when there is nothing cached" do
+      before do
+        stub_normal_did
+      end
+
+      it "fetches DID, caches it, returns it" do
+        expect(OneLogin::DidCache.cache.document_object).to be_nil
+
+        expect(described_class.document.id).to eql("did:web:identity.integration.account.gov.uk")
+        expect(described_class.cache.document_object.id).to eql("did:web:identity.integration.account.gov.uk")
+      end
+
+      it "only makes one http request" do
+        3.times do
+          described_class.document
+        end
+
+        expect(stub_normal_did).to have_been_made.once
+      end
+    end
+
+    context "when document is cached" do
+      context "when expired" do
+        before do
+          stub_normal_did
+          described_class.document
+        end
+
+        it "fetches new document" do
+          travel 3.hours do
+            described_class.document
+            expect(stub_normal_did).to have_been_made.twice
+          end
+        end
+      end
+
+      context "when expired and not 200" do
+        before do
+          stub_failure_did
+          described_class.document
+        end
+
+        it "keeps cached version" do
+          travel 3.hours do
+            expect(described_class.document.id).not_to be_nil
+          end
+        end
+
+        it "increments expiry" do
+          travel 3.hours do
+            expect { described_class.cache.document }.to change { described_class.cache.expires_at }.by(1.hour)
+          end
+        end
+      end
+    end
+  end
+
+  def stub_normal_did
+    return_headers = {
+      "Cache-Control" => "max-age=3600, private"
+    }
+
+    return_body = '{
+  "@context" : [ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" ],
+  "id" : "did:web:identity.integration.account.gov.uk",
+  "assertionMethod" : [ {
+    "type" : "JsonWebKey",
+    "id" : "did:web:identity.integration.account.gov.uk#c9f8da1c87525bb41653583c2d05274e85805ab7d0abc58376c7128129daa936",
+    "controller" : "did:web:identity.integration.account.gov.uk",
+    "publicKeyJwk" : {
+      "kty" : "EC",
+      "crv" : "P-256",
+      "x" : "NPGA7cyIKtH1nz2CJIH14s9_CtC93NwdCQcEi-ADvxg",
+      "y" : "2cTdmHAmZjighly34lXcxEw50cbKFV7FTOdZKhOG7ps",
+      "alg" : "ES256"
+    }
+  } ]
+}'
+
+    stub_request(:get, "https://identity.integration.account.gov.uk/.well-known/did.json")
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "identity.integration.account.gov.uk",
+          "User-Agent" => "Ruby"
+        }
+      )
+      .to_return(status: 200, body: return_body, headers: return_headers)
+  end
+
+  def stub_failure_did
+    return_headers = {
+      "Cache-Control" => "max-age=3600, private"
+    }
+
+    return_body = '{
+  "@context" : [ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" ],
+  "id" : "did:web:identity.integration.account.gov.uk",
+  "assertionMethod" : [ {
+    "type" : "JsonWebKey",
+    "id" : "did:web:identity.integration.account.gov.uk#c9f8da1c87525bb41653583c2d05274e85805ab7d0abc58376c7128129daa936",
+    "controller" : "did:web:identity.integration.account.gov.uk",
+    "publicKeyJwk" : {
+      "kty" : "EC",
+      "crv" : "P-256",
+      "x" : "NPGA7cyIKtH1nz2CJIH14s9_CtC93NwdCQcEi-ADvxg",
+      "y" : "2cTdmHAmZjighly34lXcxEw50cbKFV7FTOdZKhOG7ps",
+      "alg" : "ES256"
+    }
+  } ]
+}'
+
+    stub_request(:get, "https://identity.integration.account.gov.uk/.well-known/did.json")
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "identity.integration.account.gov.uk",
+          "User-Agent" => "Ruby"
+        }
+      )
+      .to_return(status: 200, body: return_body, headers: return_headers)
+      .to_return(status: 500, body: "{}", headers: return_headers)
+  end
+end

--- a/spec/models/one_login/did_spec.rb
+++ b/spec/models/one_login/did_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe OneLogin::Did do
+  let(:body) do
+    '{
+  "@context" : [ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" ],
+  "id" : "did:web:identity.integration.account.gov.uk",
+  "assertionMethod" : [ {
+    "type" : "JsonWebKey",
+    "id" : "did:web:identity.integration.account.gov.uk#c9f8da1c87525bb41653583c2d05274e85805ab7d0abc58376c7128129daa936",
+    "controller" : "did:web:identity.integration.account.gov.uk",
+    "publicKeyJwk" : {
+      "kty" : "EC",
+      "crv" : "P-256",
+      "x" : "NPGA7cyIKtH1nz2CJIH14s9_CtC93NwdCQcEi-ADvxg",
+      "y" : "2cTdmHAmZjighly34lXcxEw50cbKFV7FTOdZKhOG7ps",
+      "alg" : "ES256"
+    }
+  } ]
+}'
+  end
+
+  subject { described_class.new(document_hash: JSON.parse(body)) }
+
+  describe "#context" do
+    it "returns context" do
+      expect(subject.context).to eql(["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"])
+    end
+  end
+
+  describe "#id" do
+    it "returns id" do
+      expect(subject.id).to eql("did:web:identity.integration.account.gov.uk")
+    end
+  end
+
+  describe "#assertion_methods" do
+    it "is an collection" do
+      expect(subject.assertion_methods).to be_an(Array)
+    end
+  end
+end

--- a/spec/models/one_login/did_spec.rb
+++ b/spec/models/one_login/did_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe OneLogin::Did do
       expect(subject.assertion_methods).to be_an(Array)
     end
   end
+
+  describe "#algorithms" do
+    it "returns used algorithms" do
+      expect(subject.algorithms).to eql(["ES256"])
+    end
+  end
 end

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -8,6 +8,7 @@ DFE_SIGN_IN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.ser
 BYPASS_ONELOGIN_SIGN_IN: true
 ONELOGIN_SIGN_IN_ISSUER: https://oidc.integration.account.gov.uk/
 ONELOGIN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
+ONELOGIN_DID_URL: https://identity.account.gov.uk/.well-known/did.json
 
 DQT_API_URL: https://teacher-qualifications-api.education.gov.uk/v1
 DQT_BASE_URL: https://api-customerengagement.platform.education.gov.uk/dqt-crm/v1/

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -1,6 +1,7 @@
 ---
 BYPASS_DFE_SIGN_IN: true
 BYPASS_ONELOGIN_SIGN_IN: true
+ONELOGIN_DID_URL: https://identity.integration.account.gov.uk/.well-known/did.json
 
 DFE_SIGN_IN_API_CLIENT_ID: teacherpayments
 DFE_SIGN_IN_API_ENDPOINT: https://pp-api.signin.education.gov.uk

--- a/terraform/application/config/test_app_env.yml
+++ b/terraform/application/config/test_app_env.yml
@@ -7,6 +7,7 @@ DFE_SIGN_IN_REDIRECT_BASE_URL: https://test.claim-additional-teaching-payment.se
 
 ONELOGIN_SIGN_IN_ISSUER: https://oidc.integration.account.gov.uk/
 ONELOGIN_REDIRECT_BASE_URL: https://test.claim-additional-teaching-payment.service.gov.uk
+ONELOGIN_DID_URL: https://identity.integration.account.gov.uk/.well-known/did.json
 
 DQT_API_URL: https://test.teacher-qualifications-api.education.gov.uk/v1
 DQT_BASE_URL: https://test-api-customerengagement.platform.education.gov.uk/dqt-crm/v1/


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-851
- One Login uses a public keys which we use to verify certain JWTs
- These public keys are published in a Decentralized Identifier (DID) document
- The keys in this document are prone to rotation therefore must be handled by us to ensure we have the correct keys in place
- See One Login docs for more info https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#validate-the-core-identity-claim-jwt-using-a-public-key

# Changes

- Remove the hardcoded public key which was held in an environment variable `ONELOGIN_IDENTITY_JWT_PUBLIC_KEY_BASE64`
- Implement a wrapper to hold a DID document
- Implement fetching and caching of DID document, this is cached in memory
- We attempt to respect the caching time provided by the DID doc with its response headers
- If we cannot fetch a new DID doc we will keep the existing cached doc
- If the DID doc has expired we will also attempt to fetch a new doc
- If we cannot fetch a doc due to expiry, we extend the expiry we do not hammer the DID doc store and continue to use the cached doc

# Post deploy tasks

- After deployment the env var `ONELOGIN_IDENTITY_JWT_PUBLIC_KEY_BASE64` will no longer be used and there should be cleaned up from all environments