### PR TITLE
[CAPT-1854] Provider verification status

### DIFF
--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -57,7 +57,7 @@ class Admin::ClaimsFilterForm
       when "failed_bank_validation"
         Claim.includes(:decisions).failed_bank_validation.awaiting_decision
       when "awaiting_provider_verification"
-        Claim.by_policy(Policies::FurtherEducationPayments).awaiting_further_education_provider_verification
+        Claim.by_policy(Policies::FurtherEducationPayments).awaiting_further_education_provider_verification.awaiting_decision
       else
         Claim.includes(:decisions).not_held.awaiting_decision.not_awaiting_further_education_provider_verification
       end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -172,9 +172,7 @@ module Admin
     end
 
     def status(claim)
-      if claim.awaiting_provider_verification?
-        "Awaiting provider verification"
-      elsif claim.all_payrolled?
+      if claim.all_payrolled?
         "Payrolled"
       elsif claim.latest_decision&.approved? && claim.awaiting_qa? && !claim.held?
         "Approved awaiting QA"
@@ -182,6 +180,8 @@ module Admin
         "Approved awaiting payroll"
       elsif claim.latest_decision&.rejected?
         "Rejected"
+      elsif claim.awaiting_provider_verification?
+        "Awaiting provider verification"
       elsif claim.held?
         "Awaiting decision - on hold"
       else

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -309,6 +309,14 @@ FactoryBot.define do
       end
     end
 
+    trait :awaiting_provider_verification do
+      eligibility_trait { :not_verified }
+
+      after(:create) do |claim, _|
+        create(:note, claim:, label: "provider_verification")
+      end
+    end
+
     trait :with_dqt_teacher_status do
       dqt_teacher_status do
         {

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Admin::ClaimsFilterForm, type: :model do
+  describe "#claims" do
+    context "when rejected whilst awaiting provider verification" do
+      let!(:claim) do
+        create(
+          :claim,
+          :rejected,
+          :awaiting_provider_verification,
+          policy: Policies::FurtherEducationPayments,
+        )
+      end
+
+      let(:session) { {} }
+      let(:filters) { { status: "awaiting_provider_verification" } }
+
+      subject { described_class.new(filters:, session:) }
+
+      it "filtering by status awaiting provider verification excludes them" do
+        expect(subject.claims).not_to include(claim)
+      end
+    end
+  end
+end

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
           :claim,
           :rejected,
           :awaiting_provider_verification,
-          policy: Policies::FurtherEducationPayments,
+          policy: Policies::FurtherEducationPayments
         )
       end
 
       let(:session) { {} }
-      let(:filters) { { status: "awaiting_provider_verification" } }
+      let(:filters) { {status: "awaiting_provider_verification"} }
 
       subject { described_class.new(filters:, session:) }
 

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -547,7 +547,7 @@ describe Admin::ClaimsHelper do
           :claim,
           :rejected,
           :awaiting_provider_verification,
-          policy: Policies::FurtherEducationPayments,
+          policy: Policies::FurtherEducationPayments
         )
       end
 

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -540,6 +540,23 @@ describe Admin::ClaimsHelper do
         end
       end
     end
+
+    context "rejected claim whilst awaiting provider verification" do
+      let!(:claim) do
+        create(
+          :claim,
+          :rejected,
+          :awaiting_provider_verification,
+          policy: Policies::FurtherEducationPayments,
+        )
+      end
+
+      it "returns rejected" do
+        freeze_time do
+          expect(status(claim)).to eql "Rejected"
+        end
+      end
+    end
   end
 
   describe "#index_status_filter" do


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1854
- Fixes issue with provider verification status in back office
- If claim is rejected, this takes precedence over provider verification
- when filtering claims for `provider verification` it only includes claims awaiting a decision