### PR TITLE
Create backup storage account for test env

### DIFF
--- a/terraform/application/config/test.tfvars.json
+++ b/terraform/application/config/test.tfvars.json
@@ -10,5 +10,6 @@
   "enable_monitoring": true,
   "statuscake_contact_groups": [195955, 282453],
   "external_url": "https://test.claim-additional-teaching-payment.service.gov.uk/healthcheck",
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_postgres_backup_storage": true
 }


### PR DESCRIPTION
## Context

Create backup storage account for test environment, to allow backup workflow testing [and DR]

## Changes proposed in this pull request

Set enable_postgres_backup_storage in test env tfvars

## Guidance to review

make test-aks terraform-plan-aks

## Link to Trello card

https://trello.com/c/g8swAO8Q/2090-capt-enable-test-backup-storage-account

