### PR TITLE
[CAPT-1614] Admin task pagination

### DIFF
--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -1,9 +1,14 @@
 class Admin::DecisionsController < Admin::BaseAdminController
   before_action :ensure_service_operator
   before_action :load_claim
-  before_action :reject_decided_claims, unless: -> { qa_decision_task? }
+  before_action :reject_decided_claims, only: [:new, :create], unless: -> { qa_decision_task? }
   before_action :reject_missing_payroll_gender, only: [:create]
   before_action :reject_if_claims_preventing_payment, only: [:create]
+
+  def index
+    @decisions = @claim.decisions.order(created_at: :asc)
+    @task_pagination = Admin::TaskPagination.new(claim: @claim, current_task_name:)
+  end
 
   def new
     @decision = Decision.new
@@ -96,6 +101,10 @@ class Admin::DecisionsController < Admin::BaseAdminController
   end
 
   def current_task_name
-    "decision"
+    if params[:qa] == "true"
+      "qa_decision"
+    else
+      "decision"
+    end
   end
 end

--- a/app/models/admin/task_pagination.rb
+++ b/app/models/admin/task_pagination.rb
@@ -12,38 +12,51 @@ module Admin
     def next_task_name
       return unless current_task_index.present?
 
-      string = claim_checking_tasks
-        .applicable_task_names[current_task_index + 1]
-
-      string || "decision"
+      claim_checking_tasks
+        .pageable_tasks[current_task_index + 1]
     end
 
     def next_task_path
-      if next_task_name == "decision"
-        new_admin_claim_decision_path(claim)
+      if next_task_name == "qa_decision"
+        if claim.qa_completed?
+          admin_claim_decisions_path(claim, qa: true)
+        else
+          new_admin_claim_decision_path(claim, qa: true)
+        end
+      elsif next_task_name == "decision"
+        if claim.decisions.exists?
+          admin_claim_decisions_path(claim)
+        else
+          new_admin_claim_decision_path(claim)
+        end
       elsif next_task_name.present?
         admin_claim_task_path(claim, name: next_task_name)
       end
     end
 
     def previous_task_name
-      return claim_checking_tasks.applicable_task_names.last unless current_task_index.present?
+      return claim_checking_tasks.pageable_tasks.last unless current_task_index.present?
 
       previous_index = current_task_index - 1
-      (previous_index >= 0) ? claim_checking_tasks.applicable_task_names[current_task_index - 1] : nil
+      (previous_index >= 0) ? claim_checking_tasks.pageable_tasks[current_task_index - 1] : nil
     end
 
     def previous_task_path
       return unless previous_task_name.present?
 
-      admin_claim_task_path(claim, name: previous_task_name)
+      case previous_task_name
+      when "decision"
+        admin_claim_decisions_path(claim)
+      else
+        admin_claim_task_path(claim, name: previous_task_name)
+      end
     end
 
     private
 
     def current_task_index
       claim_checking_tasks
-        .applicable_task_names
+        .pageable_tasks
         .index(current_task_name)
     end
 

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -5,6 +5,15 @@
 class ClaimCheckingTasks
   attr_reader :claim
 
+  def self.formatted_task_name(task_name)
+    case task_name
+    when "qa_decision"
+      "QA decision"
+    else
+      task_name.humanize
+    end
+  end
+
   def initialize(claim)
     @claim = claim
   end
@@ -22,7 +31,7 @@ class ClaimCheckingTasks
         .new(claim)
         .applicable_task_names
     else
-      @applicable_task_names ||= Task::NAMES.dup.tap do |task_names|
+      Task::NAMES.dup.tap do |task_names|
         task_names.delete("previous_payment")
         task_names.delete("previous_residency")
         task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
@@ -40,6 +49,14 @@ class ClaimCheckingTasks
         task_names.delete("provider_verification")
       end
     end
+  end
+
+  def pageable_tasks
+    array = applicable_task_names
+    array << "decision"
+    array << "qa_decision" if claim.qa_required?
+
+    array
   end
 
   # Returns an Array of tasks names that have not been completed on the claim.

--- a/app/views/admin/_task_pagination.html.erb
+++ b/app/views/admin/_task_pagination.html.erb
@@ -1,24 +1,9 @@
-<nav class="govuk-pagination govuk-pagination--block" aria-label="results">
-<% if task_pagination.previous_task_name.present? %>
-  <div class="govuk-pagination__prev">
-    <%= link_to task_pagination.previous_task_path, class: "govuk-link govuk-pagination__link", rel: "prev" do %>
-      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-      </svg>
-      <span class="govuk-pagination__link-title">Previous</span><span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label"><%= task_pagination.previous_task_name.humanize %></span>
-    <% end %>
-  </div>
-<% end %>
+<%= govuk_pagination(block_mode: true) do |p| %>
+  <% if task_pagination.previous_task_name.present? %>
+    <% p.with_previous_page(text: "Previous", label_text: task_pagination.previous_task_name.humanize, href: task_pagination.previous_task_path) %>
+  <% end %>
 
-<% if task_pagination.next_task_name.present? %>
-  <div class="govuk-pagination__next">
-    <%= link_to task_pagination.next_task_path, class: "govuk-link govuk-pagination__link", rel: "next" do %>
-      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
-      <span class="govuk-pagination__link-label"><%= task_pagination.next_task_name.humanize %></span>
-    <% end %>
-  </div>
+  <% if task_pagination.next_task_name.present? %>
+    <% p.with_next_page(text: "Next", label_text: task_pagination.next_task_name.humanize, href: task_pagination.next_task_path) %>
+  <% end %>
 <% end %>
-</nav>

--- a/app/views/admin/_task_pagination.html.erb
+++ b/app/views/admin/_task_pagination.html.erb
@@ -1,9 +1,9 @@
 <%= govuk_pagination(block_mode: true) do |p| %>
   <% if task_pagination.previous_task_name.present? %>
-    <% p.with_previous_page(text: "Previous", label_text: task_pagination.previous_task_name.humanize, href: task_pagination.previous_task_path) %>
+    <% p.with_previous_page(text: "Previous", label_text: ClaimCheckingTasks.formatted_task_name(task_pagination.previous_task_name), href: task_pagination.previous_task_path) %>
   <% end %>
 
   <% if task_pagination.next_task_name.present? %>
-    <% p.with_next_page(text: "Next", label_text: task_pagination.next_task_name.humanize, href: task_pagination.next_task_path) %>
+    <% p.with_next_page(text: "Next", label_text: ClaimCheckingTasks.formatted_task_name(task_pagination.next_task_name), href: task_pagination.next_task_path) %>
   <% end %>
 <% end %>

--- a/app/views/admin/claims/policies/early_career_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/early_career_payments/_claim.html.erb
@@ -14,8 +14,9 @@
 
     <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
-    <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% (decisions = @claim.decisions.order(created_at: :asc)).each do |decision| %>
+      <% heading = (decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/policies/early_years_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/early_years_payments/_claim.html.erb
@@ -10,8 +10,9 @@
 
     <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
-    <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% (decisions = @claim.decisions.order(created_at: :asc)).each do |decision| %>
+      <% heading = (decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
@@ -98,14 +98,9 @@
       }
     ) if @matching_claims.any? %>
 
-    <% if @decision.persisted? %>
-      <%= render(
-        "admin/claims/answer_section",
-        {
-          heading: "Claim decision details",
-          answers: admin_decision_details(@decision)
-        }
-      ) %>
+    <% (decisions = @claim.decisions.order(created_at: :asc)).each do |decision| %>
+      <% heading = (decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/policies/international_relocation_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/international_relocation_payments/_claim.html.erb
@@ -10,8 +10,9 @@
 
     <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
-    <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% (decisions = @claim.decisions.order(created_at: :asc)).each do |decision| %>
+      <% heading = (decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/policies/levelling_up_premium_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/levelling_up_premium_payments/_claim.html.erb
@@ -14,8 +14,9 @@
 
     <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
-    <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% (decisions = @claim.decisions.order(created_at: :asc)).each do |decision| %>
+      <% heading = (decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/policies/student_loans/_claim.html.erb
+++ b/app/views/admin/claims/policies/student_loans/_claim.html.erb
@@ -10,8 +10,9 @@
 
     <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
-    <% if @decision.persisted? %>
-      <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
+    <% (decisions = @claim.decisions.order(created_at: :asc)).each do |decision| %>
+      <% heading = (decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/decisions/index.html.erb
+++ b/app/views/admin/decisions/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} decision") } %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <%= render "admin/tasks/#{claim_summary_view}", claim: @claim, heading: "Claim decision" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% @decisions.each do |decision| %>
+      <% heading = (@decisions.first == decision ? "Claim decision details" : nil) %>
+      <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>
+    <% end %>
+
+    <%= render partial: "admin/task_pagination", locals: { task_pagination: @task_pagination } %>
+  </div>
+</div>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -56,7 +56,11 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to "Approve or reject this claim", new_admin_claim_decision_path(@claim), class: "govuk-link" %>
+                <% if @claim.decisions.exists? %>
+                  <%= govuk_link_to "Approve or reject this claim", admin_claim_decisions_path(@claim) %>
+                <% else %>
+                  <%= govuk_link_to "Approve or reject this claim", new_admin_claim_decision_path(@claim) %>
+                <% end %>
               </span>
               <% if @claim.held? %>
                 <strong class="govuk-tag app-task-list__task-completed govuk-tag--warning">On Hold</strong>
@@ -77,7 +81,11 @@
             <ul class="app-task-list__items">
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
-                  <%= link_to "Approve or reject quality assurance of this claim", new_admin_claim_decision_path(@claim, qa: true), class: "govuk-link" %>
+                  <% if @claim.qa_completed? %>
+                    <%= govuk_link_to "Approve or reject quality assurance of this claim", admin_claim_decisions_path(@claim, qa: true) %>
+                  <% else %>
+                    <%= govuk_link_to "Approve or reject quality assurance of this claim", new_admin_claim_decision_path(@claim, qa: true) %>
+                  <% end %>
                 </span>
                 <% unless @claim.awaiting_qa? %>
                   <% if @claim.latest_decision&.approved? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
     resources :claims, only: [:index, :show] do
       resources :tasks, only: [:index, :show, :create, :update], param: :name, constraints: {name: %r{#{Task::NAMES.join("|")}}}
       resources :payroll_gender_tasks, only: [:create], param: :name, name: "payroll_gender"
-      resources :decisions, only: [:create, :new] do
+      resources :decisions, only: [:create, :new, :index] do
         resources :undos, only: [:create, :new], controller: "decisions_undo"
       end
       resources :amendments, only: [:index, :new, :create]

--- a/spec/features/admin/tasks/pagination_spec.rb
+++ b/spec/features/admin/tasks/pagination_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.feature "Admin paginates thru tasks" do
+  before do
+    sign_in_as_service_operator
+  end
+
+  context "when new claim" do
+    let!(:claim) { create(:claim, :submitted) }
+
+    scenario "can paginate thru to decision" do
+      visit admin_claims_path
+      click_link claim.reference
+      click_link "Check student loan amount"
+      click_link "Next:Decision"
+
+      expect(page).to have_link "Previous:Student loan amount"
+      expect(page).not_to have_content "Next"
+    end
+  end
+
+  context "when claim approved and needs QA" do
+    let!(:claim) { create(:claim, :submitted, :flagged_for_qa) }
+
+    scenario "can pagainate thru to QA decision" do
+      visit admin_claims_path
+      click_link claim.reference
+      click_link "Check student loan amount"
+      click_link "Next:Decision"
+
+      expect(page).to have_link "Previous:Student loan amount"
+      click_link "Next:QA decision"
+
+      expect(page).to have_link "Previous:Decision"
+      expect(page).not_to have_content "Next"
+    end
+  end
+
+  context "when QA-ed" do
+    let!(:decision) { create(:decision, :approved, claim:) }
+    let!(:claim) { create(:claim, :submitted, :qa_completed) }
+
+    scenario "can pagainate thru to QA decision" do
+      visit admin_claim_tasks_path(claim.id)
+      click_link "Check student loan amount"
+      click_link "Next:Decision"
+
+      expect(page).to have_link "Previous:Student loan amount"
+      click_link "Next:QA decision"
+
+      expect(page).to have_link "Previous:Decision"
+      expect(page).not_to have_content "Next"
+    end
+  end
+end

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{claim.full_name} submit the claim?")
-    expect(page).to have_link("Next: Qualifications")
+    expect(page).to have_link("Next:Qualifications")
     expect(page).not_to have_link("Previous")
 
     choose "Yes"
@@ -38,8 +38,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(claim.eligibility.itt_academic_year.to_s(:long))
     expect(page).to have_content("ITT subject")
     expect(page).to have_content(claim.eligibility.eligible_itt_subject.humanize)
-    expect(page).to have_link("Next: Census subjects taught")
-    expect(page).to have_link("Previous: Identity confirmation")
+    expect(page).to have_link("Next:Census subjects taught")
+    expect(page).to have_link("Previous:Identity confirmation")
 
     choose "Yes"
     click_on "Save and continue"
@@ -48,8 +48,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
 
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.census_subjects_taught.title"))
     expect(page).to have_content("Subject Mathematics")
-    expect(page).to have_link("Next: Employment")
-    expect(page).to have_link("Previous: Qualifications")
+    expect(page).to have_link("Next:Employment")
+    expect(page).to have_link("Previous:Qualifications")
 
     choose "Yes"
     click_on "Save and continue"
@@ -59,8 +59,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.employment.title"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
-    expect(page).to have_link("Next: Student loan plan")
-    expect(page).to have_link("Previous: Census subjects taught")
+    expect(page).to have_link("Next:Student loan plan")
+    expect(page).to have_link("Previous:Census subjects taught")
 
     choose "Yes"
     click_on "Save and continue"
@@ -68,16 +68,16 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
 
     expect(page).to have_content("Student loan plan")
-    expect(page).to have_link("Next: Decision")
-    expect(page).to have_link("Previous: Employment")
+    expect(page).to have_link("Next:Decision")
+    expect(page).to have_link("Previous:Employment")
     expect(page).to have_content("Passed")
     expect(page).not_to have_button("Save and continue")
 
-    click_link "Next: Decision"
+    click_link "Next:Decision"
 
     expect(page).to have_content("Claim decision")
     expect(page).not_to have_link("Next")
-    expect(page).to have_link("Previous: Student loan plan")
+    expect(page).to have_link("Previous:Student loan plan")
 
     choose "Approve"
     fill_in "Decision notes", with: "All checks passed!"
@@ -95,7 +95,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{claim.full_name} submit the claim?")
-    expect(page).to have_link("Next: Qualifications")
+    expect(page).to have_link("Next:Qualifications")
     expect(page).not_to have_link("Previous")
 
     choose "Yes"
@@ -108,8 +108,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(claim.eligibility.itt_academic_year.to_s(:long))
     expect(page).to have_content("ITT subject")
     expect(page).to have_content(claim.eligibility.eligible_itt_subject.humanize)
-    expect(page).to have_link("Next: Induction confirmation")
-    expect(page).to have_link("Previous: Identity confirmation")
+    expect(page).to have_link("Next:Induction confirmation")
+    expect(page).to have_link("Previous:Identity confirmation")
 
     choose "Yes"
     click_on "Save and continue"
@@ -119,8 +119,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.induction_confirmation.title"))
     expect(page).to have_content("ITT #{claim.eligibility.postgraduate_itt? ? "start" : "end"} year")
     expect(page).to have_content(claim.eligibility.itt_academic_year.to_s(:long))
-    expect(page).to have_link("Next: Census subjects taught")
-    expect(page).to have_link("Previous: Qualifications")
+    expect(page).to have_link("Next:Census subjects taught")
+    expect(page).to have_link("Previous:Qualifications")
 
     choose "Yes"
     click_on "Save and continue"
@@ -129,8 +129,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
 
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.census_subjects_taught.title"))
     expect(page).to have_content("Subject Mathematics")
-    expect(page).to have_link("Next: Employment")
-    expect(page).to have_link("Previous: Induction confirmation")
+    expect(page).to have_link("Next:Employment")
+    expect(page).to have_link("Previous:Induction confirmation")
 
     choose "Yes"
     click_on "Save and continue"
@@ -140,8 +140,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.employment.title"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
-    expect(page).to have_link("Next: Student loan plan")
-    expect(page).to have_link("Previous: Census subjects taught")
+    expect(page).to have_link("Next:Student loan plan")
+    expect(page).to have_link("Previous:Census subjects taught")
 
     choose "Yes"
     click_on "Save and continue"
@@ -149,16 +149,16 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
 
     expect(page).to have_content("Student loan plan")
-    expect(page).to have_link("Next: Decision")
-    expect(page).to have_link("Previous: Employment")
+    expect(page).to have_link("Next:Decision")
+    expect(page).to have_link("Previous:Employment")
     expect(page).to have_content("Passed")
     expect(page).not_to have_button("Save and continue")
 
-    click_link "Next: Decision"
+    click_link "Next:Decision"
 
     expect(page).to have_content("Claim decision")
     expect(page).not_to have_link("Next")
-    expect(page).to have_link("Previous: Student loan plan")
+    expect(page).to have_link("Previous:Student loan plan")
 
     choose "Approve"
     fill_in "Decision notes", with: "All checks passed!"
@@ -176,7 +176,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{claim.full_name} submit the claim?")
-    expect(page).to have_link("Next: Qualifications")
+    expect(page).to have_link("Next:Qualifications")
     expect(page).not_to have_link("Previous")
 
     choose "Yes"
@@ -187,8 +187,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications.title"))
     expect(page).to have_content("Award year")
     expect(page).to have_content(I18n.t("student_loans.answers.qts_award_years.#{claim.eligibility.qts_award_year}", year: Policies::StudentLoans.first_eligible_qts_award_year(claim.academic_year).to_s(:long)))
-    expect(page).to have_link("Next: Census subjects taught")
-    expect(page).to have_link("Previous: Identity confirmation")
+    expect(page).to have_link("Next:Census subjects taught")
+    expect(page).to have_link("Previous:Identity confirmation")
 
     choose "Yes"
     click_on "Save and continue"
@@ -197,8 +197,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
 
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.census_subjects_taught.title"))
     expect(page).to have_content("Subjects taught Physics")
-    expect(page).to have_link("Next: Employment")
-    expect(page).to have_link("Previous: Qualifications")
+    expect(page).to have_link("Next:Employment")
+    expect(page).to have_link("Previous:Qualifications")
 
     choose "Yes"
     click_on "Save and continue"
@@ -208,8 +208,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.employment.title"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
-    expect(page).to have_link("Next: Student loan amount")
-    expect(page).to have_link("Previous: Census subjects taught")
+    expect(page).to have_link("Next:Student loan amount")
+    expect(page).to have_link("Previous:Census subjects taught")
 
     choose "Yes"
     click_on "Save and continue"
@@ -219,8 +219,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content(I18n.t("student_loans.admin.task_questions.student_loan_amount.title"))
     expect(page).to have_content("£1,000.00")
     expect(page).to have_content("Plan 1")
-    expect(page).to have_link("Next: Decision")
-    expect(page).to have_link("Previous: Employment")
+    expect(page).to have_link("Next:Decision")
+    expect(page).to have_link("Previous:Employment")
 
     choose "Yes"
     click_on "Save and continue"
@@ -229,7 +229,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
 
     expect(page).to have_content("Claim decision")
     expect(page).not_to have_link("Next")
-    expect(page).to have_link("Previous: Student loan amount")
+    expect(page).to have_link("Previous:Student loan amount")
 
     choose "Approve"
     fill_in "Decision notes", with: "All checks passed!"
@@ -247,7 +247,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.identity_confirmation.title"))
-    expect(page).to have_link("Next: Provider verification")
+    expect(page).to have_link("Next:Provider verification")
     expect(page).not_to have_link("Previous")
 
     choose "Yes"
@@ -256,8 +256,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
 
     expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.provider_verification.title"))
-    expect(page).to have_link("Next: Student loan plan")
-    expect(page).to have_link("Previous: Identity confirmation")
+    expect(page).to have_link("Next:Student loan plan")
+    expect(page).to have_link("Previous:Identity confirmation")
 
     choose "Yes"
     click_on "Save and continue"
@@ -267,14 +267,14 @@ RSpec.shared_examples "Admin Checks" do |policy|
     expect(page).to have_content("Student loan plan")
     expect(page).to have_content("Passed")
     expect(page).not_to have_button("Save and continue")
-    expect(page).to have_link("Next: Decision")
-    expect(page).to have_link("Previous: Provider verification")
+    expect(page).to have_link("Next:Decision")
+    expect(page).to have_link("Previous:Provider verification")
 
-    click_link "Next: Decision"
+    click_link "Next:Decision"
 
     expect(page).to have_content("Claim decision")
     expect(page).not_to have_link("Next")
-    expect(page).to have_link("Previous: Student loan plan")
+    expect(page).to have_link("Previous:Student loan plan")
 
     choose "Approve"
     fill_in "Decision notes", with: "All checks passed!"


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1614
- Improve admins paginating thru tasks, so they can now paginate thru to `Decision` or `QA decision`
- The decision page now shows previous decisions rather than show full claim

# Changes

- There is a new admin `DecisonsController#index` action that displays all the previous decisions made on a claim in chronological order
- We now show this page when a decision has been made
- So when paginating thru tasks to `Decision` we now show the above page
- If QA is required we show next task as `QA decision` which displayed QA decision form
- if QA is completed we show all previous decisions

# Notes for review

- We have both a mixture of `tasks` and `decisions` from a code perspective though from a UI perspective these are all deemed as tasks. Why we have these 2 different concepts I do not know and is a decision made prior to my time.
- Given this future improvements could be to get rid of `decisions` altogether and convert these to tasks to homogenise everything
- OR write some kind of wrapper to do hide these concepts, which I feel is probably way too much effort for reward gained
- The concept of `decisions` are agnostic, there is no data so to signify if it was the original approval or a QA approval. as are result in this code and existing code there need to flags passed around to deal with this shortcoming. To remedy this we should probably attach the type of decision it was rather than guessing