### PR TITLE
Send emails when claim approved

### DIFF
--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -84,7 +84,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
   def send_claim_result_email
     return if @claim.awaiting_qa?
 
-    ClaimMailer.approved(@claim).deliver_later if @claim.latest_decision.result == "approved"
+    @claim.policy.mailer.approved(@claim).deliver_later if @claim.latest_decision.result == "approved"
 
     if @claim.latest_decision.result == "rejected" && @claim.email_address.present?
       ClaimMailer.rejected(@claim).deliver_later

--- a/app/mailers/early_years_payments_mailer.rb
+++ b/app/mailers/early_years_payments_mailer.rb
@@ -25,6 +25,43 @@ class EarlyYearsPaymentsMailer < ApplicationMailer
     )
   end
 
+  def approved(claim)
+    self.class.practitioner_approved(claim).deliver_later
+    self.class.provider_approved(claim).deliver_later
+  end
+
+  def practitioner_approved(claim)
+    personalisation = {
+      ref_number: claim.reference,
+      first_name: claim.first_name
+    }
+
+    template_mail(
+      "13b60fab-8306-4cb4-84e1-8a0ff905aba6",
+      to: claim.email_address,
+      subject: nil,
+      reply_to_id: claim.policy.notify_reply_to_id,
+      personalisation:
+    )
+  end
+
+  def provider_approved(claim)
+    personalisation = {
+      ref_number: claim.reference,
+      first_name: claim.provider_contact_name,
+      practitioner_first_name: claim.first_name,
+      practitioner_last_name: claim.surname
+    }
+
+    template_mail(
+      "aa714fac-3fd7-4d3c-a510-2445c16be446",
+      to: claim.eligibility.eligible_ey_provider.primary_key_contact_email_address,
+      subject: nil,
+      reply_to_id: claim.policy.notify_reply_to_id,
+      personalisation:
+    )
+  end
+
   private
 
   def submitted_by_provider_and_send_to_provider(claim)

--- a/app/models/claim_auto_approval.rb
+++ b/app/models/claim_auto_approval.rb
@@ -25,7 +25,7 @@ class ClaimAutoApproval
         claim.notes.create!(body: "This claim has been marked for a quality assurance review")
       end
 
-      ClaimMailer.approved(claim).deliver_later unless claim.awaiting_qa?
+      claim.policy.mailer.approved(claim).deliver_later unless claim.awaiting_qa?
     rescue ActiveRecord::RecordInvalid => e
       raise AutoApprovalFailed, e
     end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -168,6 +168,16 @@ FactoryBot.define do
       end
     end
 
+    trait :approveable do
+      submitted
+
+      after(:create) do |claim|
+        ClaimCheckingTasks.new(claim).applicable_task_names.each do |task_name|
+          create(:task, :automated, :passed, name: task_name, claim: claim)
+        end
+      end
+    end
+
     trait :payrollable do
       approved
     end

--- a/spec/features/admin/approvals_spec.rb
+++ b/spec/features/admin/approvals_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "Approvals" do
+  before do
+    stub_const("Policies::EarlyYearsPayments::MIN_QA_THRESHOLD", 0)
+  end
+
+  context "when the claim is auto-approved" do
+    context "when the claim is for an EarlyYearsPayment" do
+      it "emails the provider and practitioner" do
+        provider = create(
+          :eligible_ey_provider,
+          primary_key_contact_email_address: "provider@example.com"
+        )
+
+        claim = create(
+          :claim,
+          :approveable,
+          :current_academic_year,
+          policy: Policies::EarlyYearsPayments,
+          email_address: "practitioner@example.com",
+          first_name: "practitioner_first_name",
+          surname: "practitioner_last_name",
+          provider_contact_name: "provider_contact_name",
+          eligibility_attributes: {
+            nursery_urn: provider.urn
+          }
+        )
+
+        perform_enqueued_jobs do
+          AutoApproveClaimsJob.perform_now
+        end
+
+        expect("practitioner@example.com").to have_received_email(
+          "13b60fab-8306-4cb4-84e1-8a0ff905aba6",
+          ref_number: claim.reference,
+          first_name: "practitioner_first_name"
+        )
+
+        expect("provider@example.com").to have_received_email(
+          "aa714fac-3fd7-4d3c-a510-2445c16be446",
+          ref_number: claim.reference,
+          first_name: "provider_contact_name",
+          practitioner_first_name: "practitioner_first_name",
+          practitioner_last_name: "practitioner_last_name"
+        )
+      end
+    end
+  end
+
+  context "when the claim is manually approved" do
+    context "when the claim is for an EarlyYearsPayment" do
+      it "emails the provider and practitioner" do
+        provider = create(
+          :eligible_ey_provider,
+          primary_key_contact_email_address: "provider@example.com"
+        )
+
+        claim = create(
+          :claim,
+          :approveable,
+          :current_academic_year,
+          policy: Policies::EarlyYearsPayments,
+          email_address: "practitioner@example.com",
+          first_name: "practitioner_first_name",
+          surname: "practitioner_last_name",
+          provider_contact_name: "provider_contact_name",
+          eligibility_attributes: {
+            nursery_urn: provider.urn
+          }
+        )
+
+        sign_in_as_service_operator
+
+        visit new_admin_claim_decision_path(claim)
+
+        choose "Approve"
+
+        fill_in "Decision notes", with: "LGTM"
+
+        perform_enqueued_jobs do
+          click_on "Confirm decision"
+        end
+
+        expect("practitioner@example.com").to have_received_email(
+          "13b60fab-8306-4cb4-84e1-8a0ff905aba6",
+          ref_number: claim.reference,
+          first_name: "practitioner_first_name"
+        )
+
+        expect("provider@example.com").to have_received_email(
+          "aa714fac-3fd7-4d3c-a510-2445c16be446",
+          ref_number: claim.reference,
+          first_name: "provider_contact_name",
+          practitioner_first_name: "practitioner_first_name",
+          practitioner_last_name: "practitioner_last_name"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
When an EY claim is approved we want to send an email to the
practitioner and the provider.
Mailers don't let us send two email from one action, so the approve
method enqueues jobs to send each of the emails.
I think it would probably be better for policies to be told a claim has
been approved and handle policy specific actions like sending emails in
the polciy, so rather than:
`@claimpolicy.mailer.approved(@claim).deliver_later`
we'd do
`@claim.policy.claim_approved(@claim)`
and let the policy determine the action to take (sending emails).
However this is a bit different to how we do things now, so for the time
being we'll just call the mailer, even it it's a bit odd and sends two
emails.
