### PR TITLE
LUPEYALPHA 991/view full claim

### DIFF
--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -127,7 +127,7 @@ module Journeys
         end
 
         def contract_type
-          if claim.eligibility.fixed_contract?
+          if claim.eligibility.long_term_employed?
             :fixed_contract
           else
             :variable_contract

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -36,7 +36,7 @@ module Admin
 
     def admin_personal_details(claim)
       [
-        [translate("admin.teacher_reference_number"), claim.eligibility.teacher_reference_number],
+        [translate("admin.teacher_reference_number"), claim.eligibility.teacher_reference_number.presence || "Not provided"],
         [translate("govuk_verify_fields.full_name").capitalize, claim.personal_data_removed? ? personal_data_removed_text : claim.full_name],
         [translate("govuk_verify_fields.date_of_birth").capitalize, claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year)],
         [translate("admin.national_insurance_number"), claim.personal_data_removed? ? personal_data_removed_text : claim.national_insurance_number],

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -59,6 +59,10 @@ module Policies
         end
       end
 
+      def permanent_contract?
+        contract_type == "permanent"
+      end
+
       def verified?
         verification.present?
       end

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -48,7 +48,7 @@ module Policies
         end.flatten
       end
 
-      def fixed_contract?
+      def long_term_employed?
         case contract_type
         when "permanent"
           true

--- a/app/models/policies/further_education_payments/eligibility_admin_answers_presenter.rb
+++ b/app/models/policies/further_education_payments/eligibility_admin_answers_presenter.rb
@@ -2,6 +2,7 @@ module Policies
   module FurtherEducationPayments
     class EligibilityAdminAnswersPresenter
       include Admin::PresenterMethods
+      include ActionView::Helpers::NumberHelper
 
       attr_reader :eligibility
 
@@ -15,6 +16,71 @@ module Policies
         end
       end
 
+      def provider_details
+        [
+          teaching_responsibilities,
+          fe_provider
+        ]
+      end
+
+      def employment_contract
+        [
+          contract_type,
+          teaching_hours_per_week
+        ]
+      end
+
+      def academic_year_claimant_started_teaching
+        [
+          [
+            question(:further_education_teaching_start_year),
+            "September #{eligibility.further_education_teaching_start_year.to_i} " \
+            "to August #{eligibility.further_education_teaching_start_year.to_i + 1}"
+          ]
+        ]
+      end
+
+      def subjects_taught
+        [
+          subjects
+        ] + courses
+      end
+
+      def teaching_hours
+        [
+          hours_teaching_eligible_subjects,
+          half_teaching_hours
+        ]
+      end
+
+      def teaching_qualification
+        [
+          [
+            question(:teaching_qualification),
+            selected_option(
+              :teaching_qualification,
+              eligibility.teaching_qualification
+            )
+          ]
+        ]
+      end
+
+      def performance_and_disciplinary_measures
+        [
+          disciplinary_measures,
+          performance_measures
+        ]
+      end
+
+      def policy_options_provided
+        [
+          [
+            I18n.t("further_education_payments.policy_short_name"),
+            number_to_currency(eligibility.award_amount, precision: 0)
+          ]
+        ]
+      end
+
       private
 
       def current_school
@@ -22,6 +88,107 @@ module Policies
           translate("admin.current_school"),
           display_school(eligibility.current_school)
         ]
+      end
+
+      def teaching_responsibilities
+        [
+          question(:teaching_responsibilities),
+          display_boolean(eligibility.teaching_responsibilities)
+        ]
+      end
+
+      def fe_provider
+        [
+          question(:further_education_provision_search),
+          eligibility.school.name
+        ]
+      end
+
+      def contract_type
+        [
+          question(:contract_type, school_name: eligibility.school.name),
+          contract_type_answer
+        ]
+      end
+
+      def teaching_hours_per_week
+        [
+          question(:teaching_hours_per_week, school_name: eligibility.school.name),
+          selected_option(:teaching_hours_per_week, eligibility.teaching_hours_per_week)
+        ]
+      end
+
+      def subjects
+        [
+          question(:subjects_taught),
+          eligibility.subjects_taught.map { |subject| selected_option(:subjects_taught, subject) }
+        ]
+      end
+
+      def courses
+        eligibility.subjects_taught.map do |subject|
+          [
+            I18n.t("further_education_payments.forms.#{subject}_courses.question_check_your_answers"),
+            course_descriptions_for_subject(subject)
+          ]
+        end
+      end
+
+      def course_descriptions_for_subject(subject)
+        eligibility.courses
+          .select { |course| course.subject == subject }
+          .map(&:description)
+          .map(&:html_safe)
+      end
+
+      def hours_teaching_eligible_subjects
+        [
+          question(:hours_teaching_eligible_subjects),
+          display_boolean(eligibility.hours_teaching_eligible_subjects)
+        ]
+      end
+
+      def half_teaching_hours
+        [
+          question(:half_teaching_hours),
+          display_boolean(eligibility.half_teaching_hours)
+        ]
+      end
+
+      def performance_measures
+        [
+          question("poor_performance.questions.performance"),
+          display_boolean(eligibility.subject_to_formal_performance_action)
+        ]
+      end
+
+      def disciplinary_measures
+        [
+          question("poor_performance.questions.disciplinary"),
+          display_boolean(eligibility.subject_to_disciplinary_action)
+        ]
+      end
+
+      def question(attr, **)
+        I18n.t("further_education_payments.forms.#{attr}.question", **)
+      end
+
+      def selected_option(attr, value)
+        I18n.t("further_education_payments.forms.#{attr}.options.#{value}")
+      end
+
+      def contract_type_answer
+        if eligibility.fixed_contract?
+          "Permanent contract (including full-time and part-time contracts)"
+        elsif eligibility.contract_type == "variable_hours"
+          "Variable hours contract"
+        else
+          "Fixed term contract"
+        end
+      end
+
+      def display_boolean(value)
+        value ? "Yes" : "No"
       end
     end
   end

--- a/app/models/policies/further_education_payments/eligibility_admin_answers_presenter.rb
+++ b/app/models/policies/further_education_payments/eligibility_admin_answers_presenter.rb
@@ -115,7 +115,7 @@ module Policies
       end
 
       def taught_at_least_one_term
-        return nil if eligibility.fixed_contract?
+        return nil if eligibility.long_term_employed?
 
         [
           question(

--- a/app/views/admin/claims/_answers.html.erb
+++ b/app/views/admin/claims/_answers.html.erb
@@ -6,7 +6,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= answer %>
+        <%= safe_join(Array.wrap(answer), tag.br + tag.br) %>
       </dd>
     </div>
   <% end %>

--- a/app/views/admin/claims/policies/early_career_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/early_career_payments/_claim.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+
+    <% if @claim.policy_options_provided.present? %>
+      <%= render "admin/claims/answer_section", {heading: "Policy options provided", answers: admin_policy_options_provided(@claim)} %>
+    <% end %>
+
+    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+
+    <% if @decision.persisted? %>
+      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/policies/early_years_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/early_years_payments/_claim.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+
+    <% if @decision.persisted? %>
+      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+
+    <% if @decision.persisted? %>
+      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
@@ -1,17 +1,111 @@
+<% admin_answers_presenter = Policies::FurtherEducationPayments::EligibilityAdminAnswersPresenter.new(@claim.eligibility) %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+  <div class="govuk-grid-column-full">
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Personal details",
+        answers: admin_personal_details(@claim)
+      }
+    ) %>
 
-    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Provider details",
+        answers: admin_answers_presenter.provider_details
+      }
+    ) %>
 
-    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Employment contract",
+        answers: admin_answers_presenter.employment_contract
+      }
+    ) %>
 
-    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Academic year claimant started teaching",
+        answers: admin_answers_presenter.academic_year_claimant_started_teaching
+      }
+    ) %>
 
-    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Subjects taught",
+        answers: admin_answers_presenter.subjects_taught
+      }
+    ) %>
+
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Teaching hours",
+        answers: admin_answers_presenter.teaching_hours
+      }
+    ) %>
+
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Qualification",
+        answers: admin_answers_presenter.teaching_qualification
+      }
+    ) %>
+
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Performance and disciplinary measures",
+        answers: admin_answers_presenter.performance_and_disciplinary_measures
+      }
+    ) %>
+
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Policy options provided",
+        answers: admin_answers_presenter.policy_options_provided
+      }
+    ) %>
+
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Student loan details",
+        answers: admin_student_loan_details(@claim)
+      }
+    ) %>
+
+    <%= render(
+      "admin/claims/answer_section",
+      {
+        heading: "Submission details",
+        answers: admin_submission_details(@claim)
+      }
+    ) %>
+
+    <%= render(
+      "claims_with_matching_details",
+      {
+        matching_claims: @matching_claims,
+        claim: @claim,
+        show_caption: true
+      }
+    ) if @matching_claims.any? %>
 
     <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+      <%= render(
+        "admin/claims/answer_section",
+        {
+          heading: "Claim decision details",
+          answers: admin_decision_details(@decision)
+        }
+      ) %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/policies/international_relocation_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/international_relocation_payments/_claim.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+
+    <% if @decision.persisted? %>
+      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/policies/levelling_up_premium_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/levelling_up_premium_payments/_claim.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+
+    <% if @claim.policy_options_provided.present? %>
+      <%= render "admin/claims/answer_section", {heading: "Policy options provided", answers: admin_policy_options_provided(@claim)} %>
+    <% end %>
+
+    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+
+    <% if @decision.persisted? %>
+      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/policies/student_loans/_claim.html.erb
+++ b/app/views/admin/claims/policies/student_loans/_claim.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
+    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
+
+    <% if @decision.persisted? %>
+      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -26,24 +26,4 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
-
-    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
-
-    <% if @claim.has_ecp_or_lupp_policy? && @claim.policy_options_provided.present? %>
-      <%= render "admin/claims/answer_section", {heading: "Policy options provided", answers: admin_policy_options_provided(@claim)} %>
-    <% end %>
-
-    <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
-
-    <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
-
-    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
-
-    <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
-    <% end %>
-  </div>
-</div>
+<%= render("admin/claims/policies/#{@claim.policy.to_s.underscore}/claim") %>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -3,7 +3,10 @@
 <%= link_to "Back", admin_claim_tasks_path(@claim), class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="<%= class_names(
+    "govuk-grid-column-two-thirds": !@claim.policy.further_education_payments?,
+    "govuk-grid-column-full": @claim.policy.further_education_payments?
+  ) %>">
     <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
 
     <% if @claim.personal_data_removed? %>
@@ -14,7 +17,7 @@
 
     <span class="govuk-caption-xl"><%= @claim.policy.short_name %>  (<%= @claim.academic_year %>)</span>
     <h1 class="govuk-heading-xl govuk-heading--navigation">
-      <%= @claim.reference %>
+      <%= claim_summary_heading(@claim) %>
       <span class="govuk-body-m">
         <%= link_to "View tasks", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-link" %>
         <%= link_to "Amend claim", new_admin_claim_amendment_path(@claim), class: "govuk-link" if @claim.amendable? %>

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
     trait :eligible do
       eligible_school
+      contract_type { "permanent" }
     end
 
     trait :eligible_school do

--- a/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+
+RSpec.feature "Admin views claim details for FurtherEducationPayments" do
+  before do
+    create(:journey_configuration, :further_education_payments)
+  end
+
+  it "shows the full claim details" do
+    school = create(
+      :school,
+      :further_education,
+      :fe_eligible,
+      name: "Springfield Elementary"
+    )
+
+    claim = create(
+      :claim,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      national_insurance_number: "QQ123456C",
+      address_line_1: "82 Evergreen Terrace",
+      address_line_2: "Springfield",
+      address_line_4: "Oregon",
+      postcode: "AB12 3CD",
+      email_address: "edna.krabappel@springfield-elementary.edu",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+      submitted_at: DateTime.new(2024, 8, 1, 11, 0, 0)
+    )
+
+    create(
+      :further_education_payments_eligibility,
+      claim: claim,
+      school: school,
+      teacher_reference_number: nil,
+      teaching_responsibilities: true,
+      contract_type: "fixed_term",
+      fixed_term_full_year: true,
+      teaching_hours_per_week: "more_than_12",
+      further_education_teaching_start_year: "2023",
+      subjects_taught: ["maths", "computing"],
+      maths_courses: ["approved_level_321_maths", "gcse_maths"],
+      computing_courses: ["level3_and_below_ict_for_practitioners"],
+      hours_teaching_eligible_subjects: true,
+      half_teaching_hours: true,
+      teaching_qualification: "yes",
+      subject_to_formal_performance_action: false,
+      subject_to_disciplinary_action: false,
+      award_amount: 6_000
+    )
+
+    sign_in_as_service_operator
+
+    visit admin_claim_path(claim)
+
+    expect(summary_row("Teacher reference number")).to have_content(
+      "Not provided"
+    )
+
+    expect(summary_row("Full name")).to have_content("Edna Krabappel")
+
+    expect(summary_row("Date of birth")).to have_content("03/07/1945")
+
+    expect(summary_row("National Insurance number")).to have_content(
+      "QQ123456C"
+    )
+
+    expect(summary_row("Address")).to have_content("82 Evergreen Terrace")
+    expect(summary_row("Address")).to have_content("Springfield")
+    expect(summary_row("Address")).to have_content("Oregon")
+    expect(summary_row("Address")).to have_content("AB12 3CD")
+
+    expect(summary_row("Email address")).to have_content(
+      "edna.krabappel@springfield-elementary.edu"
+    )
+
+    expect(
+      summary_row("Are you a member of staff with teaching responsibilities?")
+    ).to have_content("Yes")
+
+    expect(
+      summary_row("Which FE provider are you employed by?")
+    ).to have_content("Springfield Elementary")
+
+    expect(
+      summary_row(
+        "What type of contract do you have with Springfield Elementary?"
+      )
+    ).to have_content(
+      "Permanent contract (including full-time and part-time contracts)"
+    )
+
+    expect(
+      summary_row(
+        "On average, how many hours per week are you timetabled to teach at " \
+        "Springfield Elementary during the current term?"
+      )
+    ).to have_content("More than 12 hours per week")
+
+    expect(
+      summary_row(
+        "Which academic year did you start teaching in " \
+        "further education (FE) in England?"
+      )
+    ).to have_content("September 2023 to August 2024")
+
+    expect(summary_row("Which subject areas do you teach?")).to have_content(
+      "Maths"
+    )
+
+    expect(summary_row("Which subject areas do you teach?")).to have_content(
+      "Computing, including digital and ICT"
+    )
+
+    expect(summary_row("Maths courses")).to have_content(
+      "Qualifications approved for funding at level 3 and below"
+    )
+
+    expect(summary_row("Maths courses")).to have_content(
+      "GCSE in maths, functional skills qualifications"
+    )
+
+    expect(summary_row("Computing courses")).to have_content(
+      "Qualifications approved for funding at level 3 and below"
+    )
+
+    expect(
+      summary_row(
+        "Do you spend at least half of your timetabled teaching hours " \
+        "teaching these eligible courses?"
+      )
+    ).to have_content("Yes")
+
+    expect(
+      summary_row(
+        "Are at least half of your timetabled teaching hours spent teaching " \
+        "16 to 19-year-olds, including those up to age 25 with an Education, " \
+        "Health and Care Plan (EHCP)?"
+      )
+    ).to have_content("Yes")
+
+    expect(summary_row("Do you have a teaching qualification?")).to(
+      have_content("Yes")
+    )
+
+    expect(
+      summary_row("Have any performance measures been started against you?")
+    ).to have_content("No")
+
+    expect(
+      summary_row("Are you currently subject to disciplinary action?")
+    ).to have_content("No")
+
+    expect(
+      summary_row("Targeted Retention Incentive Payment For FE Teachers")
+    ).to have_content("£6,000")
+
+    expect(summary_row("Started at")).to have_content("1 August 2024 10:00am")
+
+    expect(summary_row("Submitted at")).to have_content("1 August 2024 12:00pm")
+
+    expect(summary_row("Decision deadline")).to have_content("24 October 2024")
+  end
+
+  def summary_row(label)
+    find("dt", text: label).sibling("dd")
+  end
+end

--- a/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
@@ -5,162 +5,169 @@ RSpec.feature "Admin views claim details for FurtherEducationPayments" do
     create(:journey_configuration, :further_education_payments)
   end
 
-  it "shows the full claim details" do
-    school = create(
-      :school,
-      :further_education,
-      :fe_eligible,
-      name: "Springfield Elementary"
-    )
-
-    claim = create(
-      :claim,
-      first_name: "Edna",
-      surname: "Krabappel",
-      date_of_birth: Date.new(1945, 7, 3),
-      reference: "AB123456",
-      national_insurance_number: "QQ123456C",
-      address_line_1: "82 Evergreen Terrace",
-      address_line_2: "Springfield",
-      address_line_4: "Oregon",
-      postcode: "AB12 3CD",
-      email_address: "edna.krabappel@springfield-elementary.edu",
-      created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
-      submitted_at: DateTime.new(2024, 8, 1, 11, 0, 0)
-    )
-
-    create(
-      :further_education_payments_eligibility,
-      claim: claim,
-      school: school,
-      teacher_reference_number: nil,
-      teaching_responsibilities: true,
-      contract_type: "fixed_term",
-      fixed_term_full_year: true,
-      teaching_hours_per_week: "more_than_12",
-      further_education_teaching_start_year: "2023",
-      subjects_taught: ["maths", "computing"],
-      maths_courses: ["approved_level_321_maths", "gcse_maths"],
-      computing_courses: ["level3_and_below_ict_for_practitioners"],
-      hours_teaching_eligible_subjects: true,
-      half_teaching_hours: true,
-      teaching_qualification: "yes",
-      subject_to_formal_performance_action: false,
-      subject_to_disciplinary_action: false,
-      award_amount: 6_000
-    )
-
-    sign_in_as_service_operator
-
-    visit admin_claim_path(claim)
-
-    expect(summary_row("Teacher reference number")).to have_content(
-      "Not provided"
-    )
-
-    expect(summary_row("Full name")).to have_content("Edna Krabappel")
-
-    expect(summary_row("Date of birth")).to have_content("03/07/1945")
-
-    expect(summary_row("National Insurance number")).to have_content(
-      "QQ123456C"
-    )
-
-    expect(summary_row("Address")).to have_content("82 Evergreen Terrace")
-    expect(summary_row("Address")).to have_content("Springfield")
-    expect(summary_row("Address")).to have_content("Oregon")
-    expect(summary_row("Address")).to have_content("AB12 3CD")
-
-    expect(summary_row("Email address")).to have_content(
-      "edna.krabappel@springfield-elementary.edu"
-    )
-
-    expect(
-      summary_row("Are you a member of staff with teaching responsibilities?")
-    ).to have_content("Yes")
-
-    expect(
-      summary_row("Which FE provider are you employed by?")
-    ).to have_content("Springfield Elementary")
-
-    expect(
-      summary_row(
-        "What type of contract do you have with Springfield Elementary?"
+  context "with a fixed contract" do
+    it "shows the full claim details" do
+      school = create(
+        :school,
+        :further_education,
+        :fe_eligible,
+        name: "Springfield Elementary"
       )
-    ).to have_content(
-      "Permanent contract (including full-time and part-time contracts)"
-    )
 
-    expect(
-      summary_row(
-        "On average, how many hours per week are you timetabled to teach at " \
-        "Springfield Elementary during the current term?"
+      claim = create(
+        :claim,
+        first_name: "Edna",
+        surname: "Krabappel",
+        date_of_birth: Date.new(1945, 7, 3),
+        reference: "AB123456",
+        national_insurance_number: "QQ123456C",
+        address_line_1: "82 Evergreen Terrace",
+        address_line_2: "Springfield",
+        address_line_4: "Oregon",
+        postcode: "AB12 3CD",
+        email_address: "edna.krabappel@springfield-elementary.edu",
+        created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+        submitted_at: DateTime.new(2024, 8, 1, 11, 0, 0),
+        academic_year: AcademicYear.new(2024)
       )
-    ).to have_content("More than 12 hours per week")
 
-    expect(
-      summary_row(
-        "Which academic year did you start teaching in " \
-        "further education (FE) in England?"
+      create(
+        :further_education_payments_eligibility,
+        claim: claim,
+        school: school,
+        teacher_reference_number: nil,
+        teaching_responsibilities: true,
+        contract_type: "permanent",
+        fixed_term_full_year: true,
+        teaching_hours_per_week: "more_than_12",
+        further_education_teaching_start_year: "2023",
+        subjects_taught: ["maths", "computing"],
+        maths_courses: ["approved_level_321_maths", "gcse_maths"],
+        computing_courses: ["level3_and_below_ict_for_practitioners"],
+        hours_teaching_eligible_subjects: true,
+        half_teaching_hours: true,
+        teaching_qualification: "yes",
+        subject_to_formal_performance_action: false,
+        subject_to_disciplinary_action: false,
+        award_amount: 6_000
       )
-    ).to have_content("September 2023 to August 2024")
 
-    expect(summary_row("Which subject areas do you teach?")).to have_content(
-      "Maths"
-    )
+      sign_in_as_service_operator
 
-    expect(summary_row("Which subject areas do you teach?")).to have_content(
-      "Computing, including digital and ICT"
-    )
+      visit admin_claim_path(claim)
 
-    expect(summary_row("Maths courses")).to have_content(
-      "Qualifications approved for funding at level 3 and below"
-    )
-
-    expect(summary_row("Maths courses")).to have_content(
-      "GCSE in maths, functional skills qualifications"
-    )
-
-    expect(summary_row("Computing courses")).to have_content(
-      "Qualifications approved for funding at level 3 and below"
-    )
-
-    expect(
-      summary_row(
-        "Do you spend at least half of your timetabled teaching hours " \
-        "teaching these eligible courses?"
+      expect(summary_row("Teacher reference number")).to have_content(
+        "Not provided"
       )
-    ).to have_content("Yes")
 
-    expect(
-      summary_row(
-        "Are at least half of your timetabled teaching hours spent teaching " \
-        "16 to 19-year-olds, including those up to age 25 with an Education, " \
-        "Health and Care Plan (EHCP)?"
+      expect(summary_row("Full name")).to have_content("Edna Krabappel")
+
+      expect(summary_row("Date of birth")).to have_content("03/07/1945")
+
+      expect(summary_row("National Insurance number")).to have_content(
+        "QQ123456C"
       )
-    ).to have_content("Yes")
 
-    expect(summary_row("Do you have a teaching qualification?")).to(
-      have_content("Yes")
-    )
+      expect(summary_row("Address")).to have_content("82 Evergreen Terrace")
+      expect(summary_row("Address")).to have_content("Springfield")
+      expect(summary_row("Address")).to have_content("Oregon")
+      expect(summary_row("Address")).to have_content("AB12 3CD")
 
-    expect(
-      summary_row("Have any performance measures been started against you?")
-    ).to have_content("No")
+      expect(summary_row("Email address")).to have_content(
+        "edna.krabappel@springfield-elementary.edu"
+      )
 
-    expect(
-      summary_row("Are you currently subject to disciplinary action?")
-    ).to have_content("No")
+      expect(
+        summary_row("Are you a member of staff with teaching responsibilities?")
+      ).to have_content("Yes")
 
-    expect(
-      summary_row("Targeted Retention Incentive Payment For FE Teachers")
-    ).to have_content("£6,000")
+      expect(
+        summary_row("Which FE provider are you employed by?")
+      ).to have_content("Springfield Elementary")
 
-    expect(summary_row("Started at")).to have_content("1 August 2024 10:00am")
+      expect(
+        summary_row(
+          "What type of contract do you have with Springfield Elementary?"
+        )
+      ).to have_content(
+        "Permanent contract (including full-time and part-time contracts)"
+      )
 
-    expect(summary_row("Submitted at")).to have_content("1 August 2024 12:00pm")
+      expect(page).not_to have_content(
+        "Does your fixed-term contract cover the full 2024 to 2025 academic year?"
+      )
 
-    expect(summary_row("Decision deadline")).to have_content("24 October 2024")
+      expect(
+        summary_row(
+          "On average, how many hours per week are you timetabled to teach at " \
+          "Springfield Elementary during the current term?"
+        )
+      ).to have_content("More than 12 hours per week")
+
+      expect(
+        summary_row(
+          "Which academic year did you start teaching in " \
+          "further education (FE) in England?"
+        )
+      ).to have_content("September 2023 to August 2024")
+
+      expect(summary_row("Which subject areas do you teach?")).to have_content(
+        "Maths"
+      )
+
+      expect(summary_row("Which subject areas do you teach?")).to have_content(
+        "Computing, including digital and ICT"
+      )
+
+      expect(summary_row("Maths courses")).to have_content(
+        "Qualifications approved for funding at level 3 and below"
+      )
+
+      expect(summary_row("Maths courses")).to have_content(
+        "GCSE in maths, functional skills qualifications"
+      )
+
+      expect(summary_row("Computing courses")).to have_content(
+        "Qualifications approved for funding at level 3 and below"
+      )
+
+      expect(
+        summary_row(
+          "Do you spend at least half of your timetabled teaching hours " \
+          "teaching these eligible courses?"
+        )
+      ).to have_content("Yes")
+
+      expect(
+        summary_row(
+          "Are at least half of your timetabled teaching hours spent teaching " \
+          "16 to 19-year-olds, including those up to age 25 with an Education, " \
+          "Health and Care Plan (EHCP)?"
+        )
+      ).to have_content("Yes")
+
+      expect(summary_row("Do you have a teaching qualification?")).to(
+        have_content("Yes")
+      )
+
+      expect(
+        summary_row("Have any performance measures been started against you?")
+      ).to have_content("No")
+
+      expect(
+        summary_row("Are you currently subject to disciplinary action?")
+      ).to have_content("No")
+
+      expect(
+        summary_row("Targeted Retention Incentive Payment For FE Teachers")
+      ).to have_content("£6,000")
+
+      expect(summary_row("Started at")).to have_content("1 August 2024 10:00am")
+
+      expect(summary_row("Submitted at")).to have_content("1 August 2024 12:00pm")
+
+      expect(summary_row("Decision deadline")).to have_content("24 October 2024")
+    end
   end
 
   def summary_row(label)

--- a/spec/models/policies/further_education_payments/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/policies/further_education_payments/eligibility_admin_answers_presenter_spec.rb
@@ -1,0 +1,271 @@
+require "rails_helper"
+
+RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresenter do
+  let(:school) do
+    create(
+      :school,
+      :further_education,
+      :fe_eligible,
+      name: "Springfield Elementary"
+    )
+  end
+
+  let(:contract_type) { "permanent" }
+  let(:fixed_term_full_year) { nil }
+  let(:teaching_hours_per_week) { "more_than_12" }
+
+  let(:eligibility) do
+    create(
+      :further_education_payments_eligibility,
+      :eligible,
+      school: school,
+      teaching_responsibilities: true,
+      contract_type: contract_type,
+      fixed_term_full_year: fixed_term_full_year,
+      teaching_hours_per_week: teaching_hours_per_week,
+      further_education_teaching_start_year: "2023",
+      subjects_taught: ["maths", "engineering_manufacturing"],
+      maths_courses: ["approved_level_321_maths", "gcse_maths"],
+      engineering_manufacturing_courses: ["approved_level_321_engineering"],
+      hours_teaching_eligible_subjects: true,
+      half_teaching_hours: true,
+      teaching_qualification: "no_but_planned",
+      subject_to_formal_performance_action: false,
+      subject_to_disciplinary_action: false,
+      award_amount: 6_000
+    )
+  end
+
+  let(:presenter) { described_class.new(eligibility) }
+
+  describe "provider_details" do
+    subject { presenter.provider_details }
+
+    it do
+      is_expected.to include(
+        [
+          "Are you a member of staff with teaching responsibilities?",
+          "Yes"
+        ],
+        [
+          "Which FE provider are you employed by?",
+          "Springfield Elementary"
+        ]
+      )
+    end
+  end
+
+  describe "#employment_contract" do
+    subject { presenter.employment_contract }
+
+    describe "contract_type answer" do
+      context "with a permant contract claim" do
+        let(:contract_type) { "permanent" }
+
+        it do
+          is_expected.to include(
+            [
+              "What type of contract do you have with Springfield Elementary?",
+              "Permanent contract (including full-time and part-time contracts)"
+            ]
+          )
+        end
+      end
+
+      context "with a fixed term contract claim" do
+        let(:contract_type) { "fixed_term" }
+
+        context "with a fixed_term_full_year contract" do
+          let(:fixed_term_full_year) { true }
+
+          it do
+            is_expected.to include(
+              [
+                "What type of contract do you have with Springfield Elementary?",
+                "Permanent contract (including full-time and part-time contracts)"
+              ]
+            )
+          end
+        end
+
+        context "without a fixed_term_full_year contract" do
+          let(:fixed_term_full_year) { false }
+
+          it do
+            is_expected.to include(
+              [
+                "What type of contract do you have with Springfield Elementary?",
+                "Fixed term contract" # TODO RL check this
+              ]
+            )
+          end
+        end
+      end
+
+      context "with a variable_hours contract" do
+        let(:contract_type) { "variable_hours" }
+
+        it do
+          is_expected.to include(
+            [
+              "What type of contract do you have with Springfield Elementary?",
+              "Variable hours contract" # TODO RL check this
+            ]
+          )
+        end
+      end
+    end
+
+    describe "teaching_hours_per_week answer" do
+      context "when more_than_12" do
+        let(:teaching_hours_per_week) { "more_than_12" }
+
+        it do
+          is_expected.to include(
+            [
+              "On average, how many hours per week are you timetabled to teach at Springfield Elementary during the current term?",
+              "More than 12 hours per week"
+            ]
+          )
+        end
+      end
+
+      context "when between_2_5_and_12" do
+        let(:teaching_hours_per_week) { "between_2_5_and_12" }
+
+        it do
+          is_expected.to include(
+            [
+              "On average, how many hours per week are you timetabled to teach at Springfield Elementary during the current term?",
+              "Between 2.5 and 12 hours per week"
+            ]
+          )
+        end
+      end
+
+      context "when less_than_2_5" do
+        let(:teaching_hours_per_week) { "less_than_2_5" }
+
+        it do
+          is_expected.to include(
+            [
+              "On average, how many hours per week are you timetabled to teach at Springfield Elementary during the current term?",
+              "Less than 2.5 hours per week"
+            ]
+          )
+        end
+      end
+    end
+  end
+
+  describe "#academic_year_claimant_started_teaching" do
+    subject { presenter.academic_year_claimant_started_teaching }
+
+    it do
+      is_expected.to eq(
+        [
+          [
+            "Which academic year did you start teaching in further education (FE) in England?",
+            "September 2023 to August 2024"
+          ]
+        ]
+      )
+    end
+  end
+
+  describe "#subjects_taught" do
+    subject { presenter.subjects_taught }
+
+    it do
+      is_expected.to eq(
+        [
+          [
+            "Which subject areas do you teach?",
+            ["Maths", "Engineering and manufacturing, including transport engineering and electronics"]
+          ],
+          [
+            "Maths courses",
+            [
+              "Qualifications approved for funding at level 3 and below in the <a class=\"govuk-link\" target=\"_blank\" rel=\"noreferrer noopener\" href=\"https://www.qualifications.education.gov.uk/Search?Status=Approved&amp;Level=0,1,2,3,4&amp;Sub=28&amp;PageSize=10&amp;Sort=Status\">mathematics and statistics (opens in new tab)</a> sector subject area",
+              "GCSE in maths, functional skills qualifications and <a class=\"govuk-link\" target=\"_blank\" rel=\"noreferrer noopener\" href=\"https://submit-learner-data.service.gov.uk/find-a-learning-aim/LearningAimSearchResult?TeachingYear=2324&amp;HasFilters=False&amp;EFAFundingConditions=EFACONFUNDMATHS\">other maths qualifications (opens in new tab)</a> approved for teaching to 16 to 19-year-olds who meet the condition of funding"
+            ]
+          ],
+          [
+            "Engineering and manufacturing courses",
+            [
+              "Qualifications approved for funding at level 3 and below in the <a class=\"govuk-link\" target=\"_blank\" rel=\"noreferrer noopener\" href=\"https://www.qualifications.education.gov.uk/Search?Status=Approved&amp;Level=0,1,2,3,4&amp;Sub=13&amp;PageSize=10&amp;Sort=Status\">engineering (opens in new tab)</a> sector subject area"
+            ]
+          ]
+        ]
+      )
+    end
+  end
+
+  describe "#teaching_hours" do
+    subject { presenter.teaching_hours }
+
+    it do
+      is_expected.to eq(
+        [
+          [
+            "Do you spend at least half of your timetabled teaching hours teaching these eligible courses?",
+            "Yes"
+          ],
+          [
+            "Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?",
+            "Yes"
+          ]
+        ]
+      )
+    end
+  end
+
+  describe "#teaching_qualification" do
+    subject { presenter.teaching_qualification }
+
+    it do
+      is_expected.to eq(
+        [
+          [
+            "Do you have a teaching qualification?",
+            "No, but I plan to enrol on one in the next 12 months"
+          ]
+        ]
+      )
+    end
+  end
+
+  describe "#performance_and_disciplinary_measures" do
+    subject { presenter.performance_and_disciplinary_measures }
+
+    it do
+      is_expected.to eq(
+        [
+          [
+            "Are you currently subject to disciplinary action?",
+            "No"
+          ],
+          [
+            "Have any performance measures been started against you?",
+            "No"
+          ]
+        ]
+      )
+    end
+  end
+
+  describe "#policy_options_provided" do
+    subject { presenter.policy_options_provided }
+
+    it do
+      is_expected.to eq(
+        [
+          [
+            "Targeted Retention Incentive Payment For FE Teachers",
+            "£6,000"
+          ]
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Add claim show page for further education claims
Probably worth reviewing [each commit](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3181/commits) separately.

FE claims show different information to other claims, rather than a single
"Eligibility" section the eligibility answers are split into multiple sections.
The admin claim show page now renders a policy specific partial for a given
claim so we can handle any policy specific display requirements.
