### PR TITLE
[CAPT-1402] Back office can filter for auto approved claims

### DIFF
--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -48,6 +48,8 @@ class Admin::ClaimsFilterForm
         Claim.approved.awaiting_qa
       when "approved_awaiting_payroll"
         approved_awaiting_payroll
+      when "automatically_approved"
+        Claim.current_academic_year.auto_approved
       when "automatically_approved_awaiting_payroll"
         Claim.current_academic_year.payrollable.auto_approved
       when "rejected"
@@ -94,6 +96,7 @@ class Admin::ClaimsFilterForm
       ["Awaiting decision - failed bank details", "failed_bank_validation"],
       ["Approved awaiting QA", "approved_awaiting_qa"],
       ["Approved awaiting payroll", "approved_awaiting_payroll"],
+      ["Automatically approved", "automatically_approved"],
       ["Automatically approved awaiting payroll", "automatically_approved_awaiting_payroll"],
       ["Approved", "approved"],
       ["Rejected", "rejected"]

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
       claim.academic_year = claim_academic_year unless claim.academic_year_before_type_cast
     end
 
+    trait :current_academic_year do
+      academic_year { AcademicYear.current }
+    end
+
     trait :with_onelogin_idv_data do
       identity_confirmed_with_onelogin { true }
       onelogin_uid { SecureRandom.uuid }

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -80,5 +80,21 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         )
       end
     end
+
+    context "filtering for unassigned + auto approved claims" do
+      subject { described_class.new(session:, filters: {team_member:, status:}) }
+
+      let(:team_member) { "unassigned" }
+      let(:status) { "automatically_approved" }
+      let(:session) { {} }
+
+      before do
+        create(:claim, :submitted, :auto_approved, :current_academic_year)
+      end
+
+      it "works" do
+        expect(subject.claims.count).to eql(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1402
- Back office can filter for auto approved claims