### PR TITLE
[LUPEYALPHA-1112] When no entry in SLC data, do not create task (shows as incomplete on admin view)

### DIFF
--- a/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
@@ -38,7 +38,7 @@ module AutomatedChecks
       def no_student_loan_data_entry
         return if student_loans_data.any?
 
-        create_task(match: nil)
+        create_note(match: nil)
       end
 
       def student_loan_data_exists

--- a/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
@@ -65,7 +65,7 @@ module AutomatedChecks
 
       def note_body(match:)
         prefix = "[SLC Student loan plan]"
-        return "#{prefix} - No data" unless match
+        return "#{prefix} - SLC data checked, no matching entry found" unless match
 
         if slc_repaying_plan_types
           "#{prefix} - Matched - has a student loan"

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -19,7 +19,8 @@ module Policies
     VERIFIERS = [
       AutomatedChecks::ClaimVerifiers::Identity,
       AutomatedChecks::ClaimVerifiers::ProviderVerification,
-      AutomatedChecks::ClaimVerifiers::Employment
+      AutomatedChecks::ClaimVerifiers::Employment,
+      AutomatedChecks::ClaimVerifiers::StudentLoanPlan
     ]
 
     # Options shown to admins when rejecting a claim

--- a/app/views/admin/tasks/student_loan_plan.html.erb
+++ b/app/views/admin/tasks/student_loan_plan.html.erb
@@ -18,6 +18,7 @@
     <% if @task.persisted? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
+      <%= render "admin/tasks/notes", notes: @notes, display_description: false %>
       <div class="govuk-inset-text task-outcome">
         <p class="govuk-body">
           <%= task_status_content_tag(status_colour: "grey", status: "Incomplete") %>

--- a/app/views/admin/tasks/student_loan_plan.html.erb
+++ b/app/views/admin/tasks/student_loan_plan.html.erb
@@ -24,7 +24,7 @@
           <%= task_status_content_tag(status_colour: "grey", status: "Incomplete") %>
         </p>
         <p class="govuk-body">
-          This task has not been checked against Student Loan Company data yet.
+          No matching entry has been found in the Student Loan Company data yet.
         </p>
       </div>
     <% end %>

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -116,7 +116,7 @@ RSpec.feature "Upload SLC data" do
     expect(claim.has_student_loan).to eq true
 
     claim = ecp_claim_no_slc_data
-    then_the_student_loan_plan_task_should_show_as(state: "No data", for_claim: claim)
+    then_the_student_loan_plan_task_should_show_as(state: "Incomplete", for_claim: claim)
     expect(claim.reload.student_loan_plan).to be nil # this was "not_applicable" before LUPEYALPHA-1031
     expect(claim.has_student_loan).to be nil # this was false before LUPEYALPHA-1031
 
@@ -133,7 +133,7 @@ RSpec.feature "Upload SLC data" do
     expect(claim.has_student_loan).to eq true
 
     claim = fe_claim_no_slc_data_nil_submitted_using_slc_data
-    then_the_student_loan_plan_task_should_show_as(state: "No data", for_claim: claim)
+    then_the_student_loan_plan_task_should_show_as(state: "Incomplete", for_claim: claim)
     expect(claim.reload.student_loan_plan).to be nil
     expect(claim.has_student_loan).to be nil
 
@@ -148,7 +148,7 @@ RSpec.feature "Upload SLC data" do
     expect(claim.has_student_loan).to eq true
 
     claim = fe_claim_no_slc_data
-    then_the_student_loan_plan_task_should_show_as(state: "No data", for_claim: claim)
+    then_the_student_loan_plan_task_should_show_as(state: "Incomplete", for_claim: claim)
     expect(claim.reload.student_loan_plan).to be nil
     expect(claim.has_student_loan).to be nil
   end

--- a/spec/features/further_education_payments/student_loan_spec.rb
+++ b/spec/features/further_education_payments/student_loan_spec.rb
@@ -15,8 +15,7 @@ RSpec.feature "Further education payments" do
 
     sign_in_as_service_operator
 
-    visit admin_claims_path
-    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+    visit admin_claim_tasks_path(claim)
     within "li.student_loan_plan" do
       expect(page).to have_content "Incomplete"
     end
@@ -32,8 +31,7 @@ RSpec.feature "Further education payments" do
 
     sign_in_as_service_operator
 
-    visit admin_claims_path
-    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+    visit admin_claim_tasks_path(claim)
     expect(page).not_to have_content "Student loan plan"
   end
 end

--- a/spec/features/further_education_payments/student_loan_spec.rb
+++ b/spec/features/further_education_payments/student_loan_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments" do
+  include ActionView::Helpers::NumberHelper
+
+  let(:college) { create(:school, :further_education, :fe_eligible) }
+  let(:claim) { Claim.last }
+
+  scenario "student loan data does not exist on submission" do
+    when_further_education_journey_ready_to_submit
+
+    perform_enqueued_jobs { click_on "Accept and send" }
+
+    expect(claim.tasks.where(name: "student_loan_plan")).to be_empty
+
+    sign_in_as_service_operator
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+    within "li.student_loan_plan" do
+      expect(page).to have_content "Incomplete"
+    end
+  end
+
+  scenario "student loan data does exist on submission" do
+    when_student_loan_data_exists
+    when_further_education_journey_ready_to_submit
+
+    perform_enqueued_jobs { click_on "Accept and send" }
+
+    expect(claim.student_loan_plan).to eq "plan_1"
+
+    sign_in_as_service_operator
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+    expect(page).not_to have_content "Student loan plan"
+  end
+end

--- a/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/student_loan_plan_spec.rb
@@ -114,7 +114,7 @@ module AutomatedChecks
               let(:submitted_using_slc_data) { false }
 
               context "when there is no student loan data for the claim" do
-                let(:expected_note) { "[SLC Student loan plan] - No data" }
+                let(:expected_note) { "[SLC Student loan plan] - SLC data checked, no matching entry found" }
 
                 it_behaves_like :creating_a_note_but_no_task
               end
@@ -149,7 +149,7 @@ module AutomatedChecks
               let(:submitted_using_slc_data) { nil }
 
               context "when there is no student loan data for the claim" do
-                let(:expected_note) { "[SLC Student loan plan] - No data" }
+                let(:expected_note) { "[SLC Student loan plan] - SLC data checked, no matching entry found" }
 
                 it_behaves_like :creating_a_note_but_no_task
               end

--- a/spec/support/steps/dqt.rb
+++ b/spec/support/steps/dqt.rb
@@ -1,0 +1,5 @@
+def when_dqt_stubbed
+  dqt_teacher_resource = instance_double(Dqt::TeacherResource, find: nil)
+  dqt_client = instance_double(Dqt::Client, teacher: dqt_teacher_resource)
+  allow(Dqt::Client).to receive(:new).and_return(dqt_client)
+end

--- a/spec/support/steps/further_education_journey.rb
+++ b/spec/support/steps/further_education_journey.rb
@@ -67,8 +67,6 @@ def when_further_education_journey_ready_to_submit
   choose "No"
   click_on "Continue"
 
-  choose "Personal bank account"
-  click_on "Continue"
   fill_in "Name on your account", with: "Jo Bloggs"
   fill_in "Sort code", with: "123456"
   fill_in "Account number", with: "87654321"

--- a/spec/support/steps/further_education_journey.rb
+++ b/spec/support/steps/further_education_journey.rb
@@ -1,0 +1,81 @@
+def when_further_education_journey_ready_to_submit
+  when_dqt_stubbed
+  when_further_education_payments_journey_configuration_exists
+  college
+
+  visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+  click_link "Start now"
+  choose "Yes"
+  click_button "Continue"
+  fill_in "Which FE provider are you employed by?", with: college.name
+  click_button "Continue"
+  choose college.name
+  click_button "Continue"
+  choose("Permanent contract")
+  click_button "Continue"
+  choose("12 hours or more per week")
+  click_button "Continue"
+  choose("September 2023 to August 2024")
+  click_button "Continue"
+  check("Physics")
+  click_button "Continue"
+  check "A or AS level physics"
+  click_button "Continue"
+  choose("Yes")
+  click_button "Continue"
+  choose "Yes"
+  click_button "Continue"
+  choose("Yes")
+  click_button "Continue"
+  within all(".govuk-fieldset")[0] do
+    choose("No")
+  end
+  within all(".govuk-fieldset")[1] do
+    choose("No")
+  end
+  click_button "Continue"
+  click_button "Continue"
+  click_button "Apply now"
+
+  sign_in_with_one_login
+  click_button "Continue"
+
+  fill_in "First name", with: "John"
+  fill_in "Last name", with: "Doe"
+  fill_in "Day", with: "28"
+  fill_in "Month", with: "2"
+  fill_in "Year", with: "1988"
+  fill_in "National Insurance number", with: "PX321499A"
+  click_on "Continue"
+
+  click_link("Enter your address manually")
+  fill_in "House number or name", with: "57"
+  fill_in "Building and street", with: "Walthamstow Drive"
+  fill_in "Town or city", with: "Derby"
+  fill_in "County", with: "City of Derby"
+  fill_in "Postcode", with: "DE22 4BS"
+  click_on "Continue"
+
+  fill_in "Email address", with: "johndoe@example.com"
+  click_on "Continue"
+
+  mail = ActionMailer::Base.deliveries.last
+  otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
+  fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+  click_on "Confirm"
+
+  choose "No"
+  click_on "Continue"
+
+  choose "Personal bank account"
+  click_on "Continue"
+  fill_in "Name on your account", with: "Jo Bloggs"
+  fill_in "Sort code", with: "123456"
+  fill_in "Account number", with: "87654321"
+  click_on "Continue"
+  choose "Female"
+  click_on "Continue"
+
+  fill_in "claim-teacher-reference-number-field", with: "1234567"
+  click_on "Continue"
+end


### PR DESCRIPTION
All journeys now behave the same (except TSLR which does not have a student loan plan task):
* when the claim is submitted, and there is no SLC data for the claimant, the task shows as 'Incomplete'
* when the SLC data is subsequently uploaded, the 'Incomplete' tasks will show as 'Passed' or 'Incomplete' depending if a SLC data entry has been found for that claimant
* when the claim is submitted, and there is SLC data for the claimant, the task does not show, but the plan is set correctly

For the 'Incomplete' student loan plan tasks, I've added the notes back, as that shows if the automated check was carried out (it used to show on the old 'No data' tasks).

We don't show 'No data' for student loan plan tasks any more - it's either 'Incomplete' or 'Passed'.