### PR TITLE
[LUPEYALPHA-1045] EY practitioner find reference screen

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -77,7 +77,7 @@ class ClaimsController < BasePublicController
   def check_page_is_in_sequence
     unless correct_journey_for_claim_in_progress?
       clear_claim_session
-      return redirect_to new_claim_path
+      return redirect_to new_claim_path(request.query_parameters)
     end
 
     raise ActionController::RoutingError.new("Not Found for #{params[:slug]}") unless page_sequence.in_sequence?(params[:slug])

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -91,7 +91,7 @@ module FormSubmittable
       raise NoMethodError, "End of sequence: you must define #{current_slug.underscore}_after_form_save_success" unless next_slug
       raise NoMethodError, "Missing path helper for resource: \"#{path_helper_resource}\"; try overriding it with #path_helper_resource" unless respond_to?(:"#{path_helper_resource}_path")
 
-      redirect_to send(:"#{path_helper_resource}_path", current_journey_routing_name, slug)
+      redirect_to send(:"#{path_helper_resource}_path", current_journey_routing_name, slug, request.query_parameters)
     end
 
     def redirect_to_next_slug

--- a/app/forms/current_school_form.rb
+++ b/app/forms/current_school_form.rb
@@ -1,5 +1,6 @@
 class CurrentSchoolForm < Form
   attribute :current_school_id
+  attribute :change_school
 
   attr_reader :schools
 

--- a/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
@@ -2,8 +2,35 @@ module Journeys
   module EarlyYearsPayment
     module Practitioner
       class FindReferenceForm < Form
+        attribute :reference_number, :string
+
+        validates :reference_number, presence: {message: i18n_error_message(:presence)}
+        validate :validate_permissible_reference_number
+
         def save
-          true
+          return false if invalid?
+
+          journey_session.answers.assign_attributes(reference_number:)
+          journey_session.save!
+        end
+
+        private
+
+        def claim_exists?
+          Claim
+            .by_policy(Policies::EarlyYearsPayments)
+            .where(reference: reference_number)
+            .exists?
+        end
+
+        def validate_permissible_reference_number
+          unless claim_exists?
+            errors.add(
+              :reference_number,
+              :impermissible,
+              message: self.class.i18n_error_message(:impermissible)
+            )
+          end
         end
       end
     end

--- a/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
@@ -3,6 +3,7 @@ module Journeys
     module Practitioner
       class FindReferenceForm < Form
         attribute :reference_number, :string
+        attribute :email, :string
 
         validates :reference_number, presence: {message: i18n_error_message(:presence)}
         validate :validate_permissible_reference_number
@@ -20,6 +21,7 @@ module Journeys
           Claim
             .by_policy(Policies::EarlyYearsPayments)
             .where(reference: reference_number)
+            .where(practitioner_email_address: email)
             .exists?
         end
 

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -2,6 +2,7 @@ module Journeys
   module TeacherStudentLoanReimbursement
     class ClaimSchoolForm < Form
       attribute :claim_school_id
+      attribute :change_school
 
       attr_reader :schools
 

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -90,8 +90,7 @@ class ClaimMailer < ApplicationMailer
       full_name: claim.full_name,
       setting_name: claim.eligibility.eligible_ey_provider.nursery_name,
       ref_number: claim.reference,
-      # TODO: Reference new route for practitioner journey
-      complete_claim_url: "https://gov.uk/claim-an-early-years-financial-incentive-payment?claim=#{claim.reference}&email=#{CGI.escape claim.practitioner_email_address}"
+      complete_claim_url: early_years_practitioner_invite_link(claim:)
     }
 
     template_id = template_ids(claim)[:CLAIM_PRACTITIONER_NOTIFY_TEMPLATE_ID]
@@ -210,6 +209,10 @@ class ClaimMailer < ApplicationMailer
 
   def early_years_payment_provider_magic_link(one_time_password, email)
     "https://#{ENV["CANONICAL_HOSTNAME"]}/#{Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME}/claim?code=#{one_time_password}&email=#{email}"
+  end
+
+  def early_years_practitioner_invite_link(claim:)
+    "https://#{ENV["CANONICAL_HOSTNAME"]}/#{Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME}/find-reference?skip_landing_page=true&email=#{CGI.escape(claim.practitioner_email_address)}"
   end
 
   def policy_check!(claim, policy)

--- a/app/models/journeys/early_years_payment/practitioner/session_answers.rb
+++ b/app/models/journeys/early_years_payment/practitioner/session_answers.rb
@@ -2,6 +2,8 @@ module Journeys
   module EarlyYearsPayment
     module Practitioner
       class SessionAnswers < Journeys::SessionAnswers
+        attribute :reference_number, :string
+
         def policy
           Policies::EarlyYearsPayments
         end

--- a/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
+++ b/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
@@ -1,2 +1,43 @@
-<p class="govuk-body">find reference page goes here</p>
-<%= govuk_button_to "Continue", claim_path(current_journey_routing_name), method: :patch %>
+<% content_for(:page_title, page_title(@form.t(:question), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= @form.t(:question) %>
+      <h1>
+
+      <%= f.govuk_text_field :reference_number,
+        width: 10,
+        label: {
+          text: "Claim reference number",
+          tag: "h2",
+          size: "m"
+        },
+        hint: { text: "For example, ABC1234D" } %>
+
+      <%= govuk_details(summary_text: "Where you can find your claim reference number") do %>
+        <p>
+          Check your confirmation email from the Department for Education for your claim reference number.
+        </p>
+
+        <p>
+          If you can’t find the email:
+        </p>
+
+        <%= govuk_list [
+          "check your spam or junk folder",
+          "ask your employer to confirm they have sent your application. They will have received the reference number in their confirmation email."
+        ], type: :bullet %>
+
+        <p>
+          Contact us at <%= govuk_link_to "help@opsteam.com", "mailto:help@opsteam.com" %> for assistance.
+        </p>
+      <% end %>
+
+      <%= f.govuk_submit "Submit" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
+++ b/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: claim_path(current_journey_routing_name, request.query_parameters), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :email, value: params[:email] %>

--- a/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
+++ b/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
@@ -35,7 +35,7 @@
         ], type: :bullet %>
 
         <p>
-          Contact us at <%= govuk_link_to "help@opsteam.com", "mailto:help@opsteam.com" %> for assistance.
+          Contact us at <%= govuk_mail_to t("#{journey::I18N_NAMESPACE}.support_email") %> for assistance.
         </p>
       <% end %>
 

--- a/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
+++ b/app/views/early_years_payment/practitioner/claims/find_reference.html.erb
@@ -5,6 +5,8 @@
     <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= f.hidden_field :email, value: params[:email] %>
+
       <h1 class="govuk-heading-l">
         <%= @form.t(:question) %>
       <h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1400,6 +1400,7 @@ en:
   early_years_payment_practitioner:
     journey_name: Claim an early years financial incentive payment - practitioner
     feedback_email: implementme@example.com
+    support_email: "help@opsteam.com"
     claim_description: for early years financial incentive payment
     forms:
       find_reference:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1402,6 +1402,11 @@ en:
     feedback_email: implementme@example.com
     claim_description: for early years financial incentive payment
     forms:
+      find_reference:
+        question: Track your application
+        errors:
+          presence: Enter your claim reference number
+          impermissible: Enter a valid claim reference number
       email_address:
         label: Your email address
         hint1: We’ll use this to update you with progress on your claim.

--- a/spec/factories/journeys/early_years_payment/practitioner/session.rb
+++ b/spec/factories/journeys/early_years_payment/practitioner/session.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :early_years_payment_practitioner_session, class: "Journeys::EarlyYearsPayment::Practitioner::Session" do
+    journey { Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME }
+  end
+end

--- a/spec/features/early_years_payment/practitioner/find_reference_spec.rb
+++ b/spec/features/early_years_payment/practitioner/find_reference_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Early years find reference" do
+  let(:claim) do
+    create(
+      :claim,
+      policy: Policies::EarlyYearsPayments,
+      reference: "foo",
+      practitioner_email_address: "user@example.com"
+    )
+  end
+
+  scenario "when different email address" do
+    when_early_years_payment_practitioner_journey_configuration_exists
+
+    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=other@example.com"
+    expect(page).to have_content "Track your application"
+    fill_in "Claim reference number", with: claim.reference
+    click_button "Submit"
+
+    expect(page).to have_content "Track your application"
+  end
+end

--- a/spec/features/early_years_payment/practitioner/find_reference_spec.rb
+++ b/spec/features/early_years_payment/practitioner/find_reference_spec.rb
@@ -20,4 +20,19 @@ RSpec.feature "Early years find reference" do
 
     expect(page).to have_content "Track your application"
   end
+
+  scenario "after multiple attempts should work" do
+    when_early_years_payment_practitioner_journey_configuration_exists
+
+    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=user@example.com"
+    expect(page).to have_content "Track your application"
+    fill_in "Claim reference number", with: "foo"
+    click_button "Submit"
+
+    expect(page).to have_content "Track your application"
+    fill_in "Claim reference number", with: claim.reference
+    click_button "Submit"
+
+    expect(page).to have_content "login page goes here"
+  end
 end

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -1,16 +1,23 @@
 require "rails_helper"
 
 RSpec.feature "Early years payment practitioner" do
+  let(:claim) do
+    create(
+      :claim,
+      policy: Policies::EarlyYearsPayments,
+      reference: "foo"
+     )
+  end
+
   scenario "Happy path" do
     when_early_years_payment_practitioner_journey_configuration_exists
 
-    visit landing_page_path(Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME)
+    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true"
+    expect(page).to have_content "Track your application"
+    fill_in "Claim reference number", with: claim.reference
+    click_button "Submit"
 
-    # find-reference page stuff
-    visit claim_path(Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME, :claim) # temporary step until landing page implemented
-    click_on "Continue"
-
-    # one login stuff
+    expect(page).to have_content "Sign in with GOV.UK One Login"
     click_on "Continue"
 
     expect(page.title).to have_text("How we’ll use the information you provide")

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Early years payment practitioner" do
     fill_in "Claim reference number", with: claim.reference
     click_button "Submit"
 
-    expect(page).to have_content "Sign in with GOV.UK One Login"
+    expect(page).to have_content "one login page goes here"
     click_on "Continue"
 
     expect(page.title).to have_text("How we’ll use the information you provide")

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -5,14 +5,15 @@ RSpec.feature "Early years payment practitioner" do
     create(
       :claim,
       policy: Policies::EarlyYearsPayments,
-      reference: "foo"
-     )
+      reference: "foo",
+      practitioner_email_address: "user@example.com"
+    )
   end
 
   scenario "Happy path" do
     when_early_years_payment_practitioner_journey_configuration_exists
 
-    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true"
+    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=user@example.com"
     expect(page).to have_content "Track your application"
     fill_in "Claim reference number", with: claim.reference
     click_button "Submit"

--- a/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
   let(:journey) { Journeys::EarlyYearsPayment::Practitioner }
   let(:journey_session) { create(:early_years_payment_practitioner_session) }
 
-  let(:reference_number){ nil }
+  let(:reference_number) { nil }
+  let(:email) { nil }
 
   let(:params) do
-    ActionController::Parameters.new(claim: {reference_number:})
+    ActionController::Parameters.new(claim: {reference_number:, email:})
   end
 
   describe "validations" do
@@ -21,7 +22,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
     end
 
     context "when random string" do
-      let(:reference_number){ "foo" }
+      let(:reference_number) { "foo" }
 
       it "is not valid" do
         expect(subject).to be_invalid
@@ -30,10 +31,15 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
     end
 
     context "when non EY claim" do
-      let(:reference_number){ claim.reference }
+      let(:reference_number) { claim.reference }
+      let(:email) { claim.practitioner_email_address }
 
       let(:claim) do
-        create(:claim)
+        create(
+          :claim,
+          reference: "foo",
+          practitioner_email_address: "user@example.com"
+        )
       end
 
       it "is not valid" do
@@ -43,14 +49,16 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
     end
 
     context "when EY claim" do
-      let(:reference_number){ claim.reference }
+      let(:reference_number) { claim.reference }
+      let(:email) { claim.practitioner_email_address }
 
       let(:claim) do
         create(
           :claim,
           policy: Policies::EarlyYearsPayments,
-          reference: "foo"
-         )
+          reference: "foo",
+          practitioner_email_address: "user@example.com"
+        )
       end
 
       it "is valid" do
@@ -68,7 +76,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
         :claim,
         policy: Policies::EarlyYearsPayments,
         reference: "foo"
-       )
+      )
     end
 
     it "updates reference number in session" do

--- a/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
+  subject { described_class.new(journey:, journey_session:, params:) }
+
+  let(:journey) { Journeys::EarlyYearsPayment::Practitioner }
+  let(:journey_session) { create(:early_years_payment_practitioner_session) }
+
+  let(:reference_number){ nil }
+
+  let(:params) do
+    ActionController::Parameters.new(claim: {reference_number:})
+  end
+
+  describe "validations" do
+    context "when reference number blank" do
+      it "is not valid" do
+        expect(subject).to be_invalid
+        expect(subject.errors[:reference_number]).to be_present
+      end
+    end
+
+    context "when random string" do
+      let(:reference_number){ "foo" }
+
+      it "is not valid" do
+        expect(subject).to be_invalid
+        expect(subject.errors[:reference_number]).to be_present
+      end
+    end
+
+    context "when non EY claim" do
+      let(:reference_number){ claim.reference }
+
+      let(:claim) do
+        create(:claim)
+      end
+
+      it "is not valid" do
+        expect(subject).to be_invalid
+        expect(subject.errors[:reference_number]).to be_present
+      end
+    end
+
+    context "when EY claim" do
+      let(:reference_number){ claim.reference }
+
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::EarlyYearsPayments,
+          reference: "foo"
+         )
+      end
+
+      it "is valid" do
+        expect(subject).to be_valid
+        expect(subject.errors[:reference_number]).to be_blank
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:reference_number) { claim.reference }
+
+    let(:claim) do
+      create(
+        :claim,
+        policy: Policies::EarlyYearsPayments,
+        reference: "foo"
+       )
+    end
+
+    it "updates reference number in session" do
+      expect {
+        subject.save
+      }.to change { journey_session.reload.answers.reference_number }.from(nil).to(reference_number)
+    end
+  end
+end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimSubmis
           full_name: claim.full_name,
           setting_name: claim.eligibility.eligible_ey_provider.nursery_name,
           ref_number: claim.reference,
-          complete_claim_url: "https://gov.uk/claim-an-early-years-financial-incentive-payment?claim=#{claim.reference}&email=#{CGI.escape claim.practitioner_email_address}"
+          complete_claim_url: "https://www.example.com/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=johndoe%40example.com"
         )
       )
     end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -401,7 +401,14 @@ RSpec.describe ClaimMailer, type: :mailer do
     before { claim.eligibility.update!(nursery_urn: eligible_ey_provider.urn) }
 
     it "has personalisation keys for: full_name, setting_name, ref_number, complete_claim_url" do
-      expect(mail[:personalisation].decoded).to eq("{:full_name=>\"Test Practitioner\", :setting_name=>\"Test Nursery\", :ref_number=>\"TEST123\", :complete_claim_url=>\"https://gov.uk/claim-an-early-years-financial-incentive-payment?claim=TEST123&email=practitioner%40example.com\"}")
+      expected_personalisation = {
+        full_name: "Test Practitioner",
+        setting_name: "Test Nursery",
+        ref_number: "TEST123",
+        complete_claim_url: "https://www.example.com/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=practitioner%40example.com"
+      }
+
+      expect(mail[:personalisation].unparsed_value).to eql(expected_personalisation)
       expect(mail.body).to be_empty
     end
   end

--- a/spec/requests/reminders_spec.rb
+++ b/spec/requests/reminders_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Claims" do
 
       it "redirects to /email-verfication slug" do
         submit_form
-        expect(response).to redirect_to("/additional-payments/reminders/email-verification")
+        expect(response).to redirect_to("/additional-payments/reminders/email-verification?form%5Bemail_address%5D=joe.bloggs%40example.com&form%5Bfull_name%5D=Joe+Bloggs")
       end
     end
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1045
- Adds EY practitioner find reference screen

# Changes

- In order to support email in url query params and the way the current controller/journey concerns does a lot redirect, I've had to make tweaks to ensure these get passed around so they are not lost. This will affect all journeys
- I have concern where query params are stripped, thinking of mostly Safari where it can strip certain query params, may cause this feature to not work as we use it to pass state
- Updated email sent to practitioner to inject correct url to continue their journey