### PR TITLE
Don't show DQT match if DQT record not found

### DIFF
--- a/app/views/admin/tasks/_form.html.erb
+++ b/app/views/admin/tasks/_form.html.erb
@@ -10,7 +10,7 @@
 
       <%
           I18n.t(
-            "#{translation}.body",
+            "#{translation}.body.match.#{f.object.claim_verifier_match.presence || 'nil'}",
             default: nil,
             link: link_to(
               I18n.t("#{translation}.notes"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,7 +418,11 @@ en:
       task_questions:
         identity_confirmation:
           title: "Did %{claim_full_name} submit the claim?"
-          body: "The claimant’s identity matches DQT records. See %{link}."
+          body:
+            match:
+              none: "No DQT record found. See %{link}."
+              any: "The claimant’s identity matches DQT records. See %{link}."
+              all: "The claimant’s identity matches DQT records. See %{link}."
           notes: "notes"
         qualifications:
           title:
@@ -661,7 +665,11 @@ en:
           title: "Does the claimant’s current school match the above information from their claim?"
         identity_confirmation:
           title: "Did %{claim_full_name} submit the claim?"
-          body: "The claimant’s identity matches DQT records. See %{link}."
+          body:
+            match:
+              none: "No DQT record found. See %{link}."
+              any: "The claimant’s identity matches DQT records. See %{link}."
+              all: "The claimant’s identity matches DQT records. See %{link}."
           notes: "notes"
         qualifications:
           title:

--- a/spec/features/admin/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin/admin_claim_without_verified_identity_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "Admin checking a claim without a verified identity" do
     click_on I18n.t("admin.tasks.identity_confirmation.title")
 
     expect(page).to have_content("Did #{unverified_claim.full_name} submit the claim?")
+    expect(page).not_to have_content("The claimant’s identity matches DQT records.")
     expect(page).to have_content(unverified_claim.eligibility.current_school.name)
     expect(page).to have_content(unverified_claim.eligibility.current_school.phone_number)
 


### PR DESCRIPTION
Don't show DQT match if DQT record not found

If we don't have a DQT record for the claimant we don't want to show the
text "The claimant’s identity matches DQT records.".

The for the identity task `claim_verifier_match` can be in one of 4
states:
`nil` - the check hasn't run or identity was verified by one login¹
`none` - no dqt record was found
`any` - a partial match against the returned dqt record
`all` - a full match against the dqt record

¹ If the claim was verified by one login then the match on the task will
be `nil`, however the way the task form is set up it only renders the
body section if the policy has a corresponding body section in the
locales file. FurtherEducationPayments does not have a body section in
the locales file so we don't show the dqt related messages for these
claims.

The body portion of the form is currently only present in the locales
file for the `identity_confirmation` task and only for
additional_payments and student_loans claims.

We may want to revisit how we indicate claim's have had their identify
confirmed so it's easier to infer how this was done, eg something like
an `source` column on the `Task`, or update the claim with information
about identity confirmation when the idenity claim verifier runs.

