### PR TITLE
make verification timestamps available in reports part 2

### DIFF
--- a/db/migrate/20241028110426_back_fill_claims_verified_at.rb
+++ b/db/migrate/20241028110426_back_fill_claims_verified_at.rb
@@ -1,0 +1,8 @@
+class BackFillClaimsVerifiedAt < ActiveRecord::Migration[7.0]
+  def change
+    Policies::FurtherEducationPayments::Eligibility
+      .includes(:claim).where.not(verification: {}).find_each do |eligibility|
+        eligibility.claim.update!(verified_at: eligibility.verification["created_at"])
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_28_095040) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_28_110426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"


### PR DESCRIPTION
Back fill verified_at on verified claims
[PR](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3346) to create the new column
