### PR TITLE
Fix link to approve/reject for reversed claims

### DIFF
--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -56,7 +56,7 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <% if @claim.decisions.exists? %>
+                <% if @claim.decisions.active.exists? %>
                   <%= govuk_link_to "Approve or reject this claim", admin_claim_decisions_path(@claim) %>
                 <% else %>
                   <%= govuk_link_to "Approve or reject this claim", new_admin_claim_decision_path(@claim) %>

--- a/spec/features/admin/admin_reverse_claim_decision_spec.rb
+++ b/spec/features/admin/admin_reverse_claim_decision_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Admin reverses a claim decision" do
+  it "allows admins to reverse a claim decision" do
+    sign_in_as_service_operator
+
+    claim = create(:claim, :submitted)
+
+    visit admin_claim_tasks_path(claim)
+    click_on "Approve or reject this claim"
+    choose "Reject"
+    check "Ineligible subject"
+    click_button "Confirm decision"
+
+    visit new_admin_claim_amendment_path(claim)
+    click_link "Undo decision"
+    fill_in "Change notes", with: "test"
+    click_button "Undo rejection"
+
+    visit admin_claim_tasks_path(claim)
+    click_on "Approve or reject this claim"
+    choose "Approve"
+    click_button "Confirm decision"
+
+    expect(page).to have_content "Claim has been approved successfully"
+  end
+end


### PR DESCRIPTION
The link to "approve/reject claim" changes depending on whether a
decision has been made. When determining if a decision has been made we
need to ignore decisions which have been undone.

If a claim is approved, then the decision is undone, and then the claim
is rejected, it should not show the "This claim has been marked for a
quality assurance review"
