### PR TITLE
One Login save UID + check it

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -65,6 +65,7 @@ class OmniauthCallbacksController < ApplicationController
     onelogin_credentials = auth.credentials
 
     journey_session.answers.assign_attributes(
+      onelogin_uid: auth.uid,
       onelogin_user_info:,
       onelogin_credentials:,
       logged_in_with_onelogin: true

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -38,6 +38,7 @@ module Journeys
     attribute :teacher_id_user_info, default: {}
     attribute :onelogin_user_info, default: {}
     attribute :onelogin_credentials, default: {}
+    attribute :onelogin_uid, :string
     attribute :email_address_check, :boolean
     attribute :mobile_check, :string
     attribute :qualifications_details_check, :boolean

--- a/app/models/one_login/core_identity_validator.rb
+++ b/app/models/one_login/core_identity_validator.rb
@@ -1,15 +1,27 @@
 class OneLogin::CoreIdentityValidator
-  attr_reader :jwt
+  attr_reader :jwt, :decoded_jwt
 
   def initialize(jwt:)
     @jwt = jwt
   end
 
   def call
-    JWT.decode(jwt, nil, true, algorithms:, jwks:)
+    @decoded_jwt ||= JWT.decode(jwt, nil, true, algorithms:, jwks:)
+  end
+
+  def first_name
+    name_parts.find { |part| part["type"] == "GivenName" }["value"]
+  end
+
+  def surname
+    name_parts.find { |part| part["type"] == "FamilyName" }["value"]
   end
 
   private
+
+  def name_parts
+    decoded_jwt[0]["vc"]["credentialSubject"]["name"][0]["nameParts"]
+  end
 
   def algorithms
     OneLogin::DidCache.document.algorithms

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -109,19 +109,18 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
   end
 
   describe "#onelogin" do
-    def set_mock_auth
-      OmniAuth.config.mock_auth[:onelogin] = OmniAuth::AuthHash.new(
+    let(:omniauth_hash) do
+      OmniAuth::AuthHash.new(
         "uid" => "12345",
         "extra" => {
           "raw_info" => {}
         }
       )
-
-      Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:onelogin]
     end
 
     before do
-      set_mock_auth
+      OmniAuth.config.mock_auth[:onelogin] = omniauth_hash
+      Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:onelogin]
 
       allow(OneLoginSignIn).to receive(:bypass?).and_return(false)
 
@@ -129,12 +128,46 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
       get "/further-education-payments/claim"
     end
 
-    it "sets onelogin_uid from omniauth hash" do
-      journey_session = Journeys::FurtherEducationPayments::Session.last
+    context "signing in" do
+      it "sets onelogin_uid from omniauth hash" do
+        journey_session = Journeys::FurtherEducationPayments::Session.last
 
-      expect {
+        expect {
+          get auth_onelogin_path
+        }.to change { journey_session.reload.answers.onelogin_uid }.from(nil).to("12345")
+      end
+    end
+
+    context "idv step" do
+      let(:omniauth_hash) do
+        OmniAuth::AuthHash.new(
+          "uid" => "12345",
+          "extra" => {
+            "raw_info" => {
+              "https://vocab.account.gov.uk/v1/coreIdentityJWT" => ""
+            }
+          }
+        )
+      end
+
+      it "ensure idv matches logged in user" do
+        journey_session = Journeys::FurtherEducationPayments::Session.last
+        journey_session.answers.onelogin_uid = "54321"
+        journey_session.save!
+
+        validator_double = double(
+          OneLogin::CoreIdentityValidator,
+          call: nil,
+          first_name: "John",
+          surname: "Doe"
+        )
+
+        allow(OneLogin::CoreIdentityValidator).to receive(:new).and_return(validator_double)
+
         get auth_onelogin_path
-      }.to change { journey_session.reload.answers.onelogin_uid }.from(nil).to("12345")
+
+        expect(response).to redirect_to("http://www.example.com/auth/failure?strategy=onelogin&message=access_denied&origin=http://www.example.com/further-education-payments/sign-in")
+      end
     end
   end
 end


### PR DESCRIPTION
# Context

- At the moment the One Login UID is not saved in against the record which makes it harder later to marry up accounts
- We also do not check if the user who auth-ed is the same user that passes IDV. This means that potentially one person could auth then use another account to pass IDV.

# Changes

- After the OL auth callback also save their OL UID
- After their IDV callback ensure UID in this callback matches the UID we saved in the auth step