### PR TITLE
admin provider verification task

### DIFF
--- a/app/forms/journeys/further_education_payments/provider/omniauth_callback_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/omniauth_callback_form.rb
@@ -12,6 +12,7 @@ module Journeys
             dfe_sign_in_uid: dfe_sign_in_uid,
             dfe_sign_in_organisation_id: dfe_sign_in_organisation_id,
             dfe_sign_in_organisation_ukprn: dfe_sign_in_organisation_ukprn,
+            dfe_sign_in_organisation_name: dfe_sign_in_organisation_name,
             dfe_sign_in_service_access: dfe_sign_in_service_access?,
             dfe_sign_in_role_codes: dfe_sign_in_role_codes,
             dfe_sign_in_first_name: dfe_sign_in_first_name,
@@ -36,6 +37,10 @@ module Journeys
 
         def dfe_sign_in_organisation_id
           auth.dig("extra", "raw_info", "organisation", "id")
+        end
+
+        def dfe_sign_in_organisation_name
+          auth.dig("extra", "raw_info", "organisation", "name")
         end
 
         def dfe_sign_in_service_access?

--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -10,7 +10,7 @@ module Journeys
             teaching_responsibilities
             further_education_teaching_start_year
             teaching_hours_per_week
-            hours_teaching_eligible_subjects
+            half_teaching_hours
             subjects_taught
           ],
           variable_contract: %i[
@@ -19,7 +19,7 @@ module Journeys
             further_education_teaching_start_year
             taught_at_least_one_term
             teaching_hours_per_week
-            hours_teaching_eligible_subjects
+            half_teaching_hours
             subjects_taught
             teaching_hours_per_week_next_term
           ]

--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -99,7 +99,9 @@ module Journeys
                 dfe_sign_in_uid: answers.dfe_sign_in_uid,
                 first_name: answers.dfe_sign_in_first_name,
                 last_name: answers.dfe_sign_in_last_name,
-                email: answers.dfe_sign_in_email
+                email: answers.dfe_sign_in_email,
+                dfe_sign_in_organisation_name: answers.dfe_sign_in_organisation_name,
+                dfe_sign_in_role_codes: answers.dfe_sign_in_role_codes
               },
               created_at: DateTime.now
             }

--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -109,6 +109,8 @@ module Journeys
 
           claim.save!
 
+          ClaimVerifierJob.perform_later(claim)
+
           true
         end
 

--- a/app/models/automated_checks/claim_verifiers/provider_verification.rb
+++ b/app/models/automated_checks/claim_verifiers/provider_verification.rb
@@ -1,0 +1,64 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    class ProviderVerification
+      TASK_NAME = "provider_verification".freeze
+
+      def initialize(claim:)
+        @claim = claim
+
+        unless claim.policy.further_education_payments?
+          raise ArgumentError, "Claim must be an Further Education claim"
+        end
+      end
+
+      def perform
+        return unless claim.eligibility.verified?
+        return if task_exists?
+
+        create_task!
+      end
+
+      private
+
+      attr_reader :claim
+
+      def task_exists?
+        claim.tasks.where(name: TASK_NAME).exists?
+      end
+
+      def create_task!
+        claim.tasks.create!(
+          name: TASK_NAME,
+          created_by: created_by,
+          manual: false,
+          passed: passed?
+        )
+      end
+
+      def passed?
+        verification.fetch("assertions").all? do |assertion|
+          assertion.fetch("outcome") == true
+        end
+      end
+
+      def verification
+        @verification ||= claim.eligibility.verification
+      end
+
+      def verifier
+        verification.fetch("verifier")
+      end
+
+      def created_by
+        DfeSignIn::User.find_or_create_by!(
+          dfe_sign_in_id: verifier.fetch("dfe_sign_in_uid"),
+          given_name: verifier.fetch("first_name"),
+          family_name: verifier.fetch("last_name"),
+          email: verifier.fetch("email"),
+          organisation_name: verifier.fetch("dfe_sign_in_organisation_name"),
+          role_codes: verifier.fetch("dfe_sign_in_role_codes")
+        )
+      end
+    end
+  end
+end

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -50,4 +50,8 @@ module BasePolicy
   def international_relocation_payments?
     to_s == "InternationalRelocationPayments"
   end
+
+  def further_education_payments?
+    to_s == "FurtherEducationPayments"
+  end
 end

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -31,6 +31,9 @@ class ClaimCheckingTasks
         task_names.delete("subject")
         task_names.delete("teaching_hours")
       end
+      unless claim.policy.further_education_payments?
+        task_names.delete("provider_verification")
+      end
     end
   end
 

--- a/app/models/journeys/further_education_payments/provider/session_answers.rb
+++ b/app/models/journeys/further_education_payments/provider/session_answers.rb
@@ -7,6 +7,7 @@ module Journeys
         attribute :dfe_sign_in_uid, :string
         attribute :dfe_sign_in_organisation_id, :string
         attribute :dfe_sign_in_organisation_ukprn, :string
+        attribute :dfe_sign_in_organisation_name, :string
         attribute :dfe_sign_in_service_access, :boolean, default: false
         attribute :dfe_sign_in_role_codes, default: []
         attribute :dfe_sign_in_first_name, :string

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -11,6 +11,10 @@ module Policies
 
     URL_SPREADSHEET_ELIGIBLE_PROVIDERS = "https://assets.publishing.service.gov.uk/media/667300fe64e554df3bd0db92/List_of_eligible_FE_providers_and_payment_value_for_levelling_up_premium.xlsx".freeze
 
+    VERIFIERS = [
+      AutomatedChecks::ClaimVerifiers::ProviderVerification
+    ]
+
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [
       # FIXME RL: this `placeholder` is required to make the

--- a/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
@@ -1,0 +1,118 @@
+module Policies
+  module FurtherEducationPayments
+    class AdminProviderVerificationTaskPresenter
+      class Row < Struct.new(
+        :label,
+        :claimant_answer,
+        :provider_answer,
+        keyword_init: true
+      )
+      end
+
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      def rows
+        assertions.map do |assertion|
+          Row.new(
+            label: label(assertion),
+            claimant_answer: claimant_answer(assertion),
+            provider_answer: provider_answer(assertion)
+          )
+        end
+      end
+
+      private
+
+      def verification
+        @verification ||= claim.eligibility.verification
+      end
+
+      def assertions
+        verification["assertions"] + [courses_taught_assertion]
+      end
+
+      # The provider verifies the courses taught question as part of verifying the
+      # subjects taught question, however the admin UI designs require we
+      # display these separately, so we construct an additional "assertion" for
+      # courses taught
+      def courses_taught_assertion
+        subjects_taught_outcome = verification["assertions"].detect do |a|
+          a["name"] == "subjects_taught"
+        end.fetch("outcome")
+
+        {
+          "name" => "courses_taught",
+          "outcome" => subjects_taught_outcome
+        }
+      end
+
+      def label(assertion)
+        I18n.t(
+          [
+            "further_education_payments",
+            "admin",
+            "task_questions",
+            "provider_verification",
+            assertion["name"],
+            "label"
+          ].join(".")
+        )
+      end
+
+      def claimant_answer(assertion)
+        key = assertion["name"]
+        case key
+        when "subjects_taught"
+          subjects_taught
+        when "courses_taught"
+          courses_taught
+        when "further_education_teaching_start_year"
+          "September #{further_education_teaching_start_year.to_i} " \
+            "to August #{further_education_teaching_start_year.to_i + 1}"
+        else
+          I18n.t(
+            [
+              "further_education_payments",
+              "admin",
+              "task_questions",
+              "provider_verification",
+              key,
+              "claimant_answers",
+              claim.eligibility.send(key)
+            ].join(".")
+          )
+        end
+      end
+
+      def provider_answer(assertion)
+        assertion["outcome"] ? "Yes" : "No"
+      end
+
+      def subjects_taught
+        claim.eligibility.subjects_taught.map do |subject|
+          I18n.t(
+            [
+              "further_education_payments",
+              "forms",
+              "subjects_taught",
+              "options",
+              subject
+            ].join(".")
+          )
+        end
+      end
+
+      def courses_taught
+        claim.eligibility.courses_taught.map(&:description)
+      end
+
+      def further_education_teaching_start_year
+        claim.eligibility.further_education_teaching_start_year
+      end
+    end
+  end
+end

--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -8,6 +8,29 @@ module Policies
       def initialize(claim)
         @claim = claim
       end
+
+      def provider_verification
+        AdminProviderVerificationTaskPresenter.new(claim).rows
+      end
+
+      def provider_name
+        [verifier.fetch("first_name"), verifier.fetch("last_name")].join(" ")
+      end
+
+      def provider_verification_submitted?
+        claim.eligibility.verification.present?
+      end
+
+      # FIXME RL - temp stub so the provider verification task can be completed
+      def qualifications
+        []
+      end
+
+      private
+
+      def verifier
+        @verifier ||= claim.eligibility.verification.fetch("verifier")
+      end
     end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,7 @@
 class Task < ApplicationRecord
   NAMES = %w[
     identity_confirmation
+    provider_verification
     visa
     arrival_date
     qualifications

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -1,0 +1,69 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} provider verification check for# {@claim.policy.short_name}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim, heading: "Provider verification" %>
+
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-xl"><%= @current_task_name.humanize %></h2>
+
+    <% if @tasks_presenter.provider_verification_submitted? %>
+      <p class="govuk-body">
+        This task was verified by the provider
+        (<%= @tasks_presenter.provider_name %>).
+      </p>
+
+      <table class="govuk-table govuk-!-margin-bottom-9">
+        <caption class="govuk-table__caption govuk-visually-hidden">
+          <%= @current_task_name.humanize %>
+        </caption>
+        <thead>
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">
+              Eligibility check
+            </th>
+            <th scope="col" class="govuk-table__header">
+              Claimant submitted
+            </th>
+            <th scope="col" class="govuk-table__header">
+              Provider response
+            </th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @tasks_presenter.provider_verification.each do |row| %>
+            <tr class="govuk-table__row govuk-!-width-one-quarter">
+              <th scope="row" class="govuk-table__header">
+                <%= row.label %>
+              </th>
+              <td class="govuk-table__cell govuk-!-width-one-half">
+                <%= Array.wrap(row.claimant_answer).join("<br><br>").html_safe %>
+              </td>
+              <td class="govuk-table__cell govuk-!-width-one-quarter">
+                <%= row.provider_answer %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">
+        This task has not yet been completed by the provider
+      </p>
+    <% end %>
+  </div>
+
+  <% if @tasks_presenter.provider_verification_submitted? %>
+    <div class="govuk-grid-column-two-thirds">
+      <% if @task.persisted? %>
+        <%= render "task_outcome", task: @task, notes: @notes %>
+      <% else %>
+        <%= render "form", task_name: "provider_verification", claim: @claim %>
+      <% end %>
+
+      <%= render partial: "admin/task_pagination" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/further_education_payments/provider/claims/_dfe_sign_in_bypass_form.html.erb
+++ b/app/views/further_education_payments/provider/claims/_dfe_sign_in_bypass_form.html.erb
@@ -30,6 +30,12 @@
     ) %>
 
     <%= f.govuk_text_field(
+      "[extra][raw_info][organisation][name]",
+      label: { text: "Organisation id" },
+      value: "Springfield Elementary School"
+    ) %>
+
+    <%= f.govuk_text_field(
       "uid",
       label: { text: "DfE sign in UID" },
       value: "12345678"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,7 @@ en:
       employment: "Check employment information"
       matching_details: "Review matching details from other claims"
       identity_confirmation: "Confirm the claimant made the claim"
+      provider_verification: "Confirm the provider verification"
       payroll_gender: "Add a payroll gender for HMRC"
       student_loan_amount: "Check student loan amount"
       student_loan_plan: "Check student loan plan"
@@ -149,6 +150,7 @@ en:
       employment_start: "Check employment start date"
       subject: "Check subject"
       teaching_hours: "Check teaching hours"
+
     undo_decision:
       approved: "Undo approval"
       rejected: "Undo rejection"
@@ -836,6 +838,46 @@ en:
       task_questions:
         matching_details:
           title: Is this claim still valid despite having matching details with other claims?
+        provider_verification:
+          title: "Has the provider confirmed the claimant's details?"
+          contract_type:
+            label: "Contract of employment"
+            claimant_answers:
+              permanent: "Permanent"
+              fixed_term: "Fixed term"
+              variable_hours: "Variable hours"
+          teaching_responsibilities:
+            label: "Teaching responsibilities"
+            claimant_answers:
+              true: "Yes"
+              false: "No"
+          further_education_teaching_start_year:
+            label: "First 5 years of teaching"
+          teaching_hours_per_week:
+            label: "Timetabled teaching hours"
+            claimant_answers:
+              more_than_12: "More than 12 hours per week"
+              between_2_5_and_12: "Between 2.5 and 12 hours per week"
+              less_than_2_5: "Less than 2.5 hours per week"
+          half_teaching_hours:
+            label: "Age range taught"
+            claimant_answers:
+              true: "Yes"
+              false: "No"
+          subjects_taught:
+            label: "Subject"
+          courses_taught:
+            label: "Course"
+          teaching_hours_per_week_next_term:
+            label: "Timetabled teaching hours next term"
+            claimant_answers:
+              at_least_2_5: "At least 2.5 hours per week"
+              less_than_2_5: "Less than 2.5 hours per week"
+          taught_at_least_one_term:
+            label: "Taught at least one term"
+            claimant_answers:
+              true: "Yes"
+              false: "No"
     forms:
       ineligible:
         courses:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1146,7 +1146,7 @@ en:
               label: "Is %{claimant} timetabled to teach an average of %{hours} during the current term?"
               errors:
                 inclusion: "Select yes if %{claimant} is timetabled to teach an average of %{hours} during the current term"
-            hours_teaching_eligible_subjects:
+            half_teaching_hours:
               label: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
               errors:
                 inclusion: "Select yes if %{claimant} teaches 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP), for at least half of their timetabled teaching hours"
@@ -1175,7 +1175,7 @@ en:
               label: "Is %{claimant} timetabled to teach an average of %{hours} during the current term?"
               errors:
                 inclusion: "Select yes if %{claimant} is timetabled to teach an average of %{hours} during the current term"
-            hours_teaching_eligible_subjects:
+            half_teaching_hours:
               label: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
               errors:
                 inclusion: "Select yes if %{claimant} teaches 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP), for at least half of their timetabled teaching hours"

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
               "outcome" => true
             },
             {
-              "name" => "hours_teaching_eligible_subjects",
+              "name" => "half_teaching_hours",
               "outcome" => false
             },
             {

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -12,6 +12,15 @@ FactoryBot.define do
     end
 
     trait :verified do
+      contract_type { "permanent" }
+      teaching_responsibilities { true }
+      further_education_teaching_start_year { "2023" }
+      teaching_hours_per_week { "more_than_12" }
+      hours_teaching_eligible_subjects { false }
+      half_teaching_hours { true }
+      subjects_taught { ["maths", "physics"] }
+      maths_courses { ["approved_level_321_maths", "gcse_maths"] }
+      physics_courses { ["gcse_physics"] }
       verification do
         {
           "assertions" => [
@@ -37,6 +46,65 @@ FactoryBot.define do
             },
             {
               "name" => "subjects_taught",
+              "outcome" => false
+            }
+          ],
+          "verifier" => {
+            "dfe_sign_in_uid" => "123",
+            "first_name" => "Seymoure",
+            "last_name" => "Skinner",
+            "email" => "seymore.skinner@springfield-elementary.edu"
+          },
+          "created_at" => "2024-01-01T12:00:00.000+00:00"
+        }
+      end
+    end
+
+    trait :verified_variable_hours do
+      contract_type { "variable_hours" }
+      teaching_responsibilities { true }
+      further_education_teaching_start_year { "2023" }
+      teaching_hours_per_week { "more_than_12" }
+      hours_teaching_eligible_subjects { false }
+      half_teaching_hours { true }
+      subjects_taught { ["maths", "physics"] }
+      maths_courses { ["approved_level_321_maths", "gcse_maths"] }
+      physics_courses { ["gcse_physics"] }
+      teaching_hours_per_week_next_term { "at_least_2_5" }
+      taught_at_least_one_term { true }
+      verification do
+        {
+          "assertions" => [
+            {
+              "name" => "contract_type",
+              "outcome" => true
+            },
+            {
+              "name" => "teaching_responsibilities",
+              "outcome" => true
+            },
+            {
+              "name" => "further_education_teaching_start_year",
+              "outcome" => true
+            },
+            {
+              "name" => "taught_at_least_one_term",
+              "outcome" => true
+            },
+            {
+              "name" => "teaching_hours_per_week",
+              "outcome" => true
+            },
+            {
+              "name" => "half_teaching_hours",
+              "outcome" => true
+            },
+            {
+              "name" => "subjects_taught",
+              "outcome" => true
+            },
+            {
+              "name" => "teaching_hours_per_week_next_term",
               "outcome" => false
             }
           ],

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -53,7 +53,9 @@ FactoryBot.define do
             "dfe_sign_in_uid" => "123",
             "first_name" => "Seymoure",
             "last_name" => "Skinner",
-            "email" => "seymore.skinner@springfield-elementary.edu"
+            "email" => "seymore.skinner@springfield-elementary.edu",
+            "dfe_sign_in_organisation_name" => "Springfield Elementary",
+            "dfe_sign_in_role_codes" => ["teacher_payments_claim_verifier"]
           },
           "created_at" => "2024-01-01T12:00:00.000+00:00"
         }
@@ -112,7 +114,9 @@ FactoryBot.define do
             "dfe_sign_in_uid" => "123",
             "first_name" => "Seymoure",
             "last_name" => "Skinner",
-            "email" => "seymore.skinner@springfield-elementary.edu"
+            "email" => "seymore.skinner@springfield-elementary.edu",
+            "dfe_sign_in_organisation_name" => "Springfield Elementary",
+            "dfe_sign_in_role_codes" => ["teacher_payments_claim_verifier"]
           },
           "created_at" => "2024-01-01T12:00:00.000+00:00"
         }

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -1,0 +1,251 @@
+require "rails_helper"
+
+RSpec.feature "Admin claim further education payments" do
+  before do
+    create(:journey_configuration, :further_education_payments_provider)
+    sign_in_as_service_operator
+  end
+
+  describe "Tasks" do
+    describe "provider verification task" do
+      context "when the provider is yet to verify the claim" do
+        it "shows the task as pending" do
+          fe_provider = create(:school, :further_education, name: "Springfield A and M")
+
+          claim = create(
+            :claim,
+            first_name: "Edna",
+            surname: "Krabappel",
+            date_of_birth: Date.new(1945, 7, 3),
+            reference: "AB123456",
+            created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+            submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+          )
+
+          create(
+            :further_education_payments_eligibility,
+            contract_type: "fixed_term",
+            claim: claim,
+            school: fe_provider,
+            award_amount: 1500
+          )
+
+          visit admin_claim_path(claim)
+
+          click_on "View tasks"
+
+          click_on "Confirm the provider verification"
+
+          expect(page).to have_content(
+            "This task has not yet been completed by the provider"
+          )
+        end
+      end
+
+      context "when the provider has verified the claim" do
+        context "when the claim is for a fixed term contract" do
+          it "shows the verification information and allows the admin to complete the task" do
+            fe_provider = create(:school, :further_education, name: "Springfield A and M")
+
+            claim = create(
+              :claim,
+              first_name: "Edna",
+              surname: "Krabappel",
+              date_of_birth: Date.new(1945, 7, 3),
+              reference: "AB123456",
+              created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+              submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+            )
+
+            create(
+              :further_education_payments_eligibility,
+              :verified,
+              contract_type: "fixed_term",
+              claim: claim,
+              school: fe_provider,
+              award_amount: 1500
+            )
+
+            visit admin_claim_path(claim)
+
+            click_on "View tasks"
+
+            click_on "Confirm the provider verification"
+
+            expect(page).to have_content(
+              "This task was verified by the provider (Seymoure Skinner)"
+            )
+
+            within_table_row("Contract of employment") do |claimant, provider|
+              expect(claimant).to have_text("Fixed term")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Teaching responsibilities") do |claimant, provider|
+              expect(claimant).to have_text("Yes")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("First 5 years of teaching") do |claimant, provider|
+              expect(claimant).to have_text "September 2023 to August 2024"
+              expect(provider).to have_text "Yes"
+            end
+
+            within_table_row("Timetabled teaching hours") do |claimant, provider|
+              expect(claimant).to have_text("More than 12 hours per week")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Age range taught") do |claimant, provider|
+              expect(claimant).to have_text("Yes")
+              expect(provider).to have_text("No")
+            end
+
+            within_table_row("Subject") do |claimant, provider|
+              expect(claimant).to have_text("Maths")
+              expect(claimant).to have_text("Physics")
+              expect(provider).to have_text("No")
+            end
+
+            within_table_row("Course") do |claimant, provider|
+              expect(claimant).to have_content(
+                "Qualifications approved for funding at level 3 and below in " \
+                "the mathematics and statistics (opens in new tab) sector subject area" \
+                "GCSE in maths, functional skills qualifications and other " \
+                "maths qualifications (opens in new tab) approved for teaching " \
+                "to 16 to 19-year-olds who meet the condition of funding" \
+                "GCSE physics"
+              )
+
+              expect(provider).to have_text("No")
+            end
+
+            within_fieldset("Has the provider confirmed the claimant's details?") do
+              choose "Yes"
+            end
+
+            click_on "Save and continue"
+
+            visit admin_claim_tasks_path(claim)
+
+            expect(task_status("Provider verification")).to eq "Passed"
+          end
+        end
+
+        context "when the claim is for a varible hours contract" do
+          it "shows the verification information and allows the admin to complete the task" do
+            fe_provider = create(:school, :further_education, name: "Springfield A and M")
+
+            claim = create(
+              :claim,
+              first_name: "Edna",
+              surname: "Krabappel",
+              date_of_birth: Date.new(1945, 7, 3),
+              reference: "AB123456",
+              created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+              submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+            )
+
+            create(
+              :further_education_payments_eligibility,
+              :verified_variable_hours,
+              claim: claim,
+              school: fe_provider,
+              award_amount: 1500
+            )
+
+            visit admin_claim_path(claim)
+
+            click_on "View tasks"
+
+            click_on "Confirm the provider verification"
+
+            expect(page).to have_content(
+              "This task was verified by the provider (Seymoure Skinner)"
+            )
+
+            within_table_row("Contract of employment") do |claimant, provider|
+              expect(claimant).to have_text("Variable hours")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Teaching responsibilities") do |claimant, provider|
+              expect(claimant).to have_text("Yes")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("First 5 years of teaching") do |claimant, provider|
+              expect(claimant).to have_text "September 2023 to August 2024"
+              expect(provider).to have_text "Yes"
+            end
+
+            within_table_row("Taught at least one term") do |claimant, provider|
+              expect(claimant).to have_text("Yes")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Timetabled teaching hours") do |claimant, provider|
+              expect(claimant).to have_text("More than 12 hours per week")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Age range taught") do |claimant, provider|
+              expect(claimant).to have_text("Yes")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Subject") do |claimant, provider|
+              expect(claimant).to have_text("Maths")
+              expect(claimant).to have_text("Physics")
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Course") do |claimant, provider|
+              expect(claimant).to have_content(
+                "Qualifications approved for funding at level 3 and below in " \
+                "the mathematics and statistics (opens in new tab) sector subject area" \
+                "GCSE in maths, functional skills qualifications and other " \
+                "maths qualifications (opens in new tab) approved for teaching " \
+                "to 16 to 19-year-olds who meet the condition of funding" \
+                "GCSE physics"
+              )
+
+              expect(provider).to have_text("Yes")
+            end
+
+            within_table_row("Timetabled teaching hours next term") do |claimant, provider|
+              expect(claimant).to have_text("At least 2.5 hours per week")
+              expect(provider).to have_text("No")
+            end
+
+            within_fieldset("Has the provider confirmed the claimant's details?") do
+              choose "No"
+            end
+
+            click_on "Save and continue"
+
+            visit admin_claim_tasks_path(claim)
+
+            expect(task_status("Provider verification")).to eq "Failed"
+          end
+        end
+      end
+    end
+  end
+
+  def within_table_row(label, &block)
+    within(first("tr", text: label)) do
+      claimant_answer = find("td:first-of-type")
+      provider_answer = find("td:last-of-type")
+
+      yield(claimant_answer, provider_answer)
+    end
+  end
+
+  def task_status(task_name)
+    find(
+      :xpath,
+      "//h2[contains(@class, 'app-task-list__section') and contains(., '#{task_name}')]/following-sibling::ul//strong[contains(@class, 'govuk-tag')]"
+    ).text
+  end
+end

--- a/spec/forms/journeys/further_education_payments/provider/omniauth_callback_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/provider/omniauth_callback_form_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::OmniauthCallbackFor
           "raw_info" => {
             "organisation" => {
               "id" => "22222",
-              "ukprn" => "12345678"
+              "ukprn" => "12345678",
+              "name" => "Springfield Elementary"
             }
           }
         }
@@ -57,6 +58,10 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::OmniauthCallbackFor
             change(journey_session.answers, :dfe_sign_in_organisation_id)
               .from(nil)
               .to("22222")
+          ).and(
+            change(journey_session.answers, :dfe_sign_in_organisation_name)
+              .from(nil)
+              .to("Springfield Elementary")
           ).and(
             change(journey_session.answers, :dfe_sign_in_service_access?)
               .from(false)

--- a/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
         dfe_sign_in_uid: "123",
         dfe_sign_in_first_name: "Seymoure",
         dfe_sign_in_last_name: "Skinner",
-        dfe_sign_in_email: "seymore.skinner@springfield-elementary.edu"
+        dfe_sign_in_email: "seymour.skinner@springfield-elementary.edu",
+        dfe_sign_in_organisation_name: "Springfield Elementary",
+        dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
       }
     )
   end
@@ -302,7 +304,9 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
             "dfe_sign_in_uid" => "123",
             "first_name" => "Seymoure",
             "last_name" => "Skinner",
-            "email" => "seymore.skinner@springfield-elementary.edu"
+            "email" => "seymour.skinner@springfield-elementary.edu",
+            "dfe_sign_in_organisation_name" => "Springfield Elementary",
+            "dfe_sign_in_role_codes" => ["teacher_payments_claim_verifier"]
           },
           "created_at" => "2024-01-01T12:00:00.000+00:00"
         }

--- a/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
             teaching_responsibilities
             further_education_teaching_start_year
             teaching_hours_per_week
-            hours_teaching_eligible_subjects
+            half_teaching_hours
             subjects_taught
           ]
         )
@@ -120,7 +120,7 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
             further_education_teaching_start_year
             taught_at_least_one_term
             teaching_hours_per_week
-            hours_teaching_eligible_subjects
+            half_teaching_hours
             subjects_taught
             teaching_hours_per_week_next_term
           ]
@@ -213,8 +213,8 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
       end
     end
 
-    context "when the assertion is `hours_teaching_eligible_subjects`" do
-      let(:assertion_name) { "hours_teaching_eligible_subjects" }
+    context "when the assertion is `half_teaching_hours`" do
+      let(:assertion_name) { "half_teaching_hours" }
 
       it do
         is_expected.not_to(allow_value(nil).for(:outcome).with_message(
@@ -257,7 +257,7 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
               "1": {name: "teaching_responsibilities", outcome: "1"},
               "2": {name: "further_education_teaching_start_year", outcome: "1"},
               "3": {name: "teaching_hours_per_week", outcome: "1"},
-              "4": {name: "hours_teaching_eligible_subjects", outcome: "0"},
+              "4": {name: "half_teaching_hours", outcome: "0"},
               "5": {name: "subjects_taught", outcome: "0"}
             }
           }
@@ -290,7 +290,7 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
               "outcome" => true
             },
             {
-              "name" => "hours_teaching_eligible_subjects",
+              "name" => "half_teaching_hours",
               "outcome" => false
             },
             {

--- a/spec/models/automated_checks/claim_verifiers/provider_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/provider_verification_spec.rb
@@ -1,0 +1,202 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
+  describe "#initialize" do
+    context "with a non FE claim" do
+      it "errors" do
+        claim = create(:claim)
+
+        expect { described_class.new(claim: claim) }.to(
+          raise_error(ArgumentError, "Claim must be an Further Education claim")
+        )
+      end
+    end
+  end
+
+  describe "#perform" do
+    context "when the claim has not been verified by the provider" do
+      let(:verification) { {} }
+
+      it "doesn't create a task" do
+        claim = create(
+          :further_education_payments_eligibility,
+          verification: verification
+        ).claim
+
+        expect { described_class.new(claim: claim).perform }.not_to(
+          change { claim.tasks.count }
+        )
+      end
+    end
+
+    context "when the claim has been verified by the provider" do
+      context "when the task has already been performed" do
+        it "does not alter the task or create a new one" do
+          claim = create(
+            :further_education_payments_eligibility,
+            :verified
+          ).claim
+
+          task = create(
+            :task,
+            name: "provider_verification",
+            claim: claim,
+            passed: true
+          )
+
+          expect { described_class.new(claim: claim).perform }.to(
+            not_change { claim.tasks.count }.and(
+              not_change { task.reload.updated_at }
+            )
+          )
+        end
+      end
+
+      context "when the task has not been performed" do
+        context "when the provider has not confirmed the claimants answers" do
+          it "fails the task" do
+            claim = create(
+              :further_education_payments_eligibility,
+              verification: {
+                assertions: [
+                  {name: "contract_type", outcome: false}
+                ],
+                verifier: {
+                  dfe_sign_in_uid: "123",
+                  first_name: "Seymour",
+                  last_name: "Skinner",
+                  email: "seymore.skinner@springfield-elementary.edu",
+                  dfe_sign_in_organisation_name: "Springfield Elementary",
+                  dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
+                },
+                created_at: Time.zone.now
+              }
+            ).claim
+
+            expect { described_class.new(claim: claim).perform }.to(
+              change { claim.tasks.count }.from(0).to(1).and(
+                change(DfeSignIn::User, :count).from(0).to(1)
+              )
+            )
+
+            task = claim.tasks.last
+
+            expect(task.name).to eq("provider_verification")
+            expect(task.passed).to eq(false)
+            expect(task.manual).to eq(false)
+
+            dfe_sign_in_user = task.created_by
+
+            expect(dfe_sign_in_user.dfe_sign_in_id).to eq("123")
+            expect(dfe_sign_in_user.given_name).to eq("Seymour")
+            expect(dfe_sign_in_user.family_name).to eq("Skinner")
+            expect(dfe_sign_in_user.email).to eq(
+              "seymore.skinner@springfield-elementary.edu"
+            )
+            expect(dfe_sign_in_user.organisation_name).to eq(
+              "Springfield Elementary"
+            )
+            expect(dfe_sign_in_user.role_codes).to eq(
+              ["teacher_payments_claim_verifier"]
+            )
+          end
+        end
+
+        context "when the provider has confirmed the claimants answers" do
+          it "passes the task" do
+            claim = create(
+              :further_education_payments_eligibility,
+              verification: {
+                assertions: [
+                  {name: "contract_type", outcome: true}
+                ],
+                verifier: {
+                  dfe_sign_in_uid: "123",
+                  first_name: "Seymour",
+                  last_name: "Skinner",
+                  email: "seymore.skinner@springfield-elementary.edu",
+                  dfe_sign_in_organisation_name: "Springfield Elementary",
+                  dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
+                },
+                created_at: Time.zone.now
+              }
+            ).claim
+
+            expect { described_class.new(claim: claim).perform }.to(
+              change { claim.tasks.count }.from(0).to(1).and(
+                change(DfeSignIn::User, :count).from(0).to(1)
+              )
+            )
+
+            task = claim.tasks.last
+
+            expect(task.name).to eq("provider_verification")
+            expect(task.passed).to eq(true)
+            expect(task.manual).to eq(false)
+
+            dfe_sign_in_user = task.created_by
+
+            expect(dfe_sign_in_user.dfe_sign_in_id).to eq("123")
+            expect(dfe_sign_in_user.given_name).to eq("Seymour")
+            expect(dfe_sign_in_user.family_name).to eq("Skinner")
+            expect(dfe_sign_in_user.email).to eq(
+              "seymore.skinner@springfield-elementary.edu"
+            )
+            expect(dfe_sign_in_user.organisation_name).to eq(
+              "Springfield Elementary"
+            )
+            expect(dfe_sign_in_user.role_codes).to eq(
+              ["teacher_payments_claim_verifier"]
+            )
+          end
+        end
+
+        context "when the verifier already exists" do
+          it "does not create a new verifier" do
+            dfe_sign_in_user = create(
+              :dfe_signin_user,
+              dfe_sign_in_id: "123",
+              given_name: "Seymour",
+              family_name: "Skinner",
+              email: "seymore.skinner@springfield-elementary.edu",
+              organisation_name: "Springfield Elementary",
+              role_codes: ["teacher_payments_claim_verifier"]
+            )
+
+            claim = create(
+              :further_education_payments_eligibility,
+              verification: {
+                assertions: [
+                  {name: "contract_type", outcome: true}
+                ],
+                verifier: {
+                  dfe_sign_in_uid: "123",
+                  first_name: "Seymour",
+                  last_name: "Skinner",
+                  email: "seymore.skinner@springfield-elementary.edu",
+                  dfe_sign_in_organisation_name: "Springfield Elementary",
+                  dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
+                },
+                created_at: Time.zone.now
+              }
+            ).claim
+
+            expect { described_class.new(claim: claim).perform }.to(
+              change { claim.tasks.count }.from(0).to(1).and(
+                not_change(DfeSignIn::User, :count)
+              )
+            )
+
+            task = claim.tasks.last
+
+            expect(task.name).to eq("provider_verification")
+            expect(task.passed).to eq(true)
+            expect(task.manual).to eq(false)
+
+            expect(task.created_by).to eq(dfe_sign_in_user)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -181,7 +181,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::InternationalRelocationPayments
       ["Identity confirmation", "Visa", "Arrival date", "Employment", "Employment contract", "Employment start", "Subject", "Teaching hours", "Decision"]
     when Policies::FurtherEducationPayments
-      ["Identity confirmation", "Qualifications", "Census subjects taught", "Employment", "Matching details", "Decision"]
+      ["Identity confirmation", "Provider verification", "Qualifications", "Census subjects taught", "Employment", "Matching details", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
Adds the admin provider verification task.

Probably best to review each commit separately, the main ones are
* [Add provider verification admin task](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3131/commits/f9b57382ff5debfcafef00954cda7a8a7b15fe3e) - This commit adds the UI for displaying the verification in the admin area but leaves the task as a manual one for ops to complete.
* [Automate admin task](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3131/commits/57ff76ed538ee652a8fc8d69ef6552da656b3ccd) - This commit adds the automatic task passing based on the answers given by the provider.

I've used the existing claim verifier mechanism to handle calling the provider verification task, this means the claim verifier code will be run twice for the same claim, once when the claimant submits the claim and once when the provider verifies it. If there's an issue with he claim verifier code being ran twice that I've overlooked, let me know, can always create the task directly in the verification form.

## Walk through

https://github.com/user-attachments/assets/d791e6ef-c7cf-4a75-b56a-15a471a2b812

