### PR TITLE
[LUPEYALPHA-989] EY Practitioner check-your-answers page

### DIFF
--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -2,10 +2,6 @@ module Journeys
   module EarlyYearsPayment
     module Practitioner
       class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
-        def main_eligibility
-          @main_eligibility ||= eligibilities.detect { |e| e.policy == main_policy }
-        end
-
         def calculate_award_amount(eligibility)
           0
         end
@@ -18,6 +14,14 @@ module Journeys
 
         def generate_policy_options_provided
           []
+        end
+
+        def build_or_find_claim
+          claim = Claim.find_by(reference: journey_session.answers.reference_number) || new_claim
+          # TODO - set a new field: eligibility.practitioner_claim_started_at?
+          set_claim_attributes_from_answers(claim, answers)
+
+          claim
         end
       end
     end

--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -13,6 +13,12 @@ module Journeys
         def main_policy
           Policies::EarlyYearsPayments
         end
+
+        private
+
+        def generate_policy_options_provided
+          []
+        end
       end
     end
   end

--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -16,12 +16,13 @@ module Journeys
           []
         end
 
-        def build_or_find_claim
-          claim = Claim.find_by(reference: journey_session.answers.reference_number) || new_claim
-          set_claim_attributes_from_answers(claim, answers)
-          claim.eligibility.practitioner_claim_submitted_at = Time.zone.now
-          # TODO - do we need to set a new field here?: eligibility.practitioner_claim_started_at
-          claim
+        def new_or_find_claim
+          Claim.find_by(reference: journey_session.answers.reference_number) || Claim.new
+        end
+
+        def set_submitted_at_attributes
+          claim.eligibility.practitioner_claim_started_at = journey_session.created_at
+          claim.submitted_at = Time.zone.now
         end
       end
     end

--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -18,9 +18,9 @@ module Journeys
 
         def build_or_find_claim
           claim = Claim.find_by(reference: journey_session.answers.reference_number) || new_claim
-          # TODO - set a new field: eligibility.practitioner_claim_started_at?
           set_claim_attributes_from_answers(claim, answers)
-
+          claim.eligibility.practitioner_claim_submitted_at = Time.zone.now
+          # TODO - do we need to set a new field here?: eligibility.practitioner_claim_started_at
           claim
         end
       end

--- a/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
@@ -18,7 +18,7 @@ module Journeys
             reference_number:,
             start_email: email,
             reference_number_found: existing_claim.present?,
-            claim_already_submitted: existing_claim&.eligibility&.practitioner_claim_submitted?,
+            claim_already_submitted: existing_claim&.submitted?,
             nursery_name: existing_claim&.eligibility&.eligible_ey_provider&.nursery_name
           )
           journey_session.save!

--- a/app/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form.rb
@@ -13,10 +13,6 @@ module Journeys
 
           private
 
-          def main_eligibility
-            @main_eligibility ||= eligibilities.first
-          end
-
           def calculate_award_amount(eligibility)
             # NOOP
             # This is just for compatibility with the AdditionalPaymentsForTeaching

--- a/app/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form.rb
@@ -22,6 +22,10 @@ module Journeys
           def generate_policy_options_provided
             []
           end
+
+          def set_submitted_at_attributes
+            claim.eligibility.provider_claim_submitted_at = Time.zone.now
+          end
         end
       end
     end

--- a/app/forms/journeys/early_years_payment/provider/start/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/start/claim_submission_form.rb
@@ -5,10 +5,6 @@ module Journeys
         class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
           private
 
-          def main_eligibility
-            @main_eligibility ||= Policies::EarlyYearsPayments::Eligibility.new
-          end
-
           def calculate_award_amount(eligibility)
             # NOOP
             # This is just for compatibility with the AdditionalPaymentsForTeaching

--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -19,10 +19,6 @@ module Journeys
 
       private
 
-      def main_eligibility
-        @main_eligibility ||= eligibilities.first
-      end
-
       def calculate_award_amount(eligibility)
         # NOOP
         # This is just for compatibility with the AdditionalPaymentsForTeaching

--- a/app/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form.rb
@@ -3,10 +3,6 @@ module Journeys
     class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
       private
 
-      def main_eligibility
-        @main_eligibility ||= eligibilities.first
-      end
-
       def calculate_award_amount(eligibility)
         eligibility.award_amount = Policies::InternationalRelocationPayments.award_amount
       end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_submission_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_submission_form.rb
@@ -3,10 +3,6 @@ module Journeys
     class ClaimSubmissionForm < ::ClaimSubmissionBaseForm
       private
 
-      def main_eligibility
-        @main_eligibility ||= eligibilities.first
-      end
-
       def calculate_award_amount(eligibility)
         # NOOP
         # This is just for compatibility with the AdditionalPaymentsForTeaching

--- a/app/jobs/claim_verifier_job.rb
+++ b/app/jobs/claim_verifier_job.rb
@@ -1,12 +1,14 @@
 class ClaimVerifierJob < ApplicationJob
   def perform(claim)
-    AutomatedChecks::ClaimVerifier.new(
-      claim:,
-      dqt_teacher_status: claim.has_dqt_record? ? Dqt::Teacher.new(claim.dqt_teacher_status) : Dqt::Client.new.teacher.find(
-        claim.eligibility.teacher_reference_number,
-        birthdate: claim.date_of_birth.to_s,
-        nino: claim.national_insurance_number
-      )
-    ).perform
+    if claim.eligibility.respond_to?(:teacher_reference_number)
+      AutomatedChecks::ClaimVerifier.new(
+        claim:,
+        dqt_teacher_status: claim.has_dqt_record? ? Dqt::Teacher.new(claim.dqt_teacher_status) : Dqt::Client.new.teacher.find(
+          claim.eligibility.teacher_reference_number,
+          birthdate: claim.date_of_birth.to_s,
+          nino: claim.national_insurance_number
+        )
+      ).perform
+    end
   end
 end

--- a/app/models/journeys/early_years_payment/practitioner/answers_presenter.rb
+++ b/app/models/journeys/early_years_payment/practitioner/answers_presenter.rb
@@ -1,0 +1,30 @@
+module Journeys
+  module EarlyYearsPayment
+    module Practitioner
+      class AnswersPresenter < BaseAnswersPresenter
+        include ActionView::Helpers::TranslationHelper
+
+        def identity_answers
+          [].tap do |a|
+            a << ["Full name", answers.full_name, "personal-details"]
+            a << ["Date of birth", date_of_birth_string, "personal-details"]
+            a << ["National Insurance number", answers.national_insurance_number, "personal-details"]
+            a << ["Home address", answers.address, "enter-home-address"]
+            a << ["Preferred email address", answers.email_address, "email-address"]
+            a << ["Provide mobile number?", answers.provide_mobile_number? ? "Yes" : "No", "provide-mobile-number"]
+            a << ["Preferred mobile number", answers.mobile_number, "mobile-number"] if answers.provide_mobile_number?
+          end
+        end
+
+        def payment_answers
+          [].tap do |a|
+            a << ["Name on the account", answers.banking_name, "personal-bank-account"]
+            a << ["Sort code", answers.bank_sort_code, "personal-bank-account"]
+            a << ["Account number", answers.bank_account_number, "personal-bank-account"]
+            a << ["Payroll gender", answers.payroll_gender, "gender"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -17,8 +17,8 @@ module Policies
         EligibleEyProvider.find_by_urn(nursery_urn)
       end
 
-      def practitioner_claim_submitted?
-        practitioner_claim_submitted_at.present?
+      def provider_claim_submitted?
+        provider_claim_submitted_at.present?
       end
     end
   end

--- a/app/views/early_years_payment/practitioner/claims/check_your_answers.html.erb
+++ b/app/views/early_years_payment/practitioner/claims/check_your_answers.html.erb
@@ -1,1 +1,29 @@
-placeholder
+<% content_for(
+  :page_title,
+  page_title(
+    t("early_years_payment_practitioner.check_your_answers.title"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%# Errors are from the SubmissionsController %>
+    <% if @form.errors.any? %>
+      <%= render("shared/error_summary", instance: @form) %>
+    <% end %>
+
+    <h1 class="govuk-heading-xl">
+      <%= t("early_years_payment_practitioner.check_your_answers.title") %>
+    </h1>
+
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Personal details", answers: journey.answers_for_claim(@form.journey_session).identity_answers} %>
+
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Bank account information", answers: journey.answers_for_claim(@form.journey_session).payment_answers} %>
+
+    <%= form_with url: claim_submission_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_submit t("early_years_payment_practitioner.check_your_answers.btn_text") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/early_years_payment/practitioner/submissions/show.html.erb
+++ b/app/views/early_years_payment/practitioner/submissions/show.html.erb
@@ -1,0 +1,1 @@
+placeholder

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -318,4 +318,5 @@ shared:
     - returning_within_6_months
     - created_at
     - updated_at
-    - practitioner_claim_submitted_at
+    - provider_claim_submitted_at
+    - practitioner_claim_started_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1431,6 +1431,9 @@ en:
         label: Your email address
         hint1: We’ll use this to update you with progress on your claim.
         hint2: We recommend you use a non-work email address in case your circumstances change while we process your claim.
+    check_your_answers:
+      title: Check your answers before submitting this claim
+      btn_text: Accept and send
   activerecord:
     errors:
       models:

--- a/db/migrate/20241017113701_add_provider_claim_submitted_at_to_early_years_payment_eligibilities.rb
+++ b/db/migrate/20241017113701_add_provider_claim_submitted_at_to_early_years_payment_eligibilities.rb
@@ -1,0 +1,7 @@
+class AddProviderClaimSubmittedAtToEarlyYearsPaymentEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :early_years_payment_eligibilities, :provider_claim_submitted_at, :datetime
+    add_column :early_years_payment_eligibilities, :practitioner_claim_started_at, :datetime
+    remove_column :early_years_payment_eligibilities, :practitioner_claim_submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_15_121145) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_17_113701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -197,7 +197,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_15_121145) do
     t.date "start_date"
     t.boolean "child_facing_confirmation_given"
     t.boolean "returning_within_6_months"
-    t.datetime "practitioner_claim_submitted_at"
+    t.datetime "provider_claim_submitted_at"
+    t.datetime "practitioner_claim_started_at"
   end
 
   create_table "eligible_ey_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -106,6 +106,10 @@ FactoryBot.define do
       reference { Reference.new.to_s }
     end
 
+    trait :early_years_provider_submitted do
+      reference { Reference.new.to_s }
+    end
+
     trait :policy_options_provided_with_both do
       policy_options_provided {
         [

--- a/spec/factories/early_years_payments/eligibilities.rb
+++ b/spec/factories/early_years_payments/eligibilities.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :early_years_payments_eligibility, class: "Policies::EarlyYearsPayments::Eligibility" do
-    trait :practitioner_claim_submitted do
-      practitioner_claim_submitted_at { Time.zone.now }
+    trait :provider_claim_submitted do
+      provider_claim_submitted_at { Time.zone.now }
     end
   end
 end

--- a/spec/factories/journeys/early_years_payment/practitioner/answers.rb
+++ b/spec/factories/journeys/early_years_payment/practitioner/answers.rb
@@ -1,7 +1,21 @@
 FactoryBot.define do
-  factory(
-    :early_years_payment_practitioner_answers,
-    class: "Journeys::EarlyYearsPayment::Practitioner::SessionAnswers"
-  ) do
+  factory :early_years_payment_practitioner_answers, class: "Journeys::EarlyYearsPayment::Practitioner::SessionAnswers" do
+    trait :eligible do
+      academic_year { AcademicYear.current }
+      email_address { "practitioner@example.com" }
+      email_verified { true }
+      first_name { "John" }
+      surname { "Doe" }
+      provide_mobile_number { false }
+      national_insurance_number { generate(:national_insurance_number) }
+      date_of_birth { 20.years.ago.to_date }
+      banking_name { "John Doe" }
+      bank_sort_code { rand(100000..999999) }
+      bank_account_number { rand(10000000..99999999) }
+    end
+
+    trait :submittable do
+      eligible
+    end
   end
 end

--- a/spec/factories/journeys/early_years_payment/practitioner/answers.rb
+++ b/spec/factories/journeys/early_years_payment/practitioner/answers.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory(
+    :early_years_payment_practitioner_answers,
+    class: "Journeys::EarlyYearsPayment::Practitioner::SessionAnswers"
+  ) do
+  end
+end

--- a/spec/features/early_years_payment/practitioner/find_reference_spec.rb
+++ b/spec/features/early_years_payment/practitioner/find_reference_spec.rb
@@ -6,8 +6,7 @@ RSpec.feature "Early years find reference" do
       :claim,
       policy: Policies::EarlyYearsPayments,
       reference: "foo",
-      practitioner_email_address: "user@example.com",
-      submitted_at: Time.zone.now
+      practitioner_email_address: "user@example.com"
     )
   end
 
@@ -68,7 +67,7 @@ RSpec.feature "Early years find reference" do
         :claim,
         :submitted,
         policy: Policies::EarlyYearsPayments,
-        eligibility: build(:early_years_payments_eligibility, :practitioner_claim_submitted, nursery_urn: eligible_ey_provider.urn),
+        eligibility: build(:early_years_payments_eligibility, nursery_urn: eligible_ey_provider.urn),
         reference: "foo",
         practitioner_email_address: "user@example.com"
       )

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -75,8 +75,11 @@ RSpec.feature "Early years payment practitioner" do
     
     expect(page).to have_content("Check your answers before submitting this claim")
     expect do
-        click_on "Accept and send"
-    end.to change { Claim.count }.by(1)
-    .and change { Policies::EarlyYearsPayments::Eligibility.count }.by(1)
+      click_on "Accept and send"
+    end.to change { Claim.count }.by(0)
+      .and change { Policies::EarlyYearsPayments::Eligibility.count }.by(0)
+
+    # check answers were saved on the claim
+    expect(claim.reload.national_insurance_number).to eq "PX321499A"
   end
 end

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -76,10 +76,12 @@ RSpec.feature "Early years payment practitioner" do
     expect(page).to have_content("Check your answers before submitting this claim")
     expect do
       click_on "Accept and send"
-    end.to change { Claim.count }.by(0)
-      .and change { Policies::EarlyYearsPayments::Eligibility.count }.by(0)
+    end.to not_change { Claim.count }
+      .and not_change { Policies::EarlyYearsPayments::Eligibility.count }
+      .and not_change { claim.reload.reference }
 
-    expect(claim.eligibility.reload.practitioner_claim_submitted_at).to be_present
+    expect(claim.eligibility.practitioner_claim_started_at).to be_present
+    expect(claim.reload.submitted_at).to be_present
 
     # check answers were saved on the claim
     expect(claim.reload.national_insurance_number).to eq "PX321499A"

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -72,12 +72,14 @@ RSpec.feature "Early years payment practitioner" do
     expect(page).to have_text(I18n.t("forms.gender.questions.payroll_gender"))
     choose "Female"
     click_on "Continue"
-    
+
     expect(page).to have_content("Check your answers before submitting this claim")
     expect do
       click_on "Accept and send"
     end.to change { Claim.count }.by(0)
       .and change { Policies::EarlyYearsPayments::Eligibility.count }.by(0)
+
+    expect(claim.eligibility.reload.practitioner_claim_submitted_at).to be_present
 
     # check answers were saved on the claim
     expect(claim.reload.national_insurance_number).to eq "PX321499A"

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Early years payment practitioner" do
 
     expect(page).to have_content("Check your answers before submitting this claim")
     expect do
-      click_on "Accept and send"
+      perform_enqueued_jobs { click_on "Accept and send" }
     end.to not_change { Claim.count }
       .and not_change { Policies::EarlyYearsPayments::Eligibility.count }
       .and not_change { claim.reload.reference }

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -71,6 +71,12 @@ RSpec.feature "Early years payment practitioner" do
 
     expect(page).to have_text(I18n.t("forms.gender.questions.payroll_gender"))
     choose "Female"
-    # click_on "Continue"
+    click_on "Continue"
+    
+    expect(page).to have_content("Check your answers before submitting this claim")
+    expect do
+        click_on "Accept and send"
+    end.to change { Claim.count }.by(1)
+    .and change { Policies::EarlyYearsPayments::Eligibility.count }.by(1)
   end
 end

--- a/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
@@ -82,6 +82,8 @@ RSpec.feature "Early years payment provider" do
     claim = Claim.last
     expect(claim.provider_contact_name).to eq "John Doe"
     expect(page).to have_content(claim.reference)
+    expect(claim.submitted_at).to be_nil
+    expect(claim.eligibility.reload.provider_claim_submitted_at).to be_present
   end
 
   scenario "using magic link after having completed some of the journey" do

--- a/spec/forms/journeys/early_years_payment/practitioner/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/practitioner/claim_submission_form_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Practitioner::ClaimSubmissionForm do
+  before do
+    create(:journey_configuration, :early_years_payment_practitioner)
+  end
+
+  let(:journey) { Journeys::EarlyYearsPayment::Practitioner }
+
+  let(:journey_session) { create(:early_years_payment_practitioner_session, answers: answers) }
+  let(:form) { described_class.new(journey_session: journey_session) }
+  let!(:existing_claim) { create(:claim, :early_years_provider_submitted, policy: Policies::EarlyYearsPayments) }
+
+  describe "#save" do
+    subject { form.save }
+
+    let(:claim) { form.claim }
+    let(:eligibility) { claim.eligibility }
+    let(:answers) { build(:early_years_payment_practitioner_answers, :submittable, reference_number: existing_claim.reference) }
+
+    it { is_expected.to be_truthy }
+
+    it "saves some answers into the Claim model" do
+      subject
+      expect(claim.submitted_at).to be_present
+      expect(claim.eligibility_type).to eq "Policies::EarlyYearsPayments::Eligibility"
+      expect(claim.first_name).to eq answers.first_name
+      expect(claim.surname).to eq answers.surname
+      expect(claim.national_insurance_number).to eq answers.national_insurance_number
+      expect(claim.date_of_birth).to eq answers.date_of_birth
+      expect(claim.banking_name).to eq answers.banking_name
+      expect(claim.bank_sort_code).to eq answers.bank_sort_code
+      expect(claim.payroll_gender).to eq answers.payroll_gender
+      expect(claim.email_address).to eq answers.email_address
+    end
+
+    it "saves some answers into the Eligibility model" do
+      subject
+      expect(eligibility.practitioner_claim_started_at).to be_present
+    end
+  end
+end

--- a/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
@@ -77,9 +77,8 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
       let(:claim) do
         create(
           :claim,
-          :submitted,
           policy: Policies::EarlyYearsPayments,
-          eligibility: build(:early_years_payments_eligibility, nursery_urn: eligible_ey_provider.urn),
+          eligibility: build(:early_years_payments_eligibility, :provider_claim_submitted, nursery_urn: eligible_ey_provider.urn),
           reference: "foo"
         )
       end
@@ -97,7 +96,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
           :claim,
           :submitted,
           policy: Policies::EarlyYearsPayments,
-          eligibility: build(:early_years_payments_eligibility, :practitioner_claim_submitted, nursery_urn: eligible_ey_provider.urn),
+          eligibility: build(:early_years_payments_eligibility, nursery_urn: eligible_ey_provider.urn),
           reference: "foo"
         )
       end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimSubmis
     it "saves some answers into the Claim model" do
       subject
       expect(claim.email_address).to eq answers.email_address
-      expect(claim.submitted_at).to be_present
+      expect(claim.submitted_at).to be_nil
       expect(claim.eligibility_type).to eq "Policies::EarlyYearsPayments::Eligibility"
       expect(claim.first_name).to eq answers.first_name
       expect(claim.surname).to eq answers.surname
@@ -37,6 +37,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimSubmis
       expect(eligibility.child_facing_confirmation_given).to eq answers.child_facing_confirmation_given
       expect(eligibility.returning_within_6_months).to eq answers.returning_within_6_months
       expect(eligibility.start_date).to eq answers.start_date
+      expect(eligibility.provider_claim_submitted_at).to be_present
     end
 
     it "sends a notify email to the practitioner" do

--- a/spec/jobs/claim_verifier_job_spec.rb
+++ b/spec/jobs/claim_verifier_job_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe ClaimVerifierJob do
         expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: mock_payload)
         described_class.new.perform(claim)
       end
+
+      context "when the claim does not have a TRN" do
+        let(:claim) { build(:claim, policy: Policies::EarlyYearsPayments) }
+
+        it "does not perform the verifier job" do
+          expect(AutomatedChecks::ClaimVerifier).not_to receive(:new)
+          described_class.new.perform(claim)
+        end
+      end
     end
 
     context "when the claim does not have a DQT record payload" do

--- a/spec/models/journeys/early_years_payment/practitioner/answers_presenter_spec.rb
+++ b/spec/models/journeys/early_years_payment/practitioner/answers_presenter_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsPayment::Practitioner::AnswersPresenter do
+  let(:journey) { Journeys::EarlyYearsPayment }
+  let(:journey_session) { create(:early_years_payment_practitioner_session, answers:) }
+  let(:answers) {
+    build(
+      :early_years_payment_practitioner_answers,
+      first_name: "John",
+      surname: "Doe",
+      date_of_birth: Date.new(1970, 1, 1),
+      national_insurance_number: "QQ123456C",
+      address_line_1: "1",
+      address_line_2: "Some Street",
+      address_line_3: "Some City",
+      postcode: "AB1 C23",
+      email_address: "practitioner@example.com",
+      provide_mobile_number: true,
+      mobile_number: "07700900001",
+      banking_name: "Mr John Doe",
+      bank_account_number: "12345678",
+      bank_sort_code: "123456",
+      payroll_gender: "male"
+    )
+  }
+
+  describe "#identity_answers" do
+    subject { described_class.new(journey_session).identity_answers }
+
+    context "Full name" do
+      it { is_expected.to include(["Full name", "John Doe", "personal-details"]) }
+    end
+
+    context "Date of birth" do
+      it { is_expected.to include(["Date of birth", "1 January 1970", "personal-details"]) }
+    end
+
+    context "National Insurance number" do
+      it { is_expected.to include(["National Insurance number", "QQ123456C", "personal-details"]) }
+    end
+
+    context "Home address" do
+      it { is_expected.to include(["Home address", "1, Some Street, Some City, AB1 C23", "enter-home-address"]) }
+    end
+
+    context "Email address" do
+      it { is_expected.to include(["Preferred email address", "practitioner@example.com", "email-address"]) }
+    end
+
+    context "Mobile number" do
+      it { is_expected.to include(["Provide mobile number?", "Yes", "provide-mobile-number"]) }
+      it { is_expected.to include(["Preferred mobile number", "07700900001", "mobile-number"]) }
+    end
+  end
+
+  describe "#payment_answers" do
+    subject { described_class.new(journey_session).payment_answers }
+
+    context "Bank account name" do
+      it { is_expected.to include(["Name on the account", "Mr John Doe", "personal-bank-account"]) }
+    end
+
+    context "Sort code" do
+      it { is_expected.to include(["Sort code", "123456", "personal-bank-account"]) }
+    end
+
+    context "Account number" do
+      it { is_expected.to include(["Account number", "12345678", "personal-bank-account"]) }
+    end
+
+    context "Payroll gender" do
+      it { is_expected.to include(["Payroll gender", "male", "gender"]) }
+    end
+  end
+end


### PR DESCRIPTION
When the EY practitioner claim is submitted, it will update the existing claim (created by the EY provider) with the answers.

After discussion with @slorek, we decided that `claim.submitted_at` will only be populated when the practitioner submits the claim.
When the provider submits the claim, `claim.eligibility.provider_claim_submitted_at` will be populated.