### PR TITLE
Keep task if claim updated with gender

### DIFF
--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -20,7 +20,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "matching_details" if matching_claims.exists?
-        tasks << "payroll_gender" if claim.payroll_gender_missing?
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || claim.tasks.exists?(name: "payroll_gender")
 
         tasks
       end

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -26,7 +26,7 @@ module Policies
         tasks << "teaching_hours"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "matching_details" if matching_claims.exists?
-        tasks << "payroll_gender" if claim.payroll_gender_missing?
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || claim.tasks.exists?(name: "payroll_gender")
 
         tasks
       end

--- a/spec/features/admin/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin/admin_claim_with_missing_payroll_gender_spec.rb
@@ -45,4 +45,40 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
     expect(claim.latest_decision).to be_approved
     expect(claim.latest_decision.created_by).to eq(@signed_in_user)
   end
+
+  scenario "with a policy where payroll gender is the last task" do
+    irp_claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::InternationalRelocationPayments,
+      payroll_gender: :dont_know
+    )
+
+    fe_claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::FurtherEducationPayments,
+      payroll_gender: :dont_know
+    )
+
+    visit admin_claim_tasks_path(irp_claim)
+
+    click_on "How is the claimant’s gender recorded for payroll purposes?"
+
+    choose "Male"
+
+    click_on "Save and continue"
+
+    expect(page).to have_content("Claim decision")
+
+    visit admin_claim_tasks_path(fe_claim)
+
+    click_on "How is the claimant’s gender recorded for payroll purposes?"
+
+    choose "Male"
+
+    click_on "Save and continue"
+
+    expect(page).to have_content("Claim decision")
+  end
 end


### PR DESCRIPTION
When completing the payroll gender task we update the gender on the
claim, this removed the payroll gender task causing
`Admin::TaskPagination#current_task_index` to be `nil` ultimatly
throwing an error when we try to redirect to the
`Admin::TaskPagination#next_task_path` (which was nil).

<!-- Do you need to update CHANGELOG.md? -->
