### PR TITLE
Reminders store journey

### DIFF
--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -37,9 +37,9 @@ module Admin
     end
 
     def send_reminders
-      return unless journey_configuration.open_for_submissions && journey_configuration.additional_payments?
+      return unless journey_configuration.open_for_submissions
 
-      SendReminderEmailsJob.perform_later
+      SendReminderEmailsJob.perform_later(journey_configuration.journey)
     end
   end
 end

--- a/app/forms/email_address_form.rb
+++ b/app/forms/email_address_form.rb
@@ -30,7 +30,7 @@ class EmailAddressForm < Form
 
     journey_session.save!
 
-    ClaimMailer.email_verification(answers, otp_code, journey_session.journey_class.name).deliver_now
+    ClaimMailer.email_verification(answers, otp_code, journey_session.journey_class.journey_name).deliver_now
   end
 
   private

--- a/app/forms/reminders/confirmation_form.rb
+++ b/app/forms/reminders/confirmation_form.rb
@@ -7,7 +7,8 @@ module Reminders
           email_address: submitted_claim.email_address,
           email_verified: true,
           itt_subject: itt_subject_for_submitted_claim,
-          itt_academic_year: next_academic_year.to_s
+          itt_academic_year: next_academic_year.to_s,
+          journey_class: journey.to_s
         )
       else
         Reminder.find_by(
@@ -15,7 +16,8 @@ module Reminders
           email_address: journey_session.answers.reminder_email_address,
           email_verified: true,
           itt_subject:,
-          itt_academic_year: next_academic_year.to_s
+          itt_academic_year: next_academic_year.to_s,
+          journey_class: journey.to_s
         )
       end
     end

--- a/app/forms/reminders/email_verification_form.rb
+++ b/app/forms/reminders/email_verification_form.rb
@@ -21,7 +21,8 @@ module Reminders
         email_address: journey_session.answers.reminder_email_address,
         email_verified: true,
         itt_academic_year: next_academic_year.to_s,
-        itt_subject:
+        itt_subject:,
+        journey_class: journey.to_s
       )
 
       ReminderMailer.reminder_set(reminder).deliver_now

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -37,7 +37,7 @@ module Reminders
         reminder_otp_secret:
       )
 
-      ReminderMailer.email_verification(reminder, otp_code, journey_session.journey_class.name).deliver_now
+      ReminderMailer.email_verification(reminder, otp_code, journey_session.journey_class.journey_name).deliver_now
 
       journey_session.save!
     end

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -49,7 +49,8 @@ module Reminders
           email_address: submitted_claim.email_address,
           email_verified: true,
           itt_subject: itt_subject_for_submitted_claim,
-          itt_academic_year: next_academic_year.to_s
+          itt_academic_year: next_academic_year.to_s,
+          journey_class: journey.to_s
         )
 
         ReminderMailer.reminder_set(reminder).deliver_now

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -76,7 +76,8 @@ module Reminders
     def reminder
       @reminder ||= Reminder.new(
         full_name: reminder_full_name,
-        email_address: reminder_email_address
+        email_address: reminder_email_address,
+        journey_class: journey.to_s
       )
     end
 

--- a/app/jobs/send_reminder_email_job.rb
+++ b/app/jobs/send_reminder_email_job.rb
@@ -1,5 +1,8 @@
 class SendReminderEmailJob < ApplicationJob
   def perform(reminder)
+    # TODO: Remove when the template is updated to support other journeys
+    return unless reminder.journey == Journeys::AdditionalPaymentsForTeaching
+
     ReminderMailer.reminder(reminder).deliver_now
     reminder.update!(email_sent_at: Time.now)
   end

--- a/app/jobs/send_reminder_emails_job.rb
+++ b/app/jobs/send_reminder_emails_job.rb
@@ -1,13 +1,7 @@
 class SendReminderEmailsJob < ApplicationJob
-  def perform
-    reminders.find_each(batch_size: 100) do |reminder|
+  def perform(journey)
+    Reminder.to_be_sent.by_journey(journey).find_each(batch_size: 100) do |reminder|
       SendReminderEmailJob.perform_later(reminder)
     end
-  end
-
-  private
-
-  def reminders
-    @reminders ||= Reminder.to_be_sent
   end
 end

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -9,7 +9,7 @@ class ReminderMailer < ApplicationMailer
     @one_time_password = one_time_password
     @display_name = reminder.full_name
     @subject = "Please verify your reminder email"
-    support_email_address = translate("additional_payments.support_email_address")
+    support_email_address = translate(:support_email_address, scope: reminder.journey::I18N_NAMESPACE)
     personalisation = {
       email_subject: @subject,
       first_name: @display_name,
@@ -24,7 +24,7 @@ class ReminderMailer < ApplicationMailer
 
   def reminder_set(reminder)
     @reminder = reminder
-    support_email_address = translate("additional_payments.support_email_address")
+    support_email_address = translate(:support_email_address, scope: reminder.journey::I18N_NAMESPACE)
 
     personalisation = {
       first_name: extract_first_name(@reminder.full_name),
@@ -35,6 +35,10 @@ class ReminderMailer < ApplicationMailer
     send_mail(REMINDER_SET_NOTIFY_TEMPLATE_ID, personalisation)
   end
 
+  # TODO: This template only accommodates LUP/ECP claims currently. Needs to
+  # be changed to support other policies otherwise claimants will receive the
+  # wrong information. Also most of the personalisations are not used in the
+  # template.
   def reminder(reminder)
     @reminder = reminder
     support_email_address = translate("additional_payments.support_email_address")

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -70,7 +70,7 @@ module Journeys
       false
     end
 
-    def name
+    def journey_name
       I18n.t(:journey_name, scope: self::I18N_NAMESPACE)
     end
   end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -4,8 +4,13 @@ class Reminder < ApplicationRecord
 
   scope :email_verified, -> { where(email_verified: true) }
   scope :not_yet_sent, -> { where(email_sent_at: nil) }
+  scope :by_journey, ->(journey) { where(journey_class: journey.to_s) }
   scope :inside_academic_year, -> { where(itt_academic_year: AcademicYear.current.to_s) }
   scope :to_be_sent, -> { email_verified.not_yet_sent.inside_academic_year }
+
+  def journey
+    journey_class.constantize
+  end
 
   def send_year
     itt_academic_year.start_year

--- a/app/views/admin/journey_configurations/_ecp_reminder_warning.html.erb
+++ b/app/views/admin/journey_configurations/_ecp_reminder_warning.html.erb
@@ -1,4 +1,4 @@
-<% if journey_configuration.additional_payments? && Reminder.to_be_sent.any? %>
+<% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
   <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
     <div class="govuk-form-group">
         <div class="govuk-warning-text" id="ecp-reminder-count-warning">

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -17,6 +17,7 @@ shared:
     - itt_academic_year
     - itt_subject
     - sent_one_time_password_at
+    - journey_class
   :tasks:
     - id
     - name

--- a/db/migrate/20241126105650_add_journey_class_to_reminders.rb
+++ b/db/migrate/20241126105650_add_journey_class_to_reminders.rb
@@ -1,0 +1,49 @@
+class AddJourneyClassToReminders < ActiveRecord::Migration[7.2]
+  def up
+    add_column :reminders, :journey_class, :text
+    add_index :reminders, :journey_class
+
+    # old reminders are additional payments
+    Reminder
+      .where(itt_academic_year: ["2022/2023", "2023/2024", "2024/2025"])
+      .update_all(journey_class: Journeys::AdditionalPaymentsForTeaching.to_s)
+
+    # latest year
+    # if itt subject must be additional payments
+    Reminder
+      .where(itt_academic_year: "2025/2026")
+      .where("itt_subject IS NOT NULL")
+      .update_all(journey_class: Journeys::AdditionalPaymentsForTeaching.to_s)
+
+    # latest year
+    # if itt subject blank
+    # match emails to existing to additional payment claims
+    Reminder
+      .joins("JOIN claims on claims.email_address = reminders.email_address")
+      .where(itt_academic_year: "2025/2026")
+      .where(itt_subject: nil)
+      .where(claims: {eligibility_type: ["Policies::LevellingUpPremiumPayments::Eligibility", "Policies::EarlyCareerPayments::Eligibility"]})
+      .update_all(journey_class: Journeys::AdditionalPaymentsForTeaching.to_s)
+
+    # latest year
+    # if itt subject blank
+    # match emails to existing to tslr payment claims
+    Reminder
+      .joins("JOIN claims on claims.email_address = reminders.email_address")
+      .where(itt_academic_year: "2025/2026")
+      .where(itt_subject: nil)
+      .where(claims: {eligibility_type: ["Policies::StudentLoans::Eligibility"]})
+      .update_all(journey_class: Journeys::TeacherStudentLoanReimbursement.to_s)
+
+    # assume remaining to be FE
+    Reminder
+      .where(journey_class: nil)
+      .update_all(journey_class: Journeys::FurtherEducationPayments.to_s)
+
+    change_column_null :reminders, :journey_class, false
+  end
+
+  def down
+    remove_column :reminders, :journey_class
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_13_112028) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_26_105650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -427,6 +427,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_13_112028) do
     t.datetime "email_sent_at", precision: nil
     t.string "itt_academic_year", limit: 9
     t.string "itt_subject"
+    t.text "journey_class", null: false
+    t.index ["journey_class"], name: "index_reminders_on_journey_class"
   end
 
   create_table "risk_indicators", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :reminder do
     full_name { Faker::Name.name }
     email_address { Faker::Internet.email }
+    journey_class { Journeys.all.sample.to_s }
   end
 end

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     full_name { Faker::Name.name }
     email_address { Faker::Internet.email }
     journey_class { Journeys.all.sample.to_s }
+
+    trait :with_additonal_payments_reminder do
+      journey_class { Journeys::AdditionalPaymentsForTeaching.to_s }
+    end
+
+    trait :with_fe_reminder do
+      journey_class { Journeys::FurtherEducationPayments.to_s }
+    end
   end
 end

--- a/spec/features/admin/admin_configure_services_spec.rb
+++ b/spec/features/admin/admin_configure_services_spec.rb
@@ -63,11 +63,11 @@ RSpec.feature "Service configuration" do
     let(:count) { [*1..5].sample }
 
     before do
-      create_list(:reminder, count, email_verified: true, itt_academic_year: AcademicYear.current)
+      create_list(:reminder, count, :with_additonal_payments_reminder, email_verified: true, itt_academic_year: AcademicYear.current)
       # should not be included
-      create(:reminder, email_verified: true, itt_academic_year: AcademicYear.next)
-      create(:reminder, email_verified: true, itt_academic_year: AcademicYear.current, email_sent_at: Date.today)
-      create(:reminder, email_verified: false, itt_academic_year: AcademicYear.current)
+      create(:reminder, :with_fe_reminder, email_verified: true, itt_academic_year: AcademicYear.next)
+      create(:reminder, :with_fe_reminder, email_verified: true, itt_academic_year: AcademicYear.current, email_sent_at: Date.today)
+      create(:reminder, :with_fe_reminder, email_verified: false, itt_academic_year: AcademicYear.current)
     end
 
     scenario "Service operator opens an ECP service for submissions" do
@@ -89,7 +89,7 @@ RSpec.feature "Service configuration" do
 
       within_fieldset("Service status") { choose("Open") }
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
-      # make sure email reminder jobjob is queued
+      # make sure email reminder job is queued
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
       expect(current_path).to eq(admin_journey_configurations_path)
 

--- a/spec/features/admin/admin_configure_services_spec.rb
+++ b/spec/features/admin/admin_configure_services_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
+    expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(Journeys::TeacherStudentLoanReimbursement) }
 
     expect(current_path).to eq(admin_journey_configurations_path)
 
@@ -113,7 +113,7 @@ RSpec.feature "Service configuration" do
       end
 
       select "2023/2024", from: "Accepting claims for academic year"
-      expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
+      expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(journey_configuration.journey) }
 
       within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
         expect(page).to have_content("2023/2024")

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -200,6 +200,7 @@ RSpec.feature "Further education payments" do
     expect(reminder.email_verified).to be_truthy
     expect(reminder.itt_academic_year).to eql(AcademicYear.next.to_s)
     expect(reminder.itt_subject).to be_nil
+    expect(reminder.journey_class).to eql("Journeys::FurtherEducationPayments")
 
     expect(page).to have_content("We have set your reminder")
   end

--- a/spec/features/reminders_spec.rb
+++ b/spec/features/reminders_spec.rb
@@ -75,6 +75,8 @@ RSpec.feature "Set Reminder when Eligible Later for an Early Career Payment" do
           expect(reminder.email_address).to eq "david.tau1988@hotmail.co.uk"
           expect(reminder.itt_academic_year).to eq AcademicYear.new(args[:next_year])
           expect(reminder.itt_subject).to eq args[:subject]
+          expect(reminder.journey_class).to eql("Journeys::AdditionalPaymentsForTeaching")
+
           expect(page).to have_text("We have set your reminder")
           expect(mail.template_id).to eq "0dc80ba9-adae-43cd-98bf-58882ee401c3"
         end

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe EmailAddressForm do
           first_name: "Jo",
           one_time_password: "111111",
           support_email_address: support_email_address,
-          journey_name: journey_session.journey_class.name
+          journey_name: journey_session.journey_class.journey_name
         )
       end
 

--- a/spec/lib/tasks/fix_student_loan_repayment_amounts_spec.rb
+++ b/spec/lib/tasks/fix_student_loan_repayment_amounts_spec.rb
@@ -3,6 +3,19 @@ require "rails_helper"
 Rails.application.load_tasks
 
 describe "fix_tslr_student_loan_amounts" do
+  around do |example|
+    original_stdout = $stdout
+    original_stderr = $stderr
+
+    $stdout = File.open(File::NULL, "w")
+    $stderr = File.open(File::NULL, "w")
+
+    example.run
+
+    $stdout = original_stdout
+    $stderr = original_stderr
+  end
+
   before do
     create(:student_loans_data, nino: "QQ123456A", date_of_birth: Date.new(1980, 1, 1), amount: 100, plan_type_of_deduction: 2)
     create(:student_loans_data, nino: "QQ123456A", date_of_birth: Date.new(1980, 1, 1), amount: 50, plan_type_of_deduction: 1)

--- a/spec/models/reminder_spec.rb
+++ b/spec/models/reminder_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Reminder, type: :model do
         count,
         email_verified: verified,
         email_sent_at: email_sent_at,
-        itt_academic_year: itt_academic_year
+        itt_academic_year: itt_academic_year,
+        journey_class: Journeys.all.sample.to_s
       )
     end
 


### PR DESCRIPTION
# Context

- This PR is based on PR #3175 and has been ported to the current version which has shifted since then
- Migration adds column on reminder to store the relevant journey
- It also populates this column based off the information we have
- Opening a journey still only sends for additional payments but with a small tweak can be made to send reminders for other journeys