### PR TITLE
fix admin back link positions

### DIFF
--- a/app/views/admin/amendments/index.html.erb
+++ b/app/views/admin/amendments/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} amendments") } %>
 
-<%= link_to "Back", claims_backlink_path, class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: claims_backlink_path %>
+<% end %>
 
 <div class="govuk-grid-row">
   <%= render "admin/tasks/#{claim_summary_view}", claim: @claim, heading: @claim.reference %>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -1,6 +1,9 @@
 <% content_for(:page_title) { page_title("View claims") } %>
 
-<%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_root_path %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -1,6 +1,9 @@
 <% content_for(:page_title) { page_title("Search claims") } %>
 
-<%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_root_path %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("View claim #{@claim.reference} for #{@claim.policy.short_name}") } %>
 
-<%= link_to "Back", admin_claim_tasks_path(@claim), class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="<%= class_names(

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -1,5 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} decision") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>

--- a/app/views/admin/notes/index.html.erb
+++ b/app/views/admin/notes/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} notes") } %>
 
-<%= link_to "Back", claims_backlink_path, class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: claims_backlink_path %>
+<% end %>
 
 <%= render("shared/error_summary", instance: @note) if @note.errors.any? %>
 <%= render("shared/error_summary", instance: @hold_note, errored_field_id_overrides: {body: "hold_body"}) if @hold_note.errors.any? %>

--- a/app/views/admin/payments/index.html.erb
+++ b/app/views/admin/payments/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} payments") } %>
 
-<%= link_to "Back", claims_backlink_path, class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: claims_backlink_path %>
+<% end %>
 
 <%# render("shared/error_summary", instance: @note) if @note.errors.any? %>
 <%# render("shared/error_summary", instance: @hold_note, errored_field_id_overrides: {body: "hold_body"}) if @hold_note.errors.any? %>

--- a/app/views/admin/tasks/arrival_date.html.erb
+++ b/app/views/admin/tasks/arrival_date.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} arrival date check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/census_subjects_taught.html.erb
+++ b/app/views/admin/tasks/census_subjects_taught.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} school workforce census check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} employment check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/employment_contract.html.erb
+++ b/app/views/admin/tasks/employment_contract.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} employment contract check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/employment_start.html.erb
+++ b/app/views/admin/tasks/employment_start.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} employment start date check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/identity_confirmation.html.erb
@@ -1,7 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{@claim.policy.short_name}") } %>
+
 <% content_for :back_link do %>
-  <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
 <% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} checks for #{@claim.policy.short_name}") } %>
 
-<%= link_to "Back", claims_backlink_path, class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: claims_backlink_path %>
+<% end %>
 
 <% if @has_matching_claims %>
   <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">

--- a/app/views/admin/tasks/induction_confirmation.erb
+++ b/app/views/admin/tasks/induction_confirmation.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} induction check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/matching_details.html.erb
+++ b/app/views/admin/tasks/matching_details.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} matching details check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/payroll_details.html.erb
+++ b/app/views/admin/tasks/payroll_details.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll details check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/payroll_gender.html.erb
+++ b/app/views/admin/tasks/payroll_gender.html.erb
@@ -1,7 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll gender check for #{@claim.policy.short_name}") } %>
+
 <% content_for :back_link do %>
-  <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
 <% end %>
+
 <%= render "shared/error_summary", instance: @claim, errored_field_id_overrides: { "payroll_gender": "claim_payroll_gender_female" } if @claim.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/previous_payment.html.erb
+++ b/app/views/admin/tasks/previous_payment.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} previous payment check for #{@claim.policy.short_name}") } %>
 
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <%= render claim_summary_view, claim: @claim %>

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} provider verification check for# {@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} qualification check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} student loan amount check for #{@claim.policy.short_name}") } %>
 
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/admin/tasks/student_loan_plan.html.erb
+++ b/app/views/admin/tasks/student_loan_plan.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} student loan amount check for #{@claim.policy.short_name}") } %>
 
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/admin/tasks/subject.html.erb
+++ b/app/views/admin/tasks/subject.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} subject check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/teaching_hours.html.erb
+++ b/app/views/admin/tasks/teaching_hours.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} teaching_hours check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/tasks/visa.html.erb
+++ b/app/views/admin/tasks/visa.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} visa check for #{@claim.policy.short_name}") } %>
-<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
 <%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
# Context

- Most of the admin back link positions in the layout are incorrect
- Fixes all of them, see screen shots
- Use govuk component for back links
- Reduce verbosity of some urls

# Before
![Screenshot 2024-09-24 at 10 43 33](https://github.com/user-attachments/assets/be560fee-5e69-47bb-a59f-abf4b2677e66)

# After
![Screenshot 2024-09-24 at 10 43 45](https://github.com/user-attachments/assets/00e03fd5-e1e4-4d5e-95be-3f64c575b0f3)