### PR TITLE
[CAPT-1984] EY clear dependent answers

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -165,7 +165,7 @@ module FormSubmittable
     end
 
     def load_form_if_exists
-      @form ||= journey.form(journey_session:, params:)
+      @form ||= journey.form(journey_session:, params:, session:)
     end
   end
 end

--- a/app/forms/current_school_form.rb
+++ b/app/forms/current_school_form.rb
@@ -7,7 +7,7 @@ class CurrentSchoolForm < Form
   validates :current_school_id, presence: {message: i18n_error_message(:select_the_school_you_teach_at)}
   validate :current_school_must_be_open, if: -> { current_school_id.present? }
 
-  def initialize(journey_session:, journey:, params:)
+  def initialize(journey_session:, journey:, params:, session: {})
     super
 
     load_schools

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -8,6 +8,7 @@ class Form
   attr_accessor :journey
   attr_accessor :journey_session
   attr_accessor :params
+  attr_accessor :session
 
   delegate :answers, to: :journey_session
 
@@ -20,7 +21,7 @@ class Form
   end
 
   # TODO RL: remove journey param and pull it from the journey_session
-  def initialize(journey_session:, journey:, params:)
+  def initialize(journey_session:, journey:, params:, session: {})
     super
 
     assign_attributes(attributes_with_current_value)

--- a/app/forms/journeys/early_years_payment/provider/authenticated/current_nursery_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/current_nursery_form.rb
@@ -12,7 +12,7 @@ module Journeys
 
           attr_reader :selectable_nurseries
 
-          def initialize(journey_session:, journey:, params:)
+          def initialize(journey_session:, journey:, params:, session: {})
             super
 
             @selectable_nurseries = EligibleEyProvider.for_email(journey_session.answers.provider_email_address)

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_form.rb
@@ -12,6 +12,9 @@ module Journeys
             return false if invalid?
 
             journey_session.answers.assign_attributes(returning_within_6_months:)
+
+            reset_dependent_answers
+
             journey_session.save!
           end
 
@@ -21,6 +24,17 @@ module Journeys
 
           def six_months_before_start_date
             start_date - 6.months
+          end
+
+          private
+
+          def reset_dependent_answers
+            if !journey_session.answers.returning_within_6_months
+              journey_session.answers.assign_attributes(
+                returner_worked_with_children: nil,
+                returner_contract_type: nil
+              )
+            end
           end
         end
       end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_form.rb
@@ -34,6 +34,9 @@ module Journeys
                 returner_worked_with_children: nil,
                 returner_contract_type: nil
               )
+
+              session.fetch(:slugs, {}).delete("returner-worked-with-children")
+              session.fetch(:slugs, {}).delete("returner-contract-type")
             end
           end
         end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form.rb
@@ -12,7 +12,20 @@ module Journeys
             return false if invalid?
 
             journey_session.answers.assign_attributes(returner_worked_with_children:)
+
+            reset_dependent_answers
+
             journey_session.save!
+          end
+
+          private
+
+          def reset_dependent_answers
+            if !journey_session.answers.returner_worked_with_children
+              journey_session.answers.assign_attributes(
+                returner_contract_type: nil
+              )
+            end
           end
         end
       end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form.rb
@@ -25,6 +25,8 @@ module Journeys
               journey_session.answers.assign_attributes(
                 returner_contract_type: nil
               )
+
+              session.fetch(:slugs, {}).delete("returner-contract-type")
             end
           end
         end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/start_date_form.rb
@@ -18,7 +18,7 @@ module Journeys
             if: :start_date
           validate :start_year_has_four_digits, if: :start_date
 
-          def initialize(journey_session:, journey:, params:)
+          def initialize(journey_session:, journey:, params:, session: {})
             super
 
             # Handle setting date from multi part params see

--- a/app/forms/journeys/get_a_teacher_relocation_payment/entry_date_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/entry_date_form.rb
@@ -15,7 +15,7 @@ module Journeys
           message: i18n_error_message(:date_not_in_future)
         }, if: :date_of_entry
 
-      def initialize(journey_session:, journey:, params:)
+      def initialize(journey_session:, journey:, params:, session: {})
         super
 
         # Handle setting date from multi part params see

--- a/app/forms/journeys/get_a_teacher_relocation_payment/start_date_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/start_date_form.rb
@@ -16,7 +16,7 @@ module Journeys
           message: i18n_error_message(:date_not_in_future)
         }, if: :start_date
 
-      def initialize(journey_session:, journey:, params:)
+      def initialize(journey_session:, journey:, params:, session: {})
         super
 
         # Handle setting date from multi part params see

--- a/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/claim_school_form.rb
@@ -9,7 +9,7 @@ module Journeys
       validates :claim_school_id, presence: {message: i18n_error_message(:select_a_school)}
       validate :claim_school_must_exist, if: -> { claim_school_id.present? }
 
-      def initialize(journey_session:, journey:, params:)
+      def initialize(journey_session:, journey:, params:, session: {})
         super
 
         load_schools

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -36,7 +36,7 @@ class PersonalDetailsForm < Form
   validates :national_insurance_number, presence: {message: "Enter a National Insurance number in the correct format"}
   validate :ni_number_is_correct_format
 
-  def initialize(journey_session:, journey:, params:)
+  def initialize(journey_session:, journey:, params:, session: {})
     super
     assign_date_attributes
   end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -35,10 +35,10 @@ module Journeys
       self::SlugSequence
     end
 
-    def form(journey_session:, params:)
+    def form(journey_session:, params:, session:)
       form = SHARED_FORMS.deep_merge(forms).dig(params[:controller].split("/").last, params[:slug])
 
-      form&.new(journey: self, journey_session:, params:)
+      form&.new(journey: self, journey_session:, params:, session:)
     end
 
     def forms

--- a/app/models/journeys/early_years_payment/provider/authenticated/answers_presenter.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/answers_presenter.rb
@@ -79,7 +79,7 @@ module Journeys
 
           def returner_contract_type
             [
-              "Contact type for previous role in an early years setting",
+              "Contract type for previous role in an early years setting",
               answers.returner_contract_type,
               "returner-contract-type"
             ]

--- a/spec/features/early_years_payment/provider/authenticated/changing_answers_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/changing_answers_spec.rb
@@ -18,4 +18,72 @@ RSpec.feature "Early years payment provider" do
 
     expect(page.current_path).to eq "/early-years-payment-provider/check-your-answers"
   end
+
+  scenario "changing answers on the check-your-answers page that impacts journey" do
+    when_early_years_payment_provider_authenticated_journey_configuration_exists
+    when_early_years_payment_provider_start_journey_completed
+
+    nursery = EligibleEyProvider.last || create(:eligible_ey_provider, primary_key_contact_email_address: "johndoe@example.com")
+
+    visit magic_link
+    check "I confirm that I have obtained consent from my employee and have provided them with the relevant privacy notice."
+    click_button "Continue"
+
+    choose nursery.nursery_name
+    click_button "Continue"
+
+    fill_in "claim-paye-reference-field", with: "123/123456SE90"
+    click_button "Continue"
+
+    fill_in "First name", with: "Bobby"
+    fill_in "Last name", with: "Bobberson"
+    click_button "Continue"
+
+    date = Date.yesterday
+    fill_in("Day", with: date.day)
+    fill_in("Month", with: date.month)
+    fill_in("Year", with: date.year)
+    click_button "Continue"
+
+    expect(page).to have_content "most of their time in their job working directly with children?"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content "work in early years between"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content "previous role in an early years setting involve mostly working directly with children?"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content "Select the contract type"
+    choose "casual or temporary"
+    click_button "Continue"
+
+    fill_in "claim-practitioner-email-address-field", with: "practitioner@example.com"
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before submitting this claim"
+    find("a[href='#{claim_path(Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME, "returner-worked-with-children")}']").click
+
+    expect(page).to have_content("previous role in an early years setting involve mostly working directly with children?")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before submitting this claim"
+    expect(page).not_to have_content "Contract type"
+    find("a[href='#{claim_path(Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME, "returner-worked-with-children")}']").click
+
+    expect(page).to have_content("previous role in an early years setting involve mostly working directly with children?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content "Select the contract type"
+    choose "casual or temporary"
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before submitting this claim"
+    expect(page).to have_content "Contract type"
+  end
 end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/returner_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/returner_form_spec.rb
@@ -28,12 +28,40 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ReturnerFor
   end
 
   describe "#save" do
-    let(:returning_within_6_months) { "true" }
+    context "when returning within 6 months" do
+      let(:returning_within_6_months) { "true" }
 
-    it "updates the journey session" do
-      expect { expect(subject.save).to be(true) }.to(
-        change { journey_session.reload.answers.returning_within_6_months }.to(true)
-      )
+      it "updates the journey session" do
+        expect { expect(subject.save).to be(true) }.to(
+          change { journey_session.reload.answers.returning_within_6_months }.to(true)
+        )
+      end
+    end
+
+    context "when not returning within 6 months" do
+      let(:returning_within_6_months) { "false" }
+
+      let(:journey_session) do
+        create(
+          :early_years_payment_provider_authenticated_session,
+          answers:
+        )
+      end
+
+      let(:answers) do
+        {
+          returner_worked_with_children: true,
+          returner_contract_type: "casual or temporary"
+        }
+      end
+
+      it "updates the journey session and resets dependent answers" do
+        expect { expect(subject.save).to be(true) }.to(
+          change { journey_session.reload.answers.returning_within_6_months }.to(false)
+          .and(change { journey_session.answers.returner_worked_with_children }.to(nil)
+          .and(change { journey_session.answers.returner_contract_type }.to(nil)))
+        )
+      end
     end
   end
 end

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/returner_worked_with_children_form_spec.rb
@@ -28,12 +28,36 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ReturnerWor
   end
 
   describe "#save" do
-    let(:returner_worked_with_children) { "true" }
+    context "when returner worked with children" do
+      let(:returner_worked_with_children) { "true" }
 
-    it "updates the journey session" do
-      expect { expect(subject.save).to be(true) }.to(
-        change { journey_session.reload.answers.returner_worked_with_children }.to(true)
-      )
+      it "updates the journey session" do
+        expect { expect(subject.save).to be(true) }.to(
+          change { journey_session.reload.answers.returner_worked_with_children }.to(true)
+        )
+      end
+    end
+
+    context "when returner did work with children" do
+      let(:returner_worked_with_children) { "false" }
+      let(:journey_session) do
+        create(
+          :early_years_payment_provider_authenticated_session,
+          answers:
+        )
+      end
+      let(:answers) do
+        {
+          returner_contract_type: "casual or temporary"
+        }
+      end
+
+      it "updates the journey session and resets dependent answers" do
+        expect { expect(subject.save).to be(true) }.to(
+          change { journey_session.reload.answers.returner_worked_with_children }.to(false)
+          .and(change { journey_session.answers.returner_contract_type }.to(nil))
+        )
+      end
     end
   end
 end

--- a/spec/support/steps/early_years_provider_journey_authenticated.rb
+++ b/spec/support/steps/early_years_provider_journey_authenticated.rb
@@ -21,9 +21,11 @@ def when_early_years_payment_provider_authenticated_journey_ready_to_submit
   fill_in("Year", with: date.year)
   click_button "Continue"
 
+  expect(page).to have_content "most of their time in their job working directly with children?"
   choose "Yes"
   click_button "Continue"
 
+  expect(page).to have_content "work in early years between"
   choose "No"
   click_button "Continue"
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1984
- The ticket is actually for removing a change link on EY check answers page which should not be present

# Changes

- For EY provider journey delete dependent answers
- Inject `session` into `Form` so it is available for reading or manipulation
- Now that `session` is available, delete from `session[:slugs]` visited slugs when clearing dependent answers for EY provider journey
- This solves the problem if:
  - a user goes down the extended branch of a journey
  - then changes an answer, to shorten the branch
  - then changes their answer again to extend the branch
  - they are now asked the missing questions rather than sent back to check answers page with incomplete questions
- This bug will likely be present for all journeys where there is possible branching, but the mechanism to at least be able ti fix it has been put in place 
- Fixed a typo