### PR TITLE
[LUPEYALPHA-1010] student loan plan task for FE

### DIFF
--- a/app/controllers/claims_form_callbacks.rb
+++ b/app/controllers/claims_form_callbacks.rb
@@ -125,7 +125,7 @@ module ClaimsFormCallbacks
   end
 
   def journey_requires_student_loan_details?
-    student_loans_journey? || additional_payments_journey? || get_a_teacher_relocation_payment_journey?
+    student_loans_journey? || additional_payments_journey? || get_a_teacher_relocation_payment_journey? || further_education_payments_journey?
   end
 
   def student_loans_journey?
@@ -138,5 +138,9 @@ module ClaimsFormCallbacks
 
   def get_a_teacher_relocation_payment_journey?
     current_journey_routing_name == "get-a-teacher-relocation-payment"
+  end
+
+  def further_education_payments_journey?
+    current_journey_routing_name == "further-education-payments"
   end
 end

--- a/app/jobs/student_loan_plan_check_job.rb
+++ b/app/jobs/student_loan_plan_check_job.rb
@@ -1,8 +1,7 @@
 class StudentLoanPlanCheckJob < ApplicationJob
   def perform
     delete_no_data_student_loan_plan_tasks
-    claims = current_year_ecp_lup_claims_awaiting_decision.awaiting_task("student_loan_plan")
-
+    claims = current_year_ecp_lup_fe_claims_awaiting_decision.awaiting_task("student_loan_plan")
     claims.each do |claim|
       ClaimStudentLoanDetailsUpdater.call(claim)
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan.new(claim:).perform
@@ -20,11 +19,11 @@ class StudentLoanPlanCheckJob < ApplicationJob
   end
 
   def current_year_ecp_lup_claims_with_no_data_tasks
-    current_year_ecp_lup_claims_awaiting_decision.joins(:tasks).where(tasks: {name: "student_loan_plan", claim_verifier_match: nil, manual: false})
+    current_year_ecp_lup_fe_claims_awaiting_decision.joins(:tasks).where(tasks: {name: "student_loan_plan", claim_verifier_match: nil, manual: false})
   end
 
-  def current_year_ecp_lup_claims_awaiting_decision
-    Claim.by_academic_year(current_academic_year).by_policies([Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments]).awaiting_decision.where(submitted_using_slc_data: false)
+  def current_year_ecp_lup_fe_claims_awaiting_decision
+    Claim.by_academic_year(current_academic_year).by_policies([Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments]).awaiting_decision.where(submitted_using_slc_data: false)
   end
 
   def current_academic_year

--- a/app/jobs/student_loan_plan_check_job.rb
+++ b/app/jobs/student_loan_plan_check_job.rb
@@ -1,7 +1,13 @@
 class StudentLoanPlanCheckJob < ApplicationJob
+  APPLICABLE_POLICIES = [
+    Policies::EarlyCareerPayments,
+    Policies::LevellingUpPremiumPayments,
+    Policies::FurtherEducationPayments
+  ].freeze
+
   def perform
     delete_no_data_student_loan_plan_tasks
-    claims = current_year_ecp_lup_fe_claims_awaiting_decision.awaiting_task("student_loan_plan")
+    claims = current_year_claims_awaiting_decision.awaiting_task("student_loan_plan")
     claims.each do |claim|
       ClaimStudentLoanDetailsUpdater.call(claim)
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan.new(claim:).perform
@@ -11,22 +17,18 @@ class StudentLoanPlanCheckJob < ApplicationJob
   private
 
   def delete_no_data_student_loan_plan_tasks
-    claim_ids = current_year_ecp_lup_claims_with_no_data_tasks.pluck(:id)
+    claim_ids = current_year_claims_with_no_data_tasks.pluck(:id)
 
     claim_ids.each_slice(500) do |ids|
       Task.where(claim_id: ids, name: "student_loan_plan", claim_verifier_match: nil, manual: false).delete_all
     end
   end
 
-  def current_year_ecp_lup_claims_with_no_data_tasks
-    current_year_ecp_lup_fe_claims_awaiting_decision.joins(:tasks).where(tasks: {name: "student_loan_plan", claim_verifier_match: nil, manual: false})
+  def current_year_claims_with_no_data_tasks
+    current_year_claims_awaiting_decision.joins(:tasks).where(tasks: {name: "student_loan_plan", claim_verifier_match: nil, manual: false})
   end
 
-  def current_year_ecp_lup_fe_claims_awaiting_decision
-    Claim.by_academic_year(current_academic_year).by_policies([Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments]).awaiting_decision.where(submitted_using_slc_data: false)
-  end
-
-  def current_academic_year
-    Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year
+  def current_year_claims_awaiting_decision
+    Claim::ClaimsAwaitingDecisionFinder.new(policies: APPLICABLE_POLICIES).claims_submitted_without_slc_data
   end
 end

--- a/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
@@ -10,7 +10,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless claim.has_ecp_or_lupp_policy?
+        return unless claim.has_ecp_or_lupp_or_fe_policy?
         return unless claim.submitted_without_slc_data?
         return unless awaiting_task?
 

--- a/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
@@ -10,7 +10,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless claim.has_ecp_or_lupp_or_fe_policy?
+        return unless claim.policy.auto_check_student_loan_plan_task?
         return unless claim.submitted_without_slc_data?
         return unless awaiting_task?
 

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -55,10 +55,6 @@ module BasePolicy
     to_s == "FurtherEducationPayments"
   end
 
-  def auto_pass_identity_confirmation_task(claim)
-    :skip
-  end
-
   def auto_check_student_loan_plan_task?
     false
   end

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -54,4 +54,12 @@ module BasePolicy
   def further_education_payments?
     to_s == "FurtherEducationPayments"
   end
+
+  def auto_pass_identity_confirmation_task(claim)
+    :skip
+  end
+
+  def auto_check_student_loan_plan_task?
+    false
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -418,7 +418,8 @@ class Claim < ApplicationRecord
   end
 
   def submitted_without_slc_data?
-    submitted_using_slc_data == false
+    # FE claims prior to the deployment of LUPEYALPHA-1010 have submitted_using_slc_data = nil
+    submitted_using_slc_data != true
   end
 
   def has_dqt_record?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -405,11 +405,6 @@ class Claim < ApplicationRecord
     has_ecp_policy? || has_lupp_policy?
   end
 
-  # TODO this approach has reached its limit - refactor
-  def has_ecp_or_lupp_or_fe_policy?
-    has_ecp_policy? || has_lupp_policy? || has_fe_policy?
-  end
-
   def important_notes
     notes&.where(important: true)
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -405,6 +405,11 @@ class Claim < ApplicationRecord
     has_ecp_policy? || has_lupp_policy?
   end
 
+  # TODO this approach has reached its limit - refactor
+  def has_ecp_or_lupp_or_fe_policy?
+    has_ecp_policy? || has_lupp_policy? || has_fe_policy?
+  end
+
   def important_notes
     notes&.where(important: true)
   end

--- a/app/models/claim/claims_awaiting_decision_finder.rb
+++ b/app/models/claim/claims_awaiting_decision_finder.rb
@@ -1,0 +1,31 @@
+class Claim
+  class ClaimsAwaitingDecisionFinder
+    def initialize(policies:)
+      @policies = policies
+    end
+
+    attr_reader :policies
+
+    def claims_submitted_without_slc_data
+      policies.map do |policy|
+        journey_configuration = Journeys.for_policy(policy).configuration
+        Claim
+          .by_academic_year(journey_configuration.current_academic_year)
+          .by_policy(policy)
+          .awaiting_decision
+          .where(submitted_using_slc_data: submitted_using_slc_data(policy))
+      end.reduce(&:or)
+    end
+
+    private
+
+    def submitted_using_slc_data(policy)
+      if policy == Policies::FurtherEducationPayments
+        # For 2024/2025 academic year onwards, only FE claims prior to the deployment of LUPEYALPHA-1010 have submitted_using_slc_data = nil
+        [false, nil]
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/further_education_payments/answers_student_loans_details_updater.rb
@@ -1,0 +1,6 @@
+module Journeys
+  module FurtherEducationPayments
+    class AnswersStudentLoansDetailsUpdater < Journeys::AnswersStudentLoansDetailsUpdater
+    end
+  end
+end

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -103,5 +103,9 @@ module Policies
     def payment_and_deductions_info_url
       eligibility_page_url + "#paying-income-tax-and-national-insurance"
     end
+
+    def auto_check_student_loan_plan_task?
+      true
+    end
   end
 end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -71,5 +71,13 @@ module Policies
     def duplicate_claim?(claim)
       Claim::MatchingAttributeFinder.new(claim).matching_claims.exists?
     end
+
+    def auto_pass_identity_confirmation_task(claim)
+      claim.identity_confirmed_with_onelogin? ? :pass : :fail
+    end
+
+    def auto_check_student_loan_plan_task?
+      true
+    end
   end
 end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -72,10 +72,6 @@ module Policies
       Claim::MatchingAttributeFinder.new(claim).matching_claims.exists?
     end
 
-    def auto_pass_identity_confirmation_task(claim)
-      claim.identity_confirmed_with_onelogin? ? :pass : :fail
-    end
-
     def auto_check_student_loan_plan_task?
       true
     end

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -17,7 +17,7 @@ module Policies
         tasks << "identity_confirmation"
         tasks << "provider_verification"
         tasks << "employment" if claim.eligibility.teacher_reference_number.present?
-        tasks << "student_loan_plan"
+        tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "matching_details" if matching_claims.exists?
         tasks << "payroll_gender" if claim.payroll_gender_missing?

--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -93,5 +93,9 @@ module Policies
     def payroll_file_name
       "SchoolsLUP"
     end
+
+    def auto_check_student_loan_plan_task?
+      true
+    end
   end
 end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -29,6 +29,8 @@ FactoryBot.define do
       claim_academic_year =
         if [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].include?(evaluator.policy)
           Journeys::AdditionalPaymentsForTeaching.configuration.current_academic_year
+        elsif evaluator.policy == Policies::FurtherEducationPayments
+          Journeys::FurtherEducationPayments.configuration.current_academic_year
         else
           AcademicYear::Type.new.serialize(AcademicYear.new(2019))
         end

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -39,14 +39,36 @@ RSpec.feature "Upload SLC data" do
       eligibility: build(:early_career_payments_eligibility, :eligible),
       has_student_loan: false, student_loan_plan: "not_applicable", submitted_using_slc_data: false)
   }
-  let!(:fe_claim_no_student_loan_plan_no_slc_data) {
-      create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility: build(:further_education_payments_eligibility, :eligible), has_student_loan: nil, student_loan_plan: nil)
+
+  let!(:fe_claim_with_slc_data_no_student_loan_nil_submitted_using_slc_data) {
+    create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
+      eligibility: build(:further_education_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
-  let!(:fe_claim_no_student_loan_plan_in_slc_data) {
-      create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility: build(:further_education_payments_eligibility, :eligible), has_student_loan: nil, student_loan_plan: nil)
+  let!(:fe_claim_with_slc_data_with_student_loan_nil_submitted_using_slc_data) {
+    create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
+      eligibility: build(:further_education_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
-  let!(:fe_claim_not_in_data_file) {
-      create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments, eligibility: build(:further_education_payments_eligibility, :eligible))
+  let!(:fe_claim_no_slc_data_nil_submitted_using_slc_data) {
+    create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments,
+      eligibility: build(:further_education_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
+  }
+  let!(:fe_claim_with_slc_data_no_student_loan) {
+    create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
+      eligibility: build(:further_education_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
+  }
+  let!(:fe_claim_with_slc_data_with_student_loan) {
+    create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
+      eligibility: build(:further_education_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
+  }
+  let!(:fe_claim_no_slc_data) {
+    create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments,
+      eligibility: build(:further_education_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
 
   scenario "automated task to verify student loan plan" do
@@ -57,94 +79,96 @@ RSpec.feature "Upload SLC data" do
       click_button "Upload"
     end
     expect(page).to have_content "SLC file uploaded and queued to be imported"
-    expect(StudentLoansData.count).to eq 4
+    expect(StudentLoansData.count).to eq 8
 
     # Student Loans
 
-    click_link sl_claim_with_slc_data_no_student_loan.reference
-    expect(page).to have_content "Student loan amount"
-    within "li.student_loan_amount" do
-      expect(page).to have_content "No match"
-    end
-    expect(sl_claim_with_slc_data_no_student_loan.reload.student_loan_plan).to eq "not_applicable"
-    expect(sl_claim_with_slc_data_no_student_loan.has_student_loan).to be false
-    expect(sl_claim_with_slc_data_no_student_loan.eligibility.student_loan_repayment_amount).to eq 0
+    claim = sl_claim_with_slc_data_no_student_loan
+    then_the_student_loan_amount_task_should_show_as(state: "No match", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "not_applicable"
+    expect(claim.has_student_loan).to be false
+    expect(claim.eligibility.student_loan_repayment_amount).to eq 0
 
+    claim = sl_claim_with_slc_data_with_student_loan
     visit admin_claims_path
-    click_link ecp_claim_with_slc_data_with_student_loan.reference
-    expect(page).not_to have_content "Student loan amount"
-    expect(sl_claim_with_slc_data_with_student_loan.reload.student_loan_plan).to eq "plan_1"
-    expect(sl_claim_with_slc_data_with_student_loan.has_student_loan).to eq true
-    expect(sl_claim_with_slc_data_with_student_loan.eligibility.student_loan_repayment_amount).to eq 100
+    click_link claim.reference
+    then_the_student_loan_amount_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "plan_1"
+    expect(claim.has_student_loan).to eq true
+    expect(claim.eligibility.student_loan_repayment_amount).to eq 100
 
-    visit admin_claims_path
-    click_link sl_claim_no_slc_data.reference
-    expect(page).to have_content "Student loan amount"
-    within "li.student_loan_amount" do
-      expect(page).to have_content "No data"
-    end
-    expect(sl_claim_no_slc_data.reload.student_loan_plan).to be nil
-    expect(sl_claim_no_slc_data.has_student_loan).to be nil
-    expect(sl_claim_no_slc_data.eligibility.student_loan_repayment_amount).to eq 0
+    claim = sl_claim_no_slc_data
+    then_the_student_loan_amount_task_should_show_as(state: "No data", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to be nil
+    expect(claim.has_student_loan).to be nil
+    expect(claim.eligibility.student_loan_repayment_amount).to eq 0
 
     # Early Career Payments
 
+    claim = ecp_claim_with_slc_data_no_student_loan
+    then_the_student_loan_plan_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "not_applicable"
+    expect(claim.has_student_loan).to be false
+
+    claim = ecp_claim_with_slc_data_with_student_loan
+    then_the_student_loan_plan_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "plan_1"
+    expect(claim.has_student_loan).to eq true
+
+    claim = ecp_claim_no_slc_data
+    then_the_student_loan_plan_task_should_show_as(state: "No data", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to be nil # this was "not_applicable" before LUPEYALPHA-1031
+    expect(claim.has_student_loan).to be nil # this was false before LUPEYALPHA-1031
+
+    # Further Education Payments
+
+    claim = fe_claim_with_slc_data_no_student_loan_nil_submitted_using_slc_data
+    then_the_student_loan_plan_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "not_applicable"
+    expect(claim.has_student_loan).to eq false
+
+    claim = fe_claim_with_slc_data_with_student_loan_nil_submitted_using_slc_data
+    then_the_student_loan_plan_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "plan_1"
+    expect(claim.has_student_loan).to eq true
+
+    claim = fe_claim_no_slc_data_nil_submitted_using_slc_data
+    then_the_student_loan_plan_task_should_show_as(state: "No data", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to be nil
+    expect(claim.has_student_loan).to be nil
+
+    claim = fe_claim_with_slc_data_no_student_loan
+    then_the_student_loan_plan_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "not_applicable"
+    expect(claim.has_student_loan).to eq false
+
+    claim = fe_claim_with_slc_data_with_student_loan
+    then_the_student_loan_plan_task_should_show_as(state: "Passed", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to eq "plan_1"
+    expect(claim.has_student_loan).to eq true
+
+    claim = fe_claim_no_slc_data
+    then_the_student_loan_plan_task_should_show_as(state: "No data", for_claim: claim)
+    expect(claim.reload.student_loan_plan).to be nil
+    expect(claim.has_student_loan).to be nil
+  end
+
+  def then_the_student_loan_amount_task_should_show_as(state:, for_claim:)
     visit admin_claims_path
-    click_link ecp_claim_with_slc_data_no_student_loan.reference
+    click_link for_claim.reference
+    expect(page).to have_content "Student loan amount"
+    within "li.student_loan_amount" do
+      expect(page).to have_content state
+    end
+  end
+
+  def then_the_student_loan_plan_task_should_show_as(state:, for_claim:)
+    visit admin_claims_path
+    click_link for_claim.reference
     expect(page).to have_content "Student loan plan"
     within "li.student_loan_plan" do
-      expect(page).to have_content "Passed"
+      expect(page).to have_content state
     end
-    expect(ecp_claim_with_slc_data_no_student_loan.reload.student_loan_plan).to eq "not_applicable"
-    expect(ecp_claim_with_slc_data_no_student_loan.has_student_loan).to be false
-
-    visit admin_claims_path
-    click_link ecp_claim_with_slc_data_with_student_loan.reference
-    expect(page).to have_content "Student loan plan"
-    within "li.student_loan_plan" do
-      expect(page).to have_content "Passed"
-    end
-    expect(ecp_claim_with_slc_data_with_student_loan.reload.student_loan_plan).to eq "plan_1"
-    expect(ecp_claim_with_slc_data_with_student_loan.has_student_loan).to eq true
-
-    visit admin_claims_path
-    click_link ecp_claim_no_slc_data.reference
-    expect(page).to have_content "Student loan plan"
-    within "li.student_loan_plan" do
-      expect(page).to have_content "No data"
-    end
-    expect(ecp_claim_no_slc_data.reload.student_loan_plan).to be nil # this was "not_applicable" before LUPEYALPHA-1031
-    expect(ecp_claim_no_slc_data.has_student_loan).to be nil # this was false before LUPEYALPHA-1031
-    
-    # FE
-    
-    visit admin_claims_path
-    click_link fe_claim_no_student_loan_plan_no_slc_data.reference
-    within "li.student_loan_plan" do
-        expect(page).to have_content "Failed" # is this right?
-    end
-    expect(fe_claim_no_student_loan_plan_no_slc_data.reload.student_loan_plan).to eq "not_applicable"
-    expect(fe_claim_no_student_loan_plan_no_slc_data.has_student_loan).to eq true # doesn't seem right - legacy attribute
-    expect(fe_claim_no_student_loan_plan_no_slc_data.submitted_using_slc_data).to be false
-    
-    visit admin_claims_path
-    click_link fe_claim_no_student_loan_plan_in_slc_data.reference
-    within "li.student_loan_plan" do
-        expect(page).to have_content "Passed"
-    end
-    expect(fe_claim_no_student_loan_plan_in_slc_data.reload.student_loan_plan).to eq "plan_1"
-    expect(fe_claim_no_student_loan_plan_in_slc_data.has_student_loan).to eq true
-    expect(fe_claim_no_student_loan_plan_in_slc_data.submitted_using_slc_data).to be false
-    
-    visit admin_claims_path
-    click_link fe_claim_not_in_data_file.reference
-    within "li.student_loan_plan" do
-        expect(page).to have_content "No data"
-    end
-    expect(fe_claim_not_in_data_file.reload.student_loan_plan).to eq "not_applicable"
-    expect(fe_claim_not_in_data_file.has_student_loan).to eq false
-    expect(fe_claim_not_in_data_file.submitted_using_slc_data).to be false
-
   end
 
   def slc_data_csv_file
@@ -156,6 +180,10 @@ RSpec.feature "Upload SLC data" do
     @slc_data_csv_file.write csv_row(sl_claim_with_slc_data_with_student_loan, plan_type: "1", amount: "100")
     @slc_data_csv_file.write csv_row(ecp_claim_with_slc_data_no_student_loan, no_data: true)
     @slc_data_csv_file.write csv_row(ecp_claim_with_slc_data_with_student_loan, plan_type: "1", amount: "100")
+    @slc_data_csv_file.write csv_row(fe_claim_with_slc_data_no_student_loan, no_data: true)
+    @slc_data_csv_file.write csv_row(fe_claim_with_slc_data_with_student_loan, plan_type: "1", amount: "100")
+    @slc_data_csv_file.write csv_row(fe_claim_with_slc_data_no_student_loan_nil_submitted_using_slc_data, no_data: true)
+    @slc_data_csv_file.write csv_row(fe_claim_with_slc_data_with_student_loan_nil_submitted_using_slc_data, plan_type: "1", amount: "100")
 
     @slc_data_csv_file.rewind
 

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Further education payments" do
   let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
 
   scenario "happy path claim" do
+    when_student_loan_data_exists
     when_further_education_payments_journey_configuration_exists
     and_college_exists
 
@@ -183,6 +184,7 @@ RSpec.feature "Further education payments" do
 
     expect(claim.first_name).to eql("John")
     expect(claim.surname).to eql("Doe")
+    expect(claim.student_loan_plan).to eq "plan_1"
 
     eligibility = Policies::FurtherEducationPayments::Eligibility.last
 

--- a/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
@@ -67,8 +67,8 @@ module AutomatedChecks
           it_behaves_like :execution_without_an_outcome
         end
 
-        context "when the claim policy is ECP/LUP" do
-          [Policies::LevellingUpPremiumPayments, Policies::EarlyCareerPayments].each do |policy|
+        context "when the claim policy is ECP/LUP/FE" do
+          [Policies::LevellingUpPremiumPayments, Policies::EarlyCareerPayments, Policies::FurtherEducationPayments].each do |policy|
             context "when the policy is #{policy}" do
               let(:policy) { policy }
               let(:claim) { create(:claim, :submitted, policy:, national_insurance_number: "QQ123456A", has_student_loan: true, student_loan_plan: claim_student_loan_plan, submitted_using_slc_data:) }

--- a/spec/models/claim/claims_awaiting_decision_finder_spec.rb
+++ b/spec/models/claim/claims_awaiting_decision_finder_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Claim::ClaimsAwaitingDecisionFinder do
+  let!(:fe_journey_configuration) { create(:journey_configuration, :further_education_payments, current_academic_year: fe_academic_year) }
+  let!(:ap_journey_configuration) { create(:journey_configuration, :early_career_payments, current_academic_year: ecp_academic_year) }
+  let!(:claim_fe_awaiting_decision_submitted_using_slc_data_false) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, academic_year: fe_academic_year, submitted_using_slc_data: false) }
+  let!(:claim_fe_awaiting_decision_submitted_using_slc_data_nil) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, academic_year: fe_academic_year, submitted_using_slc_data: nil) }
+  let!(:claim_fe_awaiting_decision_submitted_using_slc_data_true) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, academic_year: fe_academic_year, submitted_using_slc_data: true) }
+  let!(:claim_fe_not_awaiting_decision) { create(:claim, :approved, policy: Policies::FurtherEducationPayments, academic_year: fe_academic_year, submitted_using_slc_data: false) }
+  let!(:claim_fe_other_year) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, academic_year: fe_previous_academic_year, submitted_using_slc_data: false) }
+  let!(:claim_ecp_awaiting_decision_submitted_using_slc_data_false) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments, academic_year: ecp_academic_year, submitted_using_slc_data: false) }
+  let!(:claim_ecp_awaiting_decision_submitted_using_slc_data_nil) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments, academic_year: ecp_academic_year, submitted_using_slc_data: nil) }
+  let!(:claim_ecp_awaiting_decision_submitted_using_slc_data_true) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments, academic_year: ecp_academic_year, submitted_using_slc_data: true) }
+  let!(:claim_ecp_not_awaiting_decision) { create(:claim, :approved, policy: Policies::EarlyCareerPayments, academic_year: ecp_academic_year, submitted_using_slc_data: false) }
+  let!(:claim_ecp_other_year) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments, academic_year: ecp_previous_academic_year, submitted_using_slc_data: false) }
+  let!(:claim_sl_awaiting_decision_submitted_using_slc_data_false) { create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: fe_academic_year, submitted_using_slc_data: false) }
+  let(:fe_academic_year) { AcademicYear.new(2024) }
+  let(:fe_previous_academic_year) { AcademicYear.new(2023) }
+  let(:ecp_academic_year) { AcademicYear.new(2023) }
+  let(:ecp_previous_academic_year) { AcademicYear.new(2022) }
+  let(:policies) { [Policies::FurtherEducationPayments, Policies::EarlyCareerPayments] }
+
+  describe "#claims_submitted_using_slc_data" do
+    subject { described_class.new(policies: policies).claims_submitted_without_slc_data }
+
+    it "returns claims for the correct academic year for each policy submitted without SLC data" do
+      expect(subject).to contain_exactly(
+        claim_fe_awaiting_decision_submitted_using_slc_data_false,
+        claim_fe_awaiting_decision_submitted_using_slc_data_nil,
+        claim_ecp_awaiting_decision_submitted_using_slc_data_false
+      )
+    end
+  end
+end

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ClaimCheckingTasks do
       it "does not include a task for student loan plan when the claim was submitted using SLC data" do
         claim.submitted_using_slc_data = true
 
-        expect(checking_tasks.applicable_task_names).to match_array(applicable_tasks - %w[student_loan_plan])
+        expect(checking_tasks.applicable_task_names).not_to include("student_loan_plan")
       end
     end
 
@@ -93,6 +93,8 @@ RSpec.describe ClaimCheckingTasks do
       subject { described_class.new(claim) }
 
       let(:policy) { Policies::FurtherEducationPayments }
+
+      include_examples :student_loan_plan_task
 
       context "when TRN is provided" do
         before do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1265,10 +1265,11 @@ RSpec.describe Claim, type: :model do
       it { is_expected.to be_submitted_without_slc_data }
     end
 
+    # For 2024/2025 academic year onwards, only FE claims prior to the deployment of LUPEYALPHA-1010 have submitted_using_slc_data = nil
     context "when `submitted_using_slc_data` is `nil`" do
       subject(:claim) { build(:claim, submitted_using_slc_data: nil) }
 
-      it { is_expected.not_to be_submitted_without_slc_data }
+      it { is_expected.to be_submitted_without_slc_data }
     end
   end
 

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
         end
       end
 
-      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].each do |policy|
+      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].each do |policy|
         context "when the policy is #{policy}" do
           let(:policy) { policy }
 
@@ -67,7 +67,7 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
         end
       end
 
-      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].each do |policy|
+      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].each do |policy|
         context "when the policy is #{policy}" do
           let(:policy) { policy }
 

--- a/spec/requests/admin/admin_student_loans_data_upload_spec.rb
+++ b/spec/requests/admin/admin_student_loans_data_upload_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "SLC (Student Loans Company) data upload " do
   let!(:journey_configuration_tslr) { create(:journey_configuration, :student_loans) }
   let!(:journey_configuration_ecp_lupp) { create(:journey_configuration, :additional_payments) }
+  let!(:journey_configuration_fe) { create(:journey_configuration, :further_education_payments) }
 
   before { @signed_in_user = sign_in_as_service_operator }
 

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -78,7 +78,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
 
     # NOTE: mirror claims factory for academic_year attribute "hardcoding" of 2019
     current_academic_year =
-      if [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].include?(policy)
+      if [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].include?(policy)
         academic_year
       else
         AcademicYear.new(2019)

--- a/spec/support/steps/student_loan_data.rb
+++ b/spec/support/steps/student_loan_data.rb
@@ -1,0 +1,3 @@
+def when_student_loan_data_exists
+  create(:student_loans_data, nino: "PX321499A", date_of_birth: Date.new(1988, 2, 28), policy_name: Policies::FurtherEducationPayments)
+end


### PR DESCRIPTION
changes in addition to LUPEYALPHA-1031 (which allows for "No data" SLC rows) https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3183

Changes:
* student loan plan updated from student loan data if it exists
* student loan plan automated check run - currently goes to 'passed' if there is matching data, or 'failed' for everything else.
* cope with `submitted_using_slc_data` being `nil` for FE claims. With the changes in this PR, it should not be `nil` for future claims.