### PR TITLE
[LUPEYALPHA-1163] Migration so claim#reference cannot be NULL

### DIFF
--- a/db/migrate/20241015121145_add_not_null_reference.rb
+++ b/db/migrate/20241015121145_add_not_null_reference.rb
@@ -1,0 +1,5 @@
+class AddNotNullReference < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :claims, :reference, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_15_093740) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_15_121145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -56,7 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_15_093740) do
     t.string "bank_sort_code", limit: 6
     t.string "bank_account_number", limit: 8
     t.datetime "submitted_at", precision: nil
-    t.string "reference", limit: 8
+    t.string "reference", limit: 8, null: false
     t.boolean "has_student_loan"
     t.integer "student_loan_country"
     t.integer "student_loan_courses"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
   factory :claim do
     started_at { Time.zone.now }
+    reference { Reference.new.to_s }
 
     transient do
       policy { Policies::StudentLoans }

--- a/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/nqt_in_academic_year_after_itt_form_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::NqtInAcademicYearAfterIt
                 logged_in_with_tid: true
               }.merge(
                 attributes_for(:claim, :with_dqt_teacher_status)
-                .except(:started_at)
+                .except(:started_at, :reference)
               )
             end
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1163
- Migration to add not NULL constraint so `Claim#reference` cannot be NULL
- DB level constraints prevents us getting into bad data integrity situations