### PR TITLE
[LUPEYALPHA-1101] remove radio buttons from Student Loan Plan task

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -155,8 +155,11 @@ module Admin
         status_colour = "red"
       end
 
-      tag_classes = "govuk-tag app-task-list__task-completed govuk-tag--#{status_colour}"
+      task_status_content_tag(status_colour:, status:)
+    end
 
+    def task_status_content_tag(status_colour:, status:)
+      tag_classes = "govuk-tag app-task-list__task-completed govuk-tag--#{status_colour}"
       content_tag("strong", status, class: tag_classes)
     end
 

--- a/app/views/admin/tasks/student_loan_plan.html.erb
+++ b/app/views/admin/tasks/student_loan_plan.html.erb
@@ -15,10 +15,17 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <% if !@task.passed.nil? %>
+    <% if @task.persisted? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
-      <%= render "form", task_name: "student_loan_plan", claim: @claim %>
+      <div class="govuk-inset-text task-outcome">
+        <p class="govuk-body">
+          <%= task_status_content_tag(status_colour: "grey", status: "Incomplete") %>
+        </p>
+        <p class="govuk-body">
+          This task has not been checked against Student Loan Company data yet.
+        </p>
+      </div>
     <% end %>
 
     <%= render partial: "admin/task_pagination" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -933,8 +933,6 @@ en:
             claimant_answers:
               true: "Yes"
               false: "No"
-        student_loan_plan:
-          title: "Does the claimant’s student loan plan match the information we hold about their loan?"
     forms:
       ineligible:
         courses:

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -6,6 +6,12 @@ FactoryBot.define do
     trait :eligible do
       eligible_school
       contract_type { "permanent" }
+      verified
+    end
+
+    trait :not_verified do
+      eligible_school
+      contract_type { "permanent" }
     end
 
     trait :eligible_school do

--- a/spec/features/admin/admin_checks_further_education_payments_claim_spec.rb
+++ b/spec/features/admin/admin_checks_further_education_payments_claim_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.feature "Admin checks an Further Education Payments claim" do
+  it_behaves_like "Admin Checks", Policies::FurtherEducationPayments
+end

--- a/spec/features/admin/admin_claims_filtering_spec.rb
+++ b/spec/features/admin/admin_claims_filtering_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Admin claim filtering" do
   let(:approved_awaiting_qa_claims) { create_list(:claim, 2, :approved, :flagged_for_qa, policy: Policies::LevellingUpPremiumPayments) }
   let(:auto_approved_awaiting_payroll_claims) { create_list(:claim, 2, :auto_approved, policy: Policies::LevellingUpPremiumPayments) }
   let(:approved_claim) { create(:claim, :approved, policy: Policies::LevellingUpPremiumPayments, assigned_to: mette, decision_creator: mary) }
-  let(:further_education_claims_awaiting_provider_verification) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible, assigned_to: valentino) }
+  let(:further_education_claims_awaiting_provider_verification) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :not_verified, assigned_to: valentino) }
   let(:rejected_claim) { create(:claim, :rejected, policy: Policies::LevellingUpPremiumPayments, assigned_to: valentino) }
 
   let!(:claims) do
@@ -74,8 +74,8 @@ RSpec.feature "Admin claim filtering" do
   scenario "the service operator can filter by themselves or other team members" do
     click_on "View claims"
 
-    expect(page.find("table")).to have_content("TSLR").exactly(5).times
-    expect(page.find("table")).to have_content("ECP").exactly(10).times
+    expect(page).to have_selector("td[text()='TSLR']", count: 5)
+    expect(page).to have_selector("td[text()='ECP']", count: 10)
 
     # Excludes payroll users and deleted users
     expect(page).to have_select("team_member", options: ["All", "Unassigned", "#{user.given_name} #{user.family_name}", "Mary Wasu Wabi", "Valentino Ricci", "Mette Jørgensen"])
@@ -109,7 +109,7 @@ RSpec.feature "Admin claim filtering" do
     select "Unassigned", from: "team_member"
     click_on "Apply filters"
 
-    expect(page.find("table")).to have_content("STRI").exactly(2).times
+    expect(page).to have_selector("td[text()='STRI']", count: 2)
 
     expect_page_to_show_claims(lup_claims_unassigned)
   end

--- a/spec/jobs/further_education_payments/provider_verification_chase_email_spec.rb
+++ b/spec/jobs/further_education_payments/provider_verification_chase_email_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FurtherEducationPayments::ProviderVerificationChaseEmailJob do
         policy: Policies::FurtherEducationPayments,
         eligibility: build(
           :further_education_payments_eligibility,
-          :eligible
+          :not_verified
         ))
     }
 
@@ -24,7 +24,7 @@ RSpec.describe FurtherEducationPayments::ProviderVerificationChaseEmailJob do
         policy: Policies::FurtherEducationPayments,
         eligibility: build(
           :further_education_payments_eligibility,
-          :eligible,
+          :not_verified,
           provider_verification_email_last_sent_at: DateTime.new(2024, 10, 1, 7, 0, 0)
         ))
     }
@@ -35,7 +35,7 @@ RSpec.describe FurtherEducationPayments::ProviderVerificationChaseEmailJob do
         policy: Policies::FurtherEducationPayments,
         eligibility: build(
           :further_education_payments_eligibility,
-          :eligible,
+          :not_verified,
           provider_verification_email_last_sent_at: DateTime.new(2024, 10, 15, 7, 0, 0)
         ))
     }

--- a/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
@@ -10,7 +10,7 @@ module AutomatedChecks
       let(:claim_arg) { claim }
       let(:claim) { create(:claim, :submitted, policy:) }
 
-      shared_examples :execution_with_an_outcome do
+      shared_examples :creating_a_task_and_note do
         let(:saved_task) { claim_arg.tasks.find_by(name: "student_loan_plan") }
         let(:saved_note) { claim_arg.notes.last }
 
@@ -49,7 +49,7 @@ module AutomatedChecks
         end
       end
 
-      shared_examples :execution_without_an_outcome do
+      shared_examples :not_creating_a_task_or_note do
         it "does not save anything and returns immediately", :aggregate_failures do
           is_expected.to be_nil
 
@@ -64,7 +64,7 @@ module AutomatedChecks
         context "when the claim policy is TSLR" do
           let(:policy) { Policies::StudentLoans }
 
-          it_behaves_like :execution_without_an_outcome
+          it_behaves_like :not_creating_a_task_or_note
         end
 
         context "when the claim policy is ECP/LUP/FE" do
@@ -79,14 +79,14 @@ module AutomatedChecks
 
                 let(:submitted_using_slc_data) { false }
 
-                it_behaves_like :execution_without_an_outcome
+                it_behaves_like :not_creating_a_task_or_note
               end
 
               context "when the claim was submitted using SLC data" do
                 let(:submitted_using_slc_data) { true }
                 let(:claim_student_loan_plan) { StudentLoan::PLAN_1 }
 
-                it_behaves_like :execution_without_an_outcome
+                it_behaves_like :not_creating_a_task_or_note
               end
 
               context "when the claim was not submitted using SLC data" do
@@ -97,7 +97,7 @@ module AutomatedChecks
                   let(:expected_match_value) { nil }
                   let(:expected_note) { "[SLC Student loan plan] - No data" }
 
-                  it_behaves_like :execution_with_an_outcome
+                  it_behaves_like :creating_a_task_and_note
                 end
 
                 context "when there is student loan data - with a plan" do
@@ -109,7 +109,7 @@ module AutomatedChecks
                   let(:expected_match_value) { "all" }
                   let(:expected_note) { "[SLC Student loan plan] - Matched - has a student loan" }
 
-                  it_behaves_like :execution_with_an_outcome
+                  it_behaves_like :creating_a_task_and_note
                 end
 
                 context "when there is student loan data - without a plan" do
@@ -121,7 +121,7 @@ module AutomatedChecks
                   let(:expected_match_value) { "all" }
                   let(:expected_note) { "[SLC Student loan plan] - Matched - does not have a student loan" }
 
-                  it_behaves_like :execution_with_an_outcome
+                  it_behaves_like :creating_a_task_and_note
                 end
               end
             end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -910,7 +910,7 @@ RSpec.describe Claim, type: :model do
     subject { described_class.awaiting_further_education_provider_verification }
 
     let!(:claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
-    let!(:claim_awaiting_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
+    let!(:claim_awaiting_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :not_verified) }
     let!(:non_fe_claim) { create(:claim, policy: Policies::StudentLoans) }
 
     it "returns claims that are awaiting FE provider verification" do


### PR DESCRIPTION
student loan plan task is always automated now, no option for manual answering.

Added missing Admin Checks feature, which we had for the other journeys.