### PR TITLE
Temp disable analytics for fe provider upload

### DIFF
--- a/app/models/eligible_fe_providers_importer.rb
+++ b/app/models/eligible_fe_providers_importer.rb
@@ -24,6 +24,10 @@ class EligibleFeProvidersImporter < CsvImporter::Base
 
   private
 
+  def sync_analytics
+    # NOOP
+  end
+
   def delete_all_scope
     target_data_model.where(academic_year:)
   end

--- a/lib/csv_importer/base.rb
+++ b/lib/csv_importer/base.rb
@@ -33,7 +33,7 @@ module CsvImporter
         target_data_model.insert_all(record_hashes) unless record_hashes.empty?
       end
 
-      AnalyticsImporter.import(target_data_model)
+      sync_analytics
     end
 
     def rows_with_data_count
@@ -41,6 +41,10 @@ module CsvImporter
     end
 
     private
+
+    def sync_analytics
+      AnalyticsImporter.import(target_data_model)
+    end
 
     def empty_row?(row)
       case row


### PR DESCRIPTION
Calling `AnalyticsImporter` is erroring. This commit temp disables theh
`EligibleFeProvidersImporter` from calling the `AnalyticsImporter` while
we decide how best to fix that class.

<!-- Do you need to update CHANGELOG.md? -->
