### PR TITLE
[LUPEYALPHA-1044] Fix missing translation

### DIFF
--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -35,7 +35,9 @@ module Policies
       end
 
       def student_loan_plan
-        []
+        [
+          ["Student loan plan", claim.student_loan_plan&.humanize]
+        ]
       end
 
       private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,6 +912,8 @@ en:
             claimant_answers:
               true: "Yes"
               false: "No"
+        student_loan_plan:
+          title: "Does the claimant’s student loan plan match the information we hold about their loan?"
     forms:
       ineligible:
         courses:


### PR DESCRIPTION
Fixes the missing translation for the studen loan plan task, and adds
the student loan plan to the answers presenter.

<!-- Do you need to update CHANGELOG.md? -->
