### PR TITLE
[CAPT-1898] Practitioner claim start timestamp

### DIFF
--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -19,11 +19,14 @@ module Journeys
         end
 
         def new_or_find_claim
-          Claim.find_by(reference: journey_session.answers.reference_number) || Claim.new
+          (Claim.find_by(reference: journey_session.answers.reference_number) || Claim.new).tap do |c|
+            if c.eligibility
+              c.eligibility.practitioner_claim_started_at = journey_session.answers.practitioner_claim_started_at
+            end
+          end
         end
 
         def set_submitted_at_attributes
-          claim.eligibility.practitioner_claim_started_at = journey_session.created_at
           claim.submitted_at = Time.zone.now
         end
       end

--- a/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/find_reference_form.rb
@@ -17,7 +17,8 @@ module Journeys
             reference_number:,
             reference_number_found: existing_claim.present?,
             claim_already_submitted: existing_claim&.submitted?,
-            nursery_name: existing_claim&.eligibility&.eligible_ey_provider&.nursery_name
+            nursery_name: existing_claim&.eligibility&.eligible_ey_provider&.nursery_name,
+            practitioner_claim_started_at: Time.now
           )
           journey_session.save!
         end

--- a/app/models/journeys/early_years_payment/practitioner/session_answers.rb
+++ b/app/models/journeys/early_years_payment/practitioner/session_answers.rb
@@ -7,6 +7,7 @@ module Journeys
         attribute :claim_already_submitted, :boolean, default: nil
         attribute :nursery_name
         attribute :start_email, :string
+        attribute :practitioner_claim_started_at, :datetime
 
         def policy
           Policies::EarlyYearsPayments

--- a/spec/factories/journeys/early_years_payment/practitioner/answers.rb
+++ b/spec/factories/journeys/early_years_payment/practitioner/answers.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
       banking_name { "John Doe" }
       bank_sort_code { rand(100000..999999) }
       bank_account_number { rand(10000000..99999999) }
+      practitioner_claim_started_at { 30.minutes.ago }
     end
 
     trait :submittable do

--- a/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/practitioner/find_reference_form_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::FindReferenceForm do
       }.to change { journey_session.reload.answers.nursery_name }.from(nil).to(eligible_ey_provider.nursery_name)
     end
 
+    it "sets practitioner_claim_started_at" do
+      expect {
+        subject.save
+      }.to change { journey_session.reload.answers.practitioner_claim_started_at }.from(nil)
+    end
+
     context "when the claim has only been submitted by the provider, not the practitioner" do
       let(:claim) do
         create(


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1898
- Change definition of when practitioner starts their claim
- Was when journey session was created, now after they submit a reference 