### PR TITLE
Create EY journey configs on production

### DIFF
--- a/db/migrate/20241107164046_create_ey_journey_configs.rb
+++ b/db/migrate/20241107164046_create_ey_journey_configs.rb
@@ -1,0 +1,27 @@
+class CreateEyJourneyConfigs < ActiveRecord::Migration[7.0]
+  def up
+    [
+      Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME,
+      Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME,
+      Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME
+    ].reject do |routing_name|
+      Journeys::Configuration.exists?(routing_name: routing_name)
+    end.each do |routing_name|
+      Journeys::Configuration.create!(
+        routing_name: routing_name,
+        current_academic_year: AcademicYear.current,
+        open_for_submissions: false
+      )
+    end
+  end
+
+  def down
+    [
+      Journeys::EarlyYearsPayment::Provider::Start::ROUTING_NAME,
+      Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME,
+      Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME
+    ].each do |routing_name|
+      Journeys::Configuration.find_by(routing_name: routing_name)&.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_30_153139) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_07_164046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"


### PR DESCRIPTION
`Claim::ClaimsAwaitingDecisionFinder` assumes that the EYPayments
journeys existing on production. This class is called by the
`StudentLoanPlanCheckJob` which has been
[erroring](https://app.rollbar.com/a/dfe-digital/fix/item/dfe-claims/1411)
and thus failing to import SLC data.

<!-- Do you need to update CHANGELOG.md? -->
