### PR TITLE
[CAPT-2027] Fix EY practitioner answer

### DIFF
--- a/app/models/journeys/early_years_payment/practitioner/answers_presenter.rb
+++ b/app/models/journeys/early_years_payment/practitioner/answers_presenter.rb
@@ -21,7 +21,7 @@ module Journeys
             a << ["Name on the account", answers.banking_name, "personal-bank-account"]
             a << ["Sort code", answers.bank_sort_code, "personal-bank-account"]
             a << ["Account number", answers.bank_account_number, "personal-bank-account"]
-            a << ["Payroll gender", answers.payroll_gender, "gender"]
+            a << ["Payroll gender", t("answers.payroll_gender.#{answers.payroll_gender}"), "gender"]
           end
         end
       end

--- a/spec/models/journeys/early_years_payment/practitioner/answers_presenter_spec.rb
+++ b/spec/models/journeys/early_years_payment/practitioner/answers_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::AnswersPresenter do
       banking_name: "Mr John Doe",
       bank_account_number: "12345678",
       bank_sort_code: "123456",
-      payroll_gender: "male"
+      payroll_gender: "dont_know"
     )
   }
 
@@ -69,7 +69,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::AnswersPresenter do
     end
 
     context "Payroll gender" do
-      it { is_expected.to include(["Payroll gender", "male", "gender"]) }
+      it { is_expected.to include(["Payroll gender", "Don’t know", "gender"]) }
     end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2027
- EY practitioner is now formatted correctly rather than using the raw internal value for payroll gender