### PR TITLE
[LUPEYALPHA-1162] separate practitioner_claim_submitted_at for EY practitioner journey

### DIFF
--- a/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
@@ -18,7 +18,7 @@ module Journeys
             reference_number:,
             start_email: email,
             reference_number_found: existing_claim.present?,
-            claim_already_submitted: existing_claim&.submitted?,
+            claim_already_submitted: existing_claim&.eligibility&.practitioner_claim_submitted?,
             nursery_name: existing_claim&.eligibility&.eligible_ey_provider&.nursery_name
           )
           journey_session.save!

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -16,6 +16,10 @@ module Policies
       def eligible_ey_provider
         EligibleEyProvider.find_by_urn(nursery_urn)
       end
+
+      def practitioner_claim_submitted?
+        practitioner_claim_submitted_at.present?
+      end
     end
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -318,3 +318,4 @@ shared:
     - returning_within_6_months
     - created_at
     - updated_at
+    - practitioner_claim_submitted_at

--- a/db/migrate/20241015093740_add_practitioner_claim_submitted_at_to_early_years_payment_eligibilities.rb
+++ b/db/migrate/20241015093740_add_practitioner_claim_submitted_at_to_early_years_payment_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddPractitionerClaimSubmittedAtToEarlyYearsPaymentEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :early_years_payment_eligibilities, :practitioner_claim_submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_24_113642) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_15_093740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -197,6 +197,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_24_113642) do
     t.date "start_date"
     t.boolean "child_facing_confirmation_given"
     t.boolean "returning_within_6_months"
+    t.datetime "practitioner_claim_submitted_at"
   end
 
   create_table "eligible_ey_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/early_years_payments/eligibilities.rb
+++ b/spec/factories/early_years_payments/eligibilities.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :early_years_payments_eligibility, class: "Policies::EarlyYearsPayments::Eligibility" do
+    trait :practitioner_claim_submitted do
+      practitioner_claim_submitted_at { Time.zone.now }
+    end
   end
 end

--- a/spec/features/early_years_payment/practitioner/find_reference_spec.rb
+++ b/spec/features/early_years_payment/practitioner/find_reference_spec.rb
@@ -6,7 +6,8 @@ RSpec.feature "Early years find reference" do
       :claim,
       policy: Policies::EarlyYearsPayments,
       reference: "foo",
-      practitioner_email_address: "user@example.com"
+      practitioner_email_address: "user@example.com",
+      submitted_at: Time.zone.now
     )
   end
 
@@ -67,7 +68,7 @@ RSpec.feature "Early years find reference" do
         :claim,
         :submitted,
         policy: Policies::EarlyYearsPayments,
-        eligibility: build(:early_years_payments_eligibility, nursery_urn: eligible_ey_provider.urn),
+        eligibility: build(:early_years_payments_eligibility, :practitioner_claim_submitted, nursery_urn: eligible_ey_provider.urn),
         reference: "foo",
         practitioner_email_address: "user@example.com"
       )

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -1,19 +1,18 @@
 require "rails_helper"
 
 RSpec.feature "Early years payment practitioner" do
-  let(:claim) do
-    create(
-      :claim,
-      policy: Policies::EarlyYearsPayments,
-      reference: "foo",
-      practitioner_email_address: "user@example.com"
-    )
-  end
+  let(:email_address) { "johndoe@example.com" }
+  let(:journey_session) { Journeys::EarlyYearsPayment::Provider::Authenticated::Session.last }
+  let(:mail) { ActionMailer::Base.deliveries.last }
+  let(:magic_link) { mail[:personalisation].unparsed_value[:magic_link] }
+  let!(:nursery) { create(:eligible_ey_provider, primary_key_contact_email_address: email_address) }
+  let(:claim) { Claim.last }
 
   scenario "Happy path" do
+    when_early_years_payment_provider_authenticated_journey_submitted
     when_early_years_payment_practitioner_journey_configuration_exists
 
-    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=user@example.com"
+    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=practitioner@example.com"
     expect(page).to have_content "Enter your claim reference"
     fill_in "Claim reference number", with: claim.reference
     click_button "Submit"

--- a/spec/support/steps/eligible_ey_journey_authenticated.rb
+++ b/spec/support/steps/eligible_ey_journey_authenticated.rb
@@ -28,3 +28,12 @@ def when_early_years_payment_provider_authenticated_journey_ready_to_submit
   fill_in "claim-practitioner-email-address-field", with: "practitioner@example.com"
   click_button "Continue"
 end
+
+def when_early_years_payment_provider_authenticated_journey_submitted
+  when_early_years_payment_provider_authenticated_journey_configuration_exists
+  when_early_years_payment_provider_start_journey_completed
+  when_early_years_payment_provider_authenticated_journey_ready_to_submit
+
+  fill_in "claim-provider-contact-name-field", with: "John Doe"
+  click_button "Accept and send"
+end


### PR DESCRIPTION
new field on EY eligibility: `practitioner_claim_submitted_at for EY practitioner journey` - used instead of `claim.submitted_at` to check if claim has been submitted by the practitioner.