### PR TITLE
[LUPEYALPHA-1006] Claim page updates: "Awaiting provider verification" filter, remove "Qualification status" column.

### DIFF
--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -25,6 +25,8 @@ class Admin::ClaimsFilterForm
         Claim.includes(:decisions).held.awaiting_decision
       when "failed_bank_validation"
         Claim.includes(:decisions).failed_bank_validation.awaiting_decision
+      when "awaiting_provider_verification"
+        Claim.awaiting_fe_provider_verification
       else
         Claim.includes(:decisions).not_held.awaiting_decision
       end

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -26,7 +26,7 @@ class Admin::ClaimsFilterForm
       when "failed_bank_validation"
         Claim.includes(:decisions).failed_bank_validation.awaiting_decision
       when "awaiting_provider_verification"
-        Claim.awaiting_fe_provider_verification
+        Claim.by_policy(Policies::FurtherEducationPayments).awaiting_further_education_provider_verification
       else
         Claim.includes(:decisions).not_held.awaiting_decision
       end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -201,6 +201,7 @@ module Admin
     end
 
     STATUS_FILTERS = [
+      ["Awaiting provider verification", "awaiting_provider_verification"],
       ["Awaiting decision - on hold", "held"],
       ["Awaiting decision - failed bank details", "failed_bank_validation"],
       ["Approved awaiting QA", "approved_awaiting_qa"],

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -211,7 +211,7 @@ class Claim < ApplicationRecord
   scope :not_awaiting_qa, -> { approved.where("qa_required = false OR (qa_required = true AND qa_completed_at IS NOT NULL)") }
   scope :awaiting_qa, -> { approved.qa_required.where(qa_completed_at: nil) }
   scope :qa_required, -> { where(qa_required: true) }
-  scope :awaiting_fe_provider_verification, -> do
+  scope :awaiting_further_education_provider_verification, -> do
     joins("INNER JOIN further_education_payments_eligibilities ON further_education_payments_eligibilities.id = claims.eligibility_id")
       .where("further_education_payments_eligibilities.verification = '{}'")
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -211,6 +211,10 @@ class Claim < ApplicationRecord
   scope :not_awaiting_qa, -> { approved.where("qa_required = false OR (qa_required = true AND qa_completed_at IS NOT NULL)") }
   scope :awaiting_qa, -> { approved.qa_required.where(qa_completed_at: nil) }
   scope :qa_required, -> { where(qa_required: true) }
+  scope :awaiting_fe_provider_verification, -> do
+    joins("INNER JOIN further_education_payments_eligibilities ON further_education_payments_eligibilities.id = claims.eligibility_id")
+      .where("further_education_payments_eligibilities.verification = '{}'")
+  end
 
   def onelogin_idv_full_name
     "#{onelogin_idv_first_name} #{onelogin_idv_last_name}"

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -59,7 +59,6 @@
             <th scope="col" class="govuk-table__header">Reference</th>
             <th scope="col" class="govuk-table__header">Applicant Name</th>
             <th scope="col" class="govuk-table__header">ID Verification</th>
-            <th scope="col" class="govuk-table__header">Qualification Status</th>
             <th scope="col" class="govuk-table__header">Policy</th>
             <% if claims_with_warning.nonzero? %>
               <th scope="col" class="govuk-table__header">Decision warning</th>
@@ -74,7 +73,6 @@
               <th scope="row" class="govuk-table__header"><%= link_to claim.reference, admin_claim_tasks_path(claim), class: "govuk-link" %></th>
               <td class="govuk-table__cell"><%= claim.full_name %></td>
               <td class="govuk-table__cell"><%= identity_confirmation_task_claim_verifier_match_status_tag(claim) %></td>
-              <td class="govuk-table__cell"><%= task_status_tag(claim, "qualifications") %></td>
               <td class="govuk-table__cell"><%= I18n.t("#{claim.policy.locale_key}.policy_acronym") %></td>
               <% if claims_with_warning.nonzero? %>
                 <td class="govuk-table__cell"><%= decision_deadline_warning(claim) %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -847,7 +847,7 @@ en:
     support_email_address: "FE-targeted.retention-incentive@education.gov.uk"
     claim_subject: "Further education payment"
     policy_acronym: FE
-    policy_short_name: Targeted Retention Incentive Payment For FE Teachers
+    policy_short_name: Further Education Targeted Retention Incentive
     eligibility_criteria_link:
       text: targeted retention incentive payments for early career further education teachers
       url: "https://www.gov.uk/guidance/levelling-up-premium-payments-for-fe-teachers"

--- a/spec/features/admin/admin_claim_allocation_spec.rb
+++ b/spec/features/admin/admin_claim_allocation_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Claims awaiting a decision" do
       "Early-Career Payments",
       "School Targeted Retention Incentive",
       "International Relocation Payments",
-      "Targeted Retention Incentive Payment For FE Teachers"
+      "Further Education Targeted Retention Incentive"
     ]
   end
 

--- a/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature "Admin views claim details for FurtherEducationPayments" do
       ).to have_content("No")
 
       expect(
-        summary_row("Targeted Retention Incentive Payment For FE Teachers")
+        summary_row("Further Education Targeted Retention Incentive")
       ).to have_content("£6,000")
 
       expect(summary_row("Started at")).to have_content("1 August 2024 10:00am")

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -906,6 +906,18 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe ".awaiting_fe_provider_verification" do
+    subject { described_class.awaiting_fe_provider_verification }
+
+    let!(:claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
+    let!(:claim_awaiting_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
+    let!(:non_fe_claim) { create(:claim, policy: Policies::StudentLoans) }
+
+    it "returns claims that are awaiting FE provider verification" do
+      is_expected.to match_array([claim_awaiting_fe_provider_verification])
+    end
+  end
+
   describe "#amendable?" do
     it "returns false for a claim that hasn’t been submitted" do
       claim = build(:claim, :submittable)

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -906,8 +906,8 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe ".awaiting_fe_provider_verification" do
-    subject { described_class.awaiting_fe_provider_verification }
+  describe ".awaiting_further_education_provider_verification" do
+    subject { described_class.awaiting_further_education_provider_verification }
 
     let!(:claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
     let!(:claim_awaiting_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }

--- a/spec/models/policies/further_education_payments/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/policies/further_education_payments/eligibility_admin_answers_presenter_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresen
       is_expected.to eq(
         [
           [
-            "Targeted Retention Incentive Payment For FE Teachers",
+            "Further Education Targeted Retention Incentive",
             "£6,000"
           ]
         ]

--- a/spec/models/policies_spec.rb
+++ b/spec/models/policies_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Policies, type: :model do
         ["Early-Career Payments", "early-career-payments"],
         ["School Targeted Retention Incentive", "levelling-up-premium-payments"],
         ["International Relocation Payments", "international-relocation-payments"],
-        ["Targeted Retention Incentive Payment For FE Teachers", "further-education-payments"]
+        ["Further Education Targeted Retention Incentive", "further-education-payments"]
       ])
     end
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net.mcas.ms/browse/LUPEYALPHA-1006

* removed "Qualification Status" column from admin claims page
* added filter for "Awaiting provider verification"
* refactored `spec/features/admin/admin_claims_filtering_spec.rb`