### PR TITLE
Remove falsely passed task

### DIFF
--- a/db/data/20241121115931_remove_student_loan_plan_task_from_claims_with_no_slc_plan.rb
+++ b/db/data/20241121115931_remove_student_loan_plan_task_from_claims_with_no_slc_plan.rb
@@ -1,0 +1,22 @@
+# Run me with `rails runner db/data/20241121115931_remove_student_loan_plan_task_from_claims_with_no_slc_plan.rb`
+
+# Put your Ruby code here
+claim_ids = Claim
+  .select(:id)
+  .joins(:notes)
+  .joins(:tasks)
+  .where(student_loan_plan: nil)
+  .where("notes.body ilike ?", "%[SLC Student loan plan] - Matched%")
+  .where(tasks: {name: "student_loan_plan", passed: true})
+
+tasks_to_destroy = Task.where(
+  claim_id: claim_ids,
+  name: "student_loan_plan",
+  passed: true
+)
+
+if tasks_to_destroy.count == 704
+  tasks_to_destroy.destroy_all
+else
+  puts "Expected to find 704 tasks, but found #{tasks_to_destroy.count}"
+end


### PR DESCRIPTION
The `ClaimStudentLoanDetailsUpdater` errored, so the `student_loan_plan`
was not set on these claims, however `ClaimStudentLoanDetailsUpdater`
swallows errors so `AutomatedChecks::ClaimVerifiers::StudentLoanPlan`
still ran. `AutomatedChecks::ClaimVerifiers::StudentLoanPlan` looks for
the presence of student loan data in the student_loans_data table but
does not check the claim has a plan when creating the passed task.
This data migration removes the tasks, allowing a future student loan
import to set the plan type on these claims (as they'll now be awaiting
the slc plan task).

See the discussion [here](https://dfedigital.atlassian.net.mcas.ms/browse/CAPT-1964) for more information.