### PR TITLE
[LUPEYALPHA-951] teaching qualification - hint content update

### DIFF
--- a/app/views/further_education_payments/claims/teaching_qualification.html.erb
+++ b/app/views/further_education_payments/claims/teaching_qualification.html.erb
@@ -11,7 +11,7 @@
           tag: "h1",
           size: "l"
         },
-        hint: { text: @form.t(:hint) } %>
+        hint: { text: t("further_education_payments.forms.teaching_qualification.hint_html") } %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1030,9 +1030,16 @@ en:
           none: I do not teach any of these courses
       teaching_qualification:
         question: Do you have a teaching qualification?
-        hint:
-          Your response will be noted for future claims. If you don’t have a teaching qualification yet, make sure that
-          you enrol on one or complete one in the next 12 months.
+        hint_html: >
+          <p>Your response will be noted for future claims.</p>
+          <p>If you don’t have a teaching qualification yet, to remain eligible for a retention payment next year,
+          make sure you either:</p>
+          <p>
+            <ul>
+              <li>complete a teaching qualification in the next 12 months</li>
+              <li>enrol on a teaching qualification in the next 12 months</li>
+            </ul>
+          </p>
         options:
           "yes": "Yes"
           not_yet: Not yet, I am currently enrolled on one and working towards completing it


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/LUPEYALPHA-951

teaching qualification hint update - now a block of html

compared to the wireframe, the spacing below the hint is slightly different:
<img width="719" alt="Screenshot 2024-08-27 at 11 50 26" src="https://github.com/user-attachments/assets/287eab46-0495-43e3-bd71-4a4e65fe3e4b">

and when there's an error:
<img width="687" alt="Screenshot 2024-08-27 at 11 50 17" src="https://github.com/user-attachments/assets/412c9ad9-f340-4be0-b507-91074eda3d76">

