### PR TITLE
[LUPEYALPHA-775] EY previous job in early years setting - unhappy path

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_contract_type_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_contract_type_form.rb
@@ -1,0 +1,42 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      module Authenticated
+        class ReturnerContractTypeForm < Form
+          attribute :returner_contract_type, :string
+
+          validates :returner_contract_type,
+            inclusion: {in: ->(form) { form.radio_options.map(&:id) }, message: i18n_error_message(:inclusion)}
+
+          def radio_options
+            [
+              OpenStruct.new(
+                id: "permanent",
+                name: t("options.permanent")
+              ),
+              OpenStruct.new(
+                id: "casual or temporary",
+                name: t("options.casual_or_temporary")
+              ),
+              OpenStruct.new(
+                id: "voluntary or unpaid",
+                name: t("options.voluntary_or_unpaid")
+              ),
+              OpenStruct.new(
+                id: "agency work and apprenticeship roles",
+                name: t("options.agency_work_and_apprenticeships")
+              )
+            ]
+          end
+
+          def save
+            return false if invalid?
+
+            journey_session.answers.assign_attributes(returner_contract_type:)
+            journey_session.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_form.rb
@@ -3,15 +3,15 @@ module Journeys
     module Provider
       module Authenticated
         class ReturnerForm < Form
-          attribute :first_job_within_6_months, :boolean
+          attribute :returning_within_6_months, :boolean
 
-          validates :first_job_within_6_months,
+          validates :returning_within_6_months,
             inclusion: {in: [true, false], message: i18n_error_message(:inclusion)}
 
           def save
             return false if invalid?
 
-            journey_session.answers.assign_attributes(first_job_within_6_months:)
+            journey_session.answers.assign_attributes(returning_within_6_months:)
             journey_session.save!
           end
 

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form.rb
@@ -1,0 +1,21 @@
+module Journeys
+  module EarlyYearsPayment
+    module Provider
+      module Authenticated
+        class ReturnerWorkedWithChildrenForm < Form
+          attribute :returner_worked_with_children, :boolean
+
+          validates :returner_worked_with_children,
+            inclusion: {in: [true, false], message: i18n_error_message(:inclusion)}
+
+          def save
+            return false if invalid?
+
+            journey_session.answers.assign_attributes(returner_worked_with_children:)
+            journey_session.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/journeys/early_years_payment/provider/authenticated.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated.rb
@@ -18,6 +18,7 @@ module Journeys
             "start-date" => StartDateForm,
             "child-facing" => ChildFacingForm,
             "returner" => ReturnerForm,
+            "returner-worked-with-children" => ReturnerWorkedWithChildrenForm,
             "employee-email" => EmployeeEmailForm,
             "check-your-answers" => CheckYourAnswersForm
           }

--- a/app/models/journeys/early_years_payment/provider/authenticated.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated.rb
@@ -19,6 +19,7 @@ module Journeys
             "child-facing" => ChildFacingForm,
             "returner" => ReturnerForm,
             "returner-worked-with-children" => ReturnerWorkedWithChildrenForm,
+            "returner-contract-type" => ReturnerContractTypeForm,
             "employee-email" => EmployeeEmailForm,
             "check-your-answers" => CheckYourAnswersForm
           }

--- a/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
@@ -10,6 +10,7 @@ module Journeys
           attribute :child_facing_confirmation_given, :boolean
           attribute :returning_within_6_months, :boolean
           attribute :returner_worked_with_children, :boolean
+          attribute :returner_contract_type
           attribute :practitioner_email_address
           attribute :provider_contact_name
 

--- a/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
@@ -8,7 +8,7 @@ module Journeys
           attribute :paye_reference
           attribute :start_date, :date
           attribute :child_facing_confirmation_given, :boolean
-          attribute :first_job_within_6_months, :boolean
+          attribute :returning_within_6_months, :boolean
           attribute :returner_worked_with_children, :boolean
           attribute :practitioner_email_address
           attribute :provider_contact_name

--- a/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
@@ -9,7 +9,7 @@ module Journeys
           attribute :start_date, :date
           attribute :child_facing_confirmation_given, :boolean
           attribute :first_job_within_6_months, :boolean
-          attribute :start_date, :date
+          attribute :returner_worked_with_children, :boolean
           attribute :practitioner_email_address
           attribute :provider_contact_name
 

--- a/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
@@ -11,6 +11,7 @@ module Journeys
             start-date
             child-facing
             returner
+            returner-worked-with-children
             employee-email
           ].freeze
 
@@ -36,7 +37,11 @@ module Journeys
           end
 
           def slugs
-            SLUGS
+            SLUGS.dup.tap do |sequence|
+              if answers.first_job_within_6_months == false
+                sequence.delete("returner-worked-with-children")
+              end
+            end
           end
 
           def magic_link?(slug)

--- a/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
@@ -12,6 +12,7 @@ module Journeys
             child-facing
             returner
             returner-worked-with-children
+            returner-contract-type
             employee-email
           ].freeze
 
@@ -40,6 +41,11 @@ module Journeys
             SLUGS.dup.tap do |sequence|
               if answers.returning_within_6_months == false
                 sequence.delete("returner-worked-with-children")
+                sequence.delete("returner-contract-type")
+              end
+
+              if answers.returner_worked_with_children == false
+                sequence.delete("returner-contract-type")
               end
             end
           end

--- a/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
@@ -38,7 +38,7 @@ module Journeys
 
           def slugs
             SLUGS.dup.tap do |sequence|
-              if answers.first_job_within_6_months == false
+              if answers.returning_within_6_months == false
                 sequence.delete("returner-worked-with-children")
               end
             end

--- a/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/slug_sequence.rb
@@ -39,12 +39,12 @@ module Journeys
 
           def slugs
             SLUGS.dup.tap do |sequence|
-              if answers.returning_within_6_months == false
+              if !answers.returning_within_6_months
                 sequence.delete("returner-worked-with-children")
                 sequence.delete("returner-contract-type")
               end
 
-              if answers.returner_worked_with_children == false
+              if !answers.returner_worked_with_children
                 sequence.delete("returner-contract-type")
               end
             end

--- a/app/models/policies/early_years_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/early_years_payments/policy_eligibility_checker.rb
@@ -24,7 +24,15 @@ module Policies
       def ineligibility_reason
         if answers.nursery_urn.to_s == "none_of_the_above"
           :nursery_is_not_listed
+        elsif ineligible_returner?
+          :returner
         end
+      end
+
+      private
+
+      def ineligible_returner?
+        answers.returning_within_6_months && answers.returner_worked_with_children && answers.returner_contract_type == "permanent"
       end
     end
   end

--- a/app/views/early_years_payment/provider/authenticated/claims/_ineligibility_returner.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/_ineligibility_returner.html.erb
@@ -1,0 +1,32 @@
+<% first_name = journey_session.answers.first_name %>
+
+<% content_for(:page_title, page_title("#{first_name} is not eligible for this payment", journey: current_journey_routing_name)) %>
+<% @backlink_path = claim_path("early-years-payment", "landing-page") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= first_name %> is not eligible for this payment
+    </h1>
+    <p class="govuk-body">
+      Based on the information you have provided, <%= first_name %> is not eligible to claim an early years incentive payment.
+    </p>
+
+    <p class="govuk-body">
+      For further guidance, you should refer to the
+      <%= govuk_link_to "full eligibility criteria", claim_path("early-years-payment", "landing-page") %>
+      at the start of this service.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      Get help with your claim
+    </h2>
+
+    <p class="govuk-body">
+      If you have any questions, contact us for help at
+      <%= govuk_link_to t("early_years_payment_provider_start.feedback_email"), "mailto:#{t("early_years_payment_provider_start.feedback_email")}", no_visited_state: true %>.
+    </p>
+
+    <%= govuk_button_link_to "Start a new claim", claim_path("early-years-payment", "landing-page") %>
+  </div>
+</div>

--- a/app/views/early_years_payment/provider/authenticated/claims/returner.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/returner.html.erb
@@ -7,15 +7,15 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(
-        :first_job_within_6_months,
+        :returning_within_6_months,
         inline: true,
         legend: {
           text: question,
           tag: "h1",
           size: "l"
         }) do %>
-        <%= f.govuk_radio_button :first_job_within_6_months, true, label: { text: "Yes" } %>
-        <%= f.govuk_radio_button :first_job_within_6_months, false, label: { text: "No" } %>
+        <%= f.govuk_radio_button :returning_within_6_months, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :returning_within_6_months, false, label: { text: "No" } %>
       <% end %>
 
       <%= f.govuk_submit %>

--- a/app/views/early_years_payment/provider/authenticated/claims/returner_contract_type.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/returner_contract_type.html.erb
@@ -1,0 +1,24 @@
+<% question = @form.t("question", first_name: answers.first_name) %>
+<% content_for(:page_title, page_title(question, journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_radio_buttons :returner_contract_type, @form.radio_options, :id, :name, legend: { text: question, tag: "h1", size: "l" } %>
+
+      <%= govuk_details(summary_text: "What does casual or temporary work include?") do %>
+        <p class="govuk-body">Casual or temporary work could include:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>zero-hour contracts</li>
+          <li>guaranteed minimum hour contracts</li>
+          <li>self-employed or freelance contracts</li>
+          <li>fixed term contracts (FTCs)</li>
+          <li>agency work and apprenticeship roles</li>
+        </ul>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>

--- a/app/views/early_years_payment/provider/authenticated/claims/returner_worked_with_children.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/returner_worked_with_children.html.erb
@@ -1,0 +1,26 @@
+<% question = @form.t("question", first_name: answers.first_name) %>
+<% content_for(:page_title, page_title(question, journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :returner_worked_with_children, inline: true, legend: { text: question, tag: "h1", size: "l" } do %>
+        <%= f.govuk_radio_button :returner_worked_with_children, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :returner_worked_with_children, false, label: { text: "No" } %>
+      <% end %>
+
+      <%= govuk_details(summary_text: "What does mostly working directly with children mean?") do %>
+        <p class="govuk-body">Your employee spends most of the time in their role (70% or more) working directly with children.</p>
+        <p class="govuk-body">Working directly with children can involve:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>working in the room with children — this can include playrooms, baserooms or classrooms</li>
+          <li>guiding, supporting, and interacting with children in their learning and development</li>
+          <li>giving hands-on care, including health and hygiene</li>
+        </ul>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1202,6 +1202,15 @@ en:
           Did %{first_name}’s previous role in an early years setting involve mostly working directly with children?
         errors:
           inclusion: You must select an option below to continue
+      returner_contract_type:
+        question: Select the contract type for %{first_name}’s previous role in an early years setting
+        options:
+          permanent: permanent
+          casual_or_temporary: casual or temporary
+          voluntary_or_unpaid: voluntary or unpaid
+          agency_work_and_apprenticeships: agency work and apprenticeship roles
+        errors:
+          inclusion: You must select an option below to continue
       employee_email:
         question: What is %{first_name}’s email address?
         hint: We’ll use this to ask your employee to provide their payment details.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1197,6 +1197,11 @@ en:
           Did %{first_name} work in an early years setting between %{six_months_before_start_date} and %{start_date}?
         errors:
           inclusion: You must select an option below to continue
+      returner_worked_with_children:
+        question:
+          Did %{first_name}’s previous role in an early years setting involve mostly working directly with children?
+        errors:
+          inclusion: You must select an option below to continue
       employee_email:
         question: What is %{first_name}’s email address?
         hint: We’ll use this to ask your employee to provide their payment details.

--- a/spec/factories/journeys/early_years_payment/provider/authenticated/early_years_payment_answers.rb
+++ b/spec/factories/journeys/early_years_payment/provider/authenticated/early_years_payment_answers.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :early_years_payment_answers, class: "Journeys::EarlyYearsPayment::Provider::Authenticated::SessionAnswers" do
+  end
+end

--- a/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
@@ -47,8 +47,28 @@ RSpec.feature "Early years payment provider" do
     expect(page.current_path).to eq "/early-years-payment-provider/returner"
     choose "No"
     click_button "Continue"
-
     expect(page.current_path).to eq "/early-years-payment-provider/employee-email"
+
+    click_link "Back"
+    expect(page.current_path).to eq "/early-years-payment-provider/returner"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/returner-worked-with-children"
+    choose "No"
+    click_button "Continue"
+    expect(page.current_path).to eq "/early-years-payment-provider/employee-email"
+
+    click_link "Back"
+    expect(page.current_path).to eq "/early-years-payment-provider/returner-worked-with-children"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/returner-contract-type"
+    choose "casual or temporary"
+    click_button "Continue"
+    expect(page.current_path).to eq "/early-years-payment-provider/employee-email"
+
     fill_in "claim-practitioner-email-address-field", with: "practitioner@example.com"
     click_button "Continue"
 

--- a/spec/features/early_years_payment/provider/authenticated/ineligible_returner_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/ineligible_returner_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Early years payment provider ineligible returner" do
     choose "permanent"
     click_button "Continue"
 
-    # expect(page.current_path).to eq "/early-years-payment-provider/ineligible"
-    # expect(page).to have_content("This nursery is not eligible")
+    expect(page.current_path).to eq "/early-years-payment-provider/ineligible"
+    expect(page).to have_content("Bobby is not eligible for this payment")
   end
 end

--- a/spec/features/early_years_payment/provider/authenticated/ineligible_returner_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/ineligible_returner_spec.rb
@@ -47,6 +47,10 @@ RSpec.feature "Early years payment provider ineligible returner" do
     choose "Yes"
     click_button "Continue"
 
+    expect(page.current_path).to eq "/early-years-payment-provider/returner-contract-type"
+    choose "permanent"
+    click_button "Continue"
+
     # expect(page.current_path).to eq "/early-years-payment-provider/ineligible"
     # expect(page).to have_content("This nursery is not eligible")
   end

--- a/spec/features/early_years_payment/provider/authenticated/ineligible_returner_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/ineligible_returner_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.feature "Early years payment provider ineligible returner" do
+  let(:email_address) { "johndoe@example.com" }
+  let(:journey_session) { Journeys::EarlyYearsPayment::Provider::Authenticated::Session.last }
+  let(:mail) { ActionMailer::Base.deliveries.last }
+  let(:magic_link) { mail[:personalisation].unparsed_value[:magic_link] }
+  let!(:nursery) { create(:eligible_ey_provider, primary_key_contact_email_address: email_address) }
+
+  scenario "returner worked with children in a permanent position" do
+    when_early_years_payment_provider_authenticated_journey_configuration_exists
+    when_early_years_payment_provider_start_journey_completed
+
+    visit magic_link
+    check "I confirm that I have obtained consent from my employee and have provided them with the relevant privacy notice."
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/current-nursery"
+    choose nursery.nursery_name
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/paye-reference"
+    fill_in "claim-paye-reference-field", with: "123/123456SE90"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/claimant-name"
+    fill_in "First name", with: "Bobby"
+    fill_in "Last name", with: "Bobberson"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/start-date"
+    date = Date.yesterday
+    fill_in("Day", with: date.day)
+    fill_in("Month", with: date.month)
+    fill_in("Year", with: date.year)
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/child-facing"
+    check "I confirm that at least 70% of Bobby’s time in their job is spent working directly with children."
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/returner"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/returner-worked-with-children"
+    choose "Yes"
+    click_button "Continue"
+
+    # expect(page.current_path).to eq "/early-years-payment-provider/ineligible"
+    # expect(page).to have_content("This nursery is not eligible")
+  end
+end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/returner_contract_type_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/returner_contract_type_form_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ReturnerContractTypeForm, type: :model do
+  let(:journey) { Journeys::EarlyYearsPayment::Provider::Authenticated }
+  let(:journey_session) { create(:early_years_payment_provider_authenticated_session) }
+  let(:returner_contract_type) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        returner_contract_type:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(journey_session:, journey:, params:)
+  end
+
+  describe "validations" do
+    context "when no option selected" do
+      it do
+        is_expected.not_to(
+          allow_value(nil)
+          .for(:returner_contract_type)
+          .with_message("You must select an option below to continue")
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:returner_contract_type) { "permanent" }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.returner_contract_type }
+        .to(returner_contract_type)
+      )
+    end
+  end
+end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/returner_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/returner_form_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ReturnerForm, type: :model do
   let(:journey) { Journeys::EarlyYearsPayment::Provider::Authenticated }
   let(:journey_session) { create(:early_years_payment_provider_authenticated_session) }
-  let(:first_job_within_6_months) { nil }
+  let(:returning_within_6_months) { nil }
 
   let(:params) do
     ActionController::Parameters.new(
       claim: {
-        first_job_within_6_months:
+        returning_within_6_months:
       }
     )
   end
@@ -20,19 +20,19 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ReturnerFor
   describe "validations" do
     it do
       is_expected.not_to(
-        allow_value(first_job_within_6_months)
-        .for(:first_job_within_6_months)
+        allow_value(returning_within_6_months)
+        .for(:returning_within_6_months)
         .with_message("You must select an option below to continue")
       )
     end
   end
 
   describe "#save" do
-    let(:first_job_within_6_months) { "true" }
+    let(:returning_within_6_months) { "true" }
 
     it "updates the journey session" do
       expect { expect(subject.save).to be(true) }.to(
-        change { journey_session.reload.answers.first_job_within_6_months }.to(true)
+        change { journey_session.reload.answers.returning_within_6_months }.to(true)
       )
     end
   end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ReturnerWorkedWithChildrenForm, type: :model do
+  let(:journey) { Journeys::EarlyYearsPayment::Provider::Authenticated }
+  let(:journey_session) { create(:early_years_payment_provider_authenticated_session) }
+  let(:returner_worked_with_children) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        returner_worked_with_children:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(journey_session:, journey:, params:)
+  end
+
+  describe "validations" do
+    it do
+      is_expected.not_to(
+        allow_value(returner_worked_with_children)
+        .for(:returner_worked_with_children)
+        .with_message("You must select an option below to continue")
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:returner_worked_with_children) { "true" }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.returner_worked_with_children }.to(true)
+      )
+    end
+  end
+end

--- a/spec/models/policies/early_years_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/early_years_payments/policy_eligibility_checker_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe Policies::EarlyYearsPayments::PolicyEligibilityChecker do
+  subject { described_class.new(answers: answers) }
+
+  describe "#status, #ineligible?, #ineligibility_reason" do
+    context "when ineligible as :returner" do
+      let(:answers) do
+        build(
+          :early_years_payment_answers,
+          returning_within_6_months: true,
+          returner_worked_with_children: true,
+          returner_contract_type: "permanent"
+        )
+      end
+
+      it "is ineligble as :returner" do
+        expect(subject).to be_ineligible
+        expect(subject.status).to eql(:ineligible)
+        expect(subject.ineligibility_reason).to eql(:returner)
+      end
+    end
+
+    context "when ineligible as :nursery_is_not_listed" do
+      let(:answers) do
+        build(
+          :early_years_payment_answers,
+          nursery_urn: "none_of_the_above"
+        )
+      end
+
+      it "is ineligble as :nursery_is_not_listed" do
+        expect(subject).to be_ineligible
+        expect(subject.status).to eql(:ineligible)
+        expect(subject.ineligibility_reason).to eql(:nursery_is_not_listed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- Branching for when the user answers 'yes' to having worked in an early years setting in the past 6 months
- Two new pages and forms
- Ineligible page for when the returner does not qualify for a payment

Also:
- Rename of an attribute `first_job_within_6_months` to `returning_within_6_months` which was named opposite to the question being asked and boolean being stored.