### PR TITLE
Capitalize trn and ni

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -105,10 +105,10 @@ module Admin
       second_eligibility_attributes = matching_attributes_for_eligibility(second_claim.eligibility)
 
       matching_attributes = first_attributes & second_attributes
-      claim_matches = matching_attributes.to_h.compact.keys.map(&:humanize).sort
+      claim_matches = matching_attributes.to_h.compact.keys.map(&:to_s).sort
 
       matching_eligibility_attributes = first_eligibility_attributes & second_eligibility_attributes
-      eligibility_matches = matching_eligibility_attributes.to_h.compact.keys.map(&:humanize).sort
+      eligibility_matches = matching_eligibility_attributes.to_h.compact.keys.map(&:to_s).sort
 
       claim_matches + eligibility_matches
     end

--- a/app/views/admin/claims/_claims_with_matching_details.html.erb
+++ b/app/views/admin/claims/_claims_with_matching_details.html.erb
@@ -18,7 +18,7 @@
         <td class="govuk-table__cell">
           <ul class="govuk-list">
             <% matching_attributes(claim, matching_claim).each do |attribute| %>
-              <li><%= attribute %></li>
+              <li><%= I18n.t(attribute, default: attribute.to_s.humanize) %></li>
             <% end %>
           </ul>
         </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,8 @@ en:
         unit: "£"
   service_name: "Claim additional payments for teaching"
   support_email_address: "additionalteachingpayment@digital.education.gov.uk"
+  teacher_reference_number: "Teacher Reference Number"
+  national_insurance_number: "National Insurance Number"
   check_your_answers:
     heading_send_application: Confirm and send your application
     statement:

--- a/spec/features/admin/admin_claim_with_matching_details_spec.rb
+++ b/spec/features/admin/admin_claim_with_matching_details_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Admin checking a claim with matching details" do
 
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.matching_details.title"))
     expect(page).to have_content(claim_with_matching_details.reference)
-    expect(page).to have_content("Teacher reference number")
+    expect(page).to have_content("Teacher Reference Number")
 
     choose "Yes"
     click_on "Save and continue"

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -198,12 +198,12 @@ describe Admin::ClaimsHelper do
     subject { helper.matching_attributes(first_claim, second_claim) }
 
     it "returns the humanised names of the matching attributes" do
-      expect(subject).to eq(["Bank account number", "Bank sort code", "Building society roll number", "National insurance number", "Teacher reference number"])
+      expect(subject).to eq(["bank_account_number", "bank_sort_code", "building_society_roll_number", "national_insurance_number", "teacher_reference_number"])
     end
 
     it "does not consider a blank building society roll number to be a match" do
       [first_claim, second_claim].each { |claim| claim.building_society_roll_number = "" }
-      expect(subject).to eq(["Bank account number", "Bank sort code", "National insurance number", "Teacher reference number"])
+      expect(subject).to eq(["bank_account_number", "bank_sort_code", "national_insurance_number", "teacher_reference_number"])
     end
   end
 


### PR DESCRIPTION
When rendering the teacher reference number or the national insurance
number in the matching details list we want to make sure they're
titlized

<!-- Do you need to update CHANGELOG.md? -->
