### PR TITLE
Fix production One Login endpoint config

### DIFF
--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -6,7 +6,7 @@ DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk:443
 DFE_SIGN_IN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 
 BYPASS_ONELOGIN_SIGN_IN: true
-ONELOGIN_SIGN_IN_ISSUER: https://oidc.integration.account.gov.uk/
+ONELOGIN_SIGN_IN_ISSUER: https://oidc.account.gov.uk/
 ONELOGIN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 ONELOGIN_DID_URL: https://identity.account.gov.uk/.well-known/did.json
 

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -5,7 +5,6 @@ DFE_SIGN_IN_IDENTIFIER: teacherpayments
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk:443
 DFE_SIGN_IN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 
-BYPASS_ONELOGIN_SIGN_IN: true
 ONELOGIN_SIGN_IN_ISSUER: https://oidc.account.gov.uk/
 ONELOGIN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.service.gov.uk
 ONELOGIN_DID_URL: https://identity.account.gov.uk/.well-known/did.json


### PR DESCRIPTION
`BYPASS_ONELOGIN_SIGN_IN` does not do anything except on review apps, and is misleadingly configured.