### PR TITLE
Depending on environment link to correct OL home

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,4 +51,8 @@ module ApplicationHelper
 
     I18n.t("#{policy.locale_key}.information_provided_further_details", link: link)&.html_safe
   end
+
+  def one_login_home_url
+    OneLogin::Config.home_url
+  end
 end

--- a/app/models/one_login/config.rb
+++ b/app/models/one_login/config.rb
@@ -1,0 +1,13 @@
+class OneLogin::Config
+  def self.home_url
+    if integration_env?
+      "https://home.integration.account.gov.uk/"
+    else
+      "https://home.account.gov.uk/"
+    end
+  end
+
+  def self.integration_env?
+    ENV.fetch("ONELOGIN_DID_URL", "").include?("integration")
+  end
+end

--- a/app/views/shared/_one_login_header.html.erb
+++ b/app/views/shared/_one_login_header.html.erb
@@ -57,7 +57,7 @@
       <nav aria-label="GOV.UK One Login menu" class="one-login-header__nav" data-open-class="one-login-header__nav--open" id="one-login-header__nav">
         <ul class="one-login-header__nav__list">
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link one-login-header__nav__link--one-login" href="https://home.account.gov.uk/">
+            <%= link_to one_login_home_url, class: "one-login-header__nav__link one-login-header__nav__link--one-login" do %>
               <span class="one-login-header__nav__link-content">
                 GOV.UK One Login
               </span>
@@ -83,7 +83,7 @@
       </svg>
     </span>
   <!--<![endif]-->
-            </a>
+            <% end %>
           </li>
           <li class="one-login-header__nav__list-item">
             <%= button_to "Sign out", deauth_onelogin_path, method: :delete, class: "one-login-header__nav__link button-to-as-link" %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -79,4 +79,30 @@ describe ApplicationHelper do
       it { is_expected.to eq('For more details, you can read about payments and deductions for the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools#paying-income-tax-and-national-insurance">early-career payment (opens in new tab)</a>') }
     end
   end
+
+  describe "#one_login_home_url" do
+    context "when ONELOGIN_DID_URL env var not present" do
+      it "defaults to production url" do
+        stub_const("ENV", {})
+
+        expect(helper.one_login_home_url).to eql("https://home.account.gov.uk/")
+      end
+    end
+
+    context "when ONELOGIN_DID_URL set to integration value" do
+      it "returns integration url" do
+        stub_const("ENV", {"ONELOGIN_DID_URL" => "https://identity.integration.account.gov.uk/.well-known/did.json"})
+
+        expect(helper.one_login_home_url).to eql("https://home.integration.account.gov.uk/")
+      end
+    end
+
+    context "when ONELOGIN_DID_URL set to production value" do
+      it "returns production url" do
+        stub_const("ENV", {"ONELOGIN_DID_URL" => "https://identity.account.gov.uk/.well-known/did.json"})
+
+        expect(helper.one_login_home_url).to eql("https://home.account.gov.uk/")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

- For one login integration environment there is a separate `home` or account area
- The One Login home link now sends to integration environment if indeed using integration environment