### PR TITLE
Temp remove analytics syncing

### DIFF
--- a/lib/csv_importer/base.rb
+++ b/lib/csv_importer/base.rb
@@ -43,7 +43,7 @@ module CsvImporter
     private
 
     def sync_analytics
-      AnalyticsImporter.import(target_data_model)
+      # NOOP
     end
 
     def empty_row?(row)

--- a/spec/lib/csv_importer/base_spec.rb
+++ b/spec/lib/csv_importer/base_spec.rb
@@ -79,13 +79,6 @@ RSpec.describe CsvImporter::Base do
     end
   end
 
-  describe "dfe-analytics syncing" do
-    it "invokes the relevant import entity job" do
-      expect(AnalyticsImporter).to receive(:import).with(target_data_model)
-      importer.run
-    end
-  end
-
   describe "data transformation and importing" do
     before { importer.run }
 


### PR DESCRIPTION
Attempting to sync analytics is erroring withh rake task not found. This
is blocking admins from uploading reports so temp disabling for now.

<!-- Do you need to update CHANGELOG.md? -->
