### PR TITLE
[CAPT-2013] OTP email now personalises with journey name

### DIFF
--- a/app/forms/email_address_form.rb
+++ b/app/forms/email_address_form.rb
@@ -30,7 +30,7 @@ class EmailAddressForm < Form
 
     journey_session.save!
 
-    ClaimMailer.email_verification(answers, otp_code).deliver_now
+    ClaimMailer.email_verification(answers, otp_code, journey_session.journey_class.name).deliver_now
   end
 
   private

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -37,7 +37,7 @@ module Reminders
         reminder_otp_secret:
       )
 
-      ReminderMailer.email_verification(reminder, otp_code).deliver_now
+      ReminderMailer.email_verification(reminder, otp_code, journey_session.journey_class.name).deliver_now
 
       journey_session.save!
     end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -76,7 +76,7 @@ class ClaimMailer < ApplicationMailer
     send_mail(template_ids(claim)[:CLAIM_UPDATE_AFTER_THREE_WEEKS_NOTIFY_TEMPLATE_ID], personalisation)
   end
 
-  def email_verification(claim, one_time_password)
+  def email_verification(claim, one_time_password, journey_name)
     unknown_policy_check(claim)
     set_common_instance_variables(claim)
     @subject = "#{@claim_subject} email verification"
@@ -86,7 +86,8 @@ class ClaimMailer < ApplicationMailer
       first_name: @claim.first_name,
       one_time_password: @one_time_password,
       support_email_address: @support_email_address,
-      validity_duration: one_time_password_validity_duration
+      validity_duration: one_time_password_validity_duration,
+      journey_name:
     }
 
     send_mail(OTP_EMAIL_NOTIFY_TEMPLATE_ID, personalisation)

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -4,7 +4,7 @@ class ReminderMailer < ApplicationMailer
   helper :application
   helper :additional_payments
 
-  def email_verification(reminder, one_time_password)
+  def email_verification(reminder, one_time_password, journey_name)
     @reminder = reminder
     @one_time_password = one_time_password
     @display_name = reminder.full_name
@@ -15,7 +15,8 @@ class ReminderMailer < ApplicationMailer
       first_name: @display_name,
       one_time_password: @one_time_password,
       support_email_address: support_email_address,
-      validity_duration: one_time_password_validity_duration
+      validity_duration: one_time_password_validity_duration,
+      journey_name:
     }
 
     send_mail(OTP_EMAIL_NOTIFY_TEMPLATE_ID, personalisation)

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -69,5 +69,9 @@ module Journeys
     def requires_student_loan_details?
       false
     end
+
+    def name
+      I18n.t(:journey_name, scope: self::I18N_NAMESPACE)
+    end
   end
 end

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -19,6 +19,10 @@ module Journeys
       unsubmitted.where(journeys_sessions: {updated_at: ..24.hours.ago})
     end
 
+    def journey_class
+      Journeys.for_routing_name(journey)
+    end
+
     def submitted?
       claim.present?
     end

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe EmailAddressForm do
           email_subject: email_subject,
           first_name: "Jo",
           one_time_password: "111111",
-          support_email_address: support_email_address
+          support_email_address: support_email_address,
+          journey_name: journey_session.journey_class.name
         )
       end
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     describe "#email_verification" do
       it "raises error" do
         expect {
-          ClaimMailer.email_verification(claim, nil).deliver!
+          ClaimMailer.email_verification(claim, nil, "some journey").deliver!
         }.to raise_error(ArgumentError, "Unknown claim policy: SomePolicy")
       end
     end
@@ -349,7 +349,7 @@ RSpec.describe ClaimMailer, type: :mailer do
   end
 
   describe "#email_verification" do
-    let(:mail) { ClaimMailer.email_verification(claim, one_time_password) }
+    let(:mail) { ClaimMailer.email_verification(claim, one_time_password, "some journey") }
     let(:one_time_password) { 123124 }
     let(:claim) { build(:claim, policy: policy, first_name: "Ellie", email_address: "test@test.com") }
 
@@ -359,7 +359,13 @@ RSpec.describe ClaimMailer, type: :mailer do
       let(:policy) { Policies::EarlyCareerPayments }
 
       it "has personalisation keys for: one time password, validity_duration,first_name and support_email_address" do
-        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"Early-career payment email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"earlycareerteacherpayments@digital.education.gov.uk\", :validity_duration=>\"15 minutes\"}")
+        expect(mail.personalisation.keys.sort).to eql([:email_subject, :first_name, :journey_name, :one_time_password, :support_email_address, :validity_duration])
+        expect(mail.personalisation[:email_subject]).to eql("Early-career payment email verification")
+        expect(mail.personalisation[:first_name]).to eql("Ellie")
+        expect(mail.personalisation[:journey_name]).to eql("some journey")
+        expect(mail.personalisation[:one_time_password]).to eql(123124)
+        expect(mail.personalisation[:support_email_address]).to eql("earlycareerteacherpayments@digital.education.gov.uk")
+        expect(mail.personalisation[:validity_duration]).to eql("15 minutes")
         expect(mail.body).to be_empty
       end
     end
@@ -368,7 +374,13 @@ RSpec.describe ClaimMailer, type: :mailer do
       let(:policy) { Policies::LevellingUpPremiumPayments }
 
       it "has personalisation keys for: one time password, validity_duration,first_name and support_email_address" do
-        expect(mail[:personalisation].decoded).to eq("{:email_subject=>\"School targeted retention incentive email verification\", :first_name=>\"Ellie\", :one_time_password=>123124, :support_email_address=>\"schools-targeted.retention-incentive@education.gov.uk\", :validity_duration=>\"15 minutes\"}")
+        expect(mail.personalisation.keys.sort).to eql([:email_subject, :first_name, :journey_name, :one_time_password, :support_email_address, :validity_duration])
+        expect(mail.personalisation[:email_subject]).to eql("School targeted retention incentive email verification")
+        expect(mail.personalisation[:first_name]).to eql("Ellie")
+        expect(mail.personalisation[:journey_name]).to eql("some journey")
+        expect(mail.personalisation[:one_time_password]).to eql(123124)
+        expect(mail.personalisation[:support_email_address]).to eql("schools-targeted.retention-incentive@education.gov.uk")
+        expect(mail.personalisation[:validity_duration]).to eql("15 minutes")
         expect(mail.body).to be_empty
       end
     end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2013
- For OTP email attach journey as part of the personalisation
- Notify template has yet to be updated and will have to be updated AFTER this has been merged
- We destroy the journey session at the end of the claim journey but the new reminders controller instantiates a new blank session for the correct journey to be able to fetch name
- Random thought is that maybe we want to be able to return journey instances which might present nicer apis rather than dealing with classes
- Not sure if there is a better way to hook up the journey name to the email?