### PR TITLE
[CAPT-2030] Fix EY started_at timestamp

### DIFF
--- a/app/forms/claim_submission_base_form.rb
+++ b/app/forms/claim_submission_base_form.rb
@@ -39,7 +39,7 @@ class ClaimSubmissionBaseForm
   end
 
   def build_claim
-    new_or_find_claim.tap do |claim|
+    Claim.new.tap do |claim|
       claim.eligibility ||= main_eligibility
       claim.started_at = journey_session.created_at
       answers.attributes.each do |name, value|
@@ -48,10 +48,6 @@ class ClaimSubmissionBaseForm
         end
       end
     end
-  end
-
-  def new_or_find_claim
-    Claim.new
   end
 
   def eligibilities

--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -18,10 +18,18 @@ module Journeys
           []
         end
 
-        def new_or_find_claim
-          (Claim.find_by(reference: journey_session.answers.reference_number) || Claim.new).tap do |c|
-            if c.eligibility
-              c.eligibility.practitioner_claim_started_at = journey_session.answers.practitioner_claim_started_at
+        def existing_or_new_claim
+          Claim.find_by(reference: journey_session.answers.reference_number) || Claim.new
+        end
+
+        def build_claim
+          existing_or_new_claim.tap do |claim|
+            claim.eligibility ||= main_eligibility
+            claim.eligibility.practitioner_claim_started_at = journey_session.answers.practitioner_claim_started_at
+            answers.attributes.each do |name, value|
+              if claim.respond_to?(:"#{name}=")
+                claim.public_send(:"#{name}=", value)
+              end
             end
           end
         end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2030
- Fix EY claim started at timestamp which is being overwritten when the practitioner starts their half of the journey
- Once deployed will need to retro populate incorrect data which I'll do by hand on the box