### PR TITLE
Rename LUPP policy

### DIFF
--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -78,7 +78,7 @@ module Policies
     end
 
     def eligibility_page_url
-      "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers"
+      "https://www.gov.uk/guidance/targeted-retention-incentive-payments-for-school-teachers"
     end
 
     def eligibility_criteria_url

--- a/app/views/additional_payments/claims/_eligibility_confirmed_multiple.html.erb
+++ b/app/views/additional_payments/claims/_eligibility_confirmed_multiple.html.erb
@@ -22,5 +22,5 @@
   For more information about why you are eligible for different additional payments, read about the
   <%= govuk_link_to "early-career payments", Policies::EarlyCareerPayments.eligibility_page_url, no_visited_state: true, new_tab: true %>
   and
-  <%= govuk_link_to "levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_page_url, no_visited_state: true, new_tab: true %>.
+  <%= govuk_link_to I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_page_url, no_visited_state: true, new_tab: true %>.
 </p>

--- a/app/views/additional_payments/claims/_eligibility_guidance_levelling_up_premium_payments.html.erb
+++ b/app/views/additional_payments/claims/_eligibility_guidance_levelling_up_premium_payments.html.erb
@@ -5,5 +5,5 @@
 <%= button_to "Apply now", claim_path(current_journey_routing_name), method: :patch, class: "govuk-button", role: :button, data: { module: "govuk-button"}, params: { claim: { selected_claim_policy: } } %>
 
 <p class="govuk-body">
-  For more information about why you are eligible, read about the <%= link_to "levelling up premium payment (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_page_url, class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>.
+  For more information about why you are eligible, read about the <%= link_to "#{I18n.t("levelling_up_premium_payments.policy_short_name").downcase} (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_page_url, class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_bad_itt_subject_for_ecp.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_bad_itt_subject_for_ecp.html.erb
@@ -6,7 +6,7 @@
 </p>
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
-  because you do not teach in an eligible school. Levelling up premium payments are offered in state-funded
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  because you do not teach in an eligible school. <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize.pluralize %> are offered in state-funded
   secondary schools identified as having a higher need for teachers.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_bad_itt_year_for_ecp.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_bad_itt_year_for_ecp.html.erb
@@ -6,7 +6,7 @@
 </p>
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because you do not teach in an eligible school.
-  Levelling up premium payments are offered in state-funded secondary schools identified as having a higher need for teachers.
+  <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize.pluralize %> are offered in state-funded secondary schools identified as having a higher need for teachers.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_current_school.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_current_school.html.erb
@@ -48,5 +48,5 @@
   For more information, check the school eligibility criteria for
   <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   and
-  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_dqt_data_ineligible.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_dqt_data_ineligible.html.erb
@@ -1,10 +1,10 @@
 <p class="govuk-body">
   You are not eligible for the
   <%= link_to("early-career payment", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %> or the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because of the subject you studied or the year you studied.
 </p>
 
 <p class="govuk-body">
-  For more information, check the eligibility criteria for <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %> and <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+  For more information, check the eligibility criteria for <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %> and <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_ecp_only_induction_not_completed.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_ecp_only_induction_not_completed.html.erb
@@ -5,13 +5,13 @@
 </p>
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link", target: "_blank") %>
-  because the school you teach in is not eligible. Levelling up premium payments are offered in schools identified as having a higher need for teachers.
+  <%= link_to("#{I18n.t("levelling_up_premium_payments.policy_short_name").downcase} (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link", target: "_blank") %>
+  because the school you teach in is not eligible. <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize.pluralize %> are offered in schools identified as having a higher need for teachers.
 </p>
 
 <p class="govuk-body">
   For more information, check the eligibility criteria for
   <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   and
-  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_ecp_only_teacher_with_ineligible_itt_year.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_ecp_only_teacher_with_ineligible_itt_year.html.erb
@@ -6,7 +6,7 @@
 
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because the school you teach in is not eligible.
-  Levelling up premium payments are offered in schools identified as having a higher need for teachers.
+  <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize %> are offered in schools identified as having a higher need for teachers.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_ecp_only_trainee_teacher.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_ecp_only_trainee_teacher.html.erb
@@ -15,11 +15,11 @@
 </ul>
 <p class="govuk-body">
   You will not be eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   once you start work as a qualified teacher. This is because your school is not eligible.
   If you move to a different school you may be eligible in the future.
 </p>
 <p class="govuk-body">
-  Levelling up premium payments are offered in state-funded secondary schools identified as having a higher need
+  <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize.pluralize %> are offered in state-funded secondary schools identified as having a higher need
   for teachers.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_generic.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_generic.html.erb
@@ -6,5 +6,5 @@
   For more information, check the eligibility criteria for
   <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   and
-  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_lack_both_valid_itt_subject_and_degree.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_lack_both_valid_itt_subject_and_degree.html.erb
@@ -2,7 +2,7 @@
   You are not eligible for the
   <%= link_to("early-career payment", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   or the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because of the subject you studied.
 </p>
 <p class="govuk-body">

--- a/app/views/additional_payments/claims/_ineligibility_no_ecp_subjects_that_itt_year.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_no_ecp_subjects_that_itt_year.html.erb
@@ -10,7 +10,7 @@
 </ul>
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
-  because you do not teach in an eligible school. Levelling up premium payments are offered in state-funded
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  because you do not teach in an eligible school. <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize %> are offered in state-funded
   secondary schools identified as having a higher need for teacher.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_teacher_with_ineligible_itt_year.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_teacher_with_ineligible_itt_year.html.erb
@@ -2,7 +2,7 @@
   You are not eligible for an
   <%= link_to("early-career payment", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   or a
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because of the year you studied.
 </p>
 
@@ -10,5 +10,5 @@
   For more information, check the eligibility criteria for
   <%= link_to("early-career payments", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   and
-  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_trainee_in_last_policy_year.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_trainee_in_last_policy_year.html.erb
@@ -6,7 +6,7 @@
   You will not be eligible for the
   <%= link_to("early-career payment", Policies::EarlyCareerPayments.eligibility_criteria_url, class: "govuk-link") %>
   or the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   once you start work as a qualified teacher.
 </p>
 
@@ -20,5 +20,5 @@
 </ul>
 
 <p class="govuk-body">
-  To be eligible for levelling up premium payments, your ITT course must have started (postgraduate) or finished (undergraduate) between the 2019 to 2020 and 2023 to 2024 academic years in computing, chemistry, mathematics or physics.
+  To be eligible for <%= I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize %>, your ITT course must have started (postgraduate) or finished (undergraduate) between the 2019 to 2020 and 2023 to 2024 academic years in computing, chemistry, mathematics or physics.
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_trainee_teaching_lacking_both_valid_itt_subject_and_degree.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_trainee_teaching_lacking_both_valid_itt_subject_and_degree.html.erb
@@ -11,9 +11,9 @@
 </ul>
 <p class="govuk-body">
   You will not be eligible for a
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   once you start work as a qualified teacher. This is because of the subject you studied.
-  Eligible subjects for levelling up premium payments are:
+  Eligible subjects for <%= I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize %> are:
 </p>
 <ul class="govuk-list govuk-list--bullet">
   <li>chemistry</li>

--- a/app/views/additional_payments/claims/_ineligibility_trainee_teaching_lacking_both_valid_itt_subject_and_degree.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_trainee_teaching_lacking_both_valid_itt_subject_and_degree.html.erb
@@ -11,7 +11,7 @@
 </ul>
 <p class="govuk-body">
   You will not be eligible for a
-  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name"), Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   once you start work as a qualified teacher. This is because of the subject you studied.
   Eligible subjects for <%= I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize %> are:
 </p>

--- a/app/views/additional_payments/claims/_ineligibility_would_be_eligible_for_both_ecp_and_lup_except_for_insufficient_teaching.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_would_be_eligible_for_both_ecp_and_lup_except_for_insufficient_teaching.html.erb
@@ -16,7 +16,7 @@
 
 <p class="govuk-body">
   Eligible subjects for
-  <%= link_to("levelling up premium payments", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase.pluralize, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   are:
 </p>
 <ul class="govuk-list govuk-list--bullet">

--- a/app/views/additional_payments/claims/_ineligibility_would_be_eligible_for_ecp_only_except_for_insufficient_teaching.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_would_be_eligible_for_ecp_only_except_for_insufficient_teaching.html.erb
@@ -5,10 +5,10 @@
 </p>
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because either:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>your school is not eligible. Levelling up premium payments are offered in state-funded secondary schools identified as having a high need for teachers.<br /> or</li>
+  <li>your school is not eligible. <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize.pluralize %> are offered in state-funded secondary schools identified as having a high need for teachers.<br /> or</li>
   <li>the subject you studied is not eligible. To be eligible your initial teacher training (ITT) course must be in chemistry, computing, mathematics or physics.</li>
 </ul>

--- a/app/views/additional_payments/claims/_ineligibility_would_be_eligible_for_lup_only_except_for_insufficient_teaching.html.erb
+++ b/app/views/additional_payments/claims/_ineligibility_would_be_eligible_for_lup_only_except_for_insufficient_teaching.html.erb
@@ -11,7 +11,7 @@
 </ul>
 <p class="govuk-body">
   You are not eligible for the
-  <%= link_to("levelling up premium payment", Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
+  <%= link_to(I18n.t("levelling_up_premium_payments.policy_short_name").downcase, Policies::LevellingUpPremiumPayments.eligibility_criteria_url, class: "govuk-link") %>
   because you do not teach chemistry, computing, mathematics or physics
   for at least half of your contracted hours.
 </p>

--- a/app/views/additional_payments/claims/eligible_later.html.erb
+++ b/app/views/additional_payments/claims/eligible_later.html.erb
@@ -40,8 +40,8 @@
 
     <p class="govuk-body">
       You are not eligible for the
-      <%= link_to "levelling up premium payment (opens in new tab)", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>
-      because the school you teach in is not eligible. Levelling up premium payments are offered in schools identified as having a higher need for teachers.
+      <%= link_to "#{I18n.t("levelling_up_premium_payments.policy_short_name").downcase} (opens in new tab)", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %>
+      because the school you teach in is not eligible. <%= I18n.t("levelling_up_premium_payments.policy_short_name").capitalize.pluralize %> are offered in schools identified as having a higher need for teachers.
     </p>
 
     <h2 class="govuk-heading-m">You may be eligible next year</h2>

--- a/app/views/additional_payments/claims/future_eligibility.html.erb
+++ b/app/views/additional_payments/claims/future_eligibility.html.erb
@@ -9,7 +9,7 @@
     </p>
 
     <p class="govuk-body">
-      You may be able to claim a <%= link_to "levelling up premium payment (opens in new tab)", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %> when you are qualified as a teacher.
+      You may be able to claim a <%= link_to "#{I18n.t("levelling_up_premium_payments.policy_short_name").downcase} (opens in new tab)", "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers", class: "govuk-link govuk-link--no-visited-state", target: "_blank" %> when you are qualified as a teacher.
     </p>
 
     <h2 class="govuk-heading-m">Set a reminder to apply next year</h2>

--- a/app/views/additional_payments/landing_page.html.erb
+++ b/app/views/additional_payments/landing_page.html.erb
@@ -78,7 +78,7 @@
         </li>
 
         <li>
-          <%= govuk_link_to "Levelling up premium payment (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_page_url, no_visited_state: true, target: "_blank" %> - payment of up to £3,000 for eligible teachers in certain schools, including computing teachers.
+          <%= govuk_link_to "#{I18n.t("levelling_up_premium_payments.policy_short_name").capitalize} (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_page_url, no_visited_state: true, target: "_blank" %> - payment of up to £3,000 for eligible teachers in certain schools, including computing teachers.
         </li>
       </ul>
 
@@ -90,7 +90,7 @@
     <h3 class="govuk-heading-s govuk-!-margin-top-6">Claim back your student loan repayments</h3>
 
     <p class="govuk-body">
-      If you have a student loan, you may be able to <a href="https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments" class="govuk-link govuk-link--no-visited-state" target="_blank">claim back student loan repayments (opens in new tab)</a> made while employed as a teacher. This is separate and you can apply for this whether or not you receive an early-career payment or levelling up premium payment.
+    If you have a student loan, you may be able to <a href="https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments" class="govuk-link govuk-link--no-visited-state" target="_blank">claim back student loan repayments (opens in new tab)</a> made while employed as a teacher. This is separate and you can apply for this whether or not you receive an early-career payment or <%= I18n.t("levelling_up_premium_payments.policy_short_name").downcase %>.
     </p>
   </div>
 </div>

--- a/app/views/additional_payments/landing_page.html.erb
+++ b/app/views/additional_payments/landing_page.html.erb
@@ -78,7 +78,12 @@
         </li>
 
         <li>
-          <%= govuk_link_to "#{I18n.t("levelling_up_premium_payments.policy_short_name").capitalize} (opens in new tab)", Policies::LevellingUpPremiumPayments.eligibility_page_url, no_visited_state: true, target: "_blank" %> - payment of up to £3,000 for eligible teachers in certain schools, including computing teachers.
+          <%= govuk_link_to(
+            "#{I18n.t("levelling_up_premium_payments.policy_short_name")} (opens in new tab)",
+            Policies::LevellingUpPremiumPayments.eligibility_page_url,
+            no_visited_state: true,
+            target: "_blank"
+          ) %> - payment of up to £6,000 for eligible teachers in certain schools, including computing teachers.
         </li>
       </ul>
 

--- a/app/views/additional_payments/submissions/show.html.erb
+++ b/app/views/additional_payments/submissions/show.html.erb
@@ -7,7 +7,7 @@
       <h1 class="govuk-panel__title" id="submitted-title">
         You applied for
         <%= "an early-career payment" if submitted_claim.has_ecp_policy? %>
-        <%= "a levelling up premium payment" if submitted_claim.has_lupp_policy? %>
+        <%= "a #{I18n.t("levelling_up_premium_payments.policy_short_name").downcase}" if submitted_claim.has_lupp_policy? %>
       </h1>
 
       <div class="govuk-panel__body">

--- a/app/views/admin/journey_configurations/_edit_additional_payments.html.erb
+++ b/app/views/admin/journey_configurations/_edit_additional_payments.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row" id="download">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">
-      Download Levelling Up Premium Payments School Awards
+      Download <%= I18n.t("levelling_up_premium_payments.policy_short_name").pluralize %> School Awards
     </h2>
 
     <% if lupp_awards_academic_years.any? %>
@@ -29,7 +29,7 @@
 <div class="govuk-grid-row" id="upload">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">
-      Upload Levelling Up Premium Payments School Awards
+      Upload <%= I18n.t("levelling_up_premium_payments.policy_short_name").pluralize %> School Awards
     </h2>
 
     <%= render("shared/error_summary", instance: @csv_upload) if @csv_upload.errors.any? %>

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -30,11 +30,11 @@
       <div class="govuk-panel govuk-panel--informational govuk-panel--small">
         <% if lupp_awards_last_updated_at %>
           <p class="govuk-panel__body">
-            The Levelling Up Premium Payments school award amounts for academic year <%= journey_configuration.current_academic_year %> were updated on <%= l(lupp_awards_last_updated_at) %>.
+            The <%= I18n.t("levelling_up_premium_payments.policy_short_name") %> school award amounts for academic year <%= journey_configuration.current_academic_year %> were updated on <%= l(lupp_awards_last_updated_at) %>.
           </p>
         <% else %>
           <p class="govuk-panel__body">
-            No Levelling Up Premium Payments school award data has been uploaded for academic year <%= journey_configuration.current_academic_year %>.
+            No <%= I18n.t("levelling_up_premium_payments.policy_short_name") %> school award data has been uploaded for academic year <%= journey_configuration.current_academic_year %>.
           </p>
         <% end %>
       </div>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -84,7 +84,7 @@
           </tr>
         <% end %>
         <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header">Levelling Up Premium Payments Top Ups</th>
+          <th scope="row" class="govuk-table__header"><%= I18n.t("levelling_up_premium_payments.policy_short_name") %> Top Ups</th>
           <td class="govuk-table__cell"><%= @payroll_run.number_of_claims_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups) %></td>
           <td class="govuk-table__cell"><%= number_to_currency(@payroll_run.total_claim_amount_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups)) %></td>
           </tr>
@@ -135,7 +135,7 @@
               <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
             <% end %>
             <td class="govuk-table__cell"><%= link_to claim.reference, admin_claim_path(claim), class: "govuk-link" %></td>
-            <td class="govuk-table__cell"><%= line_item.is_a?(Topup) ? "Levelling Up Premium Payments (top up)" : claim.policy.short_name %></td>
+            <td class="govuk-table__cell"><%= line_item.is_a?(Topup) ? "#{I18n.t("levelling_up_premium_payments.policy_short_name")} (top up)" : claim.policy.short_name %></td>
             <td class="govuk-table__cell"><%= number_to_currency(line_item.award_amount) %></td>
             <% if index == 0 %>
               <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= number_to_currency(payment.award_amount) %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -686,13 +686,13 @@ en:
   levelling_up_premium_payments:
     <<: *additional_payments
     purpose: For early career teachers who teach certain subjects and work in disadvantaged schools.
-    policy_short_name: "Levelling Up Premium Payments"
-    policy_acronym: "LUP"
-    payment_name: "Levelling up premium payment"
-    claim_subject: "Levelling up premium payment"
+    policy_short_name: "School Targeted Retention Incentive"
+    policy_acronym: "STRI"
+    payment_name: "School targeted retention incentive"
+    claim_subject: "School targeted retention incentive"
     claim_amount_description: "Additional payment for teaching"
     support_email_address: "levellinguppremiumpayments@digital.education.gov.uk"
-    information_provided_further_details_link_text: levelling up premium payment (opens in new tab)
+    information_provided_further_details_link_text: school targeted retention incentive (opens in new tab)
   get_a_teacher_relocation_payment: &get_a_teacher_relocation_payment
     journey_name: "Get a teacher relocation payment"
     feedback_email: "international.RELOCATIONPAYMENT@education.gov.uk"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -691,7 +691,7 @@ en:
     payment_name: "School targeted retention incentive"
     claim_subject: "School targeted retention incentive"
     claim_amount_description: "Additional payment for teaching"
-    support_email_address: "levellinguppremiumpayments@digital.education.gov.uk"
+    support_email_address: "schools-targeted.retention-incentive@education.gov.uk"
     information_provided_further_details_link_text: school targeted retention incentive (opens in new tab)
   get_a_teacher_relocation_payment: &get_a_teacher_relocation_payment
     journey_name: "Get a teacher relocation payment"

--- a/spec/features/admin/admin_claim_allocation_spec.rb
+++ b/spec/features/admin/admin_claim_allocation_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Claims awaiting a decision" do
       "All",
       "Student Loans",
       "Early-Career Payments",
-      "Levelling Up Premium Payments",
+      "School Targeted Retention Incentive",
       "International Relocation Payments",
       "Targeted Retention Incentive Payment For FE Teachers"
     ]

--- a/spec/features/admin/admin_claims_filtering_spec.rb
+++ b/spec/features/admin/admin_claims_filtering_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Admin claim filtering" do
 
     expect(page.find("table")).to have_content("ECP").exactly(10).times
     expect(page.find("table")).to have_content("TSLR").exactly(7).times
-    expect(page.find("table")).to have_content("LUP").exactly(2).times
+    expect(page.find("table")).to have_content("STRI").exactly(2).times
 
     click_on "View claims"
     select "Student Loans", from: "policy"
@@ -99,7 +99,7 @@ RSpec.feature "Admin claim filtering" do
     select "Unassigned", from: "team_member"
     click_on "Apply filters"
 
-    expect(page.find("table")).to have_content("LUP").exactly(2).times
+    expect(page.find("table")).to have_content("STRI").exactly(2).times
 
     lup_claims_unassigned.each do |c|
       expect(page).to have_content(c.reference)

--- a/spec/features/admin/admin_manage_lupp_school_awards_spec.rb
+++ b/spec/features/admin/admin_manage_lupp_school_awards_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Managing Levelling Up Premium Payments school awards" do
       create(:levelling_up_premium_payments_award, academic_year: journey_configuration.current_academic_year - 1)
 
       visit current_path
-      expect(page).to have_text "The Levelling Up Premium Payments school award amounts for academic year #{journey_configuration.current_academic_year} were updated on #{Time.zone.now.strftime("%-d %B %Y")}"
+      expect(page).to have_text "The School Targeted Retention Incentive school award amounts for academic year #{journey_configuration.current_academic_year} were updated on #{Time.zone.now.strftime("%-d %B %Y")}"
 
       within "#download" do
         expect(page).to have_select "Academic year", options: [journey_configuration.current_academic_year, journey_configuration.current_academic_year - 1]
@@ -45,7 +45,7 @@ RSpec.feature "Managing Levelling Up Premium Payments school awards" do
 
   scenario "uploading school awards" do
     # When no awards exist
-    expect(page).to have_text "No Levelling Up Premium Payments school award data has been uploaded for academic year #{journey_configuration.current_academic_year}."
+    expect(page).to have_text "No School Targeted Retention Incentive school award data has been uploaded for academic year #{journey_configuration.current_academic_year}."
 
     # No CSV file
     within "#upload" do

--- a/spec/features/admin/admin_payroll_runs_spec.rb
+++ b/spec/features/admin/admin_payroll_runs_spec.rb
@@ -45,8 +45,8 @@ RSpec.feature "Payroll" do
 
     expect(page).to have_content("Student Loans 2 £2,000.00")
     expect(page).to have_content("Early-Career Payments 1 £5,000.00")
-    expect(page).to have_content("Levelling Up Premium Payments 1 £2,000.00")
-    expect(page).to have_content("Levelling Up Premium Payments Top Ups 1 £500.00")
+    expect(page).to have_content("School Targeted Retention Incentive 1 £2,000.00")
+    expect(page).to have_content("School Targeted Retention Incentive Top Ups 1 £500.00")
   end
 
   context "when a payroll run already exists for the month" do

--- a/spec/features/combined_teacher_claim_journey_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_spec.rb
@@ -106,10 +106,10 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
 
     expect(page).to have_text("You’re eligible for an additional payment")
     expect(page).to have_field("£2,000 early-career payment")
-    expect(page).to have_field("£2,000 levelling up premium payment")
+    expect(page).to have_field("£2,000 school targeted retention incentive")
     expect(page).to have_selector('input[type="radio"]', count: 2)
 
-    choose("£2,000 levelling up premium payment")
+    choose("£2,000 school targeted retention incentive")
 
     click_on("Apply now")
 
@@ -230,7 +230,7 @@ RSpec.feature "Levelling up premium payments and early-career payments combined 
 
     submitted_claim = Claim.by_policy(Policies::LevellingUpPremiumPayments).order(:created_at).last
     # - Application complete
-    expect(page).to have_text("You applied for a levelling up premium payment")
+    expect(page).to have_text("You applied for a school targeted retention incentive")
     expect(page).to have_text("What happens next")
     expect(page).to have_text("Set a reminder to apply next year")
     expect(page).to have_text("Apply for additional payment each academic year")

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_email_spec.rb
@@ -138,7 +138,7 @@ RSpec.feature "Combined journey with Teacher ID email check" do
     click_on("Continue")
 
     expect(page).to have_text("You’re eligible for an additional payment")
-    choose("£2,000 levelling up premium payment")
+    choose("£2,000 school targeted retention incentive")
     click_on("Apply now")
 
     # - How will we use the information you provide

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature "Combined journey with Teacher ID mobile check" do
     click_on("Continue")
 
     # - Eligibility confirmed
-    choose "£2,000 levelling up premium payment"
+    choose "£2,000 school targeted retention incentive"
     click_on("Apply now")
 
     # - How we will use the information you provide

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -111,10 +111,10 @@ RSpec.feature "Combined journey with Teacher ID" do
 
     # - You are eligible for an early career payment
     expect(page).to have_text("You’re eligible for an additional payment")
-    expect(page).to have_field("£2,000 levelling up premium payment")
+    expect(page).to have_field("£2,000 school targeted retention incentive")
     expect(page).to have_selector('input[type="radio"]', count: 2)
 
-    choose("£2,000 levelling up premium payment")
+    choose("£2,000 school targeted retention incentive")
 
     click_on("Apply now")
 
@@ -231,7 +231,7 @@ RSpec.feature "Combined journey with Teacher ID" do
     click_on "Continue"
     click_on "Continue"
 
-    choose "£2,000 levelling up premium payment"
+    choose "£2,000 school targeted retention incentive"
     click_on "Apply now"
     click_on "Continue"
 

--- a/spec/features/hmrc_bank_validation_spec.rb
+++ b/spec/features/hmrc_bank_validation_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Bank account validation on claim journey", :with_hmrc_bank_valida
     # - Check your answers for eligibility
     click_on("Continue")
 
-    choose("£2,000 levelling up premium payment")
+    choose("£2,000 school targeted retention incentive")
     click_on("Apply now")
 
     # - How will we use the information you provide

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature "Levelling up premium payments claims" do
     click_on("Continue")
 
     expect(page).to have_text("You’re eligible for an additional payment")
-    expect(page).to have_text("levelling up premium payment of:\n£2,000")
+    expect(page).to have_text("school targeted retention incentive of:\n£2,000")
 
     click_on("Apply now")
   end
@@ -124,7 +124,7 @@ RSpec.feature "Levelling up premium payments claims" do
 
     # - How will we use the information you provide
     expect(page).to have_text("How we will use the information you provide")
-    expect(page).to have_text("For more details, you can read about payments and deductions for the levelling up premium payment")
+    expect(page).to have_text("For more details, you can read about payments and deductions for the school targeted retention incentive")
     click_on "Continue"
 
     # - Personal details
@@ -258,7 +258,7 @@ RSpec.feature "Levelling up premium payments claims" do
       expect(submitted_claim.eligibility.teacher_reference_number).to eql("1234567")
 
       # - Application complete (make sure its Word for Word and styling matches)
-      expect(page).to have_text("You applied for a levelling up premium payment")
+      expect(page).to have_text("You applied for a school targeted retention incentive")
       expect(page).to have_text("What happens next")
       expect(page).to have_text("Set a reminder to apply next year")
       expect(page).to have_text("Apply for additional payment each academic year")

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -644,11 +644,11 @@ describe Admin::ClaimsHelper do
   end
 
   describe "#admin_policy_options_provided" do
-    context "Eligible for ECP and LUP" do
+    context "Eligible for ECP and STRI" do
       let(:claim) { create(:claim, :submitted, :policy_options_provided_with_both, policy: Policies::EarlyCareerPayments) }
 
       it "returns both polices" do
-        answers = [["Early-career payment", "£2,000"], ["Levelling up premium payment", "£2,000"]]
+        answers = [["Early-career payment", "£2,000"], ["School targeted retention incentive", "£2,000"]]
 
         expect(admin_policy_options_provided(claim)).to match_array answers
       end
@@ -664,17 +664,17 @@ describe Admin::ClaimsHelper do
       end
     end
 
-    context "Eligible for LUP only" do
+    context "Eligible for STRI only" do
       let(:claim) { create(:claim, :submitted, :policy_options_provided_lup_only, policy: Policies::LevellingUpPremiumPayments) }
 
-      it "returns LUP only" do
-        answers = [["Levelling up premium payment", "£2,000"]]
+      it "returns STRI only" do
+        answers = [["School targeted retention incentive", "£2,000"]]
 
         expect(admin_policy_options_provided(claim)).to match_array answers
       end
     end
 
-    context "No policy_options_provided (not ECP/LUP claim)" do
+    context "No policy_options_provided (not ECP/STRI claim)" do
       let(:claim) { create(:claim, :submitted) }
 
       it "returns no options" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -70,7 +70,7 @@ describe ApplicationHelper do
     context "policy is a LevellingUpPremiumPayments" do
       let(:policy) { Policies::LevellingUpPremiumPayments }
 
-      it { is_expected.to eq('For more details, you can read about payments and deductions for the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#payments-and-deductions">levelling up premium payment (opens in new tab)</a>') }
+      it { is_expected.to eq('For more details, you can read about payments and deductions for the <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://www.gov.uk/guidance/targeted-retention-incentive-payments-for-school-teachers#payments-and-deductions">school targeted retention incentive (opens in new tab)</a>') }
     end
 
     context "policy is a EarlyCareerPayments" do

--- a/spec/helpers/claims/show_helper_spec.rb
+++ b/spec/helpers/claims/show_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Claims::ShowHelper do
     context "with a LevellingUpPremiumPayments policy" do
       let(:policy) { Policies::LevellingUpPremiumPayments }
 
-      it { is_expected.to eq "levelling up premium payment" }
+      it { is_expected.to eq "school targeted retention incentive" }
     end
   end
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe ClaimMailer, type: :mailer do
       let(:policy) { Policies::LevellingUpPremiumPayments }
 
       it "has personalisation keys for: one time password, validity_duration,first_name and support_email_address" do
-        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"Levelling up premium payment email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"levellinguppremiumpayments@digital.education.gov.uk\", :validity_duration=>\"15 minutes\"}")
+        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"School targeted retention incentive email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"levellinguppremiumpayments@digital.education.gov.uk\", :validity_duration=>\"15 minutes\"}")
         expect(mail.body).to be_empty
       end
     end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe ClaimMailer, type: :mailer do
       let(:policy) { Policies::LevellingUpPremiumPayments }
 
       it "has personalisation keys for: one time password, validity_duration,first_name and support_email_address" do
-        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"School targeted retention incentive email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"levellinguppremiumpayments@digital.education.gov.uk\", :validity_duration=>\"15 minutes\"}")
+        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"School targeted retention incentive email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"schools-targeted.retention-incentive@education.gov.uk\", :validity_duration=>\"15 minutes\"}")
         expect(mail.body).to be_empty
       end
     end

--- a/spec/models/levelling_up_premium_payments_spec.rb
+++ b/spec/models/levelling_up_premium_payments_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe Policies::LevellingUpPremiumPayments, type: :model do
 
   specify {
     expect(subject).to have_attributes(
-      short_name: "Levelling Up Premium Payments",
+      short_name: "School Targeted Retention Incentive",
       locale_key: "levelling_up_premium_payments",
       notify_reply_to_id: "03ece7eb-2a5b-461b-9c91-6630d0051aa6",
-      eligibility_page_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers",
-      eligibility_criteria_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#eligibility-criteria",
-      payment_and_deductions_info_url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers#payments-and-deductions"
+      eligibility_page_url: "https://www.gov.uk/guidance/targeted-retention-incentive-payments-for-school-teachers",
+      eligibility_criteria_url: "https://www.gov.uk/guidance/targeted-retention-incentive-payments-for-school-teachers#eligibility-criteria",
+      payment_and_deductions_info_url: "https://www.gov.uk/guidance/targeted-retention-incentive-payments-for-school-teachers#payments-and-deductions"
     )
   }
 

--- a/spec/models/policies_spec.rb
+++ b/spec/models/policies_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Policies, type: :model do
       expect(described_class.options_for_select).to eq([
         ["Student Loans", "student-loans"],
         ["Early-Career Payments", "early-career-payments"],
-        ["Levelling Up Premium Payments", "levelling-up-premium-payments"],
+        ["School Targeted Retention Incentive", "levelling-up-premium-payments"],
         ["International Relocation Payments", "international-relocation-payments"],
         ["Targeted Retention Incentive Payment For FE Teachers", "further-education-payments"]
       ])


### PR DESCRIPTION
Renames all user facing mentions of levelling up premium payments, replacing them with school targeted retention incentive.
We haven't renamed any of the code references to LUPP just the claimant facing references - making a new STRI policy will be done in a future piece of work.