### PR TITLE
[LUPEYALPHA-869] [LUPEYALPHA-870] One login FE failure

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -24,7 +24,16 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   def failure
-    render layout: false
+    case params[:strategy]
+    when "onelogin"
+      render OneLogin::FailureHandler.new(
+        message: params[:message],
+        origin: params[:origin],
+        answers: journey_session.answers
+      ).template
+    else
+      render layout: false
+    end
   end
 
   def onelogin

--- a/app/models/one_login/failure_handler.rb
+++ b/app/models/one_login/failure_handler.rb
@@ -1,0 +1,21 @@
+class OneLogin::FailureHandler
+  attr_reader :message, :origin, :answers
+
+  def initialize(message:, origin:, answers:)
+    @message = message
+    @origin = origin
+    @answers = answers
+  end
+
+  def template
+    if answers.logged_in_with_onelogin
+      "#{journey::VIEW_PATH}_idv_failure"
+    end
+  end
+
+  private
+
+  def journey
+    Journeys::FurtherEducationPayments
+  end
+end

--- a/app/models/one_login/failure_handler.rb
+++ b/app/models/one_login/failure_handler.rb
@@ -8,7 +8,9 @@ class OneLogin::FailureHandler
   end
 
   def template
-    if answers.logged_in_with_onelogin
+    if !answers.logged_in_with_onelogin
+      "#{journey::VIEW_PATH}_auth_failure"
+    elsif answers.logged_in_with_onelogin
       "#{journey::VIEW_PATH}_idv_failure"
     end
   end

--- a/app/views/omniauth_callbacks/further_education_payments_auth_failure.html.erb
+++ b/app/views/omniauth_callbacks/further_education_payments_auth_failure.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:page_title, page_title("Sorry, there is a problem with the service", journey: current_journey_routing_name, show_error: false)) %>
+
+<% @backlink_path = claim_path(journey: current_journey_routing_name, slug: "sign-in") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Sorry, there is a problem with the service
+    </h1>
+
+    <p class="govuk-body">
+      Try again later.
+    </p>
+
+    <p class="govuk-body">
+      Email <%= govuk_link_to "help@opsteam.education.gov.uk", "mailto:help@opsteam.education.gov.uk" %> if you need help.
+    </p>
+
+    <%= govuk_button_link_to "Try again", claim_path(journey: current_journey_routing_name, slug: "sign-in") %>
+  </div>
+</div>

--- a/app/views/omniauth_callbacks/further_education_payments_idv_failure.html.erb
+++ b/app/views/omniauth_callbacks/further_education_payments_idv_failure.html.erb
@@ -1,0 +1,19 @@
+<% content_for(:page_title, page_title("We cannot progress your application", journey: current_journey_routing_name, show_error: false)) %>
+
+<% @backlink_path = claim_path(journey: current_journey_routing_name, slug: "sign-in") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      We cannot progress your application
+    </h1>
+
+    <p class="govuk-body">
+      You need to be able to prove your identity in GOV.UK One Login to continue your application. You can find more information about <%= govuk_link_to "proving your identity", "https://www.gov.uk/using-your-gov-uk-one-login" %> on GOV.UK.
+    </p>
+
+    <p class="govuk-body">
+      If you have any queries about the application process, contact us at <%= govuk_link_to t("further_education_payments.support_email_address"), "mailto:#{t("further_education_payments.support_email_address")}" %>.
+    </p>
+  </div>
+</div>

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -82,7 +82,15 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
         create(:journey_configuration, :further_education_payments)
       end
 
-      context "when onelogin auth fail"
+      context "when onelogin auth fail" do
+        it "renders problem with service page" do
+          get "/further-education-payments/claim"
+
+          get "/auth/failure?message=access_denied&origin=http%3A%2F%2Flocalhost%3A3000%2Ffurther-education-payments%2Fsign-in&strategy=onelogin"
+
+          expect(response.body).to include("Sorry, there is a problem with the service")
+        end
+      end
 
       context "when onelogin idv fail" do
         it "renders cannot progress page" do

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -75,4 +75,28 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
       end
     end
   end
+
+  describe "#failure" do
+    context "FE journey" do
+      before do
+        create(:journey_configuration, :further_education_payments)
+      end
+
+      context "when onelogin auth fail"
+
+      context "when onelogin idv fail" do
+        it "renders cannot progress page" do
+          get "/further-education-payments/claim"
+
+          journey_session = Journeys::FurtherEducationPayments::Session.last
+          journey_session.answers.logged_in_with_onelogin = true
+          journey_session.save!
+
+          get "/auth/failure?message=access_denied&origin=http%3A%2F%2Flocalhost%3A3000%2Ffurther-education-payments%2Fsign-in&strategy=onelogin"
+
+          expect(response.body).to include("We cannot progress your application")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-869
- https://dfedigital.atlassian.net/browse/LUPEYALPHA-870
- Handle failure from One Login auth

# Changes

- When user is not logged in and there is an auth error from one login show `Sorry, there is a problem with the service` page
- When user is logged in and there is an auth error from one login show `We cannot progress your application` page
- Should be relatively trivial to adapt this to handle EY journey too
- Not all parameters passed in are used, but are available should they be needed by the next person