### PR TITLE
Match across all policies

### DIFF
--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -30,7 +30,8 @@ module Policies
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       LevellingUpPremiumPayments,
-      StudentLoans
+      StudentLoans,
+      FurtherEducationPayments
     ].freeze
 
     ELIGIBILITY_MATCHING_ATTRIBUTES = [["teacher_reference_number"]].freeze

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -26,7 +26,6 @@ module Policies
     POLICY_END_YEAR = AcademicYear.new(2024).freeze
 
     # Used in
-    #  - checking payments with multiple policies: ClaimsPreventingPaymentFinder
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       LevellingUpPremiumPayments,

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -4,7 +4,6 @@ module Policies
     extend self
 
     # Used in
-    #  - checking payments with multiple policies: ClaimsPreventingPaymentFinder
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       EarlyCareerPayments,

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -3,7 +3,15 @@ module Policies
     include BasePolicy
     extend self
 
-    OTHER_CLAIMABLE_POLICIES = []
+    # Used in
+    #  - checking payments with multiple policies: ClaimsPreventingPaymentFinder
+    #  - matching claims with multiple policies: MatchingAttributeFinder
+    OTHER_CLAIMABLE_POLICIES = [
+      EarlyCareerPayments,
+      StudentLoans,
+      LevellingUpPremiumPayments
+    ]
+
     ELIGIBILITY_MATCHING_ATTRIBUTES = [["teacher_reference_number"]].freeze
 
     # Percentage of claims to QA

--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -17,7 +17,8 @@ module Policies
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       EarlyCareerPayments,
-      StudentLoans
+      StudentLoans,
+      FurtherEducationPayments
     ].freeze
 
     ELIGIBILITY_MATCHING_ATTRIBUTES = [["teacher_reference_number"]].freeze

--- a/app/models/policies/levelling_up_premium_payments.rb
+++ b/app/models/policies/levelling_up_premium_payments.rb
@@ -13,7 +13,6 @@ module Policies
     ].freeze
 
     # Used in
-    #  - checking payments with multiple policies: ClaimsPreventingPaymentFinder
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       EarlyCareerPayments,

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -30,7 +30,8 @@ module Policies
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       EarlyCareerPayments,
-      LevellingUpPremiumPayments
+      LevellingUpPremiumPayments,
+      FurtherEducationPayments
     ]
 
     ELIGIBILITY_MATCHING_ATTRIBUTES = [["teacher_reference_number"]].freeze

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -26,7 +26,6 @@ module Policies
     ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR = 11
 
     # Used in
-    #  - checking payments with multiple policies: ClaimsPreventingPaymentFinder
     #  - matching claims with multiple policies: MatchingAttributeFinder
     OTHER_CLAIMABLE_POLICIES = [
       EarlyCareerPayments,


### PR DESCRIPTION
Requirement is to check for matching claims across all policies, except
for IRP, which should only flag matches with other IRP policies.

At the minute the only attribute we use on eligibility when checking for
matches is TRN, which is present in all the eligibilities we compare, if
however we start checking other attributes the db will throw an error as
the column may not be present on all eligibilities, hence having to
update the "matching_claims - blank trn" test.

<!-- Do you need to update CHANGELOG.md? -->
