### PR TITLE
Allow deleting payroll runs on review apps

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -49,5 +49,16 @@ module Admin
       @payroll_run = PayrollRun.where(id: params[:id]).includes({claims: [:eligibility]}, {payments: [{claims: [:eligibility]}]}).first
       @pagy, @payments = pagy(@payroll_run.payments.ordered.includes(claims: [:eligibility]).includes(:topups))
     end
+
+    def destroy
+      if PayrollRun.allow_destroy?
+        PayrollRun.find(params[:id]).destroy!
+        redirect_to admin_payroll_runs_path, notice: "Payroll run deleted"
+      else
+        redirect_to(
+          admin_payroll_runs_path, alert: "Payroll run deletion is not allowed"
+        )
+      end
+    end
   end
 end

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -17,6 +17,12 @@ class PayrollRun < ApplicationRecord
 
   scope :this_month, -> { where(created_at: DateTime.now.all_month) }
 
+  def self.allow_destroy?
+    ENV["ENVIRONMENT_NAME"].start_with?("review") ||
+      ENV["ENVIRONMENT_NAME"] == "test" ||
+      Rails.env.development?
+  end
+
   def total_award_amount
     payments.sum(:award_amount)
   end

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -157,4 +157,15 @@
 
     <%== render partial: 'pagination', locals: { pagy: @pagy } %>
   </div>
+
+  <% if PayrollRun.allow_destroy? %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= button_to(
+        "Delete payroll run",
+        admin_payroll_run_path(@payroll_run),
+        method: :delete,
+        class: "govuk-button govuk-button--warning",
+      ) %>
+    </div>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
     resources :student_loans_data_uploads, only: [:new, :create]
     resources :tps_data_uploads, only: [:new, :create]
 
-    resources :payroll_runs, only: [:index, :new, :create, :show] do
+    resources :payroll_runs, only: [:index, :new, :create, :show, :destroy] do
       resources :payment_confirmation_report_uploads, only: [:new, :create]
       resource :download, only: [:new, :create, :show], controller: "payroll_run_downloads"
       resources :payments, only: [:destroy] do


### PR DESCRIPTION
When testing we need to spin up a new review app for each payroll run we
want to test. This commit adds a button, for review apps, staging, and development
only, to allow admins to delete a payroll run on a review app.

<!-- Do you need to update CHANGELOG.md? -->
