### PR TITLE
Start date validations

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
@@ -8,7 +8,8 @@ module Journeys
           attribute :start_date, :date
 
           validates :start_date, presence: {message: i18n_error_message(:presence)}
-          validate :start_year_has_four_digits, if: -> { start_date.present? }
+          validates :start_date, comparison: {less_than: ->(_) { Date.tomorrow }, message: i18n_error_message(:date_not_in_future)}, if: :start_date
+          validate :start_year_has_four_digits, if: :start_date
 
           def initialize(journey_session:, journey:, params:)
             super
@@ -34,7 +35,7 @@ module Journeys
 
           def start_year_has_four_digits
             if start_date.year < 1000
-              errors.add(:start_date, "Year must include 4 numbers")
+              errors.add(:start_date, i18n_errors_path(:year_must_have_4_digits))
             end
           end
         end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
@@ -8,6 +8,7 @@ module Journeys
           attribute :start_date, :date
 
           validates :start_date, presence: {message: i18n_error_message(:presence)}
+          validate :start_year_has_four_digits, if: -> { start_date.present? }
 
           def initialize(journey_session:, journey:, params:)
             super
@@ -29,6 +30,12 @@ module Journeys
 
           def nursery_name
             EligibleEyProvider.find_by(urn: answers.nursery_urn)&.nursery_name
+          end
+
+          def start_year_has_four_digits
+            if start_date.year < 1000
+              errors.add(:start_date, "Year must include 4 numbers")
+            end
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1149,6 +1149,8 @@ en:
         hint: For example, 27 3 2024.
         errors:
           presence: Provide a date in the format 27 3 2024
+          date_not_in_future: Start date cannot be in the future
+          year_must_have_4_digits: Year must include 4 numbers
       child_facing:
         question: Confirm %{first_name} spends most of their time in their job working directly with children
         hint:

--- a/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
@@ -34,9 +34,10 @@ RSpec.feature "Early years payment provider" do
     click_button "Continue"
 
     expect(page.current_path).to eq "/early-years-payment-provider/start-date"
-    fill_in("Day", with: "1")
-    fill_in("Month", with: "12")
-    fill_in("Year", with: "2024")
+    date = Date.yesterday
+    fill_in("Day", with: date.day)
+    fill_in("Month", with: date.month)
+    fill_in("Year", with: date.year)
     click_button "Continue"
 
     expect(page.current_path).to eq "/early-years-payment-provider/child-facing"

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/start_date_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/start_date_form_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::StartDateFo
 
   describe "validations" do
     it { should validate_presence_of(:start_date).with_message("Provide a date in the format 27 3 2024") }
+
+    context "when the year doesn't have 4 digits" do
+      let(:day) { 1 }
+      let(:month) { 1 }
+      let(:year) { 24 }
+
+      it "returns an error" do
+        subject.save
+        expect(subject.errors[:start_date]).to include("Year must include 4 numbers")
+      end
+    end
   end
 
   describe "#save" do

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/start_date_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/start_date_form_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::StartDateFo
   describe "validations" do
     it { should validate_presence_of(:start_date).with_message("Provide a date in the format 27 3 2024") }
 
+    context "with a date in the future" do
+      it do
+        is_expected.not_to(
+          allow_value(Date.tomorrow)
+          .for(:start_date)
+          .with_message("Start date cannot be in the future")
+        )
+      end
+    end
+
     context "when the year doesn't have 4 digits" do
       let(:day) { 1 }
       let(:month) { 1 }


### PR DESCRIPTION
## Changes in this PR

Validate that the start_date:
- year has four digits, otherwise if the user enters something like 13/1/90 it saves in the database as if it was 13/1/0090
- is not in the future