### PR TITLE
Set started at on claims #1

### DIFF
--- a/app/forms/claim_submission_base_form.rb
+++ b/app/forms/claim_submission_base_form.rb
@@ -38,6 +38,8 @@ class ClaimSubmissionBaseForm
 
     claim.eligibility = main_eligibility
 
+    claim.started_at = journey_session.created_at
+
     answers.attributes.each do |name, value|
       if claim.respond_to?(:"#{name}=")
         claim.public_send(:"#{name}=", value)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -91,7 +91,8 @@ class Claim < ApplicationRecord
     onelogin_idv_date_of_birth: true,
     paye_reference: true,
     practitioner_email_address: true,
-    provider_contact_name: true
+    provider_contact_name: true,
+    started_at: false
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -78,6 +78,7 @@ shared:
     - logged_in_with_onelogin
     - onelogin_auth_at
     - onelogin_idv_at
+    - started_at
   :decisions:
     - id
     - result

--- a/db/migrate/20240924091408_add_started_at_to_claims.rb
+++ b/db/migrate/20240924091408_add_started_at_to_claims.rb
@@ -1,0 +1,5 @@
+class AddStartedAtToClaims < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :started_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_23_130010) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_24_091408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_23_130010) do
     t.text "onelogin_idv_first_name"
     t.text "onelogin_idv_last_name"
     t.date "onelogin_idv_date_of_birth"
+    t.datetime "started_at", precision: nil
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/forms/journeys/additional_payments_for_teaching/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/claim_submission_form_spec.rb
@@ -79,7 +79,11 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm do
   end
 
   let(:journey_session) do
-    build(:additional_payments_session, journey: journey::ROUTING_NAME, answers: answers)
+    create(
+      :additional_payments_session,
+      journey: journey::ROUTING_NAME,
+      answers: answers
+    )
   end
 
   let(:form) { described_class.new(journey_session: journey_session) }
@@ -261,6 +265,8 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::ClaimSubmissionForm do
         )
 
         expect(journey_session.claim).to eq(claim)
+
+        expect(claim.started_at).to eq(journey_session.created_at)
 
         expect(ClaimMailer).to have_received(:submitted).with(claim)
         expect(ClaimVerifierJob).to have_received(:perform_later).with(claim)

--- a/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
       expect(claim.logged_in_with_onelogin).to eq(answers.logged_in_with_onelogin)
       expect(claim.onelogin_credentials).to eq(answers.onelogin_credentials)
       expect(claim.onelogin_user_info).to eq(answers.onelogin_user_info)
+      expect(claim.started_at).to eql(journey_session.created_at)
 
       expect(claim.onelogin_uid).to eql(answers.onelogin_uid)
       expect(claim.onelogin_auth_at).to eql(answers.onelogin_auth_at)

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ClaimSubmissionForm do
 
       expect(claim.reference).to be_present
 
+      expect(claim.started_at).to eq(journey_session.created_at)
+
       eligibility_answers.each do |attribute, value|
         expect(eligibility.public_send(attribute)).to eq(value)
       end

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/claim_submission_form_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSubmissionForm do
     }
   end
 
-  let(:journey_session) { build(:student_loans_session, answers: answers) }
+  let(:journey_session) { create(:student_loans_session, answers: answers) }
 
   let(:form) { described_class.new(journey_session: journey_session) }
 
@@ -198,6 +198,8 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSubmissionForm do
       expect(claim.eligibility_type).to(
         eq("Policies::StudentLoans::Eligibility")
       )
+
+      expect(claim.started_at).to eq(journey_session.created_at)
 
       expect(journey_session.claim).to eq(claim)
 


### PR DESCRIPTION
Before the introduction of the journey session claims were created at
the start of the claimant journey, however as claims are now created at
the end of the claimant journey we can no longer use the claim's created
at timestamp to infer when the journey was started.

PR 1 of 3
2 https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3222
3 https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3224
