### PR TITLE
Add name and dob check to matching claims

### DIFF
--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -4,7 +4,8 @@ class Claim
     CLAIM_ATTRIBUTE_GROUPS_TO_MATCH = [
       ["email_address"],
       ["national_insurance_number"],
-      ["bank_account_number", "bank_sort_code", "building_society_roll_number"]
+      ["bank_account_number", "bank_sort_code", "building_society_roll_number"],
+      ["first_name", "surname", "date_of_birth"]
     ].freeze
 
     def initialize(source_claim)

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Claim::MatchingAttributeFinder do
   describe "#matching_claims for ECP/LUP claims" do
     let!(:source_claim) {
       create(:claim,
+        first_name: "Genghis",
+        surname: "Khan",
+        date_of_birth: Date.new(1162, 5, 31),
         national_insurance_number: "QQ891011C",
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
@@ -17,6 +20,9 @@ RSpec.describe Claim::MatchingAttributeFinder do
     let!(:student_loans_claim) {
       create(:claim,
         :submitted,
+        first_name: "Genghis",
+        surname: "Khan",
+        date_of_birth: Date.new(1162, 5, 31),
         national_insurance_number: "QQ891011C",
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
@@ -30,6 +36,9 @@ RSpec.describe Claim::MatchingAttributeFinder do
     let!(:lup_claim) {
       create(:claim,
         :submitted,
+        first_name: "Genghis",
+        surname: "Khan",
+        date_of_birth: Date.new(1162, 5, 31),
         national_insurance_number: "QQ891011C",
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
@@ -50,6 +59,9 @@ RSpec.describe Claim::MatchingAttributeFinder do
   describe "#matching_claims" do
     let(:source_claim) {
       create(:claim,
+        first_name: "Genghis",
+        surname: "Khan",
+        date_of_birth: Date.new(1162, 5, 31),
         national_insurance_number: "QQ891011C",
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
@@ -172,6 +184,39 @@ RSpec.describe Claim::MatchingAttributeFinder do
 
       expect(matching_claims).to be_empty
     end
+
+    it "does not include a claim with a matching name" do
+      create(
+        :claim,
+        :submitted,
+        first_name: source_claim.first_name,
+        surname: source_claim.surname
+      )
+
+      expect(matching_claims).to be_empty
+    end
+
+    it "does not include a claim with a matching date of birth" do
+      create(
+        :claim,
+        :submitted,
+        date_of_birth: source_claim.date_of_birth
+      )
+
+      expect(matching_claims).to be_empty
+    end
+
+    it "includes a claim with a matching name and date of birth" do
+      claim_with_matching_attributes = create(
+        :claim,
+        :submitted,
+        first_name: source_claim.first_name,
+        surname: source_claim.surname,
+        date_of_birth: source_claim.date_of_birth
+      )
+
+      expect(matching_claims).to eq([claim_with_matching_attributes])
+    end
   end
 
   describe "matching_claims - blank trn" do
@@ -193,7 +238,8 @@ RSpec.describe Claim::MatchingAttributeFinder do
         :claim,
         :submitted,
         policy: policy,
-        eligibility: eligibility
+        eligibility: eligibility,
+        surname: Faker::Name.last_name
       )
     }
 
@@ -221,7 +267,8 @@ RSpec.describe Claim::MatchingAttributeFinder do
         :claim,
         :submitted,
         policy: policy,
-        eligibility: eligibility
+        eligibility: eligibility,
+        surname: Faker::Name.last_name
       )
     }
 
@@ -253,7 +300,8 @@ RSpec.describe Claim::MatchingAttributeFinder do
         :claim,
         :submitted,
         policy: policy,
-        eligibility: eligibility
+        eligibility: eligibility,
+        surname: Faker::Name.last_name
       )
     }
 
@@ -266,6 +314,8 @@ RSpec.describe Claim::MatchingAttributeFinder do
     it "returns the attributes that match" do
       source_claim = create(
         :claim,
+        first_name: "genghis",
+        surname: "khan",
         email_address: "genghis.khan@example.com",
         national_insurance_number: "QQ891011C",
         bank_account_number: "34682151",
@@ -277,6 +327,8 @@ RSpec.describe Claim::MatchingAttributeFinder do
 
       other_claim = create(
         :claim,
+        first_name: "genghis",
+        surname: "khan2",
         email_address: "genghis.khan@example.com",
         national_insurance_number: "QQ891011C",
         bank_account_number: "11111111",

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ClaimCheckingTasks do
       end
 
       it "includes a task for payroll gender when a payroll gender task has previously been completed" do
-        claim.tasks << create(:task, name: "payroll_gender")
+        create(:task, name: "payroll_gender", claim: claim)
 
         expect(checking_tasks.applicable_task_names).to match_array(applicable_tasks + %w[payroll_gender])
       end

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -8,7 +8,9 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       :claim,
       :submitted,
       policy: policy,
-      eligibility: eligibility
+      eligibility: eligibility,
+      first_name: Faker::Name.first_name,
+      surname: Faker::Name.last_name
     )
   }
 


### PR DESCRIPTION
A requirement is to trigger a "multiple claims with matching details"
warning if there is another claim with a matching name and date of
birth. This check is to work across all policies.

We can hold off merging this one until after Monday
