### PR TITLE
[LUPEYALPHA-1012] Admin gender task hint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,8 @@ gem "activerecord-copy", require: false
 gem "pagy"
 gem "rubyzip", require: "zip"
 
+gem "ostruct"
+
 group :development, :test do
   gem "pry"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,7 @@ GEM
       validate_url
       webfinger (~> 1.2)
     os (1.1.4)
+    ostruct (0.6.0)
     pagy (8.6.3)
     parallel (1.25.1)
     parallel_tests (4.7.1)
@@ -590,6 +591,7 @@ DEPENDENCIES
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect
+  ostruct
   pagy
   pg (>= 0.18, < 2.0)
   pry

--- a/app/views/admin/decisions/_incomplete_tasks.html.erb
+++ b/app/views/admin/decisions/_incomplete_tasks.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list claim-error-summary__list--warning">
       <% incomplete_task_names.each do |name| %>
-        <li><%= link_to(t("admin.tasks.#{name}"), admin_claim_task_url(claim, name: name)) %></li>
+        <li><%= link_to(t("admin.tasks.#{name}.title"), admin_claim_task_url(claim, name: name)) %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div class="govuk-notification-banner__content">
       <p class="govuk-notification-banner__heading">
-        <%= link_to "Multiple claims",  admin_claim_task_path(claim_id: @claim.id, name: "matching_details") %>
+        <%= link_to "Multiple claims", admin_claim_task_path(claim_id: @claim.id, name: "matching_details") %>
         with matching details have been made in this claim window.
       </p>
     </div>
@@ -39,7 +39,7 @@
             <ul class="app-task-list__items">
               <li class="app-task-list__item <%= task_name %>">
                 <span class="app-task-list__task-name">
-                  <%= link_to I18n.t("admin.tasks.#{task_name}"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
+                  <%= link_to I18n.t("admin.tasks.#{task_name}.title"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
                 </span>
                 <%= task_status_tag(@claim, task_name) %>
               </li>

--- a/app/views/admin/tasks/payroll_gender.html.erb
+++ b/app/views/admin/tasks/payroll_gender.html.erb
@@ -5,7 +5,6 @@
 <%= render "shared/error_summary", instance: @claim, errored_field_id_overrides: { "payroll_gender": "claim_payroll_gender_female" } if @claim.errors.any? %>
 
 <div class="govuk-grid-row">
-
   <%= render claim_summary_view, claim: @claim, heading: "Payroll gender" %>
 
   <div class="govuk-grid-column-two-thirds">
@@ -24,7 +23,7 @@
             </legend>
 
             <p class="govuk-body">
-              The claimant answered ‘Don't know’ to the question ‘What gender does your school's payroll system associate with you?’
+              <%= t("#{Journeys.for_policy(@claim.policy)::I18N_NAMESPACE}.admin.tasks.payroll_gender.hint", default: [:"admin.tasks.payroll_gender.hint"]) %>
             </p>
 
             <%= hidden_field_tag "task[passed]", "true" %>

--- a/app/views/admin/tasks/payroll_gender.html.erb
+++ b/app/views/admin/tasks/payroll_gender.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll gender check for #{@claim.policy.short_name}") } %>
-
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% end %>
 <%= render "shared/error_summary", instance: @claim, errored_field_id_overrides: { "payroll_gender": "claim_payroll_gender_female" } if @claim.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,24 +133,41 @@ en:
     unknown_payroll_gender_preventing_approval_message:
       This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
     tasks:
-      qualifications: "Check qualification information"
-      induction_confirmation: "Check induction information"
-      employment: "Check employment information"
-      matching_details: "Review matching details from other claims"
-      identity_confirmation: "Confirm the claimant made the claim"
-      provider_verification: "Confirm the provider verification"
-      payroll_gender: "Add a payroll gender for HMRC"
-      student_loan_amount: "Check student loan amount"
-      student_loan_plan: "Check student loan plan"
-      payroll_details: "Check bank/building society account details"
-      census_subjects_taught: "Check eligible subjects are taught"
-      visa: "Check visa"
-      arrival_date: "Check arrival date"
-      employment_contract: "Check employment contract"
-      employment_start: "Check employment start date"
-      subject: "Check subject"
-      teaching_hours: "Check teaching hours"
-
+      qualifications:
+        title: "Check qualification information"
+      induction_confirmation:
+        title: "Check induction information"
+      employment:
+        title: "Check employment information"
+      matching_details:
+        title: "Review matching details from other claims"
+      identity_confirmation:
+        title: "Confirm the claimant made the claim"
+      provider_verification:
+        title: "Confirm the provider verification"
+      payroll_gender:
+        title: "Add a payroll gender for HMRC"
+        hint: "The claimant answered ‘Don't know’ to the question ‘What gender does your school's payroll system associate with you?’"
+      student_loan_amount:
+        title: "Check student loan amount"
+      student_loan_plan:
+        title: "Check student loan plan"
+      payroll_details:
+        title: "Check bank/building society account details"
+      census_subjects_taught:
+        title: "Check eligible subjects are taught"
+      visa:
+        title: "Check visa"
+      arrival_date:
+        title: "Check arrival date"
+      employment_contract:
+        title: "Check employment contract"
+      employment_start:
+        title: "Check employment start date"
+      subject:
+        title: "Check subject"
+      teaching_hours:
+        title: "Check teaching hours"
     undo_decision:
       approved: "Undo approval"
       rejected: "Undo rejection"
@@ -847,6 +864,9 @@ en:
           duplicate_claim: "Duplicate claim"
           no_response: "No response"
           other: "Other"
+      tasks:
+        payroll_gender:
+          hint: "The claimant answered ‘Don't know’ to the question ‘How is your gender recorded on your employer’s payroll system?'"
       task_questions:
         matching_details:
           title: Is this claim still valid despite having matching details with other claims?

--- a/spec/features/admin/admin_claim_payroll_details_task_spec.rb
+++ b/spec/features/admin/admin_claim_payroll_details_task_spec.rb
@@ -27,11 +27,11 @@ RSpec.feature "Admin checking a claim's payroll details" do
       find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
       expect(page).to have_content("Payroll details")
-      expect(page).to have_content I18n.t("admin.tasks.payroll_details")
+      expect(page).to have_content I18n.t("admin.tasks.payroll_details.title")
 
       expect(page.find(".app-task-list__item.payroll_details")).to have_text("Incomplete")
 
-      click_on I18n.t("admin.tasks.payroll_details")
+      click_on I18n.t("admin.tasks.payroll_details.title")
 
       expect(page).to have_content I18n.t("student_loans.admin.task_questions.payroll_details.title", bank_or_building_society: I18n.t("admin.#{claim.bank_or_building_society}"))
 

--- a/spec/features/admin/admin_claim_with_matching_details_spec.rb
+++ b/spec/features/admin/admin_claim_with_matching_details_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Admin checking a claim with matching details" do
     expect(page).to have_content("6. Matching details")
     expect(page).to have_content("7. Decision")
 
-    click_on I18n.t("admin.tasks.matching_details")
+    click_on I18n.t("admin.tasks.matching_details.title")
 
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.matching_details.title"))
     expect(page).to have_content(claim_with_matching_details.reference)

--- a/spec/features/admin/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin/admin_claim_with_missing_payroll_gender_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
     expect(page).to have_content("6. Payroll gender")
     expect(page).to have_content("7. Decision")
 
-    click_on I18n.t("admin.tasks.payroll_gender")
+    click_on I18n.t("admin.tasks.payroll_gender.title")
 
     expect(page).to have_content("What gender should be passed to payroll and HMRC?")
 

--- a/spec/features/admin/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin/admin_claim_without_verified_identity_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Admin checking a claim without a verified identity" do
 
     expect(page).to have_content("1. Identity confirmation")
 
-    click_on I18n.t("admin.tasks.identity_confirmation")
+    click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{unverified_claim.full_name} submit the claim?")
     expect(page).to have_content(unverified_claim.eligibility.current_school.name)

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     visit admin_claims_path
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    click_on I18n.t("admin.tasks.identity_confirmation")
+    click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{claim.full_name} submit the claim?")
     expect(page).to have_link("Next: Qualifications")
@@ -93,7 +93,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     visit admin_claims_path
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    click_on I18n.t("admin.tasks.identity_confirmation")
+    click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{claim.full_name} submit the claim?")
     expect(page).to have_link("Next: Qualifications")
@@ -176,7 +176,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     visit admin_claims_path
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    click_on I18n.t("admin.tasks.identity_confirmation")
+    click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{claim.full_name} submit the claim?")
     expect(page).to have_link("Next: Qualifications")


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1012
- Update admin payroll gender hint copy depending on policy

# Other changes

- Added `ostruct` gem to fix deprecation warning
- Fix back link position on payroll gender admin task page