### PR TITLE
Record who sent the email to the provider

### DIFF
--- a/app/controllers/admin/further_education_payments/provider_verification_emails_controller.rb
+++ b/app/controllers/admin/further_education_payments/provider_verification_emails_controller.rb
@@ -6,6 +6,12 @@ module Admin
       def create
         claim = Claim.find(params[:claim_id])
 
+        claim.notes.create!(
+          created_by: admin_user,
+          label: "provider_verification",
+          body: "Verification email sent to #{claim.school.name}"
+        )
+
         ClaimMailer.further_education_payment_provider_verification_email(claim).deliver_later
 
         flash[:notice] = "Verification email sent to #{claim.school.name}"

--- a/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
@@ -25,8 +25,16 @@ module Policies
         end
       end
 
-      def latest_email
+      def latest_admin_sent_email
         claim.notes.by_label("provider_verification").order(created_at: :desc).first
+      end
+
+      def verification_email_sent?
+        !claim.eligibility.flagged_as_duplicate? || verification_email_sent_by_admin_team?
+      end
+
+      def verification_email_sent_by_admin_team?
+        latest_admin_sent_email.present?
       end
 
       private

--- a/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
@@ -25,6 +25,10 @@ module Policies
         end
       end
 
+      def latest_email
+        claim.notes.by_label("provider_verification").order(created_at: :desc).first
+      end
+
       private
 
       def verification

--- a/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
@@ -25,8 +25,8 @@ module Policies
         end
       end
 
-      def latest_admin_sent_email
-        claim.notes.by_label("provider_verification").order(created_at: :desc).first
+      def admin_sent_emails
+        @admin_sent_emails ||= claim.notes.by_label("provider_verification").order(created_at: :desc)
       end
 
       def verification_email_sent?
@@ -34,7 +34,7 @@ module Policies
       end
 
       def verification_email_sent_by_admin_team?
-        latest_admin_sent_email.present?
+        admin_sent_emails.any?
       end
 
       private

--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -10,7 +10,7 @@ module Policies
       end
 
       def provider_verification
-        AdminProviderVerificationTaskPresenter.new(claim).rows
+        AdminProviderVerificationTaskPresenter.new(claim)
       end
 
       def provider_name

--- a/app/views/admin/tasks/_provider_verification_submitted.html.erb
+++ b/app/views/admin/tasks/_provider_verification_submitted.html.erb
@@ -1,0 +1,38 @@
+<p class="govuk-body">
+  This task was verified by the provider
+  (<%= @tasks_presenter.provider_name %>).
+</p>
+
+<table class="govuk-table govuk-!-margin-bottom-9">
+  <caption class="govuk-table__caption govuk-visually-hidden">
+    <%= @current_task_name.humanize %>
+  </caption>
+  <thead>
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">
+        Eligibility check
+      </th>
+      <th scope="col" class="govuk-table__header">
+        Claimant submitted
+      </th>
+      <th scope="col" class="govuk-table__header">
+        Provider response
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @tasks_presenter.provider_verification.rows.each do |row| %>
+      <tr class="govuk-table__row govuk-!-width-one-quarter">
+        <th scope="row" class="govuk-table__header">
+          <%= row.label %>
+        </th>
+        <td class="govuk-table__cell govuk-!-width-one-half">
+          <%= Array.wrap(row.claimant_answer).join("<br><br>").html_safe %>
+        </td>
+        <td class="govuk-table__cell govuk-!-width-one-quarter">
+          <%= row.provider_answer %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/tasks/_provider_verification_unsubmitted.html.erb
+++ b/app/views/admin/tasks/_provider_verification_unsubmitted.html.erb
@@ -1,11 +1,12 @@
 <% if @tasks_presenter.provider_verification.verification_email_sent? %>
   <% if @tasks_presenter.provider_verification.verification_email_sent_by_admin_team? %>
-    <% verification_email = @tasks_presenter.provider_verification.latest_admin_sent_email %>
     <div class="govuk-inset-text">
-      <p>
-        The verification request was sent to the provider by
-        <%= user_details(verification_email.created_by) %> on <%= l(verification_email.created_at) %>
-      </p>
+      <% @tasks_presenter.provider_verification.admin_sent_emails.each do |verification_email| %>
+        <p>
+          The verification request was sent to the provider by
+          <%= user_details(verification_email.created_by) %> on <%= l(verification_email.created_at) %>
+        </p>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/admin/tasks/_provider_verification_unsubmitted.html.erb
+++ b/app/views/admin/tasks/_provider_verification_unsubmitted.html.erb
@@ -1,0 +1,34 @@
+<% if @tasks_presenter.provider_verification.verification_email_sent? %>
+  <% if @tasks_presenter.provider_verification.verification_email_sent_by_admin_team? %>
+    <% verification_email = @tasks_presenter.provider_verification.latest_admin_sent_email %>
+    <div class="govuk-inset-text">
+      <p>
+        The verification request was sent to the provider by
+        <%= user_details(verification_email.created_by) %> on <%= l(verification_email.created_at) %>
+      </p>
+    </div>
+  <% end %>
+
+  <%= govuk_button_to(
+    "Resend provider verification request",
+    admin_claim_further_education_payments_provider_verification_emails_path(@claim),
+    class: "govuk-!-margin-bottom-0"
+  ) %>
+<% else %>
+  <p class="govuk-body">
+    This task has not been sent to the provider yet.
+  </p>
+
+  <div class="govuk-inset-text">
+    <p>
+      You need to check the matching details and confirm if this is a
+      duplicate claim. If it isn't a duplicate claim, send the verification
+      request to the provider.
+    </p>
+    <%= govuk_button_to(
+      "Send provider verification request",
+      admin_claim_further_education_payments_provider_verification_emails_path(@claim),
+      class: "govuk-!-margin-bottom-0"
+    ) %>
+  </div>
+<% end %>

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -10,69 +10,9 @@
     <h2 class="govuk-heading-xl"><%= @current_task_name.humanize %></h2>
 
     <% if @tasks_presenter.provider_verification_submitted? %>
-      <p class="govuk-body">
-        This task was verified by the provider
-        (<%= @tasks_presenter.provider_name %>).
-      </p>
-
-      <table class="govuk-table govuk-!-margin-bottom-9">
-        <caption class="govuk-table__caption govuk-visually-hidden">
-          <%= @current_task_name.humanize %>
-        </caption>
-        <thead>
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">
-              Eligibility check
-            </th>
-            <th scope="col" class="govuk-table__header">
-              Claimant submitted
-            </th>
-            <th scope="col" class="govuk-table__header">
-              Provider response
-            </th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <% @tasks_presenter.provider_verification.rows.each do |row| %>
-            <tr class="govuk-table__row govuk-!-width-one-quarter">
-              <th scope="row" class="govuk-table__header">
-                <%= row.label %>
-              </th>
-              <td class="govuk-table__cell govuk-!-width-one-half">
-                <%= Array.wrap(row.claimant_answer).join("<br><br>").html_safe %>
-              </td>
-              <td class="govuk-table__cell govuk-!-width-one-quarter">
-                <%= row.provider_answer %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <%= render "provider_verification_submitted" %>
     <% else %>
-      <p class="govuk-body">
-        This task has not been sent to the provider yet.
-      </p>
-
-      <div class="govuk-inset-text">
-        <% if @tasks_presenter.provider_verification.latest_email.present? %>
-          <% verification_email = @tasks_presenter.provider_verification.latest_email %>
-          <p>
-            The verification request was sent to the provider by
-            <%= user_details(verification_email.created_by) %> on <%= l(verification_email.created_at) %>
-          </p>
-        <% else %>
-          <p>
-            You need to check the matching details and confirm if this is a
-            duplicate claim. If it isn't a duplicate claim, send the verification
-            request to the provider.
-          </p>
-        <% end %>
-        <%= govuk_button_to(
-          "Resend provider verification’",
-          admin_claim_further_education_payments_provider_verification_emails_path(@claim),
-          class: "govuk-!-margin-bottom-0"
-        ) %>
-      </div>
+      <%= render "provider_verification_unsubmitted" %>
     <% end %>
   </div>
 

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -33,7 +33,7 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @tasks_presenter.provider_verification.each do |row| %>
+          <% @tasks_presenter.provider_verification.rows.each do |row| %>
             <tr class="govuk-table__row govuk-!-width-one-quarter">
               <th scope="row" class="govuk-table__header">
                 <%= row.label %>
@@ -54,11 +54,19 @@
       </p>
 
       <div class="govuk-inset-text">
-        <p>
-          You need to check the matching details and confirm if this is a
-          duplicate claim. If it isn't a duplicate claim, send the verification
-          request to the provider.
-        </p>
+        <% if @tasks_presenter.provider_verification.latest_email.present? %>
+          <% verification_email = @tasks_presenter.provider_verification.latest_email %>
+          <p>
+            The verification request was sent to the provider by
+            <%= user_details(verification_email.created_by) %> on <%= l(verification_email.created_at) %>
+          </p>
+        <% else %>
+          <p>
+            You need to check the matching details and confirm if this is a
+            duplicate claim. If it isn't a duplicate claim, send the verification
+            request to the provider.
+          </p>
+        <% end %>
         <%= govuk_button_to(
           "Send provider verification request",
           admin_claim_further_education_payments_provider_verification_emails_path(@claim),

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -68,7 +68,7 @@
           </p>
         <% end %>
         <%= govuk_button_to(
-          "Send provider verification request",
+          "Resend provider verification’",
           admin_claim_further_education_payments_provider_verification_emails_path(@claim),
           class: "govuk-!-margin-bottom-0"
         ) %>

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Admin claim further education payments" do
+  around do |example|
+    travel_to DateTime.new(AcademicYear.current.start_year, 9, 9, 10, 0, 0) do
+      example.run
+    end
+  end
+
   before do
     create(:journey_configuration, :further_education_payments_provider)
     sign_in_as_service_operator
@@ -48,6 +54,11 @@ RSpec.feature "Admin claim further education payments" do
           perform_enqueued_jobs do
             click_on "Send provider verification request"
           end
+
+          expect(page).to have_content(
+            "The verification request was sent to the provider by " \
+            "Aaron Admin on 9 September 2024 11:00am"
+          )
 
           provider_email_address = claim.school.eligible_fe_provider.primary_key_contact_email_address
 

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Admin claim further education payments" do
           )
 
           perform_enqueued_jobs do
-            click_on "Send provider verification request"
+            click_on "Resend provider verification’"
           end
 
           expect(page).to have_content(


### PR DESCRIPTION
The figma designs require us to display the admin who resent the provider verification email. To capture this information we use the existing note mechanism on claims. This is a bit fragile as we assume the only "provider_verification" note is for emails being sent. It seems like the label on notes maps to a task name, so we went with that for the label. If in future we can take other provider verification notes we may want to consider renaming this email specific label.

![Screenshot 2024-09-09 at 16 39 03](https://github.com/user-attachments/assets/452d01f7-b512-4033-b3af-8632fbe862ad)
![Screenshot 2024-09-09 at 16 41 38](https://github.com/user-attachments/assets/df68fc1c-132e-4332-94dc-18a09c8a89c2)
