### PR TITLE
Rescue notify api errors

### DIFF
--- a/app/forms/mobile_number_form.rb
+++ b/app/forms/mobile_number_form.rb
@@ -28,6 +28,9 @@ class MobileNumberForm < Form
     )
 
     journey_session.save!
+  rescue NotifySmsMessage::NotifySmsError => e
+    handle_notify_error(e)
+    false
   end
 
   private
@@ -47,5 +50,13 @@ class MobileNumberForm < Form
 
   def mobile_number_changed?
     mobile_number != answers.mobile_number
+  end
+
+  def handle_notify_error(error)
+    if error.message.include?("ValidationError: phone_number Number is not valid")
+      errors.add(:mobile_number, i18n_errors_path("invalid"))
+    else
+      raise error
+    end
   end
 end


### PR DESCRIPTION
Notify uses the https://pypi.org/project/phonenumbers/ library to
validate phone numbers. There's some scenarios where our regex permits a
phone number that libphonenumber doesn't allow, causing notify to return
an error when sending to that number.
We've gone for rescuing this api error and adding a validation error to
the the form. We may at some point, especially if we move message sending
into a background job, want to investigate using a gem like
https://github.com/daddyz/phonelib that will provide stricter phone
number validations.

<!-- Do you need to update CHANGELOG.md? -->
