### PR TITLE
[LUPEYALPHA-1173] EY claim rejection reasons

### DIFF
--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -4,7 +4,8 @@ module Policies
     EarlyCareerPayments,
     LevellingUpPremiumPayments,
     InternationalRelocationPayments,
-    FurtherEducationPayments
+    FurtherEducationPayments,
+    EarlyYearsPayments
   ].freeze
 
   AMENDABLE_ELIGIBILITY_ATTRIBUTES = POLICIES.map do |policy|

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -37,6 +37,15 @@ module Policies
     # NOOP as PERSONAL_DATA_ATTRIBUTES_TO_RETAIN_FOR_EXTENDED_PERIOD is empty
     EXTENDED_PERIOD_END_DATE = ->(start_of_academic_year) {}
 
+    # Options shown to admins when rejecting a claim
+    ADMIN_DECISION_REJECTED_REASONS = [
+      :claim_cancelled_by_employer,
+      :six_month_retention_check_failed,
+      :duplicate,
+      :no_response,
+      :other
+    ]
+
     # TODO: This is needed once the reply-to email address has been added to Gov Notify
     def notify_reply_to_id
       nil

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -1,6 +1,8 @@
 module Policies
   module EarlyYearsPayments
     class Eligibility < ApplicationRecord
+      AMENDABLE_ATTRIBUTES = [].freeze
+
       self.table_name = "early_years_payment_eligibilities"
 
       has_one :claim, as: :eligibility, inverse_of: :eligibility

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1418,6 +1418,14 @@ en:
   early_years_payments:
     <<: *early_years_payment_provider_authenticated
     claim_subject: "Early Years Payment"
+    admin:
+      decision:
+        rejected_reasons:
+          claim_cancelled_by_employer: Claim cancelled by employer
+          six_month_retention_check_failed: 6 month retention check failed
+          duplicate: Duplicate
+          no_response: No response
+          other: Other
   early_years_payment_practitioner:
     journey_name: Claim an early years financial incentive payment - practitioner
     feedback_email: "help@opsteam.education.gov.uk"

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -138,6 +138,15 @@ RSpec.describe Decision, type: :model do
         :other
       ]
     end
+    let(:expected_reasons_ey) do
+      [
+        :claim_cancelled_by_employer,
+        :six_month_retention_check_failed,
+        :duplicate,
+        :no_response,
+        :other
+      ]
+    end
 
     context "when the claim policy is ECP" do
       let(:policy) { Policies::EarlyCareerPayments }
@@ -155,6 +164,12 @@ RSpec.describe Decision, type: :model do
       let(:policy) { Policies::StudentLoans }
 
       it { is_expected.to eq(expected_reasons_tslr) }
+    end
+
+    context "when the claim policy is EY" do
+      let(:policy) { Policies::EarlyYearsPayments }
+
+      it { is_expected.to eq(expected_reasons_ey) }
     end
   end
 
@@ -230,6 +245,27 @@ RSpec.describe Decision, type: :model do
           reason_ineligible_qualification: "0",
           reason_no_qts_or_qtls: "1",
           reason_no_repayments_to_slc: "0",
+          reason_duplicate: "0",
+          reason_no_response: "0",
+          reason_other: "0"
+        )
+      end
+    end
+
+    context "with an EY claim" do
+      let(:rejected_reasons) do
+        {
+          rejected_reasons_claim_cancelled_by_employer: "1",
+          rejected_reasons_six_month_retention_check_failed: "1"
+        }
+      end
+
+      let(:claim) { create(:claim, policy: Policies::EarlyYearsPayments) }
+
+      it do
+        is_expected.to eq(
+          reason_claim_cancelled_by_employer: "1",
+          reason_six_month_retention_check_failed: "1",
           reason_duplicate: "0",
           reason_no_response: "0",
           reason_other: "0"


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/LUPEYALPHA-1173

Sets out the reasons for rejecting an EY claim:

 - Claim cancelled by employer
 - 6 month retention check failed
 - Duplicate
 - No response
 - Other
