### PR TITLE
Update error message copy

### DIFF
--- a/app/views/further_education_payments/provider/claims/verify_claim.html.erb
+++ b/app/views/further_education_payments/provider/claims/verify_claim.html.erb
@@ -60,7 +60,7 @@
           legend: {
             size: "s",
             text: f.object.t(
-              [:assertions, f.object.contract_type, ff.object.name],
+              [:assertions, f.object.contract_type, ff.object.name, :label],
               claimant: f.object.claimant_name,
               provider: f.object.claim.school.name,
             ),

--- a/app/views/further_education_payments/provider/claims/verify_claim.html.erb
+++ b/app/views/further_education_payments/provider/claims/verify_claim.html.erb
@@ -63,6 +63,7 @@
               [:assertions, f.object.contract_type, ff.object.name, :label],
               claimant: f.object.claimant_name,
               provider: f.object.claim.school.name,
+              hours: f.object.teaching_hours_per_week
             ),
           },
           hint: -> do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1134,9 +1134,9 @@ en:
               errors:
                 inclusion: "Select yes if %{claimant} is in the first 5 years of their further education teaching career in England"
             teaching_hours_per_week:
-              label: "Is %{claimant} timetabled to teach an average of 12 hours per week during the current term?"
+              label: "Is %{claimant} timetabled to teach an average of %{hours} during the current term?"
               errors:
-                inclusion: "Select yes if %{claimant} is timetabled to teach an average of 12 hours per week during the current term"
+                inclusion: "Select yes if %{claimant} is timetabled to teach an average of %{hours} during the current term"
             hours_teaching_eligible_subjects:
               label: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
               errors:
@@ -1163,9 +1163,9 @@ en:
               errors:
                 inclusion: "Select yes if %{claimant} has taught at least one academic term at %{provider}"
             teaching_hours_per_week:
-              label: "Is %{claimant} timetabled to teach an average of 12 hours per week during the current term?"
+              label: "Is %{claimant} timetabled to teach an average of %{hours} during the current term?"
               errors:
-                inclusion: "Select yes if %{claimant} is timetabled to teach an average of 12 hours per week during the current term"
+                inclusion: "Select yes if %{claimant} is timetabled to teach an average of %{hours} during the current term"
             hours_teaching_eligible_subjects:
               label: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
               errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1116,23 +1116,68 @@ en:
         claimant_date_of_birth: "Claimant date of birth"
         claimant_trn: "Claimant teacher reference number (TRN)"
         claim_date: "Claim date"
+        errors:
+          declaration:
+            acceptance: "Tick the box to confirm that the information provided in this form is correct to the best of your knowledge"
         assertions:
           fixed_contract:
-            contract_type: "Does %{claimant} have a permanent contract of employment at %{provider}?"
-            teaching_responsibilities: "Is %{claimant} a member of staff with teaching responsibilities?"
-            further_education_teaching_start_year: "Is %{claimant} in the first 5 years of their further education teaching career in England?"
-            teaching_hours_per_week: "Is %{claimant} timetabled to teach an average of 12 hours per week during the current term?"
-            hours_teaching_eligible_subjects: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
-            subjects_taught: "For at least half of their timetabled teaching hours, does %{claimant} teach:"
+            contract_type:
+              label: "Does %{claimant} have a permanent contract of employment at %{provider}?"
+              errors:
+                inclusion: "Select yes if %{claimant} has a fixed term contract of employment at %{provider}"
+            teaching_responsibilities:
+              label: "Is %{claimant} a member of staff with teaching responsibilities?"
+              errors:
+                inclusion: "Select yes if %{claimant} is a member of staff with teaching responsibilities"
+            further_education_teaching_start_year:
+              label: "Is %{claimant} in the first 5 years of their further education teaching career in England?"
+              errors:
+                inclusion: "Select yes if %{claimant} is in the first 5 years of their further education teaching career in England"
+            teaching_hours_per_week:
+              label: "Is %{claimant} timetabled to teach an average of 12 hours per week during the current term?"
+              errors:
+                inclusion: "Select yes if %{claimant} is timetabled to teach an average of 12 hours per week during the current term"
+            hours_teaching_eligible_subjects:
+              label: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
+              errors:
+                inclusion: "Select yes if %{claimant} teaches 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP), for at least half of their timetabled teaching hours"
+            subjects_taught:
+              label: "For at least half of their timetabled teaching hours, does %{claimant} teach:"
+              errors:
+                inclusion: "Select yes if %{claimant} teaches this course for at least half their timetabled teaching hours"
           variable_contract:
-            contract_type: "Does %{claimant} have a variable hour contract of employment at %{provider}?"
-            teaching_responsibilities: "Is %{claimant} a member of staff with teaching responsibilities?"
-            further_education_teaching_start_year: "Is %{claimant} in the first 5 years of their further education teaching career in England?"
-            taught_at_least_one_term: "Has %{claimant} taught for at least one academic term at %{provider}?"
-            teaching_hours_per_week: "Is %{claimant} timetabled to teach an average of 12 hours per week during the current term?"
-            hours_teaching_eligible_subjects: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
-            subjects_taught: "For at least half of their timetabled teaching hours, does %{claimant} teach:"
-            teaching_hours_per_week_next_term: "Will %{claimant} be timetabled to teach at least 2.5 hours per week next term?"
+            contract_type:
+              label: "Does %{claimant} have a variable hour contract of employment at %{provider}?"
+              errors:
+                inclusion: "Select yes if %{claimant} has a variable hours contract of employment at %{provider}"
+            teaching_responsibilities:
+              label: "Is %{claimant} a member of staff with teaching responsibilities?"
+              errors:
+                inclusion: "Select yes if %{claimant} is a member of staff with teaching responsibilities"
+            further_education_teaching_start_year:
+              label: "Is %{claimant} in the first 5 years of their further education teaching career in England?"
+              errors:
+                inclusion: "Select yes if %{claimant} is in the first 5 years of their further education teaching career in England"
+            taught_at_least_one_term:
+              label: "Has %{claimant} taught for at least one academic term at %{provider}?"
+              errors:
+                inclusion: "Select yes if %{claimant} has taught at least one academic term at %{provider}"
+            teaching_hours_per_week:
+              label: "Is %{claimant} timetabled to teach an average of 12 hours per week during the current term?"
+              errors:
+                inclusion: "Select yes if %{claimant} is timetabled to teach an average of 12 hours per week during the current term"
+            hours_teaching_eligible_subjects:
+              label: "For at least half of their timetabled teaching hours, does %{claimant} teach 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?"
+              errors:
+                inclusion: "Select yes if %{claimant} teaches 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP), for at least half of their timetabled teaching hours"
+            subjects_taught:
+              label: "For at least half of their timetabled teaching hours, does %{claimant} teach:"
+              errors:
+                inclusion: "Select yes if %{claimant} teaches this course for at least half their timetabled teaching hours"
+            teaching_hours_per_week_next_term:
+              label: "Will %{claimant} be timetabled to teach at least 2.5 hours per week next term?"
+              errors:
+                inclusion: "Select yes if %{claimant} will be timetabled to teach at least 2.5 hours per week next term"
 
   early_years_payment:
     claim_description: for an early years financial incentive payment

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -269,7 +269,8 @@ RSpec.feature "Provider verifying claims" do
     create(
       :further_education_payments_eligibility,
       claim: claim_1,
-      school: fe_provider
+      school: fe_provider,
+      teaching_hours_per_week: "more_than_12"
     )
 
     claim_2 = create(
@@ -284,7 +285,8 @@ RSpec.feature "Provider verifying claims" do
     create(
       :further_education_payments_eligibility,
       claim: claim_2,
-      school: fe_provider
+      school: fe_provider,
+      teaching_hours_per_week: "more_than_12"
     )
 
     mock_dfe_sign_in_auth_session(
@@ -395,6 +397,7 @@ RSpec.feature "Provider verifying claims" do
       :further_education_payments_eligibility,
       claim: claim,
       school: fe_provider,
+      teaching_hours_per_week: "more_than_12",
       contract_type: "fixed_term",
       subjects_taught: ["engineering_manufacturing"],
       engineering_manufacturing_courses: [
@@ -461,8 +464,8 @@ RSpec.feature "Provider verifying claims" do
     end
 
     within_fieldset(
-      "Is Edna Krabappel timetabled to teach an average of 12 hours per " \
-      "week during the current term?"
+      "Is Edna Krabappel timetabled to teach an average of more than 12 " \
+      "hours per week during the current term?"
     ) do
       choose "Yes"
     end
@@ -518,6 +521,7 @@ RSpec.feature "Provider verifying claims" do
       claim: claim,
       school: fe_provider,
       contract_type: "variable_hours",
+      teaching_hours_per_week: "between_2_5_and_12",
       subjects_taught: ["engineering_manufacturing"],
       engineering_manufacturing_courses: [
         "approved_level_321_transportation",
@@ -590,8 +594,8 @@ RSpec.feature "Provider verifying claims" do
     end
 
     within_fieldset(
-      "Is Edna Krabappel timetabled to teach an average of 12 hours per " \
-      "week during the current term?"
+      "Is Edna Krabappel timetabled to teach an average of between 2.5 and " \
+      "12 hours per week during the current term?"
     ) do
       choose "Yes"
     end

--- a/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
@@ -3,9 +3,26 @@ require "rails_helper"
 RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments::Provider }
 
-  let(:eligibility) { create(:further_education_payments_eligibility) }
+  let(:school) do
+    create(:school, :further_education, name: "Springfield Elementary")
+  end
 
-  let(:claim) { eligibility.claim }
+  let(:eligibility) do
+    create(
+      :further_education_payments_eligibility,
+      school: school
+    )
+  end
+
+  let(:claim) do
+    create(
+      :claim,
+      eligibility: eligibility,
+      policy: Policies::FurtherEducationPayments,
+      first_name: "Edna",
+      surname: "Krabappel"
+    )
+  end
 
   let(:journey_session) do
     create(
@@ -34,15 +51,11 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
     subject { form }
 
     it do
-      is_expected.to validate_acceptance_of(:declaration)
-    end
-
-    it "validates all assertions are answered" do
-      form.validate
-
-      form.assertions.each do |assertion|
-        expect(assertion.errors[:outcome]).to eq(["Select an option"])
-      end
+      is_expected.to(
+        validate_acceptance_of(:declaration).with_message(
+          "Tick the box to confirm that the information provided in this form is correct to the best of your knowledge"
+        )
+      )
     end
 
     it "validates the claim hasn't already been verified" do
@@ -106,6 +119,116 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
             teaching_hours_per_week_next_term
           ]
         )
+      end
+    end
+  end
+
+  describe "AssertionForm" do
+    let(:contract_type) { "fixed_contract" }
+
+    subject do
+      described_class::AssertionForm.new(
+        name: assertion_name,
+        type: contract_type,
+        claim: claim
+      )
+    end
+
+    context "when the assertion is `contract_type`" do
+      let(:assertion_name) { "contract_type" }
+
+      context "when fixed term" do
+        let(:contract_type) { "fixed_contract" }
+
+        it do
+          is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+            "Select yes if Edna has a fixed term contract of employment at Springfield Elementary"
+          ))
+        end
+      end
+
+      context "when variable" do
+        let(:contract_type) { "variable_contract" }
+
+        it do
+          is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+            "Select yes if Edna has a variable hours contract of employment at Springfield Elementary"
+          ))
+        end
+      end
+    end
+
+    context "when the assertion is `teaching_responsibilities`" do
+      let(:assertion_name) { "teaching_responsibilities" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna is a member of staff with teaching responsibilities"
+        ))
+      end
+    end
+
+    context "when the assertion is `further_education_teaching_start_year`" do
+      let(:assertion_name) { "further_education_teaching_start_year" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna is in the first 5 years of their further education teaching career in England"
+        ))
+      end
+    end
+
+    context "when the assertion is `taught_at_least_one_term`" do
+      let(:assertion_name) { "taught_at_least_one_term" }
+
+      let(:contract_type) { "variable_contract" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna has taught at least one academic term at Springfield Elementary"
+        ))
+      end
+    end
+
+    context "when the assertion is `teaching_hours_per_week`" do
+      let(:assertion_name) { "teaching_hours_per_week" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna is timetabled to teach an average of 12 hours per week during the current term"
+        ))
+      end
+    end
+
+    context "when the assertion is `hours_teaching_eligible_subjects`" do
+      let(:assertion_name) { "hours_teaching_eligible_subjects" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna teaches 16- to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP), for at least half of their timetabled teaching hours"
+        ))
+      end
+    end
+
+    context "when the assertion is `subjects_taught`" do
+      let(:assertion_name) { "subjects_taught" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna teaches this course for at least half their timetabled teaching hours"
+        ))
+      end
+    end
+
+    context "when the assertion is `teaching_hours_per_week_next_term`" do
+      let(:assertion_name) { "teaching_hours_per_week_next_term" }
+
+      let(:contract_type) { "variable_contract" }
+
+      it do
+        is_expected.not_to(allow_value(nil).for(:outcome).with_message(
+          "Select yes if Edna will be timetabled to teach at least 2.5 hours per week next term"
+        ))
       end
     end
   end


### PR DESCRIPTION
Updates the error messages on the verify claim form, and the nested
assertions forms, to match the copy on figma.

![Screenshot 2024-08-29 at 11 35 25](https://github.com/user-attachments/assets/d3fa7271-c1b2-4ae0-877c-3991bb37b086)

