### PR TITLE
Fixes admin matching claims ui

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -97,22 +97,6 @@ module Admin
       claim.logged_in_with_tid? ? I18n.t("admin.claim_route_with_tid") : I18n.t("admin.claim_route_not_tid")
     end
 
-    def matching_attributes(first_claim, second_claim)
-      first_attributes = matching_attributes_for_claim(first_claim)
-      second_attributes = matching_attributes_for_claim(second_claim)
-
-      first_eligibility_attributes = matching_attributes_for_eligibility(first_claim.eligibility)
-      second_eligibility_attributes = matching_attributes_for_eligibility(second_claim.eligibility)
-
-      matching_attributes = first_attributes & second_attributes
-      claim_matches = matching_attributes.to_h.compact.keys.map(&:humanize).sort
-
-      matching_eligibility_attributes = first_eligibility_attributes & second_eligibility_attributes
-      eligibility_matches = matching_eligibility_attributes.to_h.compact.keys.map(&:humanize).sort
-
-      claim_matches + eligibility_matches
-    end
-
     def identity_confirmation_task_claim_verifier_match_status_tag(claim)
       task = claim.tasks.detect { |t| t.name == "identity_confirmation" }
 
@@ -234,20 +218,6 @@ module Admin
     end
 
     private
-
-    def matching_attributes_for_claim(claim)
-      claim.attributes
-        .slice(*Claim::MatchingAttributeFinder::CLAIM_ATTRIBUTE_GROUPS_TO_MATCH.flatten)
-        .reject { |_, v| v.blank? }
-        .to_a
-    end
-
-    def matching_attributes_for_eligibility(eligibility)
-      eligibility.attributes
-        .slice(*eligibility.policy.eligibility_matching_attributes.flatten)
-        .reject { |_, v| v.blank? }
-        .to_a
-    end
 
     def days_between(first_date, second_date)
       (second_date - first_date).to_i

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -52,6 +52,18 @@ class Claim
       claims_to_compare.merge(match_queries)
     end
 
+    def matching_attributes(other_claim)
+      matching_claim_attributes = CLAIM_ATTRIBUTE_GROUPS_TO_MATCH.select do |attributes|
+        values_for_attributes(@source_claim, attributes) == values_for_attributes(other_claim, attributes)
+      end
+
+      matching_eligibility_attributes = eligibility_attributes_groups_to_match.select do |attributes|
+        values_for_attributes(@source_claim.eligibility, attributes) == values_for_attributes(other_claim.eligibility, attributes)
+      end
+
+      (matching_claim_attributes + matching_eligibility_attributes).flatten
+    end
+
     private
 
     def policies_to_find_matches

--- a/app/views/admin/claims/_claims_with_matching_details.html.erb
+++ b/app/views/admin/claims/_claims_with_matching_details.html.erb
@@ -17,7 +17,7 @@
         <th scope="row" class="govuk-table__header"><%= link_to matching_claim.reference, [:admin, matching_claim], class: "govuk-link" %>
         <td class="govuk-table__cell">
           <ul class="govuk-list">
-            <% matching_attributes(claim, matching_claim).each do |attribute| %>
+            <% Claim::MatchingAttributeFinder.new(claim).matching_attributes(matching_claim).map(&:humanize).sort.each do |attribute| %>
               <li><%= attribute %></li>
             <% end %>
           </ul>

--- a/spec/features/admin/admin_claim_with_matching_details_spec.rb
+++ b/spec/features/admin/admin_claim_with_matching_details_spec.rb
@@ -41,4 +41,34 @@ RSpec.feature "Admin checking a claim with matching details" do
 
     expect(page).to have_content("Claim has been approved successfully")
   end
+
+  scenario "partial matching details" do
+    claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::StudentLoans,
+      bank_sort_code: "123456"
+    )
+
+    # Matching claim
+    create(
+      :claim,
+      :submitted,
+      bank_sort_code: "123456",
+      eligibility_attributes: {
+        teacher_reference_number: claim.eligibility.teacher_reference_number
+      }
+    )
+
+    visit admin_claim_tasks_path(claim)
+
+    click_on "Multiple claims"
+
+    within "#claims-with-matches" do
+      expect(page).to have_content "Teacher reference number"
+      # Bank sort code on it's own isn't enough to trigger a match,
+      # so shouldn't be displayed
+      expect(page).not_to have_content "Bank sort code"
+    end
+  end
 end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -172,41 +172,6 @@ describe Admin::ClaimsHelper do
     end
   end
 
-  describe "#matching_attributes" do
-    let(:first_claim) {
-      build(
-        :claim,
-        national_insurance_number: "QQ891011C",
-        email_address: "genghis.khan@mongol-empire.com",
-        bank_account_number: "34682151",
-        bank_sort_code: "972654",
-        building_society_roll_number: "123456789/ABCD",
-        eligibility_attributes: {teacher_reference_number: "0902344"}
-      )
-    }
-    let(:second_claim) {
-      build(
-        :claim,
-        :submitted,
-        national_insurance_number: first_claim.national_insurance_number,
-        bank_account_number: first_claim.bank_account_number,
-        bank_sort_code: first_claim.bank_sort_code,
-        building_society_roll_number: first_claim.building_society_roll_number,
-        eligibility_attributes: {teacher_reference_number: first_claim.eligibility.teacher_reference_number}
-      )
-    }
-    subject { helper.matching_attributes(first_claim, second_claim) }
-
-    it "returns the humanised names of the matching attributes" do
-      expect(subject).to eq(["Bank account number", "Bank sort code", "Building society roll number", "National insurance number", "Teacher reference number"])
-    end
-
-    it "does not consider a blank building society roll number to be a match" do
-      [first_claim, second_claim].each { |claim| claim.building_society_roll_number = "" }
-      expect(subject).to eq(["Bank account number", "Bank sort code", "National insurance number", "Teacher reference number"])
-    end
-  end
-
   describe "#identity_confirmation_task_claim_verifier_match_status_tag" do
     subject(:identity_confirmation_task_claim_verifier_match_status_tag) { helper.identity_confirmation_task_claim_verifier_match_status_tag(claim) }
 

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -261,4 +261,36 @@ RSpec.describe Claim::MatchingAttributeFinder do
 
     it { is_expected.to eq [other_claim] }
   end
+
+  describe "#matching_attributes" do
+    it "returns the attributes that match" do
+      source_claim = create(
+        :claim,
+        email_address: "genghis.khan@example.com",
+        national_insurance_number: "QQ891011C",
+        bank_account_number: "34682151",
+        bank_sort_code: "972654",
+        eligibility_attributes: {
+          teacher_reference_number: "0902344"
+        }
+      )
+
+      other_claim = create(
+        :claim,
+        email_address: "genghis.khan@example.com",
+        national_insurance_number: "QQ891011C",
+        bank_account_number: "11111111",
+        bank_sort_code: "972654",
+        eligibility_attributes: {
+          teacher_reference_number: "0902344"
+        }
+      )
+
+      expect(
+        described_class.new(source_claim).matching_attributes(other_claim)
+      ).to eq(
+        %w[email_address national_insurance_number teacher_reference_number]
+      )
+    end
+  end
 end


### PR DESCRIPTION
Updates the logic used when showing which attributes on the claim
triggered a match to take into account the matching groups, eg if two
claims have a matching sort code but different account number we don't
want to show the sort code as the reason for the match in the ui.

<!-- Do you need to update CHANGELOG.md? -->
