### PR TITLE
Capture practitioner names

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/claimant_name_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/claimant_name_form.rb
@@ -17,7 +17,12 @@ module Journeys
           def save
             return false if invalid?
 
-            journey_session.answers.assign_attributes(first_name:, surname:)
+            journey_session.answers.assign_attributes(
+              first_name: first_name,
+              surname: surname,
+              practitioner_first_name: first_name,
+              practitioner_surname: surname
+            )
             journey_session.save!
           end
         end

--- a/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session_answers.rb
@@ -14,6 +14,8 @@ module Journeys
           attribute :practitioner_email_address
           attribute :provider_contact_name
           attribute :provider_email_address
+          attribute :practitioner_first_name
+          attribute :practitioner_surname
 
           def policy
             Policies::EarlyYearsPayments

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -133,3 +133,5 @@
   - answers
   :early_years_payment_eligibilities:
   - provider_email_address
+  - practitioner_first_name
+  - practitioner_surname

--- a/db/migrate/20241030153139_add_claimant_details_to_ey_eligibilities.rb
+++ b/db/migrate/20241030153139_add_claimant_details_to_ey_eligibilities.rb
@@ -1,0 +1,6 @@
+class AddClaimantDetailsToEyEligibilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :early_years_payment_eligibilities, :practitioner_first_name, :string
+    add_column :early_years_payment_eligibilities, :practitioner_surname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_28_161228) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_30_153139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -204,6 +204,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_28_161228) do
     t.boolean "returner_worked_with_children"
     t.string "returner_contract_type"
     t.decimal "award_amount", precision: 7, scale: 2
+    t.string "practitioner_first_name"
+    t.string "practitioner_surname"
   end
 
   create_table "eligible_ey_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/journeys/early_years_payment/provider/authenticated/early_years_payment_provider_authenticated_answers.rb
+++ b/spec/factories/journeys/early_years_payment/provider/authenticated/early_years_payment_provider_authenticated_answers.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
       paye_reference { "123/A" }
       first_name { "John" }
       surname { "Doe" }
+      practitioner_first_name { "John" }
+      practitioner_surname { "Doe" }
       start_date { Date.parse("1/1/2024") }
       child_facing_confirmation_given { true }
       returning_within_6_months { true }

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimSubmis
       expect(eligibility.start_date).to eq answers.start_date
       expect(eligibility.provider_claim_submitted_at).to be_present
       expect(eligibility.provider_email_address).to eq "provider@example.com"
+      expect(eligibility.practitioner_first_name).to eq answers.first_name
+      expect(eligibility.practitioner_surname).to eq answers.surname
     end
 
     it "sends a notify email to the practitioner" do

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/claimant_name_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/claimant_name_form_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimantNam
       expect { subject.save }.to(
         change { journey_session.answers.first_name }.to(first_name).and(
           change { journey_session.answers.surname }.to(surname)
+        ).and(
+          change { journey_session.answers.practitioner_first_name }.to(first_name)
+        ).and(
+          change { journey_session.answers.practitioner_surname }.to(surname)
         )
       )
     end


### PR DESCRIPTION
When the provider enters the practitioner name it's stored in the
`Claim#first_name` and `Claim#surname` fields. When the practitioner
completes their portion of the journey the details they entered on the
personal details step overwrites the values entered by the provider in
the `Claim#first_name` and `Claim#surname` fields.
We have a requirement to show and compare both the provider
entered claimant name and practitioner entered claimant name in the
admin area, this commit stores the provider entered name information in
two new fields allowing us to do this.

<!-- Do you need to update CHANGELOG.md? -->
