### PR TITLE
LUPEYALPHA-838 - send verification request to provider

### DIFF
--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -1,6 +1,12 @@
 module Journeys
   module FurtherEducationPayments
     class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
+      def save
+        super
+
+        ClaimMailer.further_education_payment_provider_verification_email(claim).deliver_later
+      end
+
       private
 
       def main_eligibility

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -35,4 +35,10 @@ class ApplicationMailer < Mail::Notify::Mailer
     CLAIM_PROVIDER_EMAIL_TEMPLATE_ID: "e0b78a08-601b-40ba-a97f-61fb00a7c951".freeze,
     CLAIM_RECEIVED_NOTIFY_TEMPLATE_ID: "149c5999-12fb-4b99-aff5-23a7c3302783".freeze
   }
+  FURTHER_EDUCATION_PAYMENTS = {
+    CLAIM_PROVIDER_VERIFICATION_EMAIL_TEMPLATE_ID: "9a25fe46-2ee4-4a5c-8d47-0f04f058a87d".freeze,
+    # FIXME this is just a place holder - it's an empty template
+    # Correct copy will be added as part of LUPEYALPHA-848
+    CLAIM_RECEIVED_NOTIFY_TEMPLATE_ID: NOTIFY_TEMPLATE_ID
+  }
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -82,6 +82,27 @@ class ClaimMailer < ApplicationMailer
     send_mail(template_ids(claim)[:CLAIM_PROVIDER_EMAIL_TEMPLATE_ID], personalisation)
   end
 
+  def further_education_payment_provider_verification_email(claim)
+    unknown_policy_check(claim)
+
+    personalisation = {
+      recipient_name: claim.school.name,
+      claimant_name: claim.full_name,
+      claim_reference: claim.reference,
+      claim_submission_date: claim.created_at.to_s(:govuk_date),
+      verification_due_date: claim.eligibility.verification_deadline.to_s(:govuk_date),
+      verification_url: Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
+    }
+
+    template_id = template_ids(claim)[:CLAIM_PROVIDER_VERIFICATION_EMAIL_TEMPLATE_ID]
+
+    template_mail(
+      template_id,
+      to: claim.school.eligible_fe_provider.primary_key_contact_email_address,
+      personalisation: personalisation
+    )
+  end
+
   private
 
   def set_common_instance_variables(claim)

--- a/app/models/journeys/further_education_payments/provider/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/provider/slug_sequence.rb
@@ -15,11 +15,13 @@ module Journeys
         ]
 
         def self.verify_claim_url(claim)
-          Rails.application.routes.url_helpers.new_claim_path(
+          Rails.application.routes.url_helpers.new_claim_url(
             module_parent::ROUTING_NAME,
             answers: {
               claim_id: claim.id
-            }
+            },
+            host: ENV.fetch("CANONICAL_HOSTNAME"),
+            protocol: "https"
           )
         end
 

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -53,6 +53,11 @@ module Policies
       def verified?
         verification.present?
       end
+
+      # FIXME LUPEYALPHA-923
+      def verification_deadline
+        created_at + 1.week
+      end
     end
   end
 end


### PR DESCRIPTION
Email the provider

When the claimant submits their application we need to send an email out
to the provider to verify the claim.
This commit adds the mechanism to send the verification email.

Currently we've stubbed the verification deadline, to submission date +
1 week, while we wait on finding out what the actual deadline should be.
We've also set the email template for the claimant email to a,
temporary, empty template so the mailer doesn't error.

