### PR TITLE
LUPEYALPHA 1171/identity task

### DIFF
--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -17,7 +17,7 @@ class Admin::TasksController < Admin::BaseAdminController
     @notes = @claim.notes.automated.by_label(params[:name])
     @task_pagination = Admin::TaskPagination.new(claim: @claim, current_task_name:)
 
-    render @task.name
+    render task_view(@task)
   end
 
   def create
@@ -102,5 +102,17 @@ class Admin::TasksController < Admin::BaseAdminController
     end
 
     messages
+  end
+
+  def task_view(task)
+    policy = task.claim.policy
+    policy_path = policy.to_s.underscore
+    policy_scoped_task_name = "#{policy_path}/#{task.name}"
+
+    if lookup_context.template_exists?(policy_scoped_task_name, [params[:controller]], false)
+      "admin/tasks/#{policy_scoped_task_name}"
+    else
+      task.name
+    end
   end
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -114,11 +114,17 @@ class OmniauthCallbacksController < ApplicationController
     )
   end
 
+  ONE_LOGIN_TEST_USER = {
+    first_name: "TEST",
+    last_name: "USER",
+    date_of_birth: Date.new(1970, 1, 1)
+  }
+
   def extract_data_from_jwt(jwt)
     if OneLoginSignIn.bypass?
-      first_name = "TEST"
-      last_name = "USER"
-      date_of_birth = Date.new(1970, 1, 1)
+      first_name = ONE_LOGIN_TEST_USER[:first_name]
+      last_name = ONE_LOGIN_TEST_USER[:last_name]
+      date_of_birth = ONE_LOGIN_TEST_USER[:date_of_birth]
     else
       validator = OneLogin::CoreIdentityValidator.new(jwt:)
       validator.call

--- a/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
@@ -1,0 +1,66 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    module EarlyYearsPayments
+      class Identity < AutomatedChecks::ClaimVerifiers::Identity
+        def perform
+          return unless claim.eligibility.practitioner_journey_completed?
+          return unless awaiting_task?(TASK_NAME)
+
+          if one_login_idv_match?
+            create_task(match: nil, passed: true)
+          elsif one_login_idv_partial_match?
+            create_task(match: :any, passed: nil)
+
+            create_note(
+              body: <<-HTML
+              [GOV UK One Login Name] - Names partially match:
+              <pre>
+                Provider: "#{claim.eligibility.practitioner_name}"
+                GOV.UK One Login: "#{claim.onelogin_idv_full_name}"
+              </pre>
+              HTML
+            )
+          elsif claim.one_login_idv_match?
+            create_task(match: nil, passed: false)
+
+            create_note(
+              body: <<-HTML
+              [GOV UK One Login Name] - Names do not match:
+              <pre>
+                Provider: "#{claim.eligibility.practitioner_name}"
+                GOV.UK One Login: "#{claim.onelogin_idv_full_name}"
+              </pre>
+              HTML
+            )
+          else
+            create_task(match: :none, passed: false)
+
+            create_note(
+              body: <<-HTML
+              [GOV UK One Login] - IDV mismatch:
+              <pre>
+                GOV.UK One Login Name: "#{claim.onelogin_idv_full_name}"
+                GOV.UK One Login DOB: "#{claim.onelogin_idv_date_of_birth}"
+              </pre>
+              HTML
+            )
+          end
+        end
+
+        private
+
+        def one_login_idv_match?
+          return false unless claim.one_login_idv_match?
+
+          claim.eligibility.practitioner_and_provider_entered_names_match?
+        end
+
+        def one_login_idv_partial_match?
+          return false unless claim.one_login_idv_match?
+
+          claim.eligibility.practitioner_and_provider_entered_names_partial_match?
+        end
+      end
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -447,6 +447,10 @@ class Claim < ApplicationRecord
     !one_login_idv_name_match? || !one_login_idv_dob_match?
   end
 
+  def one_login_idv_match?
+    one_login_idv_name_match? && one_login_idv_dob_match?
+  end
+
   def awaiting_provider_verification?
     return false unless has_further_education_policy?
 

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -7,7 +7,8 @@ module Policies
     MIN_QA_THRESHOLD = 10
 
     VERIFIERS = [
-      AutomatedChecks::ClaimVerifiers::StudentLoanPlan
+      AutomatedChecks::ClaimVerifiers::StudentLoanPlan,
+      AutomatedChecks::ClaimVerifiers::EarlyYearsPayments::Identity
     ]
 
     # Attributes to delete from claims submitted before the current academic

--- a/app/models/policies/early_years_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_tasks_presenter.rb
@@ -15,6 +15,32 @@ module Policies
           ["Start date", l(claim.eligibility.start_date)]
         ]
       end
+
+      def identity_confirmation
+        []
+      end
+
+      def provider_entered_claimant_name
+        claim.eligibility.practitioner_name
+      end
+
+      def one_login_claimant_name
+        claim.onelogin_idv_full_name
+      end
+
+      def practitioner_journey_completed?
+        claim.eligibility.practitioner_journey_completed?
+      end
+
+      def qualifications
+        []
+      end
+
+      def student_loan_plan
+        [
+          ["Student loan plan", claim.student_loan_plan&.humanize]
+        ]
+      end
     end
   end
 end

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -14,6 +14,7 @@ module Policies
       def applicable_task_names
         tasks = []
 
+        tasks << "identity_confirmation"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
 
         tasks

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -37,6 +37,20 @@ module Policies
       def practitioner_name
         [practitioner_first_name, practitioner_surname].join(" ")
       end
+
+      def practitioner_and_provider_entered_names_match?
+        practitioner_first_name.downcase == claim.onelogin_idv_first_name.downcase &&
+          practitioner_surname.downcase == claim.onelogin_idv_last_name.downcase
+      end
+
+      def practitioner_and_provider_entered_names_partial_match?
+        practitioner_first_name.downcase == claim.onelogin_idv_first_name.downcase ||
+          practitioner_surname.downcase == claim.onelogin_idv_last_name.downcase
+      end
+
+      def practitioner_journey_completed?
+        claim.submitted_at.present?
+      end
     end
   end
 end

--- a/app/views/admin/tasks/early_years_payments/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/early_years_payments/identity_confirmation.html.erb
@@ -1,0 +1,60 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{@claim.policy.short_name}") } %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+  <%= render claim_summary_view, claim: @claim, heading: "Identity confirmation" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m">
+      <%= I18n.t(
+        "admin.tasks.identity_confirmation.title",
+        claim_full_name: @claim.full_name
+      ) %>
+    </h3>
+
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            Provider entered claimant name
+          </th>
+          <td class="govuk-table__cell">
+            <%= @tasks_presenter.provider_entered_claimant_name %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            Claimant name from One login
+          </th>
+          <td class="govuk-table__cell">
+            <%= @tasks_presenter.one_login_claimant_name %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <% if @tasks_presenter.practitioner_journey_completed? %>
+      <% if @task.claim_verifier_match_any? && @task.passed.nil? %>
+        <%= render "form", task_name: "identity_confirmation", claim: @claim %>
+      <% else %>
+        <%= render "task_outcome", task: @task %>
+      <% end %>
+    <% else %>
+      <div class="govuk-inset-text">
+        This task is not available until the claimant has submitted their
+        claim.
+      </div>
+    <% end %>
+
+    <%= render partial: "admin/task_pagination", locals: { task_pagination: @task_pagination } %>
+  </div>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -47,29 +47,6 @@
       "note": "Create and update should be flagged but change is not different from existing behaviour, raising issue."
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "2e15a7fa4c8b8254b7724a1c5b8553cf4f7372f62b9401e1f5cbda1abe8c62ef",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/admin/tasks_controller.rb",
-      "line": 20,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => Claim.includes(:tasks).find(params[:claim_id]).tasks.find_or_initialize_by(:name => params[:name]).name, {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Admin::TasksController",
-        "method": "show"
-      },
-      "user_input": "params[:name]",
-      "confidence": "Weak",
-      "cwe_id": [
-        22
-      ],
-      "note": "Constrained to valid input by routes"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "46bfd0a9d4a19eb048a883184b501b060aa4d6006accc3c76bbfc00722b44dbf",
@@ -116,6 +93,29 @@
       "note": ""
     },
     {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "9e2cf5f527443878fab8807fc6ca1af5a8f27690f312694489183624ab98d66d",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/admin/tasks_controller.rb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => task_view(Claim.includes(:tasks).find(params[:claim_id]).tasks.find_or_initialize_by(:name => params[:name])), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::TasksController",
+        "method": "show"
+      },
+      "user_input": "params[:name]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "f83635b54e1ce0088178d8082ffe632ab8aa81b10fce1026caf87f286cb4d81a",
@@ -139,6 +139,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-10-23 16:53:59 +0100",
+  "updated": "2024-10-30 16:55:54 +0000",
   "brakeman_version": "6.2.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1462,6 +1462,8 @@ en:
       task_questions:
         employment:
           title: Is the claimant still working at the current nursery above?
+        identity_confirmation:
+          title: "Do these names match?"
   early_years_payment_practitioner:
     journey_name: Claim an early years financial incentive payment - practitioner
     feedback_email: "help@opsteam.education.gov.uk"

--- a/spec/features/admin/admin_ey_identity_task_spec.rb
+++ b/spec/features/admin/admin_ey_identity_task_spec.rb
@@ -1,0 +1,379 @@
+require "rails_helper"
+
+RSpec.describe "Admin EY identity task" do
+  around do |example|
+    travel_to DateTime.new(2024, 10, 30, 9, 0, 0) do
+      example.run
+    end
+  end
+
+  context "when the practitioner hasn't completed their half of the claim" do
+    it "shows that the task is unavailable" do
+      claim = complete_provider_journey
+
+      sign_in_as_service_operator
+
+      visit admin_claim_tasks_path(claim)
+
+      expect(task_status("Identity confirmation")).to eq("Incomplete")
+
+      click_on "Confirm the claimant made the claim"
+
+      expect(page).to have_content(
+        "Provider entered claimant name Bobby Bobberson"
+      )
+
+      expect(page).to have_content(
+        "This task is not available until the claimant has submitted their claim"
+      )
+    end
+  end
+
+  context "when the practitioner has completed their half of the claim" do
+    context "when OL IDV is a pass and the names match" do
+      it "passes the task" do
+        claim = complete_provider_journey
+
+        complete_practitioner_journey(
+          claim: claim,
+          date_of_birth: Date.new(1986, 1, 1),
+          one_login_first_name: "Bobby",
+          one_login_last_name: "Bobberson",
+          one_login_date_of_birth: Date.new(1986, 1, 1)
+        )
+
+        sign_in_as_service_operator
+
+        visit admin_claim_tasks_path(claim)
+
+        expect(task_status("Identity confirmation")).to eq("Passed")
+
+        click_on "Confirm the claimant made the claim"
+
+        expect(page).to have_content(
+          "Provider entered claimant name Bobby Bobberson"
+        )
+
+        expect(page).to have_content(
+          "Claimant name from One login Bobby Bobberson"
+        )
+
+        expect(page).to have_content(
+          "This task was performed by GOV.UK One Login on " \
+          "30 October 2024 9:00am"
+        )
+      end
+    end
+
+    context "when OL IDV is a pass and the names don't match" do
+      context "when the names are a parital match" do
+        let(:claim) { complete_provider_journey }
+
+        before do
+          complete_practitioner_journey(
+            claim: claim,
+            one_login_first_name: "Robby",
+            one_login_last_name: "Bobberson",
+            one_login_date_of_birth: Date.new(1986, 1, 1),
+            date_of_birth: Date.new(1986, 1, 1)
+          )
+
+          sign_in_as_service_operator
+        end
+
+        it "shows the task as a partial match" do
+          visit admin_claim_tasks_path(claim)
+
+          expect(task_status("Identity confirmation")).to eq("Partial match")
+
+          click_on "Confirm the claimant made the claim"
+
+          expect(page).to have_content(
+            "Provider entered claimant name Bobby Bobberson"
+          )
+
+          expect(page).to have_content(
+            "Claimant name from One login Robby Bobberson"
+          )
+
+          expect(page).to have_content(
+            "[GOV UK One Login Name] - Names partially match"
+          )
+
+          expect(page).to have_content('Provider: "Bobby Bobberson"')
+
+          expect(page).to have_content('GOV.UK One Login: "Robby Bobberson"')
+        end
+
+        it "allows the admin to mark the task as passed" do
+          visit admin_claim_task_path(claim, name: "identity_confirmation")
+
+          choose "Yes"
+
+          click_on "Save and continue"
+
+          visit admin_claim_task_path(claim, name: "identity_confirmation")
+
+          expect(page).to have_content(
+            "This task was performed by Aaron Admin"
+          )
+
+          visit admin_claim_tasks_path(claim)
+
+          expect(task_status("Identity confirmation")).to eq("Passed")
+        end
+
+        it "allows the admin to mark the task as failed" do
+          visit admin_claim_task_path(claim, name: "identity_confirmation")
+
+          choose "No"
+
+          click_on "Save and continue"
+
+          visit admin_claim_task_path(claim, name: "identity_confirmation")
+
+          expect(page).to have_content(
+            "This task was performed by Aaron Admin"
+          )
+
+          visit admin_claim_tasks_path(claim)
+
+          expect(task_status("Identity confirmation")).to eq("Failed")
+        end
+      end
+
+      context "when the names don't match" do
+        let(:claim) { complete_provider_journey }
+
+        before do
+          complete_practitioner_journey(
+            claim: claim,
+            one_login_first_name: "Robby",
+            one_login_last_name: "Robberson",
+            one_login_date_of_birth: Date.new(1986, 1, 1),
+            date_of_birth: Date.new(1986, 1, 1)
+          )
+
+          sign_in_as_service_operator
+        end
+
+        it "shows the task as failed" do
+          visit admin_claim_tasks_path(claim)
+
+          expect(task_status("Identity confirmation")).to eq("Failed")
+
+          click_on "Confirm the claimant made the claim"
+
+          expect(page).to have_content(
+            "Provider entered claimant name Bobby Bobberson"
+          )
+
+          expect(page).to have_content(
+            "Claimant name from One login Robby Robberson"
+          )
+
+          expect(page).to have_content(
+            "[GOV UK One Login Name] - Names do not match"
+          )
+
+          expect(page).to have_content('Provider: "Bobby Bobberson"')
+
+          expect(page).to have_content('GOV.UK One Login: "Robby Robberson"')
+        end
+
+        it "doesn't allow the admin to complete the task" do
+          visit admin_claim_task_path(claim, name: "identity_confirmation")
+
+          expect(page).not_to have_button("Save and continue")
+        end
+      end
+    end
+
+    context "when OL IDV is a fail" do
+      it "fails the task" do
+        claim = complete_provider_journey
+
+        complete_practitioner_journey(
+          claim: claim,
+          one_login_first_name: "Bobby",
+          one_login_last_name: "Bobberson",
+          date_of_birth: Date.new(1986, 1, 11),
+          one_login_date_of_birth: Date.new(1986, 1, 1)
+        )
+
+        sign_in_as_service_operator
+
+        visit admin_claim_tasks_path(claim)
+
+        expect(task_status("Identity confirmation")).to eq("Failed")
+
+        click_on "Confirm the claimant made the claim"
+
+        expect(page).to have_content(
+          "[GOV UK One Login] - IDV mismatch:"
+        )
+
+        expect(page).to have_content('GOV.UK One Login Name: "Bobby Bobberson"')
+
+        expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
+
+        expect(page).not_to have_button("Save and continue")
+      end
+    end
+  end
+
+  def complete_provider_journey
+    create(:journey_configuration, :early_years_payment_provider_start)
+
+    create(:journey_configuration, :early_years_payment_provider_authenticated)
+
+    nursery = create(
+      :eligible_ey_provider,
+      primary_key_contact_email_address: "johndoe@example.com",
+      secondary_contact_email_address: "janedoe@example.com"
+    )
+
+    visit landing_page_path(
+      Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME
+    )
+
+    click_link "Start now"
+
+    fill_in "Email address", with: "johndoe@example.com"
+    click_on "Submit"
+
+    mail = ActionMailer::Base.deliveries.last
+    magic_link = mail[:personalisation].unparsed_value[:magic_link]
+
+    visit magic_link
+
+    check(
+      "I confirm that I have obtained consent from my employee and have " \
+      "provided them with the relevant privacy notice."
+    )
+    click_button "Continue"
+
+    choose nursery.nursery_name
+    click_button "Continue"
+
+    fill_in "claim-paye-reference-field", with: "123/123456SE90"
+    click_button "Continue"
+
+    fill_in "First name", with: "Bobby"
+    fill_in "Last name", with: "Bobberson"
+    click_button "Continue"
+
+    date = Date.yesterday
+    fill_in("Day", with: date.day)
+    fill_in("Month", with: date.month)
+    fill_in("Year", with: date.year)
+    click_button "Continue"
+
+    # /early-years-payment-provider/child-facing
+    choose "Yes"
+    click_button "Continue"
+
+    # /early-years-payment-provider/returner
+    choose "Yes"
+    click_button "Continue"
+
+    # /early-years-payment-provider/returner-worked-with-children
+    choose "Yes"
+    click_button "Continue"
+
+    # /early-years-payment-provider/returner-contract-type
+    choose "casual or temporary"
+    click_button "Continue"
+
+    # /early-years-payment-provider/employee-email
+    fill_in(
+      "claim-practitioner-email-address-field",
+      with: "practitioner@example.com"
+    )
+
+    click_button "Continue"
+
+    # /early-years-payment-provider/check-your-answers
+    fill_in "claim-provider-contact-name-field", with: "John Doe"
+    perform_enqueued_jobs { click_button "Accept and send" }
+
+    Claim.last
+  end
+
+  def complete_practitioner_journey(
+    claim:,
+    date_of_birth:,
+    one_login_first_name:,
+    one_login_last_name:,
+    one_login_date_of_birth:
+  )
+    stub_const(
+      "OmniauthCallbacksController::ONE_LOGIN_TEST_USER",
+      {
+        first_name: one_login_first_name,
+        last_name: one_login_last_name,
+        date_of_birth: one_login_date_of_birth
+      }
+    )
+
+    create(:journey_configuration, :early_years_payment_practitioner)
+
+    visit "/early-years-payment-practitioner/find-reference?skip_landing_page=true&email=practitioner@example.com"
+
+    fill_in "Claim reference number", with: claim.reference
+
+    click_button "Submit"
+
+    sign_in_with_one_login
+
+    click_on "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "Day", with: date_of_birth.day
+    fill_in "Month", with: date_of_birth.month
+    fill_in "Year", with: date_of_birth.year
+    fill_in "National Insurance number", with: "PX321499A"
+    click_on "Continue"
+
+    expect(page).to have_content("What is your address?")
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    expect(page).to have_content("Your email address")
+    fill_in "claim-email-address-field", with: "johndoe@example.com"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter the 6-digit passcode")
+    mail = ActionMailer::Base.deliveries.last
+    otp_in_mail_sent = mail[:personalisation].unparsed_value[:one_time_password]
+    fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+    click_on "Confirm"
+
+    expect(page).to have_content("Would you like to provide your mobile number?")
+    choose "No"
+    click_on "Continue"
+
+    fill_in "Name on your account", with: "#{claim.first_name} #{claim.surname}"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("forms.gender.questions.payroll_gender"))
+    choose "Male"
+    click_on "Continue"
+
+    expect(page).to have_content("Check your answers before submitting this claim")
+
+    perform_enqueued_jobs { click_on "Accept and send" }
+  end
+
+  def task_status(task_name)
+    find("h2.app-task-list__section", text: task_name)
+      .find(:xpath, 'following-sibling::ul//strong[contains(@class, "govuk-tag")]')
+      .text
+  end
+end

--- a/spec/jobs/claim_verifier_job_spec.rb
+++ b/spec/jobs/claim_verifier_job_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe ClaimVerifierJob do
       end
     end
 
+    context "when the claim is for EarlyYearsPayments" do
+      let(:claim) { build(:claim, policy: Policies::EarlyYearsPayments) }
+
+      it "performs the verifier job but doesn't request dqt info" do
+        expect(AutomatedChecks::ClaimVerifier).to receive(:new)
+        expect(dbl).not_to receive(:find)
+        described_class.new.perform(claim)
+      end
+    end
+
     context "when the claim does not have a DQT record payload" do
       let(:dqt_teacher_status) { nil }
 

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -163,7 +163,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::FurtherEducationPayments
       ["Identity confirmation", "Provider verification", "Student loan plan", "Decision"]
     when Policies::EarlyYearsPayments
-      ["Student loan plan", "Decision"]
+      ["Identity confirmation", "Student loan plan", "Decision"]
     else
       raise "Unimplemented policy: #{policy}"
     end


### PR DESCRIPTION
Might be easier to review each commit separately.

The main change in this pr is adding the Identity task.
The EY identity task behaves slightly differently to the other tasks.
EY practitioners don't have DQT records so we're only using the information
from one login to check identity, additionally the rules around creating the
task are slightly different to other policies.

If the one login check passes and the name returned from OL matches the name
the provider entered the task is a pass

If the one login check passes and the names are a partial match¹ then we
create task with a partial match (see Admin::ClaimsHelper#task_status_tag)

If the one login check passes and the name from OL is different to the
provider supplied name we create a failed task.

If the one login check fails we create a failed task.

If the task is a partial match we render the task form for admins to update the
task (either passing or failing it).
Another quirk is if the practitioner hasn't completed their portion of the
journey we don't want to render the task form, and instead we want to show some
copy informing admins the practitioner is yet to complete their journey.

As there's a few differences between how other identity tasks work we've
introduced a separate task view for EY identity tasks.

¹ - we'll be changing the rules around what counts as a partial match in a
separate ticket.
