### PR TITLE
[LUPEALPHA-923] Update the verification due date

### DIFF
--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -89,8 +89,8 @@ class ClaimMailer < ApplicationMailer
       recipient_name: claim.school.name,
       claimant_name: claim.full_name,
       claim_reference: claim.reference,
-      claim_submission_date: claim.created_at.to_s(:govuk_date),
-      verification_due_date: claim.eligibility.verification_deadline.to_s(:govuk_date),
+      claim_submission_date: l(claim.created_at.to_date),
+      verification_due_date: l(Policies::FurtherEducationPayments.verification_due_date_for_claim(claim)),
       verification_url: Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
     }
 

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -21,5 +21,9 @@ module Policies
     def notify_reply_to_id
       nil
     end
+
+    def verification_due_date_for_claim(claim)
+      (claim.created_at + 2.weeks).to_date
+    end
   end
 end

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -53,11 +53,6 @@ module Policies
       def verified?
         verification.present?
       end
-
-      # FIXME LUPEYALPHA-923
-      def verification_deadline
-        created_at + 1.week
-      end
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
     it "emails the claim provider" do
       allow(ClaimVerifierJob).to receive(:perform_later)
 
-      perform_enqueued_jobs { subject }
+      travel_to DateTime.new(2024, 3, 1, 0, 0, 0) do
+        perform_enqueued_jobs { subject }
+      end
 
       claim = form.claim
 
@@ -74,8 +76,8 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
           recipient_name: claim.school.name,
           claimant_name: [answers.first_name, answers.surname].join(" "),
           claim_reference: claim.reference,
-          claim_submission_date: claim.submitted_at.to_s(:govuk_date),
-          verification_due_date: claim.eligibility.verification_deadline.to_s(:govuk_date),
+          claim_submission_date: "1 March 2024",
+          verification_due_date: "15 March 2024",
           verification_url: Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
         )
       )


### PR DESCRIPTION
We want the verification due date to be 2 weeks after the claim is
submitted.
This commit also moves the knowledge of the due date to the policy (it's
a policy concern not eligibility concern) and updates the formatting of
the dates in the emails to be consistent with our other emails.

<!-- Do you need to update CHANGELOG.md? -->
