### PR TITLE
Reset column information for Claim on a migration

### DIFF
--- a/db/migrate/20241028110426_back_fill_claims_verified_at.rb
+++ b/db/migrate/20241028110426_back_fill_claims_verified_at.rb
@@ -1,5 +1,7 @@
 class BackFillClaimsVerifiedAt < ActiveRecord::Migration[7.0]
   def change
+    Claim.reset_column_information
+
     Policies::FurtherEducationPayments::Eligibility
       .includes(:claim).where.not(verification: {}).find_each do |eligibility|
         eligibility.claim.update!(verified_at: eligibility.verification["created_at"])


### PR DESCRIPTION
A previous migration removing teacher_reference_number causes issues for this migration.

Without this I get this when running `db:migrate` from an blank db.

```
== 20241028110426 BackFillClaimsVerifiedAt: migrating =========================
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

PG::UndefinedColumn: ERROR:  column claims.teacher_reference_number does not exist
LINE 1: ...ode" AS t1_r7, "claims"."date_of_birth" AS t1_r8, "claims"."...
                                                             ^
/Users/ken/code/dfe/claim-additional-payments-for-teaching/db/migrate/20241028110426_back_fill_claims_verified_at.rb:4:in `change'
<internal:/Users/ken/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/Users/ken/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'

Caused by:
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column claims.teacher_reference_number does not exist (ActiveRecord::StatementInvalid)
LINE 1: ...ode" AS t1_r7, "claims"."date_of_birth" AS t1_r8, "claims"."...
                                                             ^
/Users/ken/code/dfe/claim-additional-payments-for-teaching/db/migrate/20241028110426_back_fill_claims_verified_at.rb:4:in `change'
<internal:/Users/ken/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/Users/ken/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'

Caused by:
PG::UndefinedColumn: ERROR:  column claims.teacher_reference_number does not exist (PG::UndefinedColumn)
LINE 1: ...ode" AS t1_r7, "claims"."date_of_birth" AS t1_r8, "claims"."...
                                                             ^
/Users/ken/code/dfe/claim-additional-payments-for-teaching/db/migrate/20241028110426_back_fill_claims_verified_at.rb:4:in `change'
<internal:/Users/ken/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/Users/ken/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```
