### PR TITLE
[CAPT-1915] Improve admin allocations

### DIFF
--- a/app/controllers/admin/allocations_controller.rb
+++ b/app/controllers/admin/allocations_controller.rb
@@ -26,16 +26,17 @@ class Admin::AllocationsController < Admin::BaseAdminController
       .includes(:decisions, eligibility: [:claim_school, :current_school])
       .awaiting_decision
       .order(:submitted_at)
-      .limit(params[:allocate_claim_count]
-    )
+      .limit(params[:allocate_claim_count])
     claims = claims.by_policy(filtered_policy) if filtered_policy
 
-    redirect_to admin_claims_path,
-      notice: I18n.t(
-        "admin.allocations.bulk_allocate.info",
-        allocate_to_policy: policy_name,
-        dfe_user: @team_member.full_name.titleize
-      ) and return if claims.size.zero?
+    if claims.size.zero?
+      redirect_to admin_claims_path,
+        notice: I18n.t(
+          "admin.allocations.bulk_allocate.info",
+          allocate_to_policy: policy_name,
+          dfe_user: @team_member.full_name.titleize
+        ) and return
+    end
 
     ClaimAllocator.new(
       claim_ids: claims.map(&:id),
@@ -56,12 +57,14 @@ class Admin::AllocationsController < Admin::BaseAdminController
     claims = Claim.where(assigned_to_id: @team_member.id)
     claims = claims.by_policy(filtered_policy) if filtered_policy
 
-    redirect_to admin_claims_path,
-      notice: I18n.t(
-        "admin.allocations.bulk_deallocate.info",
-        allocate_to_policy: policy_name,
-        dfe_user: @team_member.full_name.titleize
-      ) and return if claims.size.zero?
+    if claims.size.zero?
+      redirect_to admin_claims_path,
+        notice: I18n.t(
+          "admin.allocations.bulk_deallocate.info",
+          allocate_to_policy: policy_name,
+          dfe_user: @team_member.full_name.titleize
+        ) and return
+    end
 
     ClaimDeallocator.new(
       claim_ids: claims.ids,

--- a/app/controllers/admin/allocations_controller.rb
+++ b/app/controllers/admin/allocations_controller.rb
@@ -21,15 +21,35 @@ class Admin::AllocationsController < Admin::BaseAdminController
   end
 
   def bulk_allocate
-    claims = Claim.where(assigned_to: nil).includes(:decisions, eligibility: [:claim_school, :current_school]).awaiting_decision.order(:submitted_at).limit(params[:allocate_claim_count])
+    claims = Claim
+      .where(assigned_to: nil)
+      .includes(:decisions, eligibility: [:claim_school, :current_school])
+      .awaiting_decision
+      .order(:submitted_at)
+      .limit(params[:allocate_claim_count]
+    )
     claims = claims.by_policy(filtered_policy) if filtered_policy
 
-    redirect_to admin_claims_path, notice: I18n.t("admin.allocations.bulk_allocate.info", allocate_to_policy: params[:allocate_to_policy].titleize, dfe_user: @team_member.full_name.titleize) and return if claims.size.zero?
+    redirect_to admin_claims_path,
+      notice: I18n.t(
+        "admin.allocations.bulk_allocate.info",
+        allocate_to_policy: policy_name,
+        dfe_user: @team_member.full_name.titleize
+      ) and return if claims.size.zero?
 
-    ClaimAllocator.new(claim_ids: claims.map(&:id), admin_user_id: params[:allocate_to_team_member]).call
-    allocate_to_policy = params[:allocate_to_policy].nil? ? "" : params[:allocate_to_policy].titleize
+    ClaimAllocator.new(
+      claim_ids: claims.map(&:id),
+      admin_user_id: params[:allocate_to_team_member]
+    ).call
 
-    redirect_to request.referrer, notice: I18n.t("admin.allocations.bulk_allocate.success", quantity: claims.size, pluralized_or_singular_claim: "claim".pluralize(claims.size), allocate_to_policy: allocate_to_policy, dfe_user: @team_member.full_name.titleize)
+    redirect_to request.referrer,
+      notice: I18n.t(
+        "admin.allocations.bulk_allocate.success",
+        quantity: claims.size,
+        pluralized_or_singular_claim: "claim".pluralize(claims.size),
+        allocate_to_policy: policy_name,
+        dfe_user: @team_member.full_name.titleize
+      )
   end
 
   def bulk_deallocate
@@ -38,19 +58,47 @@ class Admin::AllocationsController < Admin::BaseAdminController
     if filtered_policy
       claims = claims.by_policy(filtered_policy) if filtered_policy
 
-      redirect_to admin_claims_path, notice: I18n.t("admin.allocations.bulk_deallocate.info", allocate_to_policy: params[:allocate_to_policy].titleize, dfe_user: @team_member.full_name.titleize) and return if claims.size.zero?
+      redirect_to admin_claims_path,
+        notice: I18n.t(
+          "admin.allocations.bulk_deallocate.info",
+          allocate_to_policy: policy_name,
+          dfe_user: @team_member.full_name.titleize
+        ) and return if claims.size.zero?
 
-      ClaimDeallocator.new(claim_ids: claims.ids, admin_user_id: @team_member.id).call
+      ClaimDeallocator.new(
+        claim_ids: claims.ids,
+        admin_user_id: @team_member.id
+      ).call
 
-      redirect_to admin_claims_path, notice: I18n.t("admin.allocations.bulk_deallocate.success", allocate_to_policy: params[:allocate_to_policy].titleize, dfe_user: @team_member.full_name.titleize) and return
+      redirect_to admin_claims_path,
+        notice: I18n.t(
+          "admin.allocations.bulk_deallocate.success",
+          allocate_to_policy: policy_name,
+          dfe_user: @team_member.full_name.titleize
+        ) and return
     else
-      redirect_to admin_claims_path, notice: I18n.t("admin.allocations.bulk_deallocate.info", allocate_to_policy: "", dfe_user: @team_member.full_name.titleize) and return if claims.size.zero?
+      redirect_to admin_claims_path,
+        notice: I18n.t(
+          "admin.allocations.bulk_deallocate.info",
+          allocate_to_policy: policy_name,
+          dfe_user: @team_member.full_name.titleize
+        ) and return if claims.size.zero?
 
-      ClaimDeallocator.new(claim_ids: claims.ids, admin_user_id: params[:allocate_to_team_member]).call
+      ClaimDeallocator.new(
+        claim_ids: claims.ids,
+        admin_user_id: params[:allocate_to_team_member]
+      ).call
 
-      redirect_to admin_claims_path, notice: I18n.t("admin.allocations.bulk_deallocate.success", allocate_to_policy: "", dfe_user: @team_member.full_name.titleize) and return
+      redirect_to admin_claims_path,
+        notice: I18n.t(
+          "admin.allocations.bulk_deallocate.success",
+          allocate_to_policy: policy_name,
+          dfe_user: @team_member.full_name.titleize
+        ) and return
     end
   end
+
+  helper_method :filtered_policy
 
   private
 
@@ -59,7 +107,7 @@ class Admin::AllocationsController < Admin::BaseAdminController
   end
 
   def load_team_member
-    @team_member = DfeSignIn::User.find params[:allocate_to_team_member]
+    @team_member = DfeSignIn::User.find(params[:allocate_to_team_member])
   end
 
   def filtered_policy
@@ -77,7 +125,9 @@ class Admin::AllocationsController < Admin::BaseAdminController
   end
 
   def policy_name
-    params[:allocate_to_policy]
+    if filtered_policy.present?
+      filtered_policy.short_name
+    end
   end
 
   def user_confirmed?

--- a/app/views/admin/allocations/bulk_deallocate.html.erb
+++ b/app/views/admin/allocations/bulk_deallocate.html.erb
@@ -2,17 +2,19 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <%= t("admin.allocations.bulk_deallocate.confirmation",
-            allocate_to_policy: policy_name&.titleize,
+            allocate_to_policy: policy_name,
             dfe_user: @team_member.full_name.titleize) %>
     </h1>
 
-    <%= form_with url: admin_bulk_deallocate_path, method: :patch do |f| %>
+    <%= form_with url: admin_bulk_deallocate_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.hidden_field :allocate_to_team_member, value: team_member_id %>
       <%= f.hidden_field :allocate_to_policy, value: filtered_policy&.policy_type %>
-      <%= f.hidden_field :user_confirmation, value: 'yes' %>
+      <%= f.hidden_field :user_confirmation, value: "yes" %>
 
-      <%= f.submit "Unassign", class: "govuk-button govuk-button--warning" %>
-      <%= link_to "Cancel", admin_claims_path, class: "govuk-button govuk-button--secondary govuk-!-margin-left-1", role: "button", data: { module: "govuk-button" } %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Unassign", warning: true %>
+        <%= govuk_button_link_to "Cancel", admin_claims_path, secondary: true %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/allocations/bulk_deallocate.html.erb
+++ b/app/views/admin/allocations/bulk_deallocate.html.erb
@@ -8,7 +8,7 @@
 
     <%= form_with url: admin_bulk_deallocate_path, method: :patch do |f| %>
       <%= f.hidden_field :allocate_to_team_member, value: team_member_id %>
-      <%= f.hidden_field :allocate_to_policy, value: policy_name %>
+      <%= f.hidden_field :allocate_to_policy, value: filtered_policy&.policy_type %>
       <%= f.hidden_field :user_confirmation, value: 'yes' %>
 
       <%= f.submit "Unassign", class: "govuk-button govuk-button--warning" %>

--- a/spec/features/admin/admin_claim_allocation_spec.rb
+++ b/spec/features/admin/admin_claim_allocation_spec.rb
@@ -355,7 +355,7 @@ RSpec.feature "Claims awaiting a decision" do
       select "Early-Career Payments", from: "allocate_to_policy"
       click_on "Unallocate"
 
-      expect(page).to have_text "Are you sure you want to unassign Early Career Payments claims from Frank Yee?"
+      expect(page).to have_text "Are you sure you want to unassign Early-Career Payments claims from Frank Yee?"
 
       click_on "Unassign"
 
@@ -416,7 +416,7 @@ RSpec.feature "Claims awaiting a decision" do
       select "Early-Career Payments", from: "allocate_to_policy"
       click_on "Unallocate"
 
-      expect(page).to have_text "Are you sure you want to unassign Early Career Payments claims from Abdul Rafiq?"
+      expect(page).to have_text "Are you sure you want to unassign Early-Career Payments claims from Abdul Rafiq?"
 
       click_on "Unassign"
 

--- a/spec/features/admin/admin_claim_allocation_spec.rb
+++ b/spec/features/admin/admin_claim_allocation_spec.rb
@@ -360,7 +360,7 @@ RSpec.feature "Claims awaiting a decision" do
       click_on "Unassign"
 
       within(".govuk-flash__notice") do
-        expect(page).to have_text I18n.t("admin.allocations.bulk_deallocate.success", allocate_to_policy: "Early Career Payments", dfe_user: frank.full_name)
+        expect(page).to have_text I18n.t("admin.allocations.bulk_deallocate.success", allocate_to_policy: "Early-Career Payments", dfe_user: frank.full_name)
       end
 
       student_loan_claims.each do |claim|
@@ -421,7 +421,7 @@ RSpec.feature "Claims awaiting a decision" do
       click_on "Unassign"
 
       within(".govuk-flash__notice") do
-        expect(page).to have_text I18n.t("admin.allocations.bulk_deallocate.info", allocate_to_policy: "Early Career Payments", dfe_user: abdul.full_name)
+        expect(page).to have_text I18n.t("admin.allocations.bulk_deallocate.info", allocate_to_policy: "Early-Career Payments", dfe_user: abdul.full_name)
       end
 
       student_loan_claims.each do |claim|


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1915
- Fix policy name in flash message

# Other changes

- use govuk formbuilder for allocations form
- some simple tidying up:
  - removing duplicate code
  - using multi line method calls over long single line method calls 