### PR TITLE
fe provider dsi bypass

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -123,6 +123,8 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   def further_education_payments_provider_callback(auth)
+    auth = params if DfESignIn.bypass?
+
     Journeys::FurtherEducationPayments::Provider::OmniauthCallbackForm.new(
       journey_session: journey_session,
       auth: auth

--- a/app/views/further_education_payments/provider/claims/_dfe_sign_in_bypass_form.html.erb
+++ b/app/views/further_education_payments/provider/claims/_dfe_sign_in_bypass_form.html.erb
@@ -1,0 +1,77 @@
+<h2 class="govuk-heading-m">
+  Set DfE sign in payload details
+</h2>
+
+<p class="govuk-body">
+  In environments where DfE Sign-in is not enabled you can use this form to
+  set payload parameters to test different DfE Sign-in scenarios.
+</p>
+
+<p class="govuk-body">
+  By default this form is set to grant access to verify the claim.
+</p>
+
+<%= form_with(
+  url: "/further-education-payments-provider/auth/callback",
+  method: :get,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
+  <div class="govuk-form-group">
+    <%= f.govuk_text_field(
+      "[extra][raw_info][organisation][ukprn]",
+      label: { text: "UKPRN" },
+      value: journey_session.answers.claim.school.ukprn
+    ) %>
+
+    <%= f.govuk_text_field(
+      "[extra][raw_info][organisation][id]",
+      label: { text: "Organisation id" },
+      value: "12345678"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "uid",
+      label: { text: "DfE sign in UID" },
+      value: "12345678"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "[info][first_name]",
+      label: { text: "First name" },
+      value: "Seymoure"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "[info][last_name]",
+      label: { text: "Last name" },
+      value: "Skinner"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "[info][email]",
+      label: { text: "Email" },
+      value: "seymoure.skinner@springfield-elementary.edu"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "[roles][0]",
+      label: { text: "Role 1" },
+      value: Journeys::FurtherEducationPayments::Provider::CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE
+    ) %>
+
+    <%= f.govuk_text_field("[roles][1]", label: { text: "Role 2" }) %>
+
+    <%= f.govuk_text_field("[roles][2]", label: { text: "Role 3" }) %>
+
+    <%= f.govuk_check_box(
+      "service_access",
+      true,
+      false,
+      label: { text: "Claim service access"},
+      multiple: false,
+      checked: true
+    ) %>
+  </div>
+
+  <%= f.govuk_submit("Start now")%>
+<% end %>

--- a/app/views/further_education_payments/provider/claims/sign_in.html.erb
+++ b/app/views/further_education_payments/provider/claims/sign_in.html.erb
@@ -21,17 +21,21 @@
       account yet, we will help you create one.
     </p>
 
-    <%= button_to(
-      "/further-education-payments-provider/auth/dfe_fe_provider",
-      class: "govuk-button govuk-button--start",
-      data: {
-        module: "govuk-button"
-      }
-    ) do %>
-      Start now
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-      </svg>
+    <% if DfESignIn.bypass? %>
+      <%= render "dfe_sign_in_bypass_form" %>
+    <% else %>
+      <%= button_to(
+        "/further-education-payments-provider/auth/dfe_fe_provider",
+        class: "govuk-button govuk-button--start",
+        data: {
+          module: "govuk-button"
+        }
+      ) do %>
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -71,26 +71,26 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       issuer:
         ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)
     }
-  end
 
-  provider :openid_connect, {
-    name: :dfe_fe_provider,
-    discovery: true,
-    response_type: :code,
-    scope: %i[openid email organisation first_name last_name],
-    callback_path: dfe_sign_in_fe_provider_callback_path,
-    path_prefix: "/further-education-payments-provider/auth",
-    client_options: {
-      port: dfe_sign_in_issuer_uri&.port,
-      scheme: dfe_sign_in_issuer_uri&.scheme,
-      host: dfe_sign_in_issuer_uri&.host,
-      identifier: ENV["DFE_SIGN_IN_IDENTIFIER"],
-      secret: ENV["DFE_SIGN_IN_SECRET"],
-      redirect_uri: dfe_sign_in_fe_provider_redirect_uri&.to_s
-    },
-    issuer:
-       ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)
-  }
+    provider :openid_connect, {
+      name: :dfe_fe_provider,
+      discovery: true,
+      response_type: :code,
+      scope: %i[openid email organisation first_name last_name],
+      callback_path: dfe_sign_in_fe_provider_callback_path,
+      path_prefix: "/further-education-payments-provider/auth",
+      client_options: {
+        port: dfe_sign_in_issuer_uri&.port,
+        scheme: dfe_sign_in_issuer_uri&.scheme,
+        host: dfe_sign_in_issuer_uri&.host,
+        identifier: ENV["DFE_SIGN_IN_IDENTIFIER"],
+        secret: ENV["DFE_SIGN_IN_SECRET"],
+        redirect_uri: dfe_sign_in_fe_provider_redirect_uri&.to_s
+      },
+      issuer:
+         ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?)
+    }
+  end
 
   provider :openid_connect, {
     name: :tid,


### PR DESCRIPTION
Add DfE sign in by pass

In review apps we can't use DfE sign in as the urls are dynamic and so
are not registered with DfE sign in. This commit provides a form to
allow testers to set the DfE sign in payload to check various sign in
scenarios.

![Screenshot 2024-08-29 at 10 37 57](https://github.com/user-attachments/assets/5f134cb6-3ed3-4c47-8f84-31d270d4dd9f)
