### PR TITLE
Fix task links not showing

### DIFF
--- a/app/views/admin/tasks/_provider_verification_unsubmitted.html.erb
+++ b/app/views/admin/tasks/_provider_verification_unsubmitted.html.erb
@@ -13,7 +13,7 @@
   <%= govuk_button_to(
     "Resend provider verification request",
     admin_claim_further_education_payments_provider_verification_emails_path(@claim),
-    class: "govuk-!-margin-bottom-0"
+    class: "govuk-!-margin-bottom-2"
   ) %>
 <% else %>
   <p class="govuk-body">

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -16,15 +16,14 @@
     <% end %>
   </div>
 
-  <% if @tasks_presenter.provider_verification_submitted? %>
-    <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @tasks_presenter.provider_verification_submitted? %>
       <% if @task.persisted? %>
         <%= render "task_outcome", task: @task, notes: @notes %>
       <% else %>
         <%= render "form", task_name: "provider_verification", claim: @claim %>
       <% end %>
-
-      <%= render partial: "admin/task_pagination" %>
-    </div>
-  <% end %>
+    <% end %>
+    <%= render partial: "admin/task_pagination" %>
+  </div>
 </div>


### PR DESCRIPTION
When the provider was yet to verify the claim we weren't showing the
links to the next and previous tasks.

<!-- Do you need to update CHANGELOG.md? -->
