### PR TITLE
Fix the labels on addresses

### DIFF
--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { "address": "#{@address_data.first[:address].gsub(",", "").gsub(" ", "_").downcase}"}) if @form.errors.any? %>
 
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |form| %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <div class="govuk-!-margin-bottom-5">
         <h1 class="govuk-heading-xl"><%= t("questions.address.home.title") %></h1>
         <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Postcode</h2>
@@ -27,10 +27,12 @@
                 <% address = option[:address].gsub(",", "").gsub(" ", "_").downcase %>
                 <% checked = params.dig(:claim, :address_line_1) == option[:address_line_1] %>
 
-                <div class="govuk-radios__item">
-                  <%= form.radio_button :address, [option[:address], option[:address_line_1], option[:address_line_2], option[:address_line_3], option[:postcode]].join(":"), { checked:, class: "govuk-radios__input", id: address } %>
-                  <%= form.label address, "#{option[:address]}", class: "govuk-label govuk-radios__label", id: address %>
-                </div>
+                <%= form.govuk_radio_button(
+                  :address,
+                  [option[:address], option[:address_line_1], option[:address_line_2], option[:address_line_3], option[:postcode]].join(":"),
+                  label: { text: option[:address] },
+                  checked: checked
+                ) %>
               <% end %>
             </div>
           </fieldset>

--- a/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
@@ -301,7 +301,7 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
       # - Select your home address
       expect(page).to have_text(I18n.t("questions.address.home.title"))
 
-      choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+      choose "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
       click_on "Continue"
 
       journey_session.reload
@@ -445,7 +445,7 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
       expect(page).to have_text("6, Wearside Road, London, SE13 7UN")
       expect(page).to have_link(href: claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "address"))
 
-      choose "5_wearside_road_london_se13_7un"
+      choose "5, Wearside Road, London, SE13 7UN"
       click_on "Continue"
 
       journey_session.reload

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
@@ -158,7 +158,7 @@ RSpec.feature "Combined journey with Teacher ID email check" do
     # - Select your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
 
-    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+    choose "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
     click_on "Continue"
   end
 end

--- a/spec/features/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments_claim_spec.rb
@@ -881,7 +881,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
       # - Select your home address
       expect(page).to have_text(I18n.t("questions.address.home.title"))
 
-      choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+      choose "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
       click_on "Continue"
 
       # - What is your address

--- a/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_check_email_spec.rb
@@ -180,7 +180,7 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
     # - Select your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
 
-    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+    choose "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
     click_on "Continue"
   end
 

--- a/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
+++ b/spec/features/tslr_claim_journey_with_teacher_id_trn_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "TSLR journey with Teacher ID teacher reference number page remova
     # - Select your home address
     expect(page).to have_text(I18n.t("questions.address.home.title"))
 
-    choose "flat_11_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+    choose "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
     click_on "Continue"
 
     # - select-email page

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -160,7 +160,7 @@ module GetATeacherRelocationPayment
       click_on "Search"
 
       expect(page).to have_text("Select an address")
-      choose "flat_1_millbrook_tower_windermere_avenue_southampton_so16_9fx"
+      choose "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
 
       click_on "Continue"
     end


### PR DESCRIPTION
Fix the labels on addresses

Labels on addresses were `for` `claim_some_address` but the radio button
had the `id` `some_address`. Update the radio buttons to use
govuk_radio_button helper and let that generate the label tag. Also
updates the specs to click the labels rather than find the radio buttons
by id.

https://github.com/user-attachments/assets/1f2fd2fd-d63f-443b-bed6-b0aa8fd8d0a0

