### PR TITLE
Fix payroll details task for scrubbed claims

### DIFF
--- a/app/views/admin/tasks/payroll_details.html.erb
+++ b/app/views/admin/tasks/payroll_details.html.erb
@@ -12,6 +12,14 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
 
+    <% if @claim.personal_data_removed_at.present? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          This claim has had it's personal data removed.
+        </strong>
+      </div>
+    <% else %>
     <div class="hmcts-timeline hmrc_responses">
       <% @claim.hmrc_bank_validation_responses.each do |response| %>
       <% bank_account_verification_response = Hmrc::BankAccountVerificationResponse.new(OpenStruct.new({code: response["code"], body: response["body"].to_json})) %>
@@ -42,6 +50,7 @@
         </div>
       <% end %>
     </div>
+    <% end %>
 
     <% if !@task.passed.nil? %>
       <%= render "task_outcome", task: @task, notes: @notes do %>

--- a/spec/features/admin/admin_claim_payroll_details_task_spec.rb
+++ b/spec/features/admin/admin_claim_payroll_details_task_spec.rb
@@ -62,4 +62,22 @@ RSpec.feature "Admin checking a claim's payroll details" do
       expect(claim.reload.latest_decision.created_by).to eq(@signed_in_user)
     end
   end
+
+  context "when the claim has been scrubbed" do
+    let!(:claim) do
+      create(
+        :claim,
+        :submitted,
+        :personal_data_removed
+      )
+    end
+
+    scenario "does not show the hmrc response" do
+      visit admin_claim_task_path(claim, "payroll_details")
+
+      expect(page).to have_content(
+        "This claim has had it's personal data removed."
+      )
+    end
+  end
 end


### PR DESCRIPTION
When viewing the payroll details task for scrubbed claims we were
throwing an error as `hmrc_bank_validation_responses` is `nil`.

<!-- Do you need to update CHANGELOG.md? -->
