### PR TITLE
[CAPT-1933] EY start date eligibility

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
@@ -8,7 +8,14 @@ module Journeys
           attribute :start_date, :date
 
           validates :start_date, presence: {message: i18n_error_message(:presence)}
-          validates :start_date, comparison: {less_than: ->(_) { Date.tomorrow }, message: i18n_error_message(:date_not_in_future)}, if: :start_date
+          validates :start_date,
+            comparison: {
+              less_than: ->(_) {
+                Date.tomorrow
+              },
+              message: i18n_error_message(:date_not_in_future)
+            },
+            if: :start_date
           validate :start_year_has_four_digits, if: :start_date
 
           def initialize(journey_session:, journey:, params:)
@@ -32,6 +39,8 @@ module Journeys
           def nursery_name
             EligibleEyProvider.find_by(urn: answers.nursery_urn)&.nursery_name
           end
+
+          private
 
           def start_year_has_four_digits
             if start_date.year < 1000

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -3,6 +3,7 @@ module Policies
     include BasePolicy
     extend self
 
+    POLICY_START_DATE = Date.new(2024, 11, 15) - 1.month # TODO: remove -1.month for launch
     RETENTION_PERIOD = 6.months
 
     OTHER_CLAIMABLE_POLICIES = [

--- a/app/models/policies/early_years_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/early_years_payments/policy_eligibility_checker.rb
@@ -38,6 +38,8 @@ module Policies
           :nursery_is_not_listed
         elsif answers.child_facing_confirmation_given == false
           :not_child_facing_enough
+        elsif answers.start_date && (answers.start_date < Policies::EarlyYearsPayments::POLICY_START_DATE)
+          :start_date_before_policy_start
         elsif ineligible_returner?
           :returner
         end

--- a/app/views/early_years_payment/provider/authenticated/claims/_ineligibility_start_date_before_policy_start.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/_ineligibility_start_date_before_policy_start.html.erb
@@ -1,0 +1,31 @@
+<% title = "This person may not be eligible" %>
+<% content_for(:page_title, page_title(title, journey: current_journey_routing_name)) %>
+<% @backlink_path = claim_path(current_journey_routing_name, "start-date") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p class="govuk-body">
+      This person needs to have started their role on or after <%= l(Policies::EarlyYearsPayments::POLICY_START_DATE) %>.
+    </p>
+
+    <p class="govuk-body">
+      Based on the date you’ve provided, this person is not eligible for an early years financial incentive payment.
+    </p>
+
+    <p class="govuk-body">
+      For further guidance, you should refer to the
+      <%= govuk_link_to "full eligibility criteria", claim_path(Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME, "landing-page") %>
+      at the start of this service.
+    </p>
+
+    <h2 class="govuk-heading-m">Get help with your claim</h2>
+
+    <p class="govuk-body">
+      Contact us for help at
+      <%= govuk_mail_to support_email_address(current_journey_routing_name), support_email_address(current_journey_routing_name) %>
+    </p>
+    <%= govuk_button_link_to "Start again", claim_path(Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME, "landing-page") %>
+  </div>
+</div>

--- a/app/views/early_years_payment/provider/start/landing_page.html.erb
+++ b/app/views/early_years_payment/provider/start/landing_page.html.erb
@@ -15,7 +15,7 @@
 
     <%= govuk_list [
       "have applied for a job with an incentive attached",
-      "have started their job after 15 May 2024",
+      "have started their job on or after #{l(Policies::EarlyYearsPayments::POLICY_START_DATE)}",
       "spend most of the time in their job (70% or more) working directly with children - there is no minimum number of hours and applies to all EYFS part and full time roles"
     ], type: :bullet %>
 

--- a/spec/factories/journeys/early_years_payment/provider/authenticated/early_years_payment_provider_authenticated_answers.rb
+++ b/spec/factories/journeys/early_years_payment/provider/authenticated/early_years_payment_provider_authenticated_answers.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       surname { "Doe" }
       practitioner_first_name { "John" }
       practitioner_surname { "Doe" }
-      start_date { Date.parse("1/1/2024") }
+      start_date { Policies::EarlyYearsPayments::POLICY_START_DATE + 1.day }
       child_facing_confirmation_given { true }
       returning_within_6_months { true }
       practitioner_email_address { "johndoe@example.com" }

--- a/spec/features/admin/admin_ey_identity_task_spec.rb
+++ b/spec/features/admin/admin_ey_identity_task_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe "Admin EY identity task" do
     fill_in "Last name", with: "Bobberson"
     click_button "Continue"
 
-    date = Date.yesterday
+    date = Policies::EarlyYearsPayments::POLICY_START_DATE + 1.day
     fill_in("Day", with: date.day)
     fill_in("Month", with: date.month)
     fill_in("Year", with: date.year)

--- a/spec/features/early_years_payment/provider/authenticated/ineligible_start_date_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/ineligible_start_date_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.feature "Early years payment provider" do
+  let(:email_address) { "johndoe@example.com" }
+  let(:journey_session) { Journeys::EarlyYearsPayment::Provider::Authenticated::Session.last }
+  let(:mail) { ActionMailer::Base.deliveries.last }
+  let(:magic_link) { mail[:personalisation].unparsed_value[:magic_link] }
+  let!(:nursery) { create(:eligible_ey_provider, primary_key_contact_email_address: email_address) }
+
+  scenario "magic link onwards" do
+    when_early_years_payment_provider_authenticated_journey_configuration_exists
+    when_early_years_payment_provider_start_journey_completed
+
+    visit magic_link
+    expect(page).to have_content("Declaration of Employee Consent")
+    expect(page.current_path).to eq "/early-years-payment-provider/consent"
+    check "I confirm that I have obtained consent from my employee and have provided them with the relevant privacy notice."
+    click_button "Continue"
+
+    expect(journey_session.reload.answers.email_address).to be nil
+    expect(journey_session.reload.answers.email_verified).to be nil
+    expect(journey_session.reload.answers.provider_email_address).to eq email_address
+
+    expect(page.current_path).to eq "/early-years-payment-provider/current-nursery"
+    choose nursery.nursery_name
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/paye-reference"
+    expect(page).to have_content("What is #{nursery.nursery_name}’s employer PAYE reference?")
+    fill_in "claim-paye-reference-field", with: "123/123456SE90"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/claimant-name"
+    fill_in "First name", with: "Bobby"
+    fill_in "Last name", with: "Bobberson"
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/start-date"
+    date = Policies::EarlyYearsPayments::POLICY_START_DATE - 10.days
+    fill_in("Day", with: date.day)
+    fill_in("Month", with: date.month)
+    fill_in("Year", with: date.year)
+    click_button "Continue"
+
+    expect(page.current_path).to eq "/early-years-payment-provider/ineligible"
+    expect(page).to have_content("This person may not be eligible")
+  end
+end

--- a/spec/models/journeys/early_years_payment/provider/authenticated/answers_presenter_spec.rb
+++ b/spec/models/journeys/early_years_payment/provider/authenticated/answers_presenter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::AnswersPres
         ],
         [
           "Employee’s start date",
-          "1 January 2024",
+          (Policies::EarlyYearsPayments::POLICY_START_DATE + 1.day).strftime("%d %B %Y"),
           "start-date"
         ],
         [

--- a/spec/models/policies/early_years_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/early_years_payments/policy_eligibility_checker_spec.rb
@@ -4,6 +4,21 @@ describe Policies::EarlyYearsPayments::PolicyEligibilityChecker do
   subject { described_class.new(answers: answers) }
 
   describe "#status, #ineligible?, #ineligibility_reason" do
+    context "start date is before POLICY_START_DATE" do
+      let(:answers) do
+        build(
+          :early_years_payment_answers,
+          start_date: Policies::EarlyYearsPayments::POLICY_START_DATE - 1.day
+        )
+      end
+
+      it "is not eligible" do
+        expect(subject).to be_ineligible
+        expect(subject.status).to eql(:ineligible)
+        expect(subject.ineligibility_reason).to eql(:start_date_before_policy_start)
+      end
+    end
+
     context "not a returner" do
       let(:answers) do
         build(


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1933
- EY now has a start date for the policy
- Any start dates prior to this send the user to ineligible page

# Notes

- I've had to make the constant `POLICY_START_DATE` 1 month prior to actual policy start date, otherwise we'd never be able to enter any claims for testing
- this needs to be removed for launch