### PR TITLE
Move payroll run to background job

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -24,7 +24,9 @@ module Admin
         return
       end
 
-      payroll_run = PayrollRun.create_with_claims!(claims, topups, created_by: admin_user)
+      payroll_run = PayrollRun.create!(created_by: admin_user)
+
+      PayrollRunJob.perform_later(payroll_run, claims.ids, topups.ids)
 
       redirect_to [:admin, payroll_run], notice: "Payroll run created"
     rescue ActiveRecord::RecordInvalid => e

--- a/app/jobs/payroll_run_job.rb
+++ b/app/jobs/payroll_run_job.rb
@@ -1,0 +1,24 @@
+class PayrollRunJob < ApplicationJob
+  def perform(payroll_run, claim_ids, topup_ids)
+    claims = Claim.where(id: claim_ids)
+    topups = Topup.where(id: topup_ids)
+
+    ActiveRecord::Base.transaction do
+      [claims, topups].reduce([], :concat).group_by(&:national_insurance_number).each_value do |grouped_items|
+        # associates the claim to the payment, for Topup that's its associated claim
+        grouped_claims = grouped_items.map { |i| i.is_a?(Topup) ? i.claim : i }
+
+        # associates the payment to the Topup, so we know it's payrolled
+        group_topups = grouped_items.select { |i| i.is_a?(Topup) }
+
+        award_amount = grouped_items.map(&:award_amount).compact.sum(0)
+        Payment.create!(payroll_run: payroll_run, claims: grouped_claims, topups: group_topups, award_amount: award_amount)
+      end
+
+      payroll_run.complete!
+    end
+  rescue => e
+    payroll_run.failed!
+    raise e
+  end
+end

--- a/app/views/admin/payroll_runs/_complete.html.erb
+++ b/app/views/admin/payroll_runs/_complete.html.erb
@@ -1,0 +1,158 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @payroll_run.created_at.strftime("%B") %> payroll run
+    </h1>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Approved claims
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= @payroll_run.number_of_claims_for_policy(:all, filter: :claims) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Top ups
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= @payroll_run.number_of_claims_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Total award amount
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= number_to_currency(@payroll_run.total_award_amount) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Created by
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= user_details(@payroll_run.created_by) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Downloaded
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= @payroll_run.download_triggered? ? l(@payroll_run.downloaded_at) : "No" %>
+        </dd>
+      </div>
+      <% if @payroll_run.download_triggered? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Downloaded by
+          </dt>
+
+          <dd class="govuk-summary-list__value">
+            <%= user_details(@payroll_run.downloaded_by) %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">Summary of claim amounts by service</h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Service</th>
+          <th scope="col" class="govuk-table__header">Number of claims</th>
+          <th scope="col" class="govuk-table__header">Total claimed amount</th>
+        </tr>
+        <% Policies.all.each do |policy| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= policy.short_name %></th>
+            <td class="govuk-table__cell"><%= @payroll_run.number_of_claims_for_policy(policy, filter: :claims) %></td>
+            <td class="govuk-table__cell"><%= number_to_currency(@payroll_run.total_claim_amount_for_policy(policy, filter: :claims)) %></td>
+          </tr>
+        <% end %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= I18n.t("levelling_up_premium_payments.policy_short_name") %> Top Ups</th>
+          <td class="govuk-table__cell"><%= @payroll_run.number_of_claims_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups) %></td>
+          <td class="govuk-table__cell"><%= number_to_currency(@payroll_run.total_claim_amount_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups)) %></td>
+          </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      </tbody>
+    </table>
+  </div>
+
+  <% unless @payroll_run.all_payments_confirmed? %>
+    <div class="govuk-grid-column-full">
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="payroll_run_download_link">
+          You can now send this link to DfE Payroll for processing.
+        </label>
+        <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), data: {"copy-to-clipboard": :true}, readonly: true, class: ["govuk-input"] %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Payments</h2>
+
+    <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Payment ID</th>
+        <th scope="col" class="govuk-table__header">Payee Name</th>
+        <th scope="col" class="govuk-table__header">Claim Reference</th>
+        <th scope="col" class="govuk-table__header">Service</th>
+        <th scope="col" class="govuk-table__header">Claim Amount</th>
+        <th scope="col" class="govuk-table__header">Payment Amount</th>
+        <% unless @payroll_run.all_payments_confirmed? %>
+          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @payments.each do |payment| %>
+        <% payment.claims.each_with_index do |claim, index| %>
+          <% number_of_claims = payment.claims.size %>
+          <% topup_claim_ids = payment.topups.pluck(:claim_id) %>
+          <% line_item = topup_claim_ids.include?(claim.id) ? payment.topups.select { |t| t.claim_id == claim.id }.first : claim %>
+
+          <tr class="govuk-table__row">
+            <% if index == 0 %>
+              <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= payment.id %></th>
+              <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
+            <% end %>
+            <td class="govuk-table__cell"><%= link_to claim.reference, admin_claim_path(claim), class: "govuk-link" %></td>
+            <td class="govuk-table__cell"><%= line_item.is_a?(Topup) ? "#{I18n.t("levelling_up_premium_payments.policy_short_name")} (top up)" : claim.policy.short_name %></td>
+            <td class="govuk-table__cell"><%= number_to_currency(line_item.award_amount) %></td>
+            <% if index == 0 %>
+              <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= number_to_currency(payment.award_amount) %></td>
+              <% unless @payroll_run.all_payments_confirmed? %>
+                <td class="govuk-table__cell" rowspan="<%= number_of_claims %>">
+                  <% unless payment.confirmation.present? %>
+                    <%= link_to remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id), class: "govuk-link" do %>
+                      Remove <span class="govuk-visually-hidden">payment row</span>
+                    <% end %>
+                  <% end %>
+                </td>
+              <% end %>
+            <% end %>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+    </table>
+
+    <%== render partial: 'pagination', locals: { pagy: @pagy } %>
+  </div>
+</div>

--- a/app/views/admin/payroll_runs/_failed.html.erb
+++ b/app/views/admin/payroll_runs/_failed.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @payroll_run.created_at.strftime("%B") %> payroll run
+    </h1>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        This payroll run errored, please contact tech support
+      </strong>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/payroll_runs/_pending.html.erb
+++ b/app/views/admin/payroll_runs/_pending.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @payroll_run.created_at.strftime("%B") %> payroll run
+    </h1>
+
+    <p class="govuk-body">
+      This payroll run is in progress
+    </p>
+
+    <%= govuk_button_link_to "Refresh", admin_payroll_run_path(@payroll_run) %>
+  </div>
+</div>
+

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -1,164 +1,18 @@
 <% content_for(:page_title) { page_title("#{@payroll_run.created_at.strftime("%B")} payroll run") } %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= @payroll_run.created_at.strftime("%B") %> payroll run
-    </h1>
+<% case @payroll_run.status %>
+<% when "pending" %>
+  <%= render "pending" %>
+<% when "complete" %>
+  <%= render "complete" %>
+<% when "failed" %>
+  <%= render "failed" %>
+<% else %>
+  <% fail "Unknown payroll run status #{@payroll_run.status}" %>
+<% end %>
 
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Approved claims
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= @payroll_run.number_of_claims_for_policy(:all, filter: :claims) %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Top ups
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= @payroll_run.number_of_claims_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups) %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Total award amount
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= number_to_currency(@payroll_run.total_award_amount) %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Created by
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= user_details(@payroll_run.created_by) %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Downloaded
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= @payroll_run.download_triggered? ? l(@payroll_run.downloaded_at) : "No" %>
-        </dd>
-      </div>
-      <% if @payroll_run.download_triggered? %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Downloaded by
-          </dt>
-
-          <dd class="govuk-summary-list__value">
-            <%= user_details(@payroll_run.downloaded_by) %>
-          </dd>
-        </div>
-      <% end %>
-    </dl>
-  </div>
-
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">Summary of claim amounts by service</h2>
-
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Service</th>
-          <th scope="col" class="govuk-table__header">Number of claims</th>
-          <th scope="col" class="govuk-table__header">Total claimed amount</th>
-        </tr>
-        <% Policies.all.each do |policy| %>
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header"><%= policy.short_name %></th>
-            <td class="govuk-table__cell"><%= @payroll_run.number_of_claims_for_policy(policy, filter: :claims) %></td>
-            <td class="govuk-table__cell"><%= number_to_currency(@payroll_run.total_claim_amount_for_policy(policy, filter: :claims)) %></td>
-          </tr>
-        <% end %>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header"><%= I18n.t("levelling_up_premium_payments.policy_short_name") %> Top Ups</th>
-          <td class="govuk-table__cell"><%= @payroll_run.number_of_claims_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups) %></td>
-          <td class="govuk-table__cell"><%= number_to_currency(@payroll_run.total_claim_amount_for_policy(Policies::LevellingUpPremiumPayments, filter: :topups)) %></td>
-          </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      </tbody>
-    </table>
-  </div>
-
-  <% unless @payroll_run.all_payments_confirmed? %>
-    <div class="govuk-grid-column-full">
-      <div class="govuk-form-group">
-        <label class="govuk-label" for="payroll_run_download_link">
-          You can now send this link to DfE Payroll for processing.
-        </label>
-        <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), data: {"copy-to-clipboard": :true}, readonly: true, class: ["govuk-input"] %>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-l">Payments</h2>
-
-    <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Payment ID</th>
-        <th scope="col" class="govuk-table__header">Payee Name</th>
-        <th scope="col" class="govuk-table__header">Claim Reference</th>
-        <th scope="col" class="govuk-table__header">Service</th>
-        <th scope="col" class="govuk-table__header">Claim Amount</th>
-        <th scope="col" class="govuk-table__header">Payment Amount</th>
-        <% unless @payroll_run.all_payments_confirmed? %>
-          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
-        <% end %>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% @payments.each do |payment| %>
-        <% payment.claims.each_with_index do |claim, index| %>
-          <% number_of_claims = payment.claims.size %>
-          <% topup_claim_ids = payment.topups.pluck(:claim_id) %>
-          <% line_item = topup_claim_ids.include?(claim.id) ? payment.topups.select { |t| t.claim_id == claim.id }.first : claim %>
-
-          <tr class="govuk-table__row">
-            <% if index == 0 %>
-              <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= payment.id %></th>
-              <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
-            <% end %>
-            <td class="govuk-table__cell"><%= link_to claim.reference, admin_claim_path(claim), class: "govuk-link" %></td>
-            <td class="govuk-table__cell"><%= line_item.is_a?(Topup) ? "#{I18n.t("levelling_up_premium_payments.policy_short_name")} (top up)" : claim.policy.short_name %></td>
-            <td class="govuk-table__cell"><%= number_to_currency(line_item.award_amount) %></td>
-            <% if index == 0 %>
-              <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= number_to_currency(payment.award_amount) %></td>
-              <% unless @payroll_run.all_payments_confirmed? %>
-                <td class="govuk-table__cell" rowspan="<%= number_of_claims %>">
-                  <% unless payment.confirmation.present? %>
-                    <%= link_to remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id), class: "govuk-link" do %>
-                      Remove <span class="govuk-visually-hidden">payment row</span>
-                    <% end %>
-                  <% end %>
-                </td>
-              <% end %>
-            <% end %>
-          </tr>
-        <% end %>
-      <% end %>
-    </tbody>
-    </table>
-
-    <%== render partial: 'pagination', locals: { pagy: @pagy } %>
-  </div>
-
-  <% if PayrollRun.allow_destroy? %>
+<% if PayrollRun.allow_destroy? %>
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= button_to(
         "Delete payroll run",
@@ -167,5 +21,5 @@
         class: "govuk-button govuk-button--warning",
       ) %>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -139,6 +139,7 @@ shared:
     - downloaded_by_id
     - scheduled_payment_date
     - confirmation_report_uploaded_by_id
+    - status
   :student_loans_eligibilities:
     - id
     - created_at

--- a/db/migrate/20241111114155_add_status_to_payroll_runs.rb
+++ b/db/migrate/20241111114155_add_status_to_payroll_runs.rb
@@ -1,0 +1,7 @@
+class AddStatusToPayrollRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :payroll_runs, :status, :string, default: "pending", null: false
+
+    PayrollRun.update_all(status: "complete")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_07_164046) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_11_114155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -410,6 +410,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_07_164046) do
     t.uuid "downloaded_by_id"
     t.date "scheduled_payment_date"
     t.uuid "confirmation_report_uploaded_by_id"
+    t.string "status", default: "pending", null: false
     t.index ["confirmation_report_uploaded_by_id"], name: "index_payroll_runs_on_confirmation_report_uploaded_by_id"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"
     t.index ["created_by_id"], name: "index_payroll_runs_on_created_by_id"

--- a/db/test_seeders/data_importer.rb
+++ b/db/test_seeders/data_importer.rb
@@ -104,6 +104,8 @@ class DataImporter < BaseImporter
     payrollable_claims ||= Claim.payrollable
     topups = []
     logger.info "Generating payroll for #{payrollable_claims.size} payments"
-    PayrollRun.create_with_claims!(payrollable_claims, topups, created_by: admin_approver)
+
+    payroll_run = PayrollRun.create!(created_by: @signed_in_user)
+    PayrollRunJob.perform_now(payroll_run, payrollable_claims.ids, topups.map(&:id))
   end
 end

--- a/spec/factories/payroll_runs.rb
+++ b/spec/factories/payroll_runs.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     association :created_by, factory: :dfe_signin_user
     association :downloaded_by, factory: :dfe_signin_user
 
+    status { :complete }
+
     transient do
       # The claim_counts attribute provides a convenient way to create a
       # payroll run with associated payment objects and associated claim

--- a/spec/jobs/payroll_run_job_spec.rb
+++ b/spec/jobs/payroll_run_job_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe PayrollRunJob, type: :job do
+  let(:user) { create(:dfe_signin_user) }
+  let(:payroll_run) { create(:payroll_run, created_by: user) }
+
+  describe "#perform" do
+    context "when successful" do
+      let(:claims) { Policies.all.map { |policy| create(:claim, :approved, policy: policy) } }
+      let(:topups) { [] }
+
+      before do
+        described_class.perform_now(payroll_run, claims.map(&:id), topups.map(&:id))
+      end
+
+      it "creates a payroll run with payments and populates the award_amount" do
+        expect(payroll_run.reload.created_by.id).to eq(user.id)
+        expect(payroll_run.claims).to match_array(claims)
+        expect(claims[0].payments.first.award_amount).to eq(claims[0].award_amount)
+        expect(claims[1].payments.first.award_amount).to eq(claims[1].award_amount)
+      end
+
+      context "with multiple claims from the same teacher reference number" do
+        let(:personal_details) do
+          {
+            national_insurance_number: generate(:national_insurance_number),
+            eligibility_attributes: {teacher_reference_number: generate(:teacher_reference_number)},
+            email_address: generate(:email_address),
+            bank_sort_code: "112233",
+            bank_account_number: "95928482",
+            address_line_1: "64 West Lane",
+            student_loan_plan: StudentLoan::PLAN_1
+          }
+        end
+        let(:matching_claims) do
+          [
+            create(:claim, :approved, personal_details.merge(policy: Policies::StudentLoans)),
+            create(:claim, :approved, personal_details.merge(policy: Policies::EarlyCareerPayments))
+          ]
+        end
+        let(:other_claim) { create(:claim, :approved) }
+        let(:claims) { matching_claims + [other_claim] }
+
+        it "groups them into a single payment and populates the award_amount" do
+          expect(payroll_run.payments.map(&:claims)).to match_array([match_array(matching_claims), [other_claim]])
+          expect(matching_claims[0].reload.payments.first.award_amount).to eq(matching_claims.sum(&:award_amount))
+        end
+      end
+    end
+
+    context "when errored" do
+      before do
+        allow(Payment).to receive(:create!).and_raise(StandardError)
+      end
+
+      it "marks the payroll run as failed and reraises the error" do
+        expect do
+          described_class.perform_now(payroll_run, [create(:claim).id], [])
+        end.to raise_error(StandardError)
+
+        expect(payroll_run.reload.failed?).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/admin/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin/admin_payroll_runs_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe "Admin payroll runs" do
       it "creates a payroll run with payments and redirects to it" do
         claims = create_list(:claim, 2, :approved)
 
-        expect { post admin_payroll_runs_path(claim_ids: claims.map(&:id)) }.to change { PayrollRun.count }.by(1)
+        perform_enqueued_jobs do
+          expect { post admin_payroll_runs_path(claim_ids: claims.map(&:id)) }.to change { PayrollRun.count }.by(1)
+        end
 
         payroll_run = PayrollRun.order(:created_at).last
         expect(payroll_run.created_by.id).to eq(@signed_in_user.id)

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -73,7 +73,8 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
   before do
     @signed_in_user = sign_in_as_service_operator
 
-    PayrollRun.create_with_claims!([approved_paid_claim], [], created_by: @signed_in_user)
+    payroll_run = PayrollRun.create!(created_by: @signed_in_user)
+    PayrollRunJob.perform_now(payroll_run, [approved_paid_claim.id], [])
 
     # NOTE: mirror claims factory for academic_year attribute "hardcoding" of 2019
     current_academic_year =

--- a/spec/support/admin_view_claim_logged_in_with_tid_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_logged_in_with_tid_feature_shared_examples.rb
@@ -34,7 +34,8 @@ RSpec.shared_examples "Admin View Claim logged in with tid" do |policy|
   before do
     @signed_in_user = sign_in_as_service_operator
 
-    PayrollRun.create_with_claims!([approved_paid_claim], [], created_by: @signed_in_user)
+    payroll_run = PayrollRun.create!(created_by: @signed_in_user)
+    PayrollRunJob.perform_now(payroll_run, [approved_paid_claim.id], [])
 
     # NOTE: mirror claims factory for academic_year attribute "hardcoding" of 2019
     current_academic_year =


### PR DESCRIPTION
Creating the November payroll run timed out (October's too).
This commit moves creating the payment records into a background job.

We need to pass the claim ids and topup ids to the background job, this
is because once the admin has reviewed the claims that will be part of
this payroll run (shown in the `new` action) we can't include any claims
created in the interim. We may want to consider someother method of
indicating what claims should be part of this payroll run (create
pending payments? flag claims / topups as reviewed for payroll?) so we
don't have to pass such a large amount of information to the background
job. Have tested this with production data and it runs fine passing all the ids.

Not sure if the payroll numbers are public so have put the video walk through of testing this with the prod db on ira https://dfedigital.atlassian.net/browse/CAPT-1975?focusedCommentId=98115