### PR TITLE
Refactor the mobile form specs

### DIFF
--- a/spec/forms/mobile_number_form_spec.rb
+++ b/spec/forms/mobile_number_form_spec.rb
@@ -68,26 +68,21 @@ RSpec.describe MobileNumberForm do
         end
       end
 
+      before do
+        allow(OneTimePassword::Generator).to receive(:new).and_return(
+          instance_double(OneTimePassword::Generator, code: "111111")
+        )
+
+        allow(NotifySmsMessage).to receive(:new).and_return(notify_double)
+      end
+
       context "when notify response is successful" do
-        before do
-          allow(OneTimePassword::Generator).to receive(:new).and_return(
-            instance_double(OneTimePassword::Generator, code: "111111")
-          )
-
-          allow(NotifySmsMessage).to receive(:new).and_return(notify_double)
-
-          form.save
-        end
-
-        let(:notify_double) do
-          instance_double(NotifySmsMessage, deliver!: notify_response)
-        end
-
         let(:mobile_number) { "07123456789" }
 
-        context "when notify is successful" do
-          let(:notify_response) do
-            Notifications::Client::ResponseNotification.new(
+        let(:notify_double) do
+          instance_double(
+            NotifySmsMessage,
+            deliver!: Notifications::Client::ResponseNotification.new(
               {
                 id: "123",
                 reference: "456",
@@ -96,39 +91,49 @@ RSpec.describe MobileNumberForm do
                 uri: "uri"
               }
             )
-          end
-
-          it "stores the mobile number" do
-            expect(journey_session.reload.answers.mobile_number).to eq(mobile_number)
-          end
-
-          it "resets dependent attributes" do
-            expect(journey_session.reload.answers.mobile_verified).to be_nil
-          end
-
-          it "sends a text message" do
-            expect(NotifySmsMessage).to have_received(:new).with(
-              phone_number: mobile_number,
-              template_id: NotifySmsMessage::OTP_PROMPT_TEMPLATE_ID,
-              personalisation: {
-                otp: "111111"
-              }
-            )
-
-            expect(notify_double).to have_received(:deliver!)
-          end
-
-          it "sets sent_one_time_password_at to the current time" do
-            expect(journey_session.reload.answers.sent_one_time_password_at).to(
-              eq(DateTime.new(2024, 1, 1, 12, 0, 0))
-            )
-          end
+          )
         end
 
-        context "when notify is unsuccessful" do
+        before { form.save }
+
+        it "stores the mobile number" do
+          expect(journey_session.reload.answers.mobile_number).to eq(mobile_number)
+        end
+
+        it "resets dependent attributes" do
+          expect(journey_session.reload.answers.mobile_verified).to be_nil
+        end
+
+        it "sends a text message" do
+          expect(NotifySmsMessage).to have_received(:new).with(
+            phone_number: mobile_number,
+            template_id: NotifySmsMessage::OTP_PROMPT_TEMPLATE_ID,
+            personalisation: {
+              otp: "111111"
+            }
+          )
+
+          expect(notify_double).to have_received(:deliver!)
+        end
+
+        it "sets sent_one_time_password_at to the current time" do
+          expect(journey_session.reload.answers.sent_one_time_password_at).to(
+            eq(DateTime.new(2024, 1, 1, 12, 0, 0))
+          )
+        end
+      end
+
+      context "when notify response is not successful" do
+        context "when the notify response is nil" do
+          let(:mobile_number) { "07123456789" }
+
           # Not sure how this could be nil rather than a bad response but that's
           # what the existing code checks for
-          let(:notify_response) { nil }
+          let(:notify_double) do
+            instance_double(NotifySmsMessage, deliver!: nil)
+          end
+
+          before { form.save }
 
           it "stores the mobile number" do
             expect(journey_session.reload.answers.mobile_number).to eq(mobile_number)
@@ -154,21 +159,17 @@ RSpec.describe MobileNumberForm do
             expect(journey_session.reload.answers.sent_one_time_password_at).to be_nil
           end
         end
-      end
 
-      context "when notify response is not successful" do
         context "when the error is an invalid phone number" do
           let(:mobile_number) { "07123456789" }
 
-          before do
-            notify_double = instance_double(NotifySmsMessage)
+          let(:notify_double) { instance_double(NotifySmsMessage) }
 
+          before do
             allow(notify_double).to receive(:deliver!).and_raise(
               NotifySmsMessage::NotifySmsError,
               "ValidationError: phone_number Number is not valid – double check the phone number you entered"
             )
-
-            allow(NotifySmsMessage).to receive(:new).and_return(notify_double)
           end
 
           it "adds a validation error" do
@@ -185,15 +186,13 @@ RSpec.describe MobileNumberForm do
         context "when some other error" do
           let(:mobile_number) { "07123456789" }
 
-          before do
-            notify_double = instance_double(NotifySmsMessage)
+          let(:notify_double) { instance_double(NotifySmsMessage) }
 
+          before do
             allow(notify_double).to receive(:deliver!).and_raise(
               NotifySmsMessage::NotifySmsError,
               "Something went wrong with the SMS service. Please try again later."
             )
-
-            allow(NotifySmsMessage).to receive(:new).and_return(notify_double)
           end
 
           it "raises the error" do


### PR DESCRIPTION
Cleans up the scenarios so all the failure contexts are grouped together

<!-- Do you need to update CHANGELOG.md? -->
