### PR TITLE
[LUPEYALPHA-1036] Admin One Login IDV

### DIFF
--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -6,6 +6,9 @@ module Journeys
 
         if Policies::FurtherEducationPayments.duplicate_claim?(claim)
           claim.eligibility.update!(flagged_as_duplicate: true)
+        elsif claim.one_login_idv_mismatch?
+          # noop
+          # do not send provider verification email
         else
           ClaimMailer.further_education_payment_provider_verification_email(claim).deliver_later
         end

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -17,8 +17,12 @@ module AutomatedChecks
       def perform
         return unless awaiting_task?(TASK_NAME)
 
-        # Order of matching matters so that subsequent conditions in methods fall through to execute the right thing
-        one_login || no_match || partial_match || complete_match
+        if claim.identity_confirmed_with_onelogin?
+          one_login
+        else
+          # Order of matching matters so that subsequent conditions in methods fall through to execute the right thing
+          no_match || partial_match || complete_match
+        end
       end
 
       private
@@ -27,12 +31,10 @@ module AutomatedChecks
       attr_reader :dqt_teacher_status
 
       def one_login
-        if claim.identity_confirmed_with_onelogin?
-          if claim.onelogin_idv_full_name.downcase == claim.full_name.downcase && claim.onelogin_idv_date_of_birth == claim.date_of_birth
-            create_task(match: nil, passed: true)
-          else
-            create_task(match: nil, passed: false)
-          end
+        if claim.onelogin_idv_full_name.downcase == claim.full_name.downcase && claim.onelogin_idv_date_of_birth == claim.date_of_birth
+          create_task(match: nil, passed: true)
+        else
+          nil # drops to manual
         end
       end
 

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -31,19 +31,11 @@ module AutomatedChecks
       attr_reader :dqt_teacher_status
 
       def one_login
-        if one_login_name_match? && one_login_dob_match?
-          create_task(match: nil, passed: true)
-        else
+        if claim.one_login_idv_mismatch?
           create_task(match: nil, passed: false)
+        else
+          create_task(match: nil, passed: true)
         end
-      end
-
-      def one_login_name_match?
-        claim.onelogin_idv_full_name.downcase == "#{claim.first_name.downcase} #{claim.surname.downcase}"
-      end
-
-      def one_login_dob_match?
-        claim.onelogin_idv_date_of_birth == claim.date_of_birth
       end
 
       def dqt_teacher_status=(dqt_teacher_status)

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -18,7 +18,7 @@ module AutomatedChecks
         return unless awaiting_task?(TASK_NAME)
 
         # Order of matching matters so that subsequent conditions in methods fall through to execute the right thing
-        auto_pass || no_match || partial_match || complete_match
+        one_login || no_match || partial_match || complete_match
       end
 
       private
@@ -26,14 +26,13 @@ module AutomatedChecks
       attr_accessor :admin_user, :claim
       attr_reader :dqt_teacher_status
 
-      def auto_pass
-        case claim.policy.auto_pass_identity_confirmation_task(claim)
-        when :pass
-          create_task(match: nil, passed: true)
-        when :fail
-          create_task(match: nil, passed: false)
-        when :skip
-          nil
+      def one_login
+        if claim.identity_confirmed_with_onelogin?
+          if claim.onelogin_idv_full_name.downcase == claim.full_name.downcase && claim.onelogin_idv_date_of_birth == claim.date_of_birth
+            create_task(match: nil, passed: true)
+          else
+            create_task(match: nil, passed: false)
+          end
         end
       end
 

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -31,11 +31,19 @@ module AutomatedChecks
       attr_reader :dqt_teacher_status
 
       def one_login
-        if claim.onelogin_idv_full_name.downcase == claim.full_name.downcase && claim.onelogin_idv_date_of_birth == claim.date_of_birth
+        if one_login_name_match? && one_login_dob_match?
           create_task(match: nil, passed: true)
         else
           create_task(match: nil, passed: false)
         end
+      end
+
+      def one_login_name_match?
+        claim.onelogin_idv_full_name.downcase == "#{claim.first_name.downcase} #{claim.surname.downcase}"
+      end
+
+      def one_login_dob_match?
+        claim.onelogin_idv_date_of_birth == claim.date_of_birth
       end
 
       def dqt_teacher_status=(dqt_teacher_status)

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -34,7 +34,7 @@ module AutomatedChecks
         if claim.onelogin_idv_full_name.downcase == claim.full_name.downcase && claim.onelogin_idv_date_of_birth == claim.date_of_birth
           create_task(match: nil, passed: true)
         else
-          nil # drops to manual
+          create_task(match: nil, passed: false)
         end
       end
 

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -54,8 +54,4 @@ module BasePolicy
   def further_education_payments?
     to_s == "FurtherEducationPayments"
   end
-
-  def auto_pass_identity_confirmation_task(claim)
-    :skip
-  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -212,6 +212,10 @@ class Claim < ApplicationRecord
   scope :awaiting_qa, -> { approved.qa_required.where(qa_completed_at: nil) }
   scope :qa_required, -> { where(qa_required: true) }
 
+  def onelogin_idv_full_name
+    "#{onelogin_idv_first_name} #{onelogin_idv_last_name}"
+  end
+
   def hold!(reason:, user:)
     if holdable? && !held?
       self.class.transaction do

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -431,7 +431,19 @@ class Claim < ApplicationRecord
     end
   end
 
+  def one_login_idv_mismatch?
+    !one_login_idv_name_match? || !one_login_idv_dob_match?
+  end
+
   private
+
+  def one_login_idv_name_match?
+    onelogin_idv_full_name.downcase == "#{first_name.downcase} #{surname.downcase}"
+  end
+
+  def one_login_idv_dob_match?
+    onelogin_idv_date_of_birth == date_of_birth
+  end
 
   def normalise_ni_number
     self.national_insurance_number = normalised_ni_number

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -71,9 +71,5 @@ module Policies
     def duplicate_claim?(claim)
       Claim::MatchingAttributeFinder.new(claim).matching_claims.exists?
     end
-
-    def auto_pass_identity_confirmation_task(claim)
-      claim.identity_confirmed_with_onelogin? ? :pass : :fail
-    end
   end
 end

--- a/app/views/admin/tasks/_one_login_idv.html.erb
+++ b/app/views/admin/tasks/_one_login_idv.html.erb
@@ -1,0 +1,31 @@
+<% if @claim.onelogin_idv_at.present? %>
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      This task was performed by GOV.UK One Login on <%= l(@claim.onelogin_idv_at) %>
+    </p>
+
+    <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Identity confirmation check") %>
+          <% row.with_cell(text: "Full name") %>
+          <% row.with_cell(text: "Date of birth") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(header: true, text: "One Login identity verification (IDV)") %>
+          <% row.with_cell(text: @claim.onelogin_idv_full_name) %>
+          <% row.with_cell(text: l(@claim.onelogin_idv_date_of_birth)) %>
+        <% end %>
+
+        <% body.with_row do |row| %>
+          <% row.with_cell(header: true, text: "Personal details") %>
+          <% row.with_cell(text: @claim.full_name) %>
+          <% row.with_cell(text: l(@claim.date_of_birth)) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/tasks/_one_login_idv.html.erb
+++ b/app/views/admin/tasks/_one_login_idv.html.erb
@@ -21,7 +21,7 @@
         <% end %>
 
         <% body.with_row do |row| %>
-          <% row.with_cell(header: true, text: "Name provided by claimant") %>
+          <% row.with_cell(header: true, text: "Details provided by claimant") %>
           <% row.with_cell(text: @claim.full_name) %>
           <% row.with_cell(text: l(@claim.date_of_birth)) %>
         <% end %>

--- a/app/views/admin/tasks/_one_login_idv.html.erb
+++ b/app/views/admin/tasks/_one_login_idv.html.erb
@@ -7,7 +7,7 @@
     <%= govuk_table do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
-          <% row.with_cell(text: "Identity confirmation check") %>
+          <% row.with_cell(text: "Claimant identity check") %>
           <% row.with_cell(text: "Full name") %>
           <% row.with_cell(text: "Date of birth") %>
         <% end %>
@@ -21,7 +21,7 @@
         <% end %>
 
         <% body.with_row do |row| %>
-          <% row.with_cell(header: true, text: "Personal details") %>
+          <% row.with_cell(header: true, text: "Name provided by claimant") %>
           <% row.with_cell(text: @claim.full_name) %>
           <% row.with_cell(text: l(@claim.date_of_birth)) %>
         <% end %>

--- a/app/views/admin/tasks/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/identity_confirmation.html.erb
@@ -5,12 +5,13 @@
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">
-
   <%= render claim_summary_view, claim: @claim, heading: "Identity confirmation" %>
 
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
   </div>
+
+  <%= render "one_login_idv" %>
 
   <% unless @claim.identity_verified? || @tasks_presenter.identity_confirmation.empty? %>
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/tasks/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/identity_confirmation.html.erb
@@ -1,5 +1,7 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% end %>
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -865,6 +865,8 @@ en:
         payroll_gender:
           hint: "The claimant answered ‘Don't know’ to the question ‘How is your gender recorded on your employer’s payroll system?'"
       task_questions:
+        identity_confirmation:
+          title: Do the One Login details match the personal details entered by the claimant?
         matching_details:
           title: Is this claim still valid despite having matching details with other claims?
         payroll_details:

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
     end
 
     trait :with_onelogin_idv_data do
+      identity_confirmed_with_onelogin { true }
       onelogin_uid { SecureRandom.uuid }
       onelogin_auth_at { rand(14.days.ago..1.day.ago).to_datetime }
       onelogin_idv_at { (onelogin_auth_at + 1.hour) }

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -36,6 +36,15 @@ FactoryBot.define do
       claim.academic_year = claim_academic_year unless claim.academic_year_before_type_cast
     end
 
+    trait :with_onelogin_idv_data do
+      onelogin_uid { SecureRandom.uuid }
+      onelogin_auth_at { rand(14.days.ago..1.day.ago).to_datetime }
+      onelogin_idv_at { (onelogin_auth_at + 1.hour) }
+      onelogin_idv_first_name { first_name }
+      onelogin_idv_last_name { surname }
+      onelogin_idv_date_of_birth { date_of_birth }
+    end
+
     trait :with_details_from_dfe_identity do
       first_name { "Jo" }
       surname { "Bloggs" }

--- a/spec/features/admin/tasks/identity_confirmation_spec.rb
+++ b/spec/features/admin/tasks/identity_confirmation_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "Admin performs identity confirmation task" do
+  let(:claim) { create(:claim, :submitted, :with_onelogin_idv_data) }
+
+  before do
+    disable_claim_qa_flagging
+    sign_in_as_service_operator
+  end
+
+  scenario "when user used One Login IDV" do
+    claim
+
+    visit admin_claims_path
+    click_link claim.reference
+    click_link "Confirm the claimant made the claim"
+
+    expect(page).to have_content "This task was performed by GOV.UK One Login on #{I18n.localize(claim.onelogin_idv_at)}"
+  end
+end

--- a/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
       :submittable,
       :with_onelogin_credentials,
       identity_confirmed_with_onelogin: true,
-      logged_in_with_onelogin: true
+      logged_in_with_onelogin: true,
+      onelogin_idv_first_name: "John",
+      onelogin_idv_last_name: "Doe",
+      onelogin_idv_date_of_birth: Date.new(1970, 1, 1),
+      first_name: "John",
+      surname: "Doe",
+      date_of_birth: Date.new(1970, 1, 1)
     )
   }
 
@@ -114,6 +120,34 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
 
       expect(original_claim.eligibility.flagged_as_duplicate).to eq(false)
       expect(duplicate_claim.eligibility.flagged_as_duplicate).to eq(true)
+    end
+
+    context "when one login IDV mismatch" do
+      let(:answers) do
+        build(
+          :further_education_payments_answers,
+          :submittable,
+          :with_onelogin_credentials,
+          identity_confirmed_with_onelogin: true,
+          logged_in_with_onelogin: true,
+          onelogin_idv_first_name: "John",
+          onelogin_idv_last_name: "Doe",
+          onelogin_idv_date_of_birth: Date.new(1970, 1, 1),
+          first_name: "Jack",
+          surname: "Doe",
+          date_of_birth: Date.new(1970, 1, 1)
+        )
+      end
+
+      it "does not email the provider" do
+        allow(ClaimMailer).to(
+          receive(:further_education_payment_provider_verification_email)
+        ).and_return(double(deliver_later: nil))
+
+        subject
+
+        expect(ClaimMailer).not_to have_received(:further_education_payment_provider_verification_email)
+      end
     end
   end
 end

--- a/spec/models/automated_checks/claim_verifiers/identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/identity_spec.rb
@@ -94,10 +94,10 @@ module AutomatedChecks
             )
           end
 
-          it "creates a failed task" do
+          it "does not create a task" do
             expect {
               subject.perform
-            }.to change(Task.automated.where(passed: false), :count).by(1)
+            }.not_to change(Task, :count)
           end
         end
 
@@ -112,10 +112,10 @@ module AutomatedChecks
             )
           end
 
-          it "creates a failed task" do
+          it "does not create a task" do
             expect {
               subject.perform
-            }.to change(Task.automated.where(passed: false), :count).by(1)
+            }.not_to change(Task, :count)
           end
         end
       end

--- a/spec/models/automated_checks/claim_verifiers/identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/identity_spec.rb
@@ -5,6 +5,8 @@ module AutomatedChecks
     RSpec.describe Identity do
       subject(:identity) { described_class.new(**identity_args) }
 
+      let(:data) { {} }
+
       before do
         if data
           body = data
@@ -66,60 +68,54 @@ module AutomatedChecks
         }
       end
 
-      describe "#perform with auto pass for FurtherEducationPayments" do
-        let(:policy) { Policies::FurtherEducationPayments }
-        let(:data) do
-          {
-            dob: claim_arg.date_of_birth,
-            name: claim_arg.full_name,
-            nino: claim_arg.national_insurance_number,
-            trn: claim_arg.eligibility.teacher_reference_number
-          }
+      describe "#perform" do
+        context "when IDV-ed with one login and data matches" do
+          let(:claim_arg) do
+            create(:claim, :submitted, :with_onelogin_idv_data)
+          end
+
+          it "creates a passed task" do
+            expect {
+              subject.perform
+            }.to change(Task.passed_automatically, :count).by(1)
+          end
         end
 
-        subject(:perform) { identity.perform }
-
-        describe "identity confirmation task" do
-          let(:identity_confirmed_with_onelogin) { true }
-
-          subject(:identity_confirmation_task) { claim_arg.tasks.find_by(name: "identity_confirmation") }
-
-          before { perform }
-
-          describe "#claim_verifier_match" do
-            subject(:claim_verifier_match) { identity_confirmation_task.claim_verifier_match }
-
-            it { is_expected.to eq nil }
+        context "when IDV-ed with one login and name does not match" do
+          let(:claim_arg) do
+            create(
+              :claim,
+              :submitted,
+              :with_onelogin_idv_data,
+              first_name: "John",
+              surname: "Doe",
+              onelogin_idv_first_name: "Tom",
+              onelogin_idv_last_name: "Jones"
+            )
           end
 
-          context "identity_confirmed_with_onelogin true" do
-            describe "#passed" do
-              subject(:passed) { identity_confirmation_task.passed }
+          it "creates a failed task" do
+            expect {
+              subject.perform
+            }.to change(Task.automated.where(passed: false), :count).by(1)
+          end
+        end
 
-              it { is_expected.to eq true }
-            end
+        context "when IDV-ed with one login and date of birth does not match" do
+          let(:claim_arg) do
+            create(
+              :claim,
+              :submitted,
+              :with_onelogin_idv_data,
+              date_of_birth: Date.new(1980, 12, 13),
+              onelogin_idv_date_of_birth: Date.new(1970, 1, 1)
+            )
           end
 
-          context "identity_confirmed_with_onelogin false" do
-            let(:identity_confirmed_with_onelogin) { false }
-
-            describe "#passed" do
-              subject(:passed) { identity_confirmation_task.passed }
-
-              it { is_expected.to eq false }
-            end
-          end
-
-          describe "#created_by" do
-            subject(:created_by) { identity_confirmation_task.created_by }
-
-            it { is_expected.to eq nil }
-          end
-
-          describe "#manual" do
-            subject(:manual) { identity_confirmation_task.manual }
-
-            it { is_expected.to eq false }
+          it "creates a failed task" do
+            expect {
+              subject.perform
+            }.to change(Task.automated.where(passed: false), :count).by(1)
           end
         end
       end

--- a/spec/models/automated_checks/claim_verifiers/identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/identity_spec.rb
@@ -94,10 +94,10 @@ module AutomatedChecks
             )
           end
 
-          it "does not create a task" do
+          it "creates a failed task" do
             expect {
               subject.perform
-            }.not_to change(Task, :count)
+            }.to change(Task.where(passed: false), :count).by(1)
           end
         end
 
@@ -112,10 +112,10 @@ module AutomatedChecks
             )
           end
 
-          it "does not create a task" do
+          it "creates a failed task" do
             expect {
               subject.perform
-            }.not_to change(Task, :count)
+            }.to change(Task.where(passed: false), :count).by(1)
           end
         end
       end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1036
- Admin for OL identity confirmation

# Changes

- If user used OL, display their OL IDV data and opposing data from their claim in ID task
- If data matches it auto passes
- if data does not match it fails
- also on claim submission we do the same check and if it fails do not send the provider the verification email

# Screenshots

![Screenshot 2024-09-18 at 15 39 09](https://github.com/user-attachments/assets/095a6ad8-d6aa-41c5-9275-f037fa553e84)

---

![Screenshot 2024-09-18 at 15 39 19](https://github.com/user-attachments/assets/14ea7740-c1b6-4ba6-b69f-eea3b8d15dff)