### PR TITLE
CAPT 1858/handle missing info

### DIFF
--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -14,7 +14,7 @@ module Policies
       end
 
       def provider_name
-        [verifier.fetch("first_name"), verifier.fetch("last_name")].join(" ")
+        [verifier.fetch("first_name"), verifier.fetch("last_name")].join(" ").presence || verifier.fetch("email")
       end
 
       def provider_verification_submitted?

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -3,6 +3,14 @@ require "rails_helper"
 RSpec.feature "Provider verifying claims" do
   before do
     create(:journey_configuration, :further_education_payments_provider)
+    # Stub fetching name from DSI, not required for these tests
+    stub_request(
+      :get,
+      %r{https://example.com/organisations/.*}
+    ).to_return(
+      status: 404,
+      body: nil
+    )
   end
 
   scenario "provider visits a claim without service access" do

--- a/spec/forms/journeys/further_education_payments/provider/omniauth_callback_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/provider/omniauth_callback_form_spec.rb
@@ -1,8 +1,25 @@
 require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::Provider::OmniauthCallbackForm do
+  let(:school) { create(:school, ukprn: "123456") }
+
+  let(:claim) do
+    create(
+      :claim,
+      policy: Policies::FurtherEducationPayments,
+      eligibility_attributes: {
+        school: school
+      }
+    )
+  end
+
   let(:journey_session) do
-    create(:further_education_payments_provider_session)
+    create(
+      :further_education_payments_provider_session,
+      answers: {
+        claim_id: claim.id
+      }
+    )
   end
 
   let(:form) do
@@ -30,8 +47,8 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::OmniauthCallbackFor
         "uid" => "11111",
         "info" => {
           "email" => "seymore.skinner@springfield-elementary.edu",
-          "first_name" => "Seymoure",
-          "last_name" => "Skinner"
+          "first_name" => info_first_name,
+          "last_name" => info_last_name
         },
         "extra" => {
           "raw_info" => {
@@ -48,47 +65,223 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::OmniauthCallbackFor
     context "with access to the service" do
       let(:service_access) { true }
 
-      it "updates the session with the auth details from dfe signin" do
-        expect { form.save! }.to(
-          change(journey_session.answers, :dfe_sign_in_uid).from(nil).to("11111").and(
-            change(journey_session.answers, :dfe_sign_in_organisation_ukprn)
-              .from(nil)
-              .to("12345678")
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_organisation_id)
-              .from(nil)
-              .to("22222")
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_organisation_name)
-              .from(nil)
-              .to("Springfield Elementary")
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_service_access?)
-              .from(false)
-              .to(true)
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_role_codes)
-              .from([])
-              .to(["teacher_payments_claim_verifier"])
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_first_name)
-              .from(nil)
-              .to("Seymoure")
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_last_name)
-              .from(nil)
-              .to("Skinner")
-          ).and(
-            change(journey_session.answers, :dfe_sign_in_email)
-              .from(nil)
-            .to("seymore.skinner@springfield-elementary.edu")
+      context "when the info payload contains the user's name" do
+        let(:info_first_name) { "Seymoure" }
+        let(:info_last_name) { "Skinner" }
+
+        it "updates the session with the auth details from dfe signin" do
+          expect { form.save! }.to(
+            change(journey_session.answers, :dfe_sign_in_uid).from(nil).to("11111").and(
+              change(journey_session.answers, :dfe_sign_in_organisation_ukprn)
+                .from(nil)
+                .to("12345678")
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_organisation_id)
+                .from(nil)
+                .to("22222")
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_organisation_name)
+                .from(nil)
+                .to("Springfield Elementary")
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_service_access?)
+                .from(false)
+                .to(true)
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_role_codes)
+                .from([])
+                .to(["teacher_payments_claim_verifier"])
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_first_name)
+                .from(nil)
+                .to("Seymoure")
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_last_name)
+                .from(nil)
+                .to("Skinner")
+            ).and(
+              change(journey_session.answers, :dfe_sign_in_email)
+                .from(nil)
+              .to("seymore.skinner@springfield-elementary.edu")
+            )
           )
-        )
+        end
+      end
+
+      context "when the info payload does not contain the user's name" do
+        let(:info_first_name) { nil }
+        let(:info_last_name) { nil }
+
+        before do
+          stub_request(
+            :get,
+            "https://example.com/organisations/123456/users?email=seymore.skinner%40springfield-elementary.edu"
+          ).to_return(
+            status: status,
+            body: body.to_json
+          )
+        end
+
+        context "when the dfe api request isn't successful" do
+          let(:status) { 404 }
+          let(:body) do
+            {}
+          end
+
+          it "updates the session with the auth details from dfe signin" do
+            expect { form.save! }.to(
+              change(journey_session.answers, :dfe_sign_in_uid).from(nil).to("11111").and(
+                change(journey_session.answers, :dfe_sign_in_organisation_ukprn)
+                  .from(nil)
+                  .to("12345678")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_organisation_id)
+                  .from(nil)
+                  .to("22222")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_organisation_name)
+                  .from(nil)
+                  .to("Springfield Elementary")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_service_access?)
+                  .from(false)
+                  .to(true)
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_role_codes)
+                  .from([])
+                  .to(["teacher_payments_claim_verifier"])
+              ).and(
+                not_change(journey_session.answers, :dfe_sign_in_first_name)
+                  .from(nil)
+              ).and(
+                not_change(journey_session.answers, :dfe_sign_in_last_name)
+                  .from(nil)
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_email)
+                  .from(nil)
+                .to("seymore.skinner@springfield-elementary.edu")
+              )
+            )
+          end
+        end
+
+        # Edge case: I don't think this can happen IRL as the user has just signed into that org!
+        context "when the dfe api request doesn't include the user" do
+          let(:status) { 200 }
+          let(:body) do
+            {
+              "ukprn" => "12345678",
+              "users" => [
+                {
+                  "email" => "someone-else@springfield-elementary.edu",
+                  "firstName" => "Seymoure",
+                  "lastName" => "Skinner",
+                  "userStatus" => 1,
+                  "roles" => ["teacher_payments_claim_verifier"]
+                }
+              ]
+            }
+          end
+
+          it "updates the session with the auth details from dfe signin" do
+            expect { form.save! }.to(
+              change(journey_session.answers, :dfe_sign_in_uid).from(nil).to("11111").and(
+                change(journey_session.answers, :dfe_sign_in_organisation_ukprn)
+                  .from(nil)
+                  .to("12345678")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_organisation_id)
+                  .from(nil)
+                  .to("22222")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_organisation_name)
+                  .from(nil)
+                  .to("Springfield Elementary")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_service_access?)
+                  .from(false)
+                  .to(true)
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_role_codes)
+                  .from([])
+                  .to(["teacher_payments_claim_verifier"])
+              ).and(
+                not_change(journey_session.answers, :dfe_sign_in_first_name)
+                  .from(nil)
+              ).and(
+                not_change(journey_session.answers, :dfe_sign_in_last_name)
+                  .from(nil)
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_email)
+                  .from(nil)
+                .to("seymore.skinner@springfield-elementary.edu")
+              )
+            )
+          end
+        end
+
+        context "when the dfe api request is successful" do
+          let(:status) { 200 }
+          let(:body) do
+            {
+              "ukprn" => "12345678",
+              "users" => [
+                {
+                  "email" => "seymore.skinner@springfield-elementary.edu",
+                  "firstName" => "Seymoure",
+                  "lastName" => "Skinner",
+                  "userStatus" => 1,
+                  "roles" => ["teacher_payments_claim_verifier"]
+                }
+              ]
+            }
+          end
+
+          it "updates the session with the auth details from dfe signin" do
+            expect { form.save! }.to(
+              change(journey_session.answers, :dfe_sign_in_uid).from(nil).to("11111").and(
+                change(journey_session.answers, :dfe_sign_in_organisation_ukprn)
+                  .from(nil)
+                  .to("12345678")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_organisation_id)
+                  .from(nil)
+                  .to("22222")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_organisation_name)
+                  .from(nil)
+                  .to("Springfield Elementary")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_service_access?)
+                  .from(false)
+                  .to(true)
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_role_codes)
+                  .from([])
+                  .to(["teacher_payments_claim_verifier"])
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_first_name)
+                  .from(nil)
+                  .to("Seymoure")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_last_name)
+                  .from(nil)
+                  .to("Skinner")
+              ).and(
+                change(journey_session.answers, :dfe_sign_in_email)
+                  .from(nil)
+                .to("seymore.skinner@springfield-elementary.edu")
+              )
+            )
+          end
+        end
       end
     end
 
     context "without access to the service" do
       let(:service_access) { false }
+      let(:info_first_name) { "Seymoure" }
+      let(:info_last_name) { "Skinner" }
 
       it "sets the service access flag to false" do
         expect { form.save! }.to(


### PR DESCRIPTION
The omniauth hash from DfE sign in is not populating the first name and
last name fields. We require these fields when displaying who verified a
claim. This commit adds a fallback to request this information from the
DSI api, if it's not present in the oauth payload.

