### PR TITLE
[CAPT-1908] EY progress update emails

### DIFF
--- a/app/jobs/early_years_progress_emails_job.rb
+++ b/app/jobs/early_years_progress_emails_job.rb
@@ -1,0 +1,34 @@
+class EarlyYearsProgressEmailsJob < CronJob
+  self.cron_expression = "0 8 * * *" # Every day at 08:00
+
+  def perform
+    periods_after_submission = [2.months, 5.months]
+    today = Date.today
+
+    periods_after_submission.each do |period_after_submission|
+      previous_date = today - period_after_submission
+
+      # handle when current month has more days then previous month
+      if today.last_day_of_the_month? && (today.day > previous_date.end_of_month.day)
+        next
+      end
+
+      window_open = previous_date.beginning_of_day
+
+      # handle when previous month has more days that current month
+      window_close = if today.last_day_of_the_month? && (previous_date.end_of_month.day > today.day)
+        previous_date.end_of_month.end_of_day
+      else # normal 1:1
+        previous_date.end_of_day
+      end
+
+      Claim
+        .by_policy(Policies::EarlyYearsPayments)
+        .awaiting_decision
+        .where(submitted_at: window_open..window_close)
+        .find_each do |claim|
+          EarlyYearsPaymentsMailer.with(claim:).progress_update.deliver_later
+        end
+    end
+  end
+end

--- a/app/jobs/send_emails_after_three_weeks_job.rb
+++ b/app/jobs/send_emails_after_three_weeks_job.rb
@@ -15,6 +15,9 @@ class SendEmailsAfterThreeWeeksJob < CronJob
   private
 
   def three_week_old_undecided_claims
-    Claim.awaiting_decision.where(submitted_at: (21.days.ago.beginning_of_day...21.days.ago.end_of_day))
+    Claim
+      .awaiting_decision
+      .where(submitted_at: (21.days.ago.beginning_of_day...21.days.ago.end_of_day))
+      .require_in_progress_update_emails
   end
 end

--- a/app/mailers/early_years_payments_mailer.rb
+++ b/app/mailers/early_years_payments_mailer.rb
@@ -7,6 +7,24 @@ class EarlyYearsPaymentsMailer < ApplicationMailer
     end
   end
 
+  def progress_update
+    claim = params[:claim]
+
+    personalisation = {
+      first_name: claim.first_name,
+      application_date: claim.submitted_at.to_date.to_fs(:long_date),
+      ref_number: claim.reference
+    }
+
+    template_mail(
+      "1d20d638-61e4-4768-beba-c447cfa8c5a7",
+      to: claim.email_address,
+      subject: nil,
+      reply_to_id: claim.policy.notify_reply_to_id,
+      personalisation:
+    )
+  end
+
   private
 
   def submitted_by_provider_and_send_to_provider(claim)

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -78,4 +78,8 @@ module BasePolicy
   def task_available?(task)
     true
   end
+
+  def require_in_progress_update_emails?
+    true
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -244,7 +244,7 @@ class Claim < ApplicationRecord
   end
 
   scope :require_in_progress_update_emails, -> {
-    by_policies(Policies.all.select{|p| p.require_in_progress_update_emails? })
+    by_policies(Policies.all.select { |p| p.require_in_progress_update_emails? })
   }
 
   def onelogin_idv_full_name

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -243,6 +243,10 @@ class Claim < ApplicationRecord
     )
   end
 
+  scope :require_in_progress_update_emails, -> {
+    by_policies(Policies.all.select{|p| p.require_in_progress_update_emails? })
+  }
+
   def onelogin_idv_full_name
     "#{onelogin_idv_first_name} #{onelogin_idv_last_name}"
   end

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -94,5 +94,9 @@ module Policies
         task.claim.eligibility.practitioner_journey_completed?
       end
     end
+
+    def require_in_progress_update_emails?
+      false
+    end
   end
 end

--- a/config/initializers/core_ext.rb
+++ b/config/initializers/core_ext.rb
@@ -1,0 +1,1 @@
+require "core_ext/date"

--- a/lib/core_ext/date.rb
+++ b/lib/core_ext/date.rb
@@ -1,0 +1,9 @@
+module CoreExt
+  module Date
+    def last_day_of_the_month?
+      day == end_of_month.day
+    end
+  end
+end
+
+Date.include CoreExt::Date

--- a/spec/jobs/early_years_progress_emails_job_spec.rb
+++ b/spec/jobs/early_years_progress_emails_job_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe EarlyYearsProgressEmailsJob do
+  let(:policy) { Policies::EarlyYearsPayments }
+
+  describe "#perform" do
+    context "when no claims" do
+      it "does not enqueue any jobs" do
+        expect { subject.perform }.not_to have_enqueued_job
+      end
+    end
+
+    context "when normal day of the month" do
+      it "enqueues jobs normally" do
+        travel_to(Date.new(2024, 11, 12)) do
+          create(:claim, :submitted, policy:, submitted_at: 2.months.ago - 1.day)
+          claim_2 = create(:claim, :submitted, policy:, submitted_at: 2.months.ago)
+          create(:claim, :submitted, policy:, submitted_at: 2.months.ago + 1.day)
+
+          create(:claim, :submitted, policy:, submitted_at: 5.months.ago - 1.day)
+          claim_5 = create(:claim, :submitted, policy:, submitted_at: 5.months.ago)
+          create(:claim, :submitted, policy:, submitted_at: 5.months.ago + 1.day)
+
+          expect { subject.perform }.to have_enqueued_job.twice
+
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[0].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_2)
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[1].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_5)
+        end
+      end
+    end
+
+    context "when current month same number of days as previous month" do
+      it "enqueues jobs normally" do
+        travel_to(Date.new(2024, 12, 31)) do
+          create(:claim, :submitted, policy:, submitted_at: 2.months.ago - 1.day)
+          claim_2 = create(:claim, :submitted, policy:, submitted_at: 2.months.ago)
+          create(:claim, :submitted, policy:, submitted_at: 2.months.ago + 1.day)
+
+          expect { subject.perform }.to have_enqueued_job.once
+
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[0].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_2)
+        end
+      end
+    end
+
+    context "when current month has more days than previous month" do
+      it "enqueues no jobs on last day" do
+        claim_1 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 2, 28))
+        claim_2 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 2, 29))
+        claim_3 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 3, 1))
+
+        travel_to(Date.new(2024, 4, 28)) do
+          expect { subject.perform }.to have_enqueued_job.once
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[0].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_1)
+        end
+
+        travel_to(Date.new(2024, 4, 29)) do
+          expect { subject.perform }.to have_enqueued_job.once
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[1].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_2)
+        end
+
+        travel_to(Date.new(2024, 4, 30)) do
+          expect { subject.perform }.not_to have_enqueued_job
+        end
+
+        travel_to(Date.new(2024, 5, 1)) do
+          expect { subject.perform }.to have_enqueued_job.once
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[2].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_3)
+        end
+      end
+    end
+
+    context "when previous month has more days than current month" do
+      it "enqueues extra jobs on last day" do
+        claim_1 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 7, 29))
+        claim_2 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 7, 30))
+        claim_3 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 7, 31))
+        claim_4 = create(:claim, :submitted, policy:, submitted_at: Date.new(2024, 8, 1))
+
+        travel_to(Date.new(2024, 9, 29)) do
+          expect { subject.perform }.to have_enqueued_job.once
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[0].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_1)
+        end
+
+        travel_to(Date.new(2024, 9, 30)) do
+          expect { subject.perform }.to have_enqueued_job.twice
+
+          expect do
+            claims = queue_adapter.enqueued_jobs[1..2].map do |job|
+              GlobalID::Locator.locate(job.dig(:args, 3, "params", "claim", "_aj_globalid"))
+            end
+
+            expect(claims).to include(claim_2)
+            expect(claims).to include(claim_3)
+          end
+        end
+
+        travel_to(Date.new(2024, 10, 1)) do
+          expect { subject.perform }.to have_enqueued_job.once
+          expect(GlobalID::Locator.locate(queue_adapter.enqueued_jobs[3].dig(:args, 3, "params", "claim", "_aj_globalid"))).to eql(claim_4)
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/early_years_payments_mailer_spec.rb
+++ b/spec/mailers/early_years_payments_mailer_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe EarlyYearsPaymentsMailer, type: :mailer do
+  let(:claim) { build(:claim, :submitted, policy: Policies::EarlyYearsPayments) }
+
+  describe "#progress_update" do
+    it "forms correct email" do
+      mail = described_class.with(claim:).progress_update
+
+      expect(mail.to).to eql([claim.email_address])
+      expect(mail.personalisation[:first_name]).to eql(claim.first_name)
+      expect(mail.personalisation[:application_date]).to eql(claim.submitted_at.to_date.to_fs(:long_date))
+      expect(mail.personalisation[:ref_number]).to eql(claim.reference)
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -2,6 +2,16 @@ require "rails_helper"
 
 RSpec.describe Claim, type: :model do
   describe "scopes" do
+    describe "::require_in_progress_update_emails" do
+      let(:claim_1) { create(:claim, policy: Policies::StudentLoans) }
+      let(:claim_2) { create(:claim, policy: Policies::EarlyYearsPayments) }
+
+      it "includes correct claims" do
+        expect(Claim.require_in_progress_update_emails).to include(claim_1)
+        expect(Claim.require_in_progress_update_emails).not_to include(claim_2)
+      end
+    end
+
     describe "::by_policy" do
       context "with Policies::EarlyCareerPayments" do
         let(:claim_1) { create(:claim, policy: Policies::StudentLoans) }


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1908

# Changes

- EY no longer gets the every 3 week progress update emails
- This is managed with a new flag to set or unset this behaviour
- Instead it gets an different progress email sent at 2 and 5 months after submission
- Theres fair bit of additional coding to handle months not have the same number of days
- I've opted not to used arguments in mailer calls as previously done in this codebase but use `.with` and `params` instead as shown in rails guides