### PR TITLE
CAPT-1850 show Start button only when the jounrney is open on the landing page

### DIFF
--- a/app/views/early_years_payment/provider/start/landing_page.html.erb
+++ b/app/views/early_years_payment/provider/start/landing_page.html.erb
@@ -132,6 +132,7 @@
       <%= govuk_link_to("early years financial incentive payment", "#") %>.
     </p>
 
+    <%# TODO: There isn't any journey closed content, for now hide the button %>
     <% if @journey_open %>
       <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>
     <% end %>

--- a/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
@@ -58,6 +58,8 @@
        "contact details for the school where you are employed"
      ], type: :bullet %>
 
+     <%# TODO: There isn't any journey closed content, for now hide the button %>
+     <% if @journey_open %>
      <p class="govuk-body">
        <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
          Start
@@ -66,6 +68,7 @@
          </svg>
        </a>
      </p>
+     <% end %>
 
      <h2 class="govuk-heading-l">Deadline for applications</h2>
 

--- a/app/views/student_loans/landing_page.html.erb
+++ b/app/views/student_loans/landing_page.html.erb
@@ -22,13 +22,15 @@
     </ul>
 
     <p class="govuk-body">
-      It takes around 5 minutes to check if you're eligible and another 5 minutes to apply.
+      It takes around 5 minutes to check if you’re eligible and another 5 minutes to apply.
     </p>
 
     <p class="govuk-body">
       You must apply before 31 March <%= @academic_year.end_year.to_s %>.
     </p>
 
+    <%# TODO: There isn't any journey closed content, for now hide the button %>
+    <% if @journey_open %>
     <p class="govuk-!-margin-top-8">
         <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now
@@ -36,12 +38,13 @@
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
           </svg>
         </a>
-      </p>
+    </p>
+    <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-4">Before you start</h2>
 
     <p class="govuk-body">
-      You can use DfE Identity with this service. You'll need to provide your personal details including your National Insurance number and teacher reference number (TRN).
+      You can use DfE Identity with this service. You’ll need to provide your personal details including your National Insurance number and teacher reference number (TRN).
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,7 +375,7 @@ en:
     award_description: "claim payment"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     feedback_email: "studentloanteacherpayment@digital.education.gov.uk"
-    landing_page: "Claim back student loan repayments if you're a teacher"
+    landing_page: "Claim back student loan repayments if you’re a teacher"
     questions:
       academic_year: "Academic year you completed your Initial Teacher Training (ITT)"
       claim_school_select_error: "Select the school you taught at between %{financial_year}"

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Backlinking during a claim" do
     expect(page).to have_text("Use DfE Identity to sign in")
     expect(page).to have_link("Back")
     click_on "Back"
-    expect(page).to have_text("Claim back student loan repayments if you're a teacher")
+    expect(page).to have_text("Claim back student loan repayments if you’re a teacher")
   end
 
   scenario "ECP/LUP journey" do


### PR DESCRIPTION
This was missing on student loans, EY practitioner and IRP.