### PR TITLE
Ensure tasks are loaded

### DIFF
--- a/lib/analytics_importer.rb
+++ b/lib/analytics_importer.rb
@@ -1,5 +1,13 @@
 class AnalyticsImporter
+  ANALYTICS_SYNC_TASK = "dfe:analytics:import_entity"
+
   def self.import(model)
-    Rake::Task["dfe:analytics:import_entity"].invoke(model.table_name) if DfE::Analytics.enabled?
+    return unless DfE::Analytics.enabled?
+
+    if Rake::Task.tasks.map(&:name).exclude?(ANALYTICS_SYNC_TASK)
+      Rails.application.load_tasks
+    end
+
+    Rake::Task[ANALYTICS_SYNC_TASK].invoke(model.table_name)
   end
 end


### PR DESCRIPTION
If the task isn't loaded this method errors with
Don't know how to build task 'dfe:analytics:import_entity'
This change ensures the rake tasks are loaded

<!-- Do you need to update CHANGELOG.md? -->
