### PR TITLE
[CAPT-1536] Add IRP specific data to admin CSV download

### DIFF
--- a/app/models/claim/data_report_request.rb
+++ b/app/models/claim/data_report_request.rb
@@ -16,7 +16,10 @@ class Claim
       "ITT subject",
       "Policy name",
       "School name",
-      "School unique reference number"
+      "School unique reference number",
+      "Payroll gender",
+      "Nationality",
+      "Passport number"
     ].freeze
 
     def initialize(claims)
@@ -76,6 +79,26 @@ class Claim
             ExcelUtils.escape_formulas(claim.policy),
             ExcelUtils.escape_formulas(claim.eligibility.school.name),
             ExcelUtils.escape_formulas(claim.eligibility.school.urn)
+          ]
+        end
+      end
+
+      class InternationalRelocationPayments < Base
+        def to_csv_row
+          [
+            ExcelUtils.escape_formulas(claim.reference),
+            ExcelUtils.escape_formulas(claim.eligibility.teacher_reference_number),
+            ExcelUtils.escape_formulas(claim.national_insurance_number),
+            ExcelUtils.escape_formulas(claim.full_name),
+            ExcelUtils.escape_formulas(claim.email_address),
+            ExcelUtils.escape_formulas(claim.date_of_birth),
+            ExcelUtils.escape_formulas(nil),
+            ExcelUtils.escape_formulas(claim.policy),
+            ExcelUtils.escape_formulas(claim.eligibility.school.name),
+            ExcelUtils.escape_formulas(claim.eligibility.school.urn),
+            ExcelUtils.escape_formulas(claim.payroll_gender),
+            ExcelUtils.escape_formulas(claim.eligibility.nationality),
+            ExcelUtils.escape_formulas(claim.eligibility.passport_number)
           ]
         end
       end

--- a/app/models/policies/international_relocation_payments/eligibility.rb
+++ b/app/models/policies/international_relocation_payments/eligibility.rb
@@ -17,6 +17,10 @@ module Policies
       def policy
         Policies::InternationalRelocationPayments
       end
+
+      def school
+        current_school
+      end
     end
   end
 end

--- a/spec/models/claim/data_report_request_spec.rb
+++ b/spec/models/claim/data_report_request_spec.rb
@@ -63,6 +63,35 @@ RSpec.describe Claim::DataReportRequest do
       end
     end
 
+    context "IRP claims" do
+      let(:claims) do
+        [
+          create(:claim, :submitted, policy: Policies::InternationalRelocationPayments)
+        ]
+      end
+
+      it "contains the correct headers" do
+        expect(csv.headers).to eql(Claim::DataReportRequest::HEADERS)
+      end
+
+      it "contains the correct values" do
+        claims.each_with_index do |claim, index|
+          expect(csv[index]["Claim reference"]).to eql(claim.reference)
+          expect(csv[index]["Teacher reference number"]).to eql(claim.eligibility.teacher_reference_number)
+          expect(csv[index]["NINO"]).to eql(claim.national_insurance_number)
+          expect(csv[index]["Full name"]).to eql(claim.full_name)
+          expect(csv[index]["Email"]).to eql(claim.email_address)
+          expect(csv[index]["Date of birth"]).to eql(claim.date_of_birth.to_s)
+          expect(csv[index]["ITT subject"]).to be_nil
+          expect(csv[index]["Policy name"]).to eql(claim.policy.to_s)
+          expect(csv[index]["School name"]).to eql(claim.eligibility.current_school.name)
+          expect(csv[index]["Payroll gender"]).to eql(claim.payroll_gender)
+          expect(csv[index]["Nationality"]).to eql(claim.eligibility.nationality)
+          expect(csv[index]["Passport number"]).to eql(claim.eligibility.passport_number)
+        end
+      end
+    end
+
     context "when there is a single quotation sign in name field" do
       let(:claims) do
         [


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1536
- Add IRP specific data to admin CSV download
- This also fixes the admin download functionality as was broken as could not handle IRP data