### PR TITLE
[LUPEYALPHA-1031] Cope with student loan data with "No data" rows. Remove invalid match logic

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -144,9 +144,9 @@ class Claim < ApplicationRecord
 
   validates :academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
 
-  validates :has_student_loan, on: [:"student-loan"], inclusion: {in: [true, false]}
+  validates :has_student_loan, on: [:"student-loan"], inclusion: {in: [true, false]}, allow_nil: true
   validates :student_loan_plan, inclusion: {in: STUDENT_LOAN_PLAN_OPTIONS}, allow_nil: true
-  validates :student_loan_plan, on: [:"student-loan", :amendment], presence: {message: "Enter a valid student loan plan"}
+  validates :student_loan_plan, on: [:amendment], presence: {message: "Enter a valid student loan plan"}
 
   # TODO: remove when a form object is created for email-address
   validates :email_address, on: [:submit], presence: {message: "Enter an email address"}

--- a/app/models/claim_student_loan_details_updater.rb
+++ b/app/models/claim_student_loan_details_updater.rb
@@ -9,9 +9,13 @@ class ClaimStudentLoanDetailsUpdater
 
   def update_claim_with_latest_data
     claim.transaction do
-      eligibility.update!(eligibility_student_loan_attributes) if claim.has_tslr_policy?
+      if claim.has_tslr_policy?
+        eligibility.update!(eligibility_student_loan_attributes)
+        claim.assign_attributes(claim_student_loans_policy_student_loan_attributes)
+      else
+        claim.assign_attributes(claim_student_loan_attributes)
+      end
 
-      claim.assign_attributes(claim_student_loan_attributes)
       claim.save!(context: :"student-loan")
     end
   rescue => e
@@ -32,8 +36,15 @@ class ClaimStudentLoanDetailsUpdater
 
   def claim_student_loan_attributes
     {
-      has_student_loan: student_loans_data.found_data?,
+      has_student_loan: student_loans_data.has_student_loan?,
       student_loan_plan: student_loans_data.student_loan_plan
+    }
+  end
+
+  def claim_student_loans_policy_student_loan_attributes
+    {
+      has_student_loan: student_loans_data.has_student_loan_for_student_loan_policy,
+      student_loan_plan: student_loans_data.student_loan_plan_for_student_loan_policy
     }
   end
 

--- a/app/models/claim_student_loan_details_updater.rb
+++ b/app/models/claim_student_loan_details_updater.rb
@@ -9,12 +9,9 @@ class ClaimStudentLoanDetailsUpdater
 
   def update_claim_with_latest_data
     claim.transaction do
-      if claim.has_tslr_policy?
-        eligibility.update!(eligibility_student_loan_attributes)
-        claim.assign_attributes(claim_student_loans_policy_student_loan_attributes)
-      else
-        claim.assign_attributes(claim_student_loan_attributes)
-      end
+      eligibility.update!(eligibility_student_loan_attributes) if claim.has_tslr_policy?
+
+      claim.assign_attributes(claim_student_loan_attributes)
 
       claim.save!(context: :"student-loan")
     end
@@ -38,13 +35,6 @@ class ClaimStudentLoanDetailsUpdater
     {
       has_student_loan: student_loans_data.has_student_loan?,
       student_loan_plan: student_loans_data.student_loan_plan
-    }
-  end
-
-  def claim_student_loans_policy_student_loan_attributes
-    {
-      has_student_loan: student_loans_data.has_student_loan_for_student_loan_policy,
-      student_loan_plan: student_loans_data.student_loan_plan_for_student_loan_policy
     }
   end
 

--- a/app/models/journeys/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/answers_student_loans_details_updater.rb
@@ -14,7 +14,7 @@ module Journeys
       # held before submission; after submission, the
       # `submitted_using_slc_data` value must not change
       journey_session.answers.assign_attributes(
-        has_student_loan: student_loans_data.found_data?,
+        has_student_loan: student_loans_data.has_student_loan?,
         student_loan_plan: student_loans_data.student_loan_plan,
         submitted_using_slc_data: student_loans_data.found_data?
       )

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_student_loans_details_updater.rb
@@ -3,10 +3,15 @@ module Journeys
     class AnswersStudentLoansDetailsUpdater < Journeys::AnswersStudentLoansDetailsUpdater
       def save!
         journey_session.answers.assign_attributes(
-          student_loan_repayment_amount: student_loans_data.total_repayment_amount
+          student_loan_repayment_amount: student_loans_data.total_repayment_amount,
+          has_student_loan: student_loans_data.has_student_loan_for_student_loan_policy,
+          student_loan_plan: student_loans_data.student_loan_plan_for_student_loan_policy,
+          submitted_using_slc_data: student_loans_data.found_data?
         )
 
-        super
+        journey_session.save!
+      rescue => e
+        Rollbar.error(e)
       end
     end
   end

--- a/app/models/journeys/teacher_student_loan_reimbursement/answers_student_loans_details_updater.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/answers_student_loans_details_updater.rb
@@ -3,15 +3,10 @@ module Journeys
     class AnswersStudentLoansDetailsUpdater < Journeys::AnswersStudentLoansDetailsUpdater
       def save!
         journey_session.answers.assign_attributes(
-          student_loan_repayment_amount: student_loans_data.total_repayment_amount,
-          has_student_loan: student_loans_data.has_student_loan_for_student_loan_policy,
-          student_loan_plan: student_loans_data.student_loan_plan_for_student_loan_policy,
-          submitted_using_slc_data: student_loans_data.found_data?
+          student_loan_repayment_amount: student_loans_data.total_repayment_amount
         )
 
-        journey_session.save!
-      rescue => e
-        Rollbar.error(e)
+        super
       end
     end
   end

--- a/app/models/policies/student_loans/policy_eligibility_checker.rb
+++ b/app/models/policies/student_loans/policy_eligibility_checker.rb
@@ -67,7 +67,10 @@ module Policies
         answers.mostly_performed_leadership_duties == true
       end
 
+      # checks two scenarios: (1) they do not have a student loan, (2) they have a student loan but the repayment amount is zero
       def made_zero_repayments?
+        return true if answers.has_student_loan == false
+
         answers.has_student_loan == true && answers.student_loan_repayment_amount == 0
       end
     end

--- a/app/models/student_loans_data_presenter.rb
+++ b/app/models/student_loans_data_presenter.rb
@@ -8,11 +8,30 @@ class StudentLoansDataPresenter
     student_loans_data.any?
   end
 
+  # This is used for the TSLR journey only
+  # The meaning of 'has_student_loan' seems to be different for this journey - it means has_student_loan_data
+  def has_student_loan_for_student_loan_policy
+    found_data?
+  end
+
+  def has_student_loan?
+    return unless found_data?
+
+    student_loans_data.repaying_plan_types.present?
+  end
+
   def student_loan_repayment_amount
     student_loans_data.total_repayment_amount
   end
 
+  # This is used for the TSLR journey only
+  def student_loan_plan_for_student_loan_policy
+    student_loans_data.repaying_plan_types || Claim::NO_STUDENT_LOAN
+  end
+
   def student_loan_plan
+    return nil if student_loans_data.repaying_plan_types.nil? && !found_data?
+
     student_loans_data.repaying_plan_types || Claim::NO_STUDENT_LOAN
   end
 

--- a/app/models/student_loans_data_presenter.rb
+++ b/app/models/student_loans_data_presenter.rb
@@ -8,12 +8,6 @@ class StudentLoansDataPresenter
     student_loans_data.any?
   end
 
-  # This is used for the TSLR journey only
-  # The meaning of 'has_student_loan' seems to be different for this journey - it means has_student_loan_data
-  def has_student_loan_for_student_loan_policy
-    found_data?
-  end
-
   def has_student_loan?
     return unless found_data?
 
@@ -22,11 +16,6 @@ class StudentLoansDataPresenter
 
   def student_loan_repayment_amount
     student_loans_data.total_repayment_amount
-  end
-
-  # This is used for the TSLR journey only
-  def student_loan_plan_for_student_loan_policy
-    student_loans_data.repaying_plan_types || Claim::NO_STUDENT_LOAN
   end
 
   def student_loan_plan

--- a/spec/factories/student_loans_data.rb
+++ b/spec/factories/student_loans_data.rb
@@ -8,5 +8,11 @@ FactoryBot.define do
     no_of_plans_currently_repaying { 1 }
     plan_type_of_deduction { 1 }
     amount { 150 }
+
+    trait :no_student_loan do
+      no_of_plans_currently_repaying { nil }
+      plan_type_of_deduction { nil }
+      amount { 0 }
+    end
   end
 end

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+RSpec.feature "Upload SLC data" do
+  before do
+    create(:journey_configuration, :student_loans) # used by StudentLoanAmountCheckJob
+    create(:journey_configuration, :early_career_payments)
+    sign_in_as_service_operator
+  end
+
+  let!(:sl_claim_with_slc_data_no_student_loan) {
+    create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: AcademicYear.current,
+      eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 0),
+      has_student_loan: false, student_loan_plan: "not_applicable", submitted_using_slc_data: false)
+  }
+  let!(:sl_claim_with_slc_data_with_student_loan) {
+    create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: AcademicYear.current,
+      eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 100),
+      has_student_loan: true, student_loan_plan: "plan_1", submitted_using_slc_data: false)
+  }
+  let!(:sl_claim_no_slc_data) {
+    create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: AcademicYear.current,
+      eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 0),
+      has_student_loan: false, student_loan_plan: "not_applicable", submitted_using_slc_data: false)
+  }
+
+  let!(:ecp_claim_with_slc_data_no_student_loan) {
+    create(:claim, :submitted, policy: Policies::EarlyCareerPayments,
+      eligibility: build(:early_career_payments_eligibility, :eligible),
+      has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
+  }
+  let!(:ecp_claim_with_slc_data_with_student_loan) {
+    create(:claim, :submitted, policy: Policies::EarlyCareerPayments,
+      eligibility: build(:early_career_payments_eligibility, :eligible),
+      has_student_loan: true, student_loan_plan: "plan_1", submitted_using_slc_data: false)
+  }
+  let!(:ecp_claim_no_slc_data) {
+    create(:claim, :submitted, policy: Policies::EarlyCareerPayments,
+      eligibility: build(:early_career_payments_eligibility, :eligible),
+      has_student_loan: false, student_loan_plan: "not_applicable", submitted_using_slc_data: false)
+  }
+
+  scenario "automated task to verify student loan plan" do
+    visit admin_claims_path
+    click_link "Upload SLC data"
+    attach_file "file", slc_data_csv_file.path
+    perform_enqueued_jobs do
+      click_button "Upload"
+    end
+    expect(page).to have_content "SLC file uploaded and queued to be imported"
+    expect(StudentLoansData.count).to eq 4
+
+    # Student Loans
+
+    click_link sl_claim_with_slc_data_no_student_loan.reference
+    expect(page).to have_content "Student loan amount"
+    within "li.student_loan_amount" do
+      expect(page).to have_content "No match"
+    end
+    expect(sl_claim_with_slc_data_no_student_loan.reload.student_loan_plan).to eq "not_applicable"
+    expect(sl_claim_with_slc_data_no_student_loan.has_student_loan).to be true # is this correct?
+    expect(sl_claim_with_slc_data_no_student_loan.eligibility.student_loan_repayment_amount).to eq 0
+
+    visit admin_claims_path
+    click_link ecp_claim_with_slc_data_with_student_loan.reference
+    expect(page).not_to have_content "Student loan amount"
+    expect(sl_claim_with_slc_data_with_student_loan.reload.student_loan_plan).to eq "plan_1"
+    expect(sl_claim_with_slc_data_with_student_loan.has_student_loan).to eq true
+    expect(sl_claim_with_slc_data_with_student_loan.eligibility.student_loan_repayment_amount).to eq 100
+
+    visit admin_claims_path
+    click_link sl_claim_no_slc_data.reference
+    expect(page).to have_content "Student loan amount"
+    within "li.student_loan_amount" do
+      expect(page).to have_content "No data"
+    end
+    expect(sl_claim_no_slc_data.reload.student_loan_plan).to eq "not_applicable"
+    expect(sl_claim_no_slc_data.has_student_loan).to be false
+    expect(sl_claim_no_slc_data.eligibility.student_loan_repayment_amount).to eq 0
+
+    # Early Career Payments
+
+    visit admin_claims_path
+    click_link ecp_claim_with_slc_data_no_student_loan.reference
+    expect(page).to have_content "Student loan plan"
+    within "li.student_loan_plan" do
+      expect(page).to have_content "Passed"
+    end
+    expect(ecp_claim_with_slc_data_no_student_loan.reload.student_loan_plan).to eq "not_applicable"
+    expect(ecp_claim_with_slc_data_no_student_loan.has_student_loan).to be false
+
+    visit admin_claims_path
+    click_link ecp_claim_with_slc_data_with_student_loan.reference
+    expect(page).to have_content "Student loan plan"
+    within "li.student_loan_plan" do
+      expect(page).to have_content "Passed"
+    end
+    expect(ecp_claim_with_slc_data_with_student_loan.reload.student_loan_plan).to eq "plan_1"
+    expect(ecp_claim_with_slc_data_with_student_loan.has_student_loan).to eq true
+
+    visit admin_claims_path
+    click_link ecp_claim_no_slc_data.reference
+    expect(page).to have_content "Student loan plan"
+    within "li.student_loan_plan" do
+      expect(page).to have_content "No data"
+    end
+    expect(ecp_claim_no_slc_data.reload.student_loan_plan).to be nil # this was "not_applicable" before LUPEYALPHA-1031
+    expect(ecp_claim_no_slc_data.has_student_loan).to be nil # this was false before LUPEYALPHA-1031
+  end
+
+  def slc_data_csv_file
+    return @slc_data_csv_file if @slc_data_csv_file
+
+    @slc_data_csv_file = Tempfile.new
+    @slc_data_csv_file.write StudentLoansDataImporter.mandatory_headers.join(",") + "\n"
+    @slc_data_csv_file.write csv_row(sl_claim_with_slc_data_no_student_loan, no_data: true)
+    @slc_data_csv_file.write csv_row(sl_claim_with_slc_data_with_student_loan, plan_type: "1", amount: "100")
+    @slc_data_csv_file.write csv_row(ecp_claim_with_slc_data_no_student_loan, no_data: true)
+    @slc_data_csv_file.write csv_row(ecp_claim_with_slc_data_with_student_loan, plan_type: "1", amount: "100")
+
+    @slc_data_csv_file.rewind
+
+    @slc_data_csv_file
+  end
+
+  def csv_row(claim, no_data: nil, plan_type: nil, amount: nil)
+    values = [
+      claim.reference,
+      claim.national_insurance_number,
+      "#{claim.first_name} #{claim.surname}",
+      claim.date_of_birth.strftime(I18n.t("date.formats.day_month_year")),
+      claim.policy.locale_key,
+      "1",
+      plan_type,
+      amount
+    ]
+    values += if no_data
+      ["No data", "No data", "No data"]
+    else
+      ["1", plan_type, amount]
+    end
+    values.join(",") << "\n"
+  end
+end

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Upload SLC data" do
       expect(page).to have_content "No match"
     end
     expect(sl_claim_with_slc_data_no_student_loan.reload.student_loan_plan).to eq "not_applicable"
-    expect(sl_claim_with_slc_data_no_student_loan.has_student_loan).to be true # is this correct?
+    expect(sl_claim_with_slc_data_no_student_loan.has_student_loan).to be false
     expect(sl_claim_with_slc_data_no_student_loan.eligibility.student_loan_repayment_amount).to eq 0
 
     visit admin_claims_path
@@ -73,8 +73,8 @@ RSpec.feature "Upload SLC data" do
     within "li.student_loan_amount" do
       expect(page).to have_content "No data"
     end
-    expect(sl_claim_no_slc_data.reload.student_loan_plan).to eq "not_applicable"
-    expect(sl_claim_no_slc_data.has_student_loan).to be false
+    expect(sl_claim_no_slc_data.reload.student_loan_plan).to be nil
+    expect(sl_claim_no_slc_data.has_student_loan).to be nil
     expect(sl_claim_no_slc_data.eligibility.student_loan_repayment_amount).to eq 0
 
     # Early Career Payments

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -245,7 +245,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       expect(answers).not_to have_student_loan
       expect(answers.student_loan_repayment_amount).to eql(0)
-      expect(answers.student_loan_plan).to eql(Claim::NO_STUDENT_LOAN)
+      expect(answers.student_loan_plan).to be nil
 
       fill_in_remaining_personal_details_and_submit
     end

--- a/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
@@ -72,56 +72,57 @@ module AutomatedChecks
             context "when the policy is #{policy}" do
               let(:policy) { policy }
               let(:claim) { create(:claim, :submitted, policy:, national_insurance_number: "QQ123456A", has_student_loan: true, student_loan_plan: claim_student_loan_plan, submitted_using_slc_data:) }
-              let(:imported_slc_data) { create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: slc_student_loan_plan) }
+              let(:claim_student_loan_plan) { nil }
 
-              let(:claim_student_loan_plan) { StudentLoan::PLAN_1 }
-              let(:slc_student_loan_plan) { 1 }
-              let(:submitted_using_slc_data) { false }
+              context "when there is already a student_loan_plan task" do
+                before { create(:task, claim: claim, name: "student_loan_plan") }
+
+                let(:submitted_using_slc_data) { false }
+
+                it_behaves_like :execution_without_an_outcome
+              end
 
               context "when the claim was submitted using SLC data" do
                 let(:submitted_using_slc_data) { true }
+                let(:claim_student_loan_plan) { StudentLoan::PLAN_1 }
 
                 it_behaves_like :execution_without_an_outcome
               end
 
-              context "when the claim was submitted using the student loan questions" do
-                let(:submitted_using_slc_data) { nil }
+              context "when the claim was not submitted using SLC data" do
+                let(:submitted_using_slc_data) { false }
 
-                it_behaves_like :execution_without_an_outcome
-              end
+                context "when there is no student loan data for the claim" do
+                  let(:expected_to_pass?) { nil }
+                  let(:expected_match_value) { nil }
+                  let(:expected_note) { "[SLC Student loan plan] - No data" }
 
-              context "when is no student loans data for the claim" do
-                let(:expected_to_pass?) { nil }
-                let(:expected_match_value) { nil }
-                let(:expected_note) { "[SLC Student loan plan] - No data" }
+                  it_behaves_like :execution_with_an_outcome
+                end
 
-                it_behaves_like :execution_with_an_outcome
-              end
+                context "when there is student loan data - with a plan" do
+                  before do
+                    create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 1)
+                  end
 
-              context "when the plan type on the claim is equal to the SLC value" do
-                before { imported_slc_data }
+                  let(:expected_to_pass?) { true }
+                  let(:expected_match_value) { "all" }
+                  let(:expected_note) { "[SLC Student loan plan] - Matched - has a student loan" }
 
-                let(:claim_student_loan_plan) { StudentLoan::PLAN_1 }
-                let(:slc_student_loan_plan) { 1 }
+                  it_behaves_like :execution_with_an_outcome
+                end
 
-                let(:expected_to_pass?) { true }
-                let(:expected_match_value) { "all" }
-                let(:expected_note) { "[SLC Student loan plan] - Matched" }
+                context "when there is student loan data - without a plan" do
+                  before do
+                    create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: nil)
+                  end
 
-                it_behaves_like :execution_with_an_outcome
-              end
+                  let(:expected_to_pass?) { true }
+                  let(:expected_match_value) { "all" }
+                  let(:expected_note) { "[SLC Student loan plan] - Matched - does not have a student loan" }
 
-              context "when the plan type on the claim is not equal to the SLC value" do
-                before { imported_slc_data }
-
-                let(:claim_student_loan_plan) { StudentLoan::PLAN_1 }
-                let(:slc_student_loan_plan) { 2 }
-
-                let(:expected_to_pass?) { false }
-                let(:expected_match_value) { "none" }
-                let(:expected_note) { "[SLC Student loan plan] - The plan type on the claim (Plan 1) didn't match the SLC value (Plan 2)" }
-
-                it_behaves_like :execution_with_an_outcome
+                  it_behaves_like :execution_with_an_outcome
+                end
               end
             end
           end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe Claim, type: :model do
   end
 
   context "when saving in the “student-loan” validation context" do
-    it "validates the presence of has_student_loan" do
-      expect(build(:claim, student_loan_plan: StudentLoan::PLAN_1, has_student_loan: nil)).not_to be_valid(:"student-loan")
+    it "validates has_student_loan" do
+      expect(build(:claim, student_loan_plan: nil, has_student_loan: nil)).to be_valid(:"student-loan")
       expect(build(:claim, student_loan_plan: StudentLoan::PLAN_1, has_student_loan: true)).to be_valid(:"student-loan")
       expect(build(:claim, student_loan_plan: StudentLoan::PLAN_1, has_student_loan: false)).to be_valid(:"student-loan")
     end

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -29,10 +29,8 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
       context "when the policy is StudentLoans" do
         let(:policy) { Policies::StudentLoans }
 
-        it "updates the claim with no student plan and zero repayment total" do
-          expect { call }.to change { claim.reload.has_student_loan }.to(false)
-            .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
-            .and change { claim.eligibility.student_loan_repayment_amount }.to(0)
+        it "does not update the claim student plan and zero repayment total" do
+          expect { call }.not_to change { claim.reload.has_student_loan }
         end
 
         it "keeps the `submitted_using_slc_data` flag to `false` (default)" do
@@ -92,7 +90,7 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
 
       context "when the policy is StudentLoans" do
         it "updates the claim with the student plan and the repayment total" do
-          expect { call }.to change { claim.reload.has_student_loan }.to(true)
+          expect { call }.to change { claim.reload.has_student_loan }.to(false)
             .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
             .and change { claim.eligibility.student_loan_repayment_amount }.to(0)
         end

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -44,19 +44,14 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
         context "when the policy is #{policy}" do
           let(:policy) { policy }
 
-          it "updates the claim with no student plan" do
-            expect { call }.to change { claim.reload.has_student_loan }.to(false)
-              .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
-          end
-
-          it "keeps the `submitted_using_slc_data` flag to `false` (default)" do
-            expect { call }.not_to change { claim.submitted_using_slc_data }.from(false)
+          it "does not update the claim" do
+            expect { call }.not_to change { claim.reload }
           end
         end
       end
     end
 
-    context "when existing SLC data is found for the claimant" do
+    context "when SLC data is found with student loan information for the claimant" do
       before do
         create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 1, amount: 50)
         create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 2, amount: 60)
@@ -86,11 +81,40 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
       end
     end
 
+    context "when SLC data is found with no student loan information for the claimant" do
+      before do
+        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: nil, amount: nil)
+      end
+
+      it "returns true" do
+        expect(call).to eq(true)
+      end
+
+      context "when the policy is StudentLoans" do
+        it "updates the claim with the student plan and the repayment total" do
+          expect { call }.to change { claim.reload.has_student_loan }.to(true)
+            .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
+            .and change { claim.eligibility.student_loan_repayment_amount }.to(0)
+        end
+      end
+
+      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].each do |policy|
+        context "when the policy is #{policy}" do
+          let(:policy) { policy }
+
+          it "updates the claim with the student plan only" do
+            expect { call }.to change { claim.reload.has_student_loan }.to(false)
+              .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
+          end
+        end
+      end
+    end
+
     context "when an error occurs while updating" do
       let(:exception) { ActiveRecord::RecordInvalid }
 
       before do
-        allow(claim).to receive_message_chain(:assign_attributes, :assign_attributes, :save!) { raise(exception) }
+        allow(claim).to receive(:save!) { raise(exception) }
         allow(Rollbar).to receive(:error)
       end
 

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Policies::StudentLoans::Eligibility, type: :model do
       context "when the has_student_loan claim flag is false" do
         let(:claim) { build(:claim, has_student_loan: false) }
 
-        it { is_expected.not_to be_ineligible }
+        it { is_expected.not_to be_ineligible } # why are they eligible if they don't have a student loan?
       end
 
       context "when the has_student_loan claim flag is nil" do

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Policies::StudentLoans::Eligibility, type: :model do
       context "when the has_student_loan claim flag is false" do
         let(:claim) { build(:claim, has_student_loan: false) }
 
-        it { is_expected.not_to be_ineligible } # why are they eligible if they don't have a student loan?
+        it { is_expected.to be_ineligible }
       end
 
       context "when the has_student_loan claim flag is nil" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -201,9 +201,28 @@ RSpec.describe "Claims", type: :request do
           set_slug_sequence_in_session(journey_session, "personal-details")
         end
 
-        it "updates the student loan details" do
-          expect { request }.to change { journey_session.reload.answers.has_student_loan }
-            .and change { journey_session.reload.answers.student_loan_plan }
+        context "when there is no student loan data for the claimant" do
+          it "does not update the student loan details" do
+            expect { request }.not_to change { journey_session.reload }
+          end
+        end
+
+        context "when there is student loan data showing the claimant has a student loan" do
+          before { create(:student_loans_data, nino: "QQ123456C", date_of_birth: Date.new(1990, 1, 1)) }
+
+          it "updates the student loan details" do
+            expect { request }.to change { journey_session.reload.answers.has_student_loan }.to(true)
+              .and change { journey_session.reload.answers.student_loan_plan }.to("plan_1")
+          end
+        end
+
+        context "when there is student loan data showing the claimant does not have student loan" do
+          before { create(:student_loans_data, :no_student_loan, nino: "QQ123456C", date_of_birth: Date.new(1990, 1, 1)) }
+
+          it "updates the student loan details" do
+            expect { request }.to change { journey_session.reload.answers.has_student_loan }.to(false)
+              .and change { journey_session.reload.answers.student_loan_plan }.to("not_applicable")
+          end
         end
       end
 
@@ -248,12 +267,28 @@ RSpec.describe "Claims", type: :request do
               journey_session.save!
             end
 
-            it "updates the student loan details" do
-              expect { request }.to(
-                change { journey_session.reload.answers.has_student_loan }.and(
-                  change { journey_session.reload.answers.student_loan_plan }
-                )
-              )
+            context "when there is no student loan data for the claimant" do
+              it "does not update the student loan details" do
+                expect { request }.not_to change { journey_session.reload }
+              end
+            end
+
+            context "when there is student loan data showing the claimant has a student loan" do
+              before { create(:student_loans_data, nino: "QQ123456C", date_of_birth: Date.new(1990, 1, 1)) }
+
+              it "updates the student loan details" do
+                expect { request }.to change { journey_session.reload.answers.has_student_loan }.to(true)
+                  .and change { journey_session.reload.answers.student_loan_plan }.to("plan_1")
+              end
+            end
+
+            context "when there is student loan data showing the claimant does not have student loan" do
+              before { create(:student_loans_data, :no_student_loan, nino: "QQ123456C", date_of_birth: Date.new(1990, 1, 1)) }
+
+              it "updates the student loan details" do
+                expect { request }.to change { journey_session.reload.answers.has_student_loan }.to(false)
+                  .and change { journey_session.reload.answers.student_loan_plan }.to("not_applicable")
+              end
             end
           end
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/LUPEYALPHA-1031

No need for the old claim verifier logic - was used to match student loan answers in the journey, which have since been removed.
Also, the student loan data file can now include rows with "No data" values, which indicates that the SLC does not have information for the given claimants, which confirms they do not have a student loan.

Main changes:
* on the claim and answers, `has_student_loan?` is `nil` if there's no SLC data, `true` if there is data with a plan, `false` if there is data with "No data" for the plan
* `student_loan_plan` is `nil` if there's no SLC data, and if there is data, it is either the correct plan(s) or "not_applicable" if they don't have a student loan
* eligibility for the TSLR journey copes with both having a student loan with zero amount (the existing scenario), and having no student loan (the new scenario)
* The automated verification for the student loan plan task, will no be "No data" if there is no SLC data, or "Match" for when there is.