### PR TITLE
Fix duplciate claims in list

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -9,7 +9,7 @@ module Admin
     end
 
     def new
-      @claims = Claim.payrollable
+      @claims = Claim.payrollable.order(submitted_at: :asc)
 
       # Due to limitations with the current payroll software we need a temporary
       # cap on the number of claims that can enter payroll, especially expecting

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -66,11 +66,9 @@ class Admin::ClaimsFilterForm
     @claims = @claims.by_claims_team_member(selected_team_member, status) if selected_team_member
     @claims = @claims.unassigned if unassigned?
 
+    @claims = Claim.where(id: @claims.select("DISTINCT ON (claims.id) claims.id"))
+
     @claims = @claims.includes(:tasks, eligibility: [:claim_school, :current_school])
-
-    @claims = @claims.select("DISTINCT ON (claims.id) claims.id")
-
-    @claims = Claim.where(id: @claims)
 
     @claims = @claims.order(:submitted_at)
     @claims

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -67,8 +67,12 @@ class Admin::ClaimsFilterForm
     @claims = @claims.unassigned if unassigned?
 
     @claims = @claims.includes(:tasks, eligibility: [:claim_school, :current_school])
-    @claims = @claims.order(:submitted_at)
 
+    @claims = @claims.select("DISTINCT ON (claims.id, claims.submitted_at) claims.id")
+
+    @claims = Claim.where(id: @claims)
+
+    @claims = @claims.order(:submitted_at)
     @claims
   end
 

--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -68,7 +68,7 @@ class Admin::ClaimsFilterForm
 
     @claims = @claims.includes(:tasks, eligibility: [:claim_school, :current_school])
 
-    @claims = @claims.select("DISTINCT ON (claims.id, claims.submitted_at) claims.id")
+    @claims = @claims.select("DISTINCT ON (claims.id) claims.id")
 
     @claims = Claim.where(id: @claims)
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -205,7 +205,7 @@ class Claim < ApplicationRecord
 
   delegate :award_amount, to: :eligibility
 
-  scope :payrollable, -> { approved.not_awaiting_qa.left_joins(:payments).where(payments: nil).order(submitted_at: :asc) }
+  scope :payrollable, -> { approved.not_awaiting_qa.left_joins(:payments).where(payments: nil) }
   scope :not_awaiting_qa, -> { approved.where("qa_required = false OR (qa_required = true AND qa_completed_at IS NOT NULL)") }
   scope :awaiting_qa, -> { approved.qa_required.where(qa_completed_at: nil) }
   scope :qa_required, -> { where(qa_required: true) }

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -21,5 +21,64 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         expect(subject.claims).not_to include(claim)
       end
     end
+
+    context "when the status is awaiting_provider_verification" do
+      it "returns the expected claims" do
+        claim_awaiting_provider_verification_1 = build(
+          :claim,
+          :submitted
+        )
+
+        create(
+          :further_education_payments_eligibility,
+          claim: claim_awaiting_provider_verification_1,
+          flagged_as_duplicate: false
+        )
+
+        claim_awaiting_provider_verification_2 = build(
+          :claim,
+          :submitted
+        )
+
+        create(
+          :further_education_payments_eligibility,
+          claim: claim_awaiting_provider_verification_2,
+          flagged_as_duplicate: true
+        )
+
+        create(
+          :note,
+          claim: claim_awaiting_provider_verification_2,
+          label: "provider_verification"
+        )
+
+        create(
+          :note,
+          claim: claim_awaiting_provider_verification_2,
+          label: "provider_verification"
+        )
+
+        _claim_not_awating_provider_verification = build(:claim, :submitted)
+
+        create(
+          :further_education_payments_eligibility,
+          :verified
+        )
+
+        form = described_class.new(
+          session: {},
+          filters: {
+            status: "awaiting_provider_verification"
+          }
+        )
+
+        expect(form.claims).to match_array(
+          [
+            claim_awaiting_provider_verification_1,
+            claim_awaiting_provider_verification_2
+          ]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
The awaiting provider verification scope joins to notes, claims can have
more than one note, if they do duplicate claims are returned from the
query. To resolve this we call distinct on the claim id. Claims have a
couple of JSON columns so we can't use the `distinct` method directly,
instead we have to explicitly use distinct with the claim.id. We also
need to wrap the whole query in a where clause so when we chain on a
`count` rails generates the correct SQL rather than something like
`SELECT COUNT(count_column) FROM (SELECT DISTINCT ON (claims.id), claims.id)`
Additionally we have to make sure to include `submitted_at` in the
distinct clause as some of the scopes used to build the query include
order by submitted_at clauses.

