### PR TITLE
[LUPALPHA-997] resend provider verification email

### DIFF
--- a/app/controllers/admin/further_education_payments/provider_verification_emails_controller.rb
+++ b/app/controllers/admin/further_education_payments/provider_verification_emails_controller.rb
@@ -1,0 +1,17 @@
+module Admin
+  module FurtherEducationPayments
+    class ProviderVerificationEmailsController < Admin::BaseAdminController
+      before_action :ensure_service_operator
+
+      def create
+        claim = Claim.find(params[:claim_id])
+
+        ClaimMailer.further_education_payment_provider_verification_email(claim).deliver_later
+
+        flash[:notice] = "Verification email sent to #{claim.school.name}"
+
+        redirect_back(fallback_location: admin_claim_path(claim))
+      end
+    end
+  end
+end

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -52,6 +52,11 @@
       <p class="govuk-body">
         This task has not yet been completed by the provider
       </p>
+
+      <%= govuk_button_to(
+        "Resend provider verification email",
+        admin_claim_further_education_payments_provider_verification_emails_path(@claim)
+      ) %>
     <% end %>
   </div>
 

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -50,13 +50,21 @@
       </table>
     <% else %>
       <p class="govuk-body">
-        This task has not yet been completed by the provider
+        This task has not been sent to the provider yet.
       </p>
 
-      <%= govuk_button_to(
-        "Resend provider verification email",
-        admin_claim_further_education_payments_provider_verification_emails_path(@claim)
-      ) %>
+      <div class="govuk-inset-text">
+        <p>
+          You need to check the matching details and confirm if this is a
+          duplicate claim. If it isn't a duplicate claim, send the verification
+          request to the provider.
+        </p>
+        <%= govuk_button_to(
+          "Send provider verification request",
+          admin_claim_further_education_payments_provider_verification_emails_path(@claim),
+          class: "govuk-!-margin-bottom-0"
+        ) %>
+      </div>
     <% end %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,9 @@ Rails.application.routes.draw do
       get "search", on: :collection
       patch "hold"
       patch "unhold"
+      namespace :further_education_payments do
+        resources :provider_verification_emails, only: [:create]
+      end
     end
 
     resources :qualification_report_uploads, only: [:new, :create]

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -42,11 +42,11 @@ RSpec.feature "Admin claim further education payments" do
           click_on "Confirm the provider verification"
 
           expect(page).to have_content(
-            "This task has not yet been completed by the provider"
+            "This task has not been sent to the provider yet."
           )
 
           perform_enqueued_jobs do
-            click_on "Resend provider verification email"
+            click_on "Send provider verification request"
           end
 
           provider_email_address = claim.school.eligible_fe_provider.primary_key_contact_email_address

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -10,7 +10,12 @@ RSpec.feature "Admin claim further education payments" do
     describe "provider verification task" do
       context "when the provider is yet to verify the claim" do
         it "shows the task as pending" do
-          fe_provider = create(:school, :further_education, name: "Springfield A and M")
+          fe_provider = create(
+            :school,
+            :further_education,
+            :fe_eligible,
+            name: "Springfield A and M"
+          )
 
           claim = create(
             :claim,
@@ -38,6 +43,24 @@ RSpec.feature "Admin claim further education payments" do
 
           expect(page).to have_content(
             "This task has not yet been completed by the provider"
+          )
+
+          perform_enqueued_jobs do
+            click_on "Resend provider verification email"
+          end
+
+          provider_email_address = claim.school.eligible_fe_provider.primary_key_contact_email_address
+
+          expect(provider_email_address).to(
+            have_received_email(
+              "9a25fe46-2ee4-4a5c-8d47-0f04f058a87d",
+              recipient_name: "Springfield A and M",
+              claimant_name: "Edna Krabappel",
+              claim_reference: "AB123456",
+              claim_submission_date: "1 August 2024",
+              verification_due_date: "15 August 2024",
+              verification_url: Journeys::FurtherEducationPayments::Provider::SlugSequence.verify_claim_url(claim)
+            )
           )
         end
       end


### PR DESCRIPTION
Add button to resend provider verification email

The provider can only start the verification process via the link in the
email. If the provider has lost this email we need a mechanisim for the
ops team to resend the email.
As this admin logic is specific only to the FE policy we've opted to
move the controller into a policy specific namespace.

