### PR TITLE
Set verified at on the claim

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -92,7 +92,8 @@ class Claim < ApplicationRecord
     paye_reference: true,
     practitioner_email_address: true,
     provider_contact_name: true,
-    started_at: false
+    started_at: false,
+    verified_at: false
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -79,6 +79,7 @@ shared:
     - onelogin_auth_at
     - onelogin_idv_at
     - started_at
+    - verified_at
   :decisions:
     - id
     - result

--- a/db/migrate/20241028095040_add_verified_at_timestamp_to_claims.rb
+++ b/db/migrate/20241028095040_add_verified_at_timestamp_to_claims.rb
@@ -1,0 +1,5 @@
+class AddVerifiedAtTimestampToClaims < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :verified_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_17_113701) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_28_095040) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -112,6 +112,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_17_113701) do
     t.text "onelogin_idv_last_name"
     t.date "onelogin_idv_date_of_birth"
     t.datetime "started_at", precision: nil, null: false
+    t.datetime "verified_at"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/provider/verify_claim_form_spec.rb
@@ -344,6 +344,8 @@ RSpec.describe Journeys::FurtherEducationPayments::Provider::VerifyClaimForm, ty
           "created_at" => "2024-01-01T12:00:00.000+00:00"
         }
       )
+
+      expect(claim.verified_at).to eq(DateTime.new(2024, 1, 1, 12, 0, 0))
     end
 
     it "creates a provider verification task" do


### PR DESCRIPTION
We need to be able to access the timestamp showing when a claim was verified in big
query. The provider verification is flagged in the analytics block list
so isn't sent over to big query (it's a json structure and some of it's
fields are pii). To ensure big query has access to the verification
timestamp we have added a new column on the claim `Claim#verified_at`
which will be sent over to big query. A follow up PR will back fill this
column on already verified claims.

[Follow up pr](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3347) to back fill the existing claims