### PR TITLE
Fix claims being flagged for qa

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -282,10 +282,11 @@ class Claim < ApplicationRecord
   def below_min_qa_threshold?
     return false if policy::MIN_QA_THRESHOLD.zero?
 
-    claims_approved_so_far = Claim.by_policy(policy).current_academic_year.approved.count
+    approved_claims = Claim.by_policy(policy).by_academic_year(academic_year).approved
+    claims_approved_so_far = approved_claims.count
     return true if claims_approved_so_far.zero?
 
-    (Claim.by_policy(policy).current_academic_year.approved.qa_required.count.to_f / claims_approved_so_far) * 100 <= policy::MIN_QA_THRESHOLD
+    (approved_claims.qa_required.count.to_f / claims_approved_so_far) * 100 <= policy::MIN_QA_THRESHOLD
   end
 
   def qa_completed?


### PR DESCRIPTION
When a new academic year has started, and we are yet to approved any claims from this academic year, all claims from the previous year are flagged for qa when approved. To avoid this we need to count the number of approved claims in the _claim's_ academic year rather than the current academic year.

<!-- Do you need to update CHANGELOG.md? -->
