### PR TITLE
Track which journey a reminder is for and use correct support email

### DIFF
--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -37,9 +37,9 @@ module Admin
     end
 
     def send_reminders
-      return unless journey_configuration.open_for_submissions && journey_configuration.additional_payments?
+      return unless journey_configuration.open_for_submissions
 
-      SendReminderEmailsJob.perform_later
+      SendReminderEmailsJob.perform_later(journey_configuration.journey)
     end
   end
 end

--- a/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
+++ b/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
@@ -58,7 +58,7 @@ module Journeys
         return unless model_for_reminder_attributes
 
         Reminder.new(
-          journey:,
+          journey_class: journey.to_s,
           full_name: model_for_reminder_attributes.full_name,
           email_address: model_for_reminder_attributes.email_address,
           itt_academic_year: next_academic_year,

--- a/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
+++ b/app/controllers/journeys/additional_payments_for_teaching/reminders_controller.rb
@@ -58,6 +58,7 @@ module Journeys
         return unless model_for_reminder_attributes
 
         Reminder.new(
+          journey:,
           full_name: model_for_reminder_attributes.full_name,
           email_address: model_for_reminder_attributes.email_address,
           itt_academic_year: next_academic_year,
@@ -79,7 +80,7 @@ module Journeys
 
       # Fallback reminder will set reminder date to the next academic year
       def default_reminder
-        Reminder.new(itt_academic_year: next_academic_year)
+        Reminder.new(journey:, itt_academic_year: next_academic_year)
       end
 
       def next_academic_year

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form.rb
@@ -31,7 +31,7 @@ module Journeys
         def save
           return false unless valid?
 
-          reminder.update!(email_verified: true)
+          reminder.update!(email_verified: true, journey:)
         end
 
         private

--- a/app/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/reminders/personal_details_form.rb
@@ -28,7 +28,7 @@ module Journeys
         def save
           return false unless valid?
 
-          reminder.update!(attributes)
+          reminder.update!(attributes.merge(journey:))
         end
 
         private

--- a/app/forms/reminders/confirmation_form.rb
+++ b/app/forms/reminders/confirmation_form.rb
@@ -2,7 +2,7 @@ module Reminders
   class ConfirmationForm < Form
     def reminder
       @reminder ||= Reminder.find_by(
-        journey: Journeys.for_routing_name(journey_session.journey).to_s,
+        journey_class: Journeys.for_routing_name(journey_session.journey).to_s,
         full_name: journey_session.answers.reminder_full_name,
         email_address: journey_session.answers.reminder_email_address,
         email_verified: true,

--- a/app/forms/reminders/confirmation_form.rb
+++ b/app/forms/reminders/confirmation_form.rb
@@ -2,6 +2,7 @@ module Reminders
   class ConfirmationForm < Form
     def reminder
       @reminder ||= Reminder.find_by(
+        journey: Journeys.for_routing_name(journey_session.journey).to_s,
         full_name: journey_session.answers.reminder_full_name,
         email_address: journey_session.answers.reminder_email_address,
         email_verified: true,

--- a/app/forms/reminders/email_verification_form.rb
+++ b/app/forms/reminders/email_verification_form.rb
@@ -11,8 +11,8 @@ module Reminders
         reminder_otp_confirmed: true
       )
       journey_session.save!
-
       reminder = Reminder.find_or_create_by(
+        journey: Journeys.for_routing_name(journey_session.journey).to_s,
         full_name: journey_session.answers.reminder_full_name,
         email_address: journey_session.answers.reminder_email_address,
         email_verified: true,

--- a/app/forms/reminders/email_verification_form.rb
+++ b/app/forms/reminders/email_verification_form.rb
@@ -12,7 +12,7 @@ module Reminders
       )
       journey_session.save!
       reminder = Reminder.find_or_create_by(
-        journey: Journeys.for_routing_name(journey_session.journey).to_s,
+        journey_class: Journeys.for_routing_name(journey_session.journey).to_s,
         full_name: journey_session.answers.reminder_full_name,
         email_address: journey_session.answers.reminder_email_address,
         email_verified: true,

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -46,6 +46,7 @@ module Reminders
 
     def reminder
       @reminder ||= Reminder.new(
+        journey: Journeys.for_routing_name(journey_session.journey).to_s,
         full_name: reminder_full_name,
         email_address: reminder_email_address
       )

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -46,7 +46,7 @@ module Reminders
 
     def reminder
       @reminder ||= Reminder.new(
-        journey: Journeys.for_routing_name(journey_session.journey).to_s,
+        journey: Journeys.for_routing_name(journey_session.journey),
         full_name: reminder_full_name,
         email_address: reminder_email_address
       )

--- a/app/jobs/send_reminder_email_job.rb
+++ b/app/jobs/send_reminder_email_job.rb
@@ -1,5 +1,8 @@
 class SendReminderEmailJob < ApplicationJob
   def perform(reminder)
+    # TODO: Remove when the template is updated to support other journeys
+    return unless reminder.journey == Journeys::AdditionalPaymentsForTeaching
+
     ReminderMailer.reminder(reminder).deliver_now
     reminder.update!(email_sent_at: Time.now)
   end

--- a/app/jobs/send_reminder_emails_job.rb
+++ b/app/jobs/send_reminder_emails_job.rb
@@ -1,13 +1,7 @@
 class SendReminderEmailsJob < ApplicationJob
-  def perform
-    reminders.find_each(batch_size: 100) do |reminder|
+  def perform(journey)
+    Reminder.to_be_sent.by_journey(journey).find_each(batch_size: 100) do |reminder|
       SendReminderEmailJob.perform_later(reminder)
     end
-  end
-
-  private
-
-  def reminders
-    @reminders ||= Reminder.to_be_sent
   end
 end

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -34,6 +34,10 @@ class ReminderMailer < ApplicationMailer
     send_mail(REMINDER_SET_NOTIFY_TEMPLATE_ID, personalisation)
   end
 
+  # TODO: This template only accommodates LUP/ECP claims currently. Needs to
+  # be changed to support other policies otherwise claimants will receive the
+  # wrong information. Also most of the personalisations are not used in the
+  # template.
   def reminder(reminder)
     @reminder = reminder
     support_email_address = translate("additional_payments.support_email_address")

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -23,7 +23,7 @@ class ReminderMailer < ApplicationMailer
 
   def reminder_set(reminder)
     @reminder = reminder
-    support_email_address = translate("additional_payments.support_email_address")
+    support_email_address = translate("#{reminder.journey::I18N_NAMESPACE}.support_email_address")
 
     personalisation = {
       first_name: extract_first_name(@reminder.full_name),

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -4,12 +4,16 @@ class Reminder < ApplicationRecord
 
   scope :email_verified, -> { where(email_verified: true) }
   scope :not_yet_sent, -> { where(email_sent_at: nil) }
-  scope :by_journey, ->(journey) { where(journey: journey.to_s) }
+  scope :by_journey, ->(journey) { where(journey_class: journey.to_s) }
   scope :inside_academic_year, -> { where(itt_academic_year: AcademicYear.current.to_s) }
   scope :to_be_sent, -> { email_verified.not_yet_sent.inside_academic_year }
 
   def journey
-    super.constantize
+    journey_class.constantize
+  end
+
+  def journey=(journey_class)
+    self[:journey_class] = journey_class.to_s
   end
 
   def send_year

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -4,8 +4,13 @@ class Reminder < ApplicationRecord
 
   scope :email_verified, -> { where(email_verified: true) }
   scope :not_yet_sent, -> { where(email_sent_at: nil) }
+  scope :by_journey, ->(journey) { where(journey: journey.to_s) }
   scope :inside_academic_year, -> { where(itt_academic_year: AcademicYear.current.to_s) }
   scope :to_be_sent, -> { email_verified.not_yet_sent.inside_academic_year }
+
+  def journey
+    super.constantize
+  end
 
   def send_year
     itt_academic_year.start_year

--- a/app/views/admin/journey_configurations/_ecp_reminder_warning.html.erb
+++ b/app/views/admin/journey_configurations/_ecp_reminder_warning.html.erb
@@ -1,4 +1,4 @@
-<% if journey_configuration.additional_payments? && Reminder.to_be_sent.any? %>
+<% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
   <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
     <div class="govuk-form-group">
         <div class="govuk-warning-text" id="ecp-reminder-count-warning">

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -17,6 +17,7 @@ shared:
     - itt_academic_year
     - itt_subject
     - sent_one_time_password_at
+    - journey
   :tasks:
     - id
     - name

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -17,7 +17,7 @@ shared:
     - itt_academic_year
     - itt_subject
     - sent_one_time_password_at
-    - journey
+    - journey_class
   :tasks:
     - id
     - name

--- a/db/migrate/20240910135453_add_journey_to_reminders.rb
+++ b/db/migrate/20240910135453_add_journey_to_reminders.rb
@@ -1,0 +1,19 @@
+class AddJourneyToReminders < ActiveRecord::Migration[7.0]
+  def up
+    add_column :reminders, :journey, :string
+
+    # Additional payments journey was not open when migration created, however
+    # the FurtherEducationPayments journey was opened for the first time on
+    # 2024/9/9 and so some reminders may also be set for the
+    # FurtherEducationPayments journey
+    Reminder.not_yet_sent.where("created_at < ?", Date.new(2024, 9, 9)).update_all(journey: Journeys::AdditionalPaymentsForTeaching)
+    Reminder.not_yet_sent.where("created_at >= ?", Date.new(2024, 9, 9)).update_all(journey: Journeys::FurtherEducationPayments)
+
+    change_column_null :reminders, :journey, false
+    add_index :reminders, :journey
+  end
+
+  def down
+    remove_column :reminders, :journey
+  end
+end

--- a/db/migrate/20240910135453_add_journey_to_reminders.rb
+++ b/db/migrate/20240910135453_add_journey_to_reminders.rb
@@ -1,19 +1,19 @@
 class AddJourneyToReminders < ActiveRecord::Migration[7.0]
   def up
-    add_column :reminders, :journey, :string
+    add_column :reminders, :journey_class, :string
 
     # Additional payments journey was not open when migration created, however
     # the FurtherEducationPayments journey was opened for the first time on
     # 2024/9/9 and so some reminders may also be set for the
     # FurtherEducationPayments journey
-    Reminder.not_yet_sent.where("created_at < ?", Date.new(2024, 9, 9)).update_all(journey: Journeys::AdditionalPaymentsForTeaching)
-    Reminder.not_yet_sent.where("created_at >= ?", Date.new(2024, 9, 9)).update_all(journey: Journeys::FurtherEducationPayments)
+    Reminder.where("created_at < ?", Date.new(2024, 9, 9)).update_all(journey_class: Journeys::AdditionalPaymentsForTeaching.to_s)
+    Reminder.not_yet_sent.where("created_at >= ?", Date.new(2024, 9, 9)).update_all(journey_class: Journeys::FurtherEducationPayments.to_s)
 
-    change_column_null :reminders, :journey, false
-    add_index :reminders, :journey
+    change_column_null :reminders, :journey_class, false
+    add_index :reminders, :journey_class
   end
 
   def down
-    remove_column :reminders, :journey
+    remove_column :reminders, :journey_class
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_04_150711) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_10_135453) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -414,6 +414,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_04_150711) do
     t.datetime "email_sent_at", precision: nil
     t.string "itt_academic_year", limit: 9
     t.string "itt_subject"
+    t.string "journey", null: false
+    t.index ["journey"], name: "index_reminders_on_journey"
   end
 
   create_table "school_workforce_censuses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -414,8 +414,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_135453) do
     t.datetime "email_sent_at", precision: nil
     t.string "itt_academic_year", limit: 9
     t.string "itt_subject"
-    t.string "journey", null: false
-    t.index ["journey"], name: "index_reminders_on_journey"
+    t.string "journey_class", null: false
+    t.index ["journey_class"], name: "index_reminders_on_journey_class"
   end
 
   create_table "school_workforce_censuses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :reminder do
     full_name { Faker::Name.name }
     email_address { Faker::Internet.email }
+    journey { Journeys::AdditionalPaymentsForTeaching }
   end
 end

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :reminder do
     full_name { Faker::Name.name }
     email_address { Faker::Internet.email }
-    journey { Journeys::AdditionalPaymentsForTeaching }
+    journey_class { Journeys::AdditionalPaymentsForTeaching }
   end
 end

--- a/spec/features/admin/admin_configure_services_spec.rb
+++ b/spec/features/admin/admin_configure_services_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
+    click_on "Save"
 
     expect(current_path).to eq(admin_journey_configurations_path)
 
@@ -90,7 +90,7 @@ RSpec.feature "Service configuration" do
       within_fieldset("Service status") { choose("Open") }
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
       # make sure email reminder jobjob is queued
-      expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
+      expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with(journey_configuration.journey)
       expect(current_path).to eq(admin_journey_configurations_path)
 
       within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
@@ -113,7 +113,8 @@ RSpec.feature "Service configuration" do
       end
 
       select "2023/2024", from: "Accepting claims for academic year"
-      expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
+
+      click_on "Save"
 
       within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
         expect(page).to have_content("2023/2024")

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -77,6 +77,7 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           expect(reminder.itt_subject).to eq args[:subject]
           expect(page).to have_text("We have set your reminder")
           expect(mail.template_id).to eq "0dc80ba9-adae-43cd-98bf-58882ee401c3"
+          expect(mail[:personalisation].decoded).to include(":support_email_address=>\"additionalteachingpayment@digital.education.gov.uk\"")
         end
       end
     end

--- a/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/reminders/email_verification_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::Reminders::EmailVerifica
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
   let(:journey_session) { build(:additional_payments_session) }
-  let(:reminder) { Reminder.create! }
+  let(:reminder) { Reminder.create!(journey:) }
   let(:slug) { "email-verification" }
   let(:params) { ActionController::Parameters.new({slug:, form: form_params}) }
   let(:form_params) { {one_time_password: "123456"} }

--- a/spec/jobs/send_reminder_emails_job_spec.rb
+++ b/spec/jobs/send_reminder_emails_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SendReminderEmailsJob do
     create(:reminder, email_verified: false)
     create(:reminder, email_verified: true, email_sent_at: Time.now)
     create(:reminder, email_verified: true, itt_academic_year: AcademicYear.next)
+    create(:reminder, journey: Journeys::FurtherEducationPayments, email_verified: true, itt_academic_year: AcademicYear.next)
   end
 
   describe "#perform" do
@@ -22,7 +23,7 @@ RSpec.describe SendReminderEmailsJob do
       # perform job
       expect {
         perform_enqueued_jobs do
-          subject.perform
+          subject.perform(Journeys::AdditionalPaymentsForTeaching)
         end
       }.to change { ActionMailer::Base.deliveries.count }.by(count)
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/LUPEYALPHA-1016

At the moment the codebase assumes that all reminders are for the additional payments journey.

I've added an extra column to `Reminder` to specify which journey the reminder is for, and removed the assumptions in the code in order to support reminders for other journeys.

At the moment the copy in the actual reminder template that is sent when the journey is opened only accommodates the additional payments journey. I've added a failsafe to prevent reminders being sent when a different journey is opened. Now only reminders for that journey which is being opened should be sent.

Additionally when the additional payments journey was opened it would send all pending reminders, including those for other journeys. This has been fixed.

Coming back to the goal of this ticket; these changes allow us to use a different email address depending on which journey the reminder is for.