### PR TITLE
[CAPT-1297] Admin claims filter and session

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -13,13 +13,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
     @pagy, @claims = pagy(@filter_form.claims)
 
     respond_to do |format|
-      format.html {
-        claims_backlink_path!(admin_claims_path(
-          team_member: params[:team_member],
-          policy: params[:policy],
-          status: params[:status]
-        ))
-      }
+      format.html
       format.csv {
         # "Download report request file" button (doesn't use the filters)
         report_request_claims = Claim.includes(:decisions).awaiting_decision

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -5,9 +5,9 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def index
     @filter_form = Admin::ClaimsFilterForm.new(
-      team_member: params[:team_member],
-      policy: params[:policy],
-      status: params[:status]
+      team_member: filter_params[:team_member],
+      policy: filter_params[:policy],
+      status: filter_params[:status]
     )
 
     @pagy, @claims = pagy(@filter_form.claims)
@@ -80,5 +80,11 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def hold_params
     params.require(:hold).permit(:body).merge(claim: @claim)
+  end
+
+  def filter_params
+    params
+      .fetch(:filter, {})
+      .permit(:team_member, :policy, :status)
   end
 end

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -10,7 +10,6 @@ class Admin::ClaimsController < Admin::BaseAdminController
       status: params[:status]
     )
 
-    @total_claim_count = @filter_form.count
     @pagy, @claims = pagy(@filter_form.claims)
 
     respond_to do |format|

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -6,7 +6,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def index
     @filter_form = Admin::ClaimsFilterForm.new(
       filters: filter_params,
-      session:,
+      session:
     )
     @filter_form.save_to_session!
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -5,10 +5,10 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def index
     @filter_form = Admin::ClaimsFilterForm.new(
-      team_member: filter_params[:team_member],
-      policy: filter_params[:policy],
-      status: filter_params[:status]
+      filters: filter_params,
+      session:,
     )
+    @filter_form.save_to_session!
 
     @pagy, @claims = pagy(@filter_form.claims)
 
@@ -17,8 +17,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
         claims_backlink_path!(admin_claims_path(
           team_member: params[:team_member],
           policy: params[:policy],
-          status: params[:status],
-          commit: params[:commit]
+          status: params[:status]
         ))
       }
       format.csv {
@@ -85,6 +84,6 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def filter_params
     params
       .fetch(:filter, {})
-      .permit(:team_member, :policy, :status)
+      .permit(:team_member, :policy, :status, :reset)
   end
 end

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -45,6 +45,39 @@ class Admin::ClaimsFilterForm
     claims.count
   end
 
+  def policy_select_options
+    array = [OpenStruct.new(id: nil, name: "All")]
+
+    array + Policies.all.map do |policy|
+      OpenStruct.new(id: policy.policy_type, name: policy.short_name)
+    end
+  end
+
+  def status_select_options
+    [
+      ["Awaiting decision - not on hold", nil],
+      ["Awaiting provider verification", "awaiting_provider_verification"],
+      ["Awaiting decision - on hold", "held"],
+      ["Awaiting decision - failed bank details", "failed_bank_validation"],
+      ["Approved awaiting QA", "approved_awaiting_qa"],
+      ["Approved awaiting payroll", "approved_awaiting_payroll"],
+      ["Automatically approved awaiting payroll", "automatically_approved_awaiting_payroll"],
+      ["Approved", "approved"],
+      ["Rejected", "rejected"]
+    ].map do |name, id|
+      OpenStruct.new(id:, name:)
+    end
+  end
+
+  def team_member_select_options
+    array = [["All", nil], ["Unassigned", "unassigned"]]
+    array = array + DfeSignIn::User.options_for_select
+
+    array.map do |name, id|
+      OpenStruct.new(id:, name:)
+    end
+  end
+
   private
 
   def approved_awaiting_payroll

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -2,9 +2,40 @@ class Admin::ClaimsFilterForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :team_member, :string
-  attribute :policy, :string
-  attribute :status, :string
+  attribute :filters
+  attribute :session
+
+  def initialize(args)
+    super
+
+    session[:filter] ||= {}
+  end
+
+  def team_member
+    filters[:team_member] || session[:filter][:team_member]
+  end
+
+  def policy
+    return if reset?
+
+    filters[:policy] || session[:filter][:policy]
+  end
+
+  def status
+    return if reset?
+
+    filters[:status] || session[:filter][:status]
+  end
+
+  def filters_applied?
+    return if reset?
+
+    team_member.present? || policy.present? || status.present?
+  end
+
+  def reset?
+    filters[:reset].present?
+  end
 
   def claims
     return @claims if @claims
@@ -76,6 +107,14 @@ class Admin::ClaimsFilterForm
     array.map do |name, id|
       OpenStruct.new(id:, name:)
     end
+  end
+
+  def save_to_session!
+    session[:filter] = {
+      team_member:,
+      policy:,
+      status:
+    }
   end
 
   private

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -12,24 +12,24 @@ class Admin::ClaimsFilterForm
   end
 
   def team_member
-    filters[:team_member] || session[:filter][:team_member]
+    return if reset?
+
+    @team_member ||= filters[:team_member] || session[:filter]["team_member"]
   end
 
   def policy
     return if reset?
 
-    filters[:policy] || session[:filter][:policy]
+    @policy ||= filters[:policy] || session[:filter]["policy"]
   end
 
   def status
     return if reset?
 
-    filters[:status] || session[:filter][:status]
+    @status ||= filters[:status] || session[:filter]["status"]
   end
 
   def filters_applied?
-    return if reset?
-
     team_member.present? || policy.present? || status.present?
   end
 

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -102,7 +102,7 @@ class Admin::ClaimsFilterForm
 
   def team_member_select_options
     array = [["All", nil], ["Unassigned", "unassigned"]]
-    array = array + DfeSignIn::User.options_for_select
+    array += DfeSignIn::User.options_for_select
 
     array.map do |name, id|
       OpenStruct.new(id:, name:)

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -189,21 +189,6 @@ module Admin
       end
     end
 
-    STATUS_FILTERS = [
-      ["Awaiting provider verification", "awaiting_provider_verification"],
-      ["Awaiting decision - on hold", "held"],
-      ["Awaiting decision - failed bank details", "failed_bank_validation"],
-      ["Approved awaiting QA", "approved_awaiting_qa"],
-      ["Approved awaiting payroll", "approved_awaiting_payroll"],
-      ["Automatically approved awaiting payroll", "automatically_approved_awaiting_payroll"],
-      ["Approved", "approved"],
-      ["Rejected", "rejected"]
-    ]
-
-    def claim_status_filters
-      STATUS_FILTERS
-    end
-
     def index_status_filter(status)
       return "awaiting a decision" unless status.present?
 

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -18,9 +18,9 @@
 
     <%= render "allocations_form" %>
 
-    <h2 class="govuk-heading-m">Filter claims</h2>
+    <h2 id="filter" class="govuk-heading-m">Filter claims</h2>
 
-    <%= form_with model: @filter_form, scope: "filter", url: admin_claims_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @filter_form, scope: "filter", url: admin_claims_path(anchor: "filter"), method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <div class="govuk-form-group admin-filter-group">
         <div>
           <%= f.govuk_collection_select :team_member, @filter_form.team_member_select_options, :id, :name, label: { text: "Team member" } %>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -20,32 +20,27 @@
 
     <h2 class="govuk-heading-m">Filter claims</h2>
 
-    <%= form_with url: admin_claims_path, method: :get do |form| %>
+    <%= form_with model: @filter_form, scope: "filter", url: admin_claims_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <div class="govuk-form-group admin-filter-group">
         <div>
-          <label class="govuk-label" for="team_member">
-            Team member:
-          </label>
-          <%= form.select :team_member, options_for_select(DfeSignIn::User.options_for_select.unshift(["Unassigned", "unassigned"]), params[:team_member]), {include_blank: "All"}, class: "govuk-select" %>
+          <%= f.govuk_collection_select :team_member, @filter_form.team_member_select_options, :id, :name, label: { text: "Team member" } %>
         </div>
+
         <div>
-          <label class="govuk-label" for="policy">
-            Policy:
-          </label>
-          <%= form.select :policy, options_for_select(Policies.options_for_select, params[:policy]), {include_blank: "All"}, class: "govuk-select" %>
+          <%= f.govuk_collection_select :policy, @filter_form.policy_select_options, :id, :name %>
         </div>
+
         <div>
-          <label class="govuk-label" for="status">
-            Status:
-          </label>
-          <%= form.select :status, options_for_select(claim_status_filters, params[:status]), {include_blank: "Awaiting decision - not on hold"}, class: "govuk-select" %>
+          <%= f.govuk_collection_select :status, @filter_form.status_select_options, :id, :name %>
         </div>
+
         <div>
-          <%= form.submit "Apply filters", class: "govuk-button govuk-button--secondary admin-filter-group__button" %>
+          <%= f.govuk_submit "Apply filters", secondary: true, class: "admin-filter-group__button" %>
+
           <% if params[:commit].present? %>
             <%= link_to "Clear filters", admin_claims_path, class: "button-link admin-filter-group__button" %>
           <% else %>
-            <%= form.submit "Clear filters", type: "reset", class: "button-link admin-filter-group__button" %>
+            <%= f.submit "Clear filters", type: "reset", class: "button-link admin-filter-group__button" %>
           <% end %>
         </div>
       </div>
@@ -54,7 +49,7 @@
     <% if @claims.any? %>
       <% claims_with_warning = Claim.approaching_decision_deadline.count + Claim.passed_decision_deadline.count %>
 
-      <h2 class="govuk-heading-m"><%= pluralize(@filter_form.count, "claim") %> <%= index_status_filter(params[:status]) %></h2>
+      <h2 class="govuk-heading-m"><%= pluralize(@filter_form.count, "claim") %> <%= index_status_filter(@filter_form.status) %></h2>
 
       <table class="govuk-table">
         <thead class="govuk-table__head">

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -21,7 +21,7 @@
     <h2 id="filter" class="govuk-heading-m">Filter claims</h2>
 
     <%= form_with model: @filter_form, scope: "filter", url: admin_claims_path(anchor: "filter"), method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <div class="govuk-form-group admin-filter-group">
+      <div class="admin-filter-group">
         <div>
           <%= f.govuk_collection_select :team_member, @filter_form.team_member_select_options, :id, :name, label: { text: "Team member" } %>
         </div>
@@ -37,8 +37,8 @@
         <div>
           <%= f.govuk_submit "Apply filters", secondary: true, class: "admin-filter-group__button" %>
 
-          <% if params[:commit].present? %>
-            <%= link_to "Clear filters", admin_claims_path, class: "button-link admin-filter-group__button" %>
+          <% if @filter_form.filters_applied? %>
+            <%= govuk_link_to "Clear filters", admin_claims_path(filter: {reset: true}, anchor: "filter"), class: "button-link admin-filter-group__button" %>
           <% else %>
             <%= f.submit "Clear filters", type: "reset", class: "button-link admin-filter-group__button" %>
           <% end %>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -54,7 +54,7 @@
     <% if @claims.any? %>
       <% claims_with_warning = Claim.approaching_decision_deadline.count + Claim.passed_decision_deadline.count %>
 
-      <h2 class="govuk-heading-m"><%= pluralize(@total_claim_count, "claim") %> <%= index_status_filter(params[:status]) %></h2>
+      <h2 class="govuk-heading-m"><%= pluralize(@filter_form.count, "claim") %> <%= index_status_filter(params[:status]) %></h2>
 
       <table class="govuk-table">
         <thead class="govuk-table__head">

--- a/spec/features/admin/admin_claims_filtering_spec.rb
+++ b/spec/features/admin/admin_claims_filtering_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Admin claim filtering" do
     expect(page).to have_selector("td[text()='FE']", count: 2)
 
     click_on "View claims"
-    select "Student Loans", from: "policy"
+    select "Student Loans", from: "filter-policy-field"
     click_on "Apply filters"
 
     student_loan_claims.each do |c|
@@ -80,9 +80,9 @@ RSpec.feature "Admin claim filtering" do
     expect(page).to have_selector("td[text()='ECP']", count: 10)
 
     # Excludes payroll users and deleted users
-    expect(page).to have_select("team_member", options: ["All", "Unassigned", "#{user.given_name} #{user.family_name}", "Mary Wasu Wabi", "Valentino Ricci", "Mette Jørgensen"])
+    expect(page).to have_select("filter-team-member-field", options: ["All", "Unassigned", "#{user.given_name} #{user.family_name}", "Mary Wasu Wabi", "Valentino Ricci", "Mette Jørgensen"])
 
-    select "Mette Jørgensen", from: "team_member"
+    select "Mette Jørgensen", from: "filter-team-member-field"
     click_on "Apply filters"
 
     expect_page_to_show_claims(
@@ -92,15 +92,15 @@ RSpec.feature "Admin claim filtering" do
     )
 
     # Assigned to Mette
-    select "Mette Jørgensen", from: "team_member"
-    select "Approved", from: "Status:"
+    select "Mette Jørgensen", from: "filter-team-member-field"
+    select "Approved", from: "filter-status-field"
     click_on "Apply filters"
     expect(page).to have_content("1 claim approved")
     expect_page_to_show_claims(approved_claim)
 
     # Approved by Mary
-    select "Mary Wasu Wabi", from: "team_member"
-    select "Approved", from: "Status:"
+    select "Mary Wasu Wabi", from: "filter-team-member-field"
+    select "Approved", from: "filter-status-field"
     click_on "Apply filters"
     expect(page).to have_content("1 claim approved")
     expect(page).to have_content(approved_claim.reference)
@@ -108,7 +108,7 @@ RSpec.feature "Admin claim filtering" do
 
   scenario "filter unassigned claims" do
     click_on "View claims"
-    select "Unassigned", from: "team_member"
+    select "Unassigned", from: "filter-team-member-field"
     click_on "Apply filters"
 
     expect(page).to have_selector("td[text()='STRI']", count: 2)
@@ -129,36 +129,36 @@ RSpec.feature "Admin claim filtering" do
       further_education_claims_provider_verification_email_not_sent
     )
 
-    select "Awaiting provider verification", from: "Status:"
+    select "Awaiting provider verification", from: "filter-status-field"
     click_button "Apply filters"
 
     expect_page_to_show_claims(further_education_claims_awaiting_provider_verification)
 
-    select "Awaiting decision - on hold", from: "Status:"
+    select "Awaiting decision - on hold", from: "filter-status-field"
     click_button "Apply filters"
 
     expect_page_to_show_claims(held_claims)
 
-    select "Awaiting decision - failed bank details", from: "Status:"
+    select "Awaiting decision - failed bank details", from: "filter-status-field"
     click_button "Apply filters"
 
     expect_page_to_show_claims(early_career_payments_claims_failed_bank_validation)
 
-    select "Approved awaiting QA", from: "Status:"
+    select "Approved awaiting QA", from: "filter-status-field"
     click_button "Apply filters"
 
     expect_page_to_show_claims(approved_awaiting_qa_claims)
 
-    select "Approved awaiting payroll", from: "Status:"
+    select "Approved awaiting payroll", from: "filter-status-field"
     click_button "Apply filters"
     expect_page_to_show_claims(auto_approved_awaiting_payroll_claims, approved_claim)
 
-    select "Automatically approved awaiting payroll", from: "Status:"
+    select "Automatically approved awaiting payroll", from: "filter-status-field"
     click_button "Apply filters"
 
     expect_page_to_show_claims(auto_approved_awaiting_payroll_claims)
 
-    select "Rejected", from: "Status:"
+    select "Rejected", from: "filter-status-field"
     click_button "Apply filters"
     expect_page_to_show_claims(rejected_claim)
   end

--- a/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
@@ -77,19 +77,21 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
   end
 
   scenario "Awaiting provider verification claim status" do
-    visit admin_claims_path(status: "awaiting_provider_verification")
+    visit admin_claims_path(filter: {status: "awaiting_provider_verification"})
     find("a[href='#{admin_claim_tasks_path(claim_not_verified)}']").click
     expect(page).to have_content("Awaiting provider verification")
 
     visit admin_claims_path
+    click_link "Clear filters"
     find("a[href='#{admin_claim_tasks_path(claim_with_duplicates_no_provider_email_sent)}']").click
     expect(page).to have_content("Awaiting decision - not on hold")
 
-    visit admin_claims_path(status: "awaiting_provider_verification")
+    visit admin_claims_path(filter: {status: "awaiting_provider_verification"})
     find("a[href='#{admin_claim_tasks_path(claim_with_duplicates_provider_email_sent)}']").click
     expect(page).to have_content("Awaiting provider verification")
 
     visit admin_claims_path
+    click_link "Clear filters"
     find("a[href='#{admin_claim_tasks_path(verified_claim)}']").click
     expect(page).to have_content("Awaiting decision - not on hold")
   end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -542,14 +542,6 @@ describe Admin::ClaimsHelper do
     end
   end
 
-  describe "#claim_status_filters" do
-    subject { helper.claim_status_filters }
-
-    it "returns the list of status filters available" do
-      is_expected.to eq(described_class::STATUS_FILTERS)
-    end
-  end
-
   describe "#index_status_filter" do
     subject { helper.index_status_filter(status) }
 

--- a/spec/requests/admin/admin_claims_spec.rb
+++ b/spec/requests/admin/admin_claims_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Admin claims", type: :request do
 
     it "can filter by policy" do
       early_career_payments_claims = create_list(:claim, 3, :submitted, policy: Policies::EarlyCareerPayments)
-      get admin_claims_path, params: {policy: "early-career-payments"}
+      get admin_claims_path, params: {filter: {policy: "early-career-payments"}}
 
       early_career_payments_claims.each do |c|
         expect(response.body).to include(c.reference)
@@ -75,7 +75,7 @@ RSpec.describe "Admin claims", type: :request do
         c.save
       }
 
-      get admin_claims_path, params: {team_member: mette.id}
+      get admin_claims_path, params: {filter:{team_member: mette.id}}
 
       [
         student_loans_claims_for_mette,

--- a/spec/requests/admin/admin_claims_spec.rb
+++ b/spec/requests/admin/admin_claims_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Admin claims", type: :request do
         c.save
       }
 
-      get admin_claims_path, params: {filter:{team_member: mette.id}}
+      get admin_claims_path, params: {filter: {team_member: mette.id}}
 
       [
         student_loans_claims_for_mette,

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -92,7 +92,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     travel_to(@within_academic_year) do
       visit admin_claims_path
 
-      select "Approved awaiting payroll", from: "Status"
+      select "Approved awaiting payroll", from: "filter-status-field"
       click_on "Apply filters"
 
       find("a[href='#{admin_claim_tasks_path(approved_awaiting_payroll_claim)}']").click
@@ -106,7 +106,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     travel_to(@within_academic_year) do
       visit admin_claims_path
 
-      select "Approved", from: "Status"
+      select "Approved", from: "filter-status-field"
       click_on "Apply filters"
 
       find("a[href='#{admin_claim_tasks_path(approved_paid_claim)}']").click
@@ -119,7 +119,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     travel_to(@within_academic_year) do
       visit admin_claims_path
 
-      select "Rejected", from: "Status"
+      select "Rejected", from: "filter-status-field"
       click_on "Apply filters"
 
       find("a[href='#{admin_claim_tasks_path(rejected_claim)}']").click


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1297
- Admin claims filtering now stays persisted in session

# Changes

- Use govuk formbuilder for filter form
- Form now has anchor so applying filter no longer bounces you to top of page
- Filters are now persisted to session therefore will always be applied unless explicitly cleared 