### PR TITLE
[LUPEYALPHA-1109] Validation for missing practitioner email

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/check_your_answers_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/check_your_answers_form.rb
@@ -5,13 +5,21 @@ module Journeys
         class CheckYourAnswersForm < Form
           attribute :provider_contact_name
 
-          validates :provider_contact_name, presence: {message: i18n_error_message(:valid)}
+          validates :provider_contact_name, presence: {message: i18n_error_message(:name)}
+
+          validate :employee_email_provided
 
           def save
             return false if invalid?
 
             journey_session.answers.assign_attributes(provider_contact_name:)
             journey_session.save!
+          end
+
+          def employee_email_provided
+            if journey_session.answers.practitioner_email_address.blank?
+              errors.add(:practitioner_email_address, Form.i18n_error_message(:email))
+            end
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1387,7 +1387,8 @@ en:
           valid: Enter a valid email address
       check_your_answers:
         errors:
-          valid: You cannot submit this claim without providing your full name
+          name: You cannot submit this claim without providing your full name
+          email: You cannot submit this claim without providing the employee’s email address
     check_your_answers:
       title: Check your answers before submitting this claim
       heading_send_application: Before submitting this claim

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/check_your_answers_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/check_your_answers_form_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::CheckYourAnswersForm, type: :model do
   let(:journey) { Journeys::EarlyYearsPayment::Provider::Authenticated }
-  let(:journey_session) { create(:early_years_payment_provider_authenticated_session) }
+  let(:journey_session) { create(:early_years_payment_provider_authenticated_session, answers:) }
+  let(:answers) { build(:early_years_payment_provider_authenticated_answers, :submittable) }
   let(:provider_contact_name) { nil }
 
   let(:params) do
@@ -25,14 +26,20 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::CheckYourAn
         .with_message("You cannot submit this claim without providing your full name")
       )
     end
+
+    it "raises a validation error when provider email address is missing" do
+      answers.practitioner_email_address = nil
+      subject.save
+      expect(subject.errors[:practitioner_email_address]).to include("You cannot submit this claim without providing the employee’s email address")
+    end
   end
 
   describe "#save" do
-    let(:provider_contact_name) { "John Doe" }
+    let(:provider_contact_name) { "Jane Doe" }
 
     it "updates the journey session" do
       expect { expect(subject.save).to be(true) }.to(
-        change { journey_session.reload.answers.provider_contact_name }.to("John Doe")
+        change { journey_session.reload.answers.provider_contact_name }.to("Jane Doe")
       )
     end
   end


### PR DESCRIPTION
Adds a validation when trying to submit a claim without supplying a practitioner email address.

![image](https://github.com/user-attachments/assets/91c78503-ea6d-43e1-869c-f16f9693ed9a)

Marking as draft because I don't like this approach:
- I think there is an underlying bug: It seems selecting "permanent" making the claim ineligible, and then going back to change the contract type, sends the user to the "check your answers" page without asking them for the practitioner email address - I'm still looking into this
- This error doesn't link to anywhere and we don't have a design pattern for errors within a summary list