### PR TITLE
[LUPEYALPHA-1235] Rejecting EY claim also emails provider

### DIFF
--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -86,6 +86,10 @@ class Admin::DecisionsController < Admin::BaseAdminController
 
     ClaimMailer.approved(@claim).deliver_later if @claim.latest_decision.result == "approved"
     ClaimMailer.rejected(@claim).deliver_later if @claim.latest_decision.result == "rejected"
+
+    if @claim.latest_decision.result == "rejected" && @claim.has_early_years_policy?
+      ClaimMailer.rejected_provider_notification(@claim).deliver_later
+    end
   end
 
   def decision_params

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -85,7 +85,10 @@ class Admin::DecisionsController < Admin::BaseAdminController
     return if @claim.awaiting_qa?
 
     ClaimMailer.approved(@claim).deliver_later if @claim.latest_decision.result == "approved"
-    ClaimMailer.rejected(@claim).deliver_later if @claim.latest_decision.result == "rejected"
+
+    if @claim.latest_decision.result == "rejected" && @claim.email_address.present?
+      ClaimMailer.rejected(@claim).deliver_later
+    end
 
     if @claim.latest_decision.result == "rejected" && @claim.has_early_years_policy?
       ClaimMailer.rejected_provider_notification(@claim).deliver_later

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -42,6 +42,26 @@ class ClaimMailer < ApplicationMailer
     send_mail(template_ids(claim)[:CLAIM_REJECTED_NOTIFY_TEMPLATE_ID], personalisation)
   end
 
+  def rejected_provider_notification(claim)
+    unknown_policy_check(claim)
+    set_common_instance_variables(claim)
+
+    personalisation = {
+      nursery_name: claim.eligibility.eligible_ey_provider.nursery_name,
+      ref_number: claim.reference,
+      practitioner_name: claim.eligibility.practitioner_name,
+      support_email_address: @support_email_address,
+      **rejected_reasons_personalisation(@claim.latest_decision&.rejected_reasons_hash)
+    }
+
+    template_mail(
+      "0c345721-c8d6-493a-95b7-006e84ba9c4e",
+      to: @claim.eligibility.eligible_ey_provider.primary_key_contact_email_address,
+      reply_to_id: @policy.notify_reply_to_id,
+      personalisation:
+    )
+  end
+
   def update_after_three_weeks(claim)
     unknown_policy_check(claim)
     set_common_instance_variables(claim)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -453,6 +453,10 @@ class Claim < ApplicationRecord
     eligibility.awaiting_provider_verification?
   end
 
+  def has_early_years_policy?
+    policy == Policies::EarlyYearsPayments
+  end
+
   private
 
   def one_login_idv_name_match?

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -56,8 +56,6 @@ module Policies
       LevellingUpPremiumPayments
     ]
 
-    VERIFIERS = []
-
     # TODO: This is needed once the reply-to email address has been added to Gov Notify
     def notify_reply_to_id
       nil

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -33,6 +33,10 @@ module Policies
       def employment_task_available?
         Date.today >= employment_task_available_at
       end
+
+      def practitioner_name
+        [practitioner_first_name, practitioner_surname].join(" ")
+      end
     end
   end
 end

--- a/spec/features/admin/admin_reject_claim_spec.rb
+++ b/spec/features/admin/admin_reject_claim_spec.rb
@@ -110,25 +110,51 @@ RSpec.feature "Admin rejects a claim" do
   end
 
   context "early years claim" do
-    let!(:claim) do
-      create(
-        :claim,
-        :submitted,
-        policy: Policies::EarlyYearsPayments
-      )
+    context "claimant has not completed their half" do
+      let!(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          email_address: nil
+        )
+      end
+
+      scenario "rejecting sends email to provider only when claimant yet to complete" do
+        visit admin_claim_tasks_path(claim)
+        click_on "Approve or reject this claim"
+        choose "Reject"
+        check "Claim cancelled by employer"
+
+        expect {
+          click_button "Confirm decision"
+        }.to change { enqueued_jobs.count { |job| job[:job] == ActionMailer::MailDeliveryJob } }.by(1)
+
+        expect(page).to have_content("Claim has been rejected successfully")
+      end
     end
 
-    scenario "rejecting sends email to claimant + provider" do
-      visit admin_claim_tasks_path(claim)
-      click_on "Approve or reject this claim"
-      choose "Reject"
-      check "Claim cancelled by employer"
+    context "claimant has completed their half" do
+      let!(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
 
-      expect {
-        click_button "Confirm decision"
-      }.to change { enqueued_jobs.count { |job| job[:job] == ActionMailer::MailDeliveryJob } }.by(2)
+      scenario "rejecting sends email to claimant + provider" do
+        visit admin_claim_tasks_path(claim)
+        click_on "Approve or reject this claim"
+        choose "Reject"
+        check "Claim cancelled by employer"
 
-      expect(page).to have_content("Claim has been rejected successfully")
+        expect {
+          click_button "Confirm decision"
+        }.to change { enqueued_jobs.count { |job| job[:job] == ActionMailer::MailDeliveryJob } }.by(2)
+
+        expect(page).to have_content("Claim has been rejected successfully")
+      end
     end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1235
- When rejecting an EY claim, provider is also notified via email

# Review notes

- I'm aware that at this moment `ClaimMailer` is not in the best of shape and rather overloaded. I think at some point we need to add some kind of service class(es) to deal with business logic of when to send email leaving mail just to deal with mail