### PR TITLE
Fixes missing reference for claim

### DIFF
--- a/app/forms/claim_submission_base_form.rb
+++ b/app/forms/claim_submission_base_form.rb
@@ -27,6 +27,8 @@ class ClaimSubmissionBaseForm
 
     ClaimMailer.submitted(claim).deliver_later
     ClaimVerifierJob.perform_later(claim)
+
+    true
   end
 
   private

--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -2,7 +2,7 @@ module Journeys
   module FurtherEducationPayments
     class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
       def save
-        super
+        return false unless super
 
         if Policies::FurtherEducationPayments.duplicate_claim?(claim)
           claim.eligibility.update!(flagged_as_duplicate: true)

--- a/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
@@ -108,9 +108,12 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
       ).and_return(double(deliver_later: nil))
 
       first_claim_form = described_class.new(journey_session: journey_session)
-      second_claim_form = described_class.new(journey_session: journey_session)
 
       first_claim_form.save
+
+      journey_session.update! claim: nil
+      second_claim_form = described_class.new(journey_session: journey_session)
+
       second_claim_form.save
 
       expect(ClaimMailer).to(


### PR DESCRIPTION
If the form is invalid, say the journey session has already been
submitted and the user double clicks the submit button, we need to
return early from the child `save` method to avoid calling the mailer
with a claim that hasn't been saved (which triggeres an error as the
claim has no reference number).

<!-- Do you need to update CHANGELOG.md? -->
