### PR TITLE
[LUPEYALPHA-1020] FE provision search errors on no results

### DIFF
--- a/app/forms/journeys/further_education_payments/select_provision_form.rb
+++ b/app/forms/journeys/further_education_payments/select_provision_form.rb
@@ -12,10 +12,11 @@ module Journeys
       def save
         return unless valid?
 
-        journey_session.answers.assign_attributes(school_id: possible_school_id)
+        journey_session.answers.assign_attributes(
+          possible_school_id:,
+          school_id: possible_school_id
+        )
         journey_session.save!
-
-        true
       end
 
       private

--- a/app/views/further_education_payments/claims/further_education_provision_search.html.erb
+++ b/app/views/further_education_payments/claims/further_education_provision_search.html.erb
@@ -31,35 +31,21 @@
       </p>
 
       <div id="autocomplete-container" class="govuk-!-margin-bottom-9">
-        <% if @form.no_results? %>
-          <%= f.govuk_text_field :provision_search,
-            class: "js-remove",
-            label: {
-              text: @form.t(:question),
-              size: "m"
-            },
-            hint: -> do %>
-              <p class="govuk-body">
-                <strong>No results match that search term. Try again.</strong>
-              </p>
-            <% end %>
-        <% else %>
-          <%= f.govuk_text_field :provision_search,
-            class: "js-remove",
-            label: {
-              text: @form.t(:question),
-              size: "m"
-            },
-            hint: -> do %>
-              <p>
-                Enter the name of your employer. If you work at an FE provider with multiple campuses, enter the name of the FE provider group.
-              </p>
+        <%= f.govuk_text_field :provision_search,
+          class: "js-remove",
+          label: {
+            text: @form.t(:question),
+            size: "m"
+          },
+          hint: -> do %>
+            <p>
+              Enter the name of your employer. If you work at an FE provider with multiple campuses, enter the name of the FE provider group.
+            </p>
 
-              <p>
-                Use at least three characters.
-              </p>
-            <% end %>
-        <% end %>
+            <p>
+              Use at least three characters.
+            </p>
+          <% end %>
       </div>
 
       <%= f.govuk_submit %>

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -24,7 +24,8 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     click_button "Continue"
 
     expect(page).to have_content("Select where you are employed")
-    expect(page).to have_selector "input[type=radio][checked=checked][value='#{college.id}']", visible: false
+    expect(page).to have_selector "input[type=radio][value='#{college.id}']", visible: false
+    choose college.name
     click_button "Continue"
 
     expect(page).to have_content("What type of contract do you have with #{college.name}?")


### PR DESCRIPTION
# Context 

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1020
- Show error when no search results

# Changes

- There seem to be some bugs around going back changing answers and supporting both JS and non-JS seem to be quirky these should now be ironed out

# Screenshots

![Screenshot 2024-09-10 at 16 22 27](https://github.com/user-attachments/assets/a69d0dfa-615e-4a38-931c-3fc5bfd03c82)