### PR TITLE
Replace call to rake task

### DIFF
--- a/app/models/eligible_fe_providers_importer.rb
+++ b/app/models/eligible_fe_providers_importer.rb
@@ -24,10 +24,6 @@ class EligibleFeProvidersImporter < CsvImporter::Base
 
   private
 
-  def sync_analytics
-    # NOOP
-  end
-
   def delete_all_scope
     target_data_model.where(academic_year:)
   end

--- a/lib/analytics_importer.rb
+++ b/lib/analytics_importer.rb
@@ -1,5 +1,15 @@
 class AnalyticsImporter
   def self.import(model)
-    Rake::Task["dfe:analytics:import_entity"].invoke(model.table_name) if DfE::Analytics.enabled?
+    return unless DfE::Analytics.enabled?
+
+    entity_name = model.table_name
+
+    entity_tag = Time.now.strftime("%Y%m%d%H%M%S")
+    DfE::Analytics::LoadEntities.new(entity_name: entity_name).run(entity_tag: entity_tag)
+    DfE::Analytics::Services::EntityTableChecks.call(
+      entity_name: entity_name,
+      entity_type: "import_entity_table_check",
+      entity_tag: entity_tag
+    )
   end
 end

--- a/lib/csv_importer/base.rb
+++ b/lib/csv_importer/base.rb
@@ -43,7 +43,7 @@ module CsvImporter
     private
 
     def sync_analytics
-      # NOOP
+      AnalyticsImporter.import(target_data_model)
     end
 
     def empty_row?(row)

--- a/spec/lib/analytics_importer_spec.rb
+++ b/spec/lib/analytics_importer_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe AnalyticsImporter do
+  around do |example|
+    travel_to DateTime.new(2024, 1, 1, 0, 0, 0) do
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+  end
+
+  let(:response) { double("response", success?: true) }
+  let(:table) { double("table", insert: response) }
+  let(:dataset) { double("dataset", table: table) }
+  let(:bigquery) { double("bigquery", dataset: dataset) }
+
+  before do
+    allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+    allow(DfE::Analytics).to receive(:log_only?).and_return(false)
+
+    DfE::Analytics.configure do |config|
+      config.bigquery_project_id = "test-123"
+      config.bigquery_table_name = "test_table"
+      config.bigquery_dataset = "test_dataset"
+      config.bigquery_api_json_key = '{ "type": "service_account" }'
+    end
+
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery)
+  end
+
+  describe ".import" do
+    it "sends the entity information to dfe analytics" do
+      claim = create(:claim)
+
+      AnalyticsImporter.import(Claim)
+
+      expect(table).to have_received(:insert).with(
+        [
+          {
+            "environment" => "test",
+            "occurred_at" => "2024-01-01T00:00:00.000000+00:00",
+            "event_type" => "import_entity",
+            "entity_table_name" => "claims",
+            "event_tags" => ["20240101000000"],
+            "data" => a_hash_including({"key" => "id", "value" => [claim.id]})
+          }
+        ],
+        ignore_unknown: true
+      )
+    end
+  end
+end

--- a/spec/lib/csv_importer/base_spec.rb
+++ b/spec/lib/csv_importer/base_spec.rb
@@ -79,6 +79,13 @@ RSpec.describe CsvImporter::Base do
     end
   end
 
+  describe "dfe-analytics syncing" do
+    it "invokes the relevant import entity job" do
+      expect(AnalyticsImporter).to receive(:import).with(target_data_model)
+      importer.run
+    end
+  end
+
   describe "data transformation and importing" do
     before { importer.run }
 


### PR DESCRIPTION
Calling the rake task on production throws an error as the rake tasks
aren't loaded. To resolve this, rather than invoking the rake task we'll
call the code the rake task calls.
The test is probably a bit OTT but we want to make sure updates to the
gem don't break the interface we're now using.

See
https://github.com/DFE-Digital/dfe-analytics/blob/212e0a7e7d1e27ba434080387b3f7b020f082b1a/lib/dfe/analytics/tasks/import_entities.rake#L18
for implementation of the `import_entity` task.

<!-- Do you need to update CHANGELOG.md? -->
