### PR TITLE
[LUPEYALPHA-769] practitioner email address

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/employee_email_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/employee_email_form.rb
@@ -1,0 +1,20 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      module Authenticated
+        class EmployeeEmailForm < Form
+          attribute :practitioner_email_address
+
+          validates :practitioner_email_address, presence: {message: i18n_error_message(:valid)}
+
+          def save
+            return false if invalid?
+
+            journey_session.answers.assign_attributes(practitioner_email_address:)
+            journey_session.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/journeys/early_years_payment/provider/authenticated.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated.rb
@@ -17,7 +17,8 @@ module Journeys
             "claimant-name" => ClaimantNameForm,
             "start-date" => StartDateForm,
             "child-facing" => ChildFacingForm,
-            "returner" => ReturnerForm
+            "returner" => ReturnerForm,
+            "employee-email" => EmployeeEmailForm
           }
         }
         START_WITH_MAGIC_LINK = true

--- a/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
@@ -10,6 +10,7 @@ module Journeys
           attribute :child_facing_confirmation_given, :boolean
           attribute :first_job_within_6_months, :boolean
           attribute :start_date, :date
+          attribute :practitioner_email_address
 
           def policy
             Policies::EarlyYearsPayments

--- a/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
@@ -3,7 +3,7 @@ module Journeys
     module Provider
       module Authenticated
         class SlugSequence
-          SLUGS = %w[
+          ELIGIBILITY_SLUGS = %w[
             consent
             current-nursery
             paye-reference
@@ -12,8 +12,14 @@ module Journeys
             child-facing
             returner
             employee-email
+          ].freeze
+
+          RESULTS_SLUGS = %w[
+            check-your-answers
             ineligible
           ].freeze
+
+          SLUGS = (ELIGIBILITY_SLUGS + RESULTS_SLUGS).freeze
 
           MAGIC_LINK_SLUG = "consent"
 

--- a/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
@@ -3,7 +3,7 @@ module Journeys
     module Provider
       module Authenticated
         class SlugSequence
-          ELIGIBILITY_SLUGS = %w[
+          CLAIM_SLUGS = %w[
             consent
             current-nursery
             paye-reference
@@ -19,7 +19,7 @@ module Journeys
             ineligible
           ].freeze
 
-          SLUGS = (ELIGIBILITY_SLUGS + RESULTS_SLUGS).freeze
+          SLUGS = (CLAIM_SLUGS + RESULTS_SLUGS).freeze
 
           MAGIC_LINK_SLUG = "consent"
 

--- a/app/views/early_years_payment/provider/authenticated/claims/employee_email.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/employee_email.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:page_title, page_title(@form.t(:question, first_name: answers.first_name), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_text_field :practitioner_email_address,
+        label: { text: @form.t(:question, first_name: answers.first_name), tag: "h1", size: "l" },
+        hint: { text: @form.t(:hint) }, spellcheck: "false" %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1163,6 +1163,11 @@ en:
           Did %{first_name} work in an early years setting between %{six_months_before_start_date} and %{start_date}?
         errors:
           inclusion: You must select an option below to continue
+      employee_email:
+        question: What is %{first_name}’s email address?
+        hint: We’ll use this to ask your employee to provide their payment details.
+        errors:
+          valid: Enter a valid email address
   early_years_payments:
     <<: *early_years_payment_provider_authenticated
     claim_subject: "Early Years Payment"

--- a/spec/features/admin/admin_timeout_spec.rb
+++ b/spec/features/admin/admin_timeout_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Admin user session timeout", js: true do
+RSpec.feature "Admin user session timeout", js: true, flaky: true do
   let(:one_second_in_minutes) { 1 / 60.to_f }
   let(:two_seconds_in_minutes) { 2 / 60.to_f }
 

--- a/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
@@ -46,7 +46,12 @@ RSpec.feature "Early years payment provider" do
     expect(page.current_path).to eq "/early-years-payment-provider/returner"
     choose "No"
     click_button "Continue"
+
     expect(page.current_path).to eq "/early-years-payment-provider/employee-email"
+    fill_in "claim-practitioner-email-address-field", with: "practitioner@example.com"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/check-your-answers"
   end
 
   scenario "using magic link after having completed some of the journey" do

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/employee_email_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/employee_email_form_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::EmployeeEmailForm, type: :model do
+  let(:journey) { Journeys::EarlyYearsPayment::Provider::Authenticated }
+  let(:journey_session) { create(:early_years_payment_provider_authenticated_session) }
+  let(:practitioner_email_address) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        practitioner_email_address:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(journey_session:, journey:, params:)
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:practitioner_email_address).with_message("Enter a valid email address") }
+  end
+
+  describe "#save" do
+    let(:practitioner_email_address) { "practitioner@example.com" }
+
+    it "updates the journey session" do
+      expect { subject.save }.to(
+        change { journey_session.answers.practitioner_email_address }.to(practitioner_email_address)
+      )
+    end
+  end
+end


### PR DESCRIPTION
The Employee Email page prompts for an email,
which gets stored as `practitioner_email_address`.