### PR TITLE
[LUPEYALPHA-1241] Extra EY rejection reason: ID check failed

### DIFF
--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -47,6 +47,7 @@ module Policies
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [
       :claim_cancelled_by_employer,
+      :identity_check_failed,
       :six_month_retention_check_failed,
       :duplicate,
       :no_response,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1455,6 +1455,7 @@ en:
       decision:
         rejected_reasons:
           claim_cancelled_by_employer: Claim cancelled by employer
+          identity_check_failed: Identity check failed
           six_month_retention_check_failed: 6 month retention check failed
           duplicate: Duplicate
           no_response: No response

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Decision, type: :model do
     let(:expected_reasons_ey) do
       [
         :claim_cancelled_by_employer,
+        :identity_check_failed,
         :six_month_retention_check_failed,
         :duplicate,
         :no_response,
@@ -169,7 +170,7 @@ RSpec.describe Decision, type: :model do
     context "when the claim policy is EY" do
       let(:policy) { Policies::EarlyYearsPayments }
 
-      it { is_expected.to eq(expected_reasons_ey) }
+      it { is_expected.to eql(expected_reasons_ey) }
     end
   end
 
@@ -265,6 +266,7 @@ RSpec.describe Decision, type: :model do
       it do
         is_expected.to eq(
           reason_claim_cancelled_by_employer: "1",
+          reason_identity_check_failed: "0",
           reason_six_month_retention_check_failed: "1",
           reason_duplicate: "0",
           reason_no_response: "0",


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/LUPEYALPHA-1241
- Add extra EY rejection reason for when ID check fails