### PR TITLE
Admin claims filter refactor

### DIFF
--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -1,0 +1,64 @@
+class Admin::ClaimsFilterForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :team_member, :string
+  attribute :policy, :string
+  attribute :status, :string
+
+  def claims
+    @claims =
+      case status
+      when "approved"
+        Claim.current_academic_year.approved
+      when "approved_awaiting_qa"
+        Claim.approved.awaiting_qa
+      when "approved_awaiting_payroll"
+        approved_awaiting_payroll
+      when "automatically_approved_awaiting_payroll"
+        Claim.current_academic_year.payrollable.auto_approved
+      when "rejected"
+        Claim.current_academic_year.rejected
+      when "held"
+        Claim.includes(:decisions).held.awaiting_decision
+      when "failed_bank_validation"
+        Claim.includes(:decisions).failed_bank_validation.awaiting_decision
+      end
+
+    @claims ||= Claim.includes(:decisions).not_held.awaiting_decision
+
+    @claims = @claims.by_policy(filtered_policy) if filtered_policy
+    @claims = @claims.by_claims_team_member(filtered_team_member, status) if filtered_team_member
+    @claims = @claims.unassigned if filtered_unassigned
+
+    @claims = @claims.includes(:tasks, eligibility: [:claim_school, :current_school])
+    @claims = @claims.order(:submitted_at)
+
+    @claims
+  end
+
+  def count
+    claims.count
+  end
+
+  private
+
+  def approved_awaiting_payroll
+    claim_ids_with_payrollable_topups = Topup.payrollable.pluck(:claim_id)
+
+    Claim.current_academic_year.payrollable.or(Claim.current_academic_year.where(id: claim_ids_with_payrollable_topups))
+  end
+
+  def filtered_policy
+    Policies[policy]
+  end
+
+  def filtered_team_member
+    return if team_member.blank? || filtered_unassigned
+    DfeSignIn::User.not_deleted.find(team_member).id
+  end
+
+  def filtered_unassigned
+    team_member == "unassigned"
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -166,7 +166,11 @@ class Claim < ApplicationRecord
   scope :submitted, -> { where.not(submitted_at: nil) }
   scope :held, -> { where(held: true) }
   scope :not_held, -> { where(held: false) }
-  scope :awaiting_decision, -> { submitted.joins("LEFT OUTER JOIN decisions ON decisions.claim_id = claims.id AND decisions.undone = false").where(decisions: {claim_id: nil}) }
+  scope :awaiting_decision, -> do
+    submitted
+      .joins("LEFT OUTER JOIN decisions ON decisions.claim_id = claims.id AND decisions.undone = false")
+      .where(decisions: {claim_id: nil})
+  end
   scope :awaiting_task, ->(task_name) { awaiting_decision.joins(sanitize_sql(["LEFT OUTER JOIN tasks ON tasks.claim_id = claims.id AND tasks.name = ?", task_name])).where(tasks: {claim_id: nil}) }
   scope :auto_approved, -> { approved.where(decisions: {created_by: nil}) }
   scope :approved, -> { joins(:decisions).merge(Decision.active.approved) }


### PR DESCRIPTION
# Context

- this refactors the admin claims filter into a form object
- although called a form object its not currently wired up to the form but has the same attribute names so could be wired up to do so later
- the object of this change is to extract excess controller code into correct objects to allow separation of responsibilities allow the code to be simplified more easily
- the original reason for this change was the attempt to introduce FE claims to admin areas which were slowed by the current form filters being coupled to the controller code  