### PR TITLE
[CAPT-1615] Admin can view amendments after payrolled

### DIFF
--- a/app/controllers/admin/amendments_controller.rb
+++ b/app/controllers/admin/amendments_controller.rb
@@ -1,7 +1,7 @@
 class Admin::AmendmentsController < Admin::BaseAdminController
   before_action :load_claim
   before_action :ensure_service_operator
-  before_action :ensure_claim_is_amendable
+  before_action :ensure_claim_is_amendable, only: [:new, :create]
 
   def index
   end

--- a/spec/features/admin/admin_amend_claim_spec.rb
+++ b/spec/features/admin/admin_amend_claim_spec.rb
@@ -186,4 +186,29 @@ RSpec.feature "Admin amends a claim" do
       expect(page).to have_content("Claim has been amended successfully")
     end
   end
+
+  context "when claim is no longer amendable" do
+    let!(:payment) do
+      create(
+        :payment,
+        claims: [claim]
+      )
+    end
+
+    scenario "admin can view amendments" do
+      visit admin_claim_url(claim)
+      click_link "View tasks"
+      click_on "Claim amendments"
+
+      expect(page).to have_content "Claim amendments"
+    end
+
+    scenario "admin cannot make amendments" do
+      visit admin_claim_url(claim)
+      expect(page).not_to have_content "Amend claim"
+
+      visit new_admin_claim_amendment_path(claim)
+      expect(page).to have_content "This claim cannot be amended"
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1615
- Admin can view amendments on a claim even after being payrolled
- The behaviour of not being able to add new amendments remains the same, ie not possible to do so