### PR TITLE
LUPEYALPHA 1096/fix claim started date 2

### DIFF
--- a/db/migrate/20240924095435_back_fill_claims_started_at.rb
+++ b/db/migrate/20240924095435_back_fill_claims_started_at.rb
@@ -1,0 +1,22 @@
+class BackFillClaimsStartedAt < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      UPDATE claims
+      SET started_at = journeys_sessions.created_at
+      FROM journeys_sessions
+      WHERE claims.journeys_session_id = journeys_sessions.id
+      AND claims.started_at IS NULL
+    SQL
+
+    execute <<-SQL
+      UPDATE claims
+      SET started_at = created_at
+      WHERE journeys_session_id IS NULL
+      AND claims.started_at IS NULL
+    SQL
+  end
+
+  def down
+    Claim.update_all(started_at: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_24_091408) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_24_095435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   sequence(:national_insurance_number, 100000) { |n| "QQ#{n}C" }
 
   factory :claim do
+    started_at { Time.zone.now }
+
     transient do
       policy { Policies::StudentLoans }
       eligibility_factory { :"#{policy.to_s.underscore}_eligibility" }

--- a/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
@@ -131,7 +131,10 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
               {
                 details_check: true,
                 logged_in_with_tid: true
-              }.merge(attributes_for(:claim, :with_dqt_teacher_status))
+              }.merge(
+                attributes_for(:claim, :with_dqt_teacher_status)
+                .except(:started_at)
+              )
             end
 
             it "sets the induction as complete" do


### PR DESCRIPTION
Back fill started at

If the claim has a journey session we try and set the `started_at` to
that, if it doesn't have a journey session we'll just use the
`created_at` timestamp, which for claims pre the introduction of journey
sessions will be the started at time.

PR 2 of 3
1 https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3221
3 https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3224