### PR TITLE
Upgrade govuk frontend 5.6.0 => 5.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,11 +64,10 @@ gem "httpclient"
 gem "daemons"
 
 # Gov form builder to structure claims
-gem "govuk_design_system_formbuilder", "~> 5.6"
+gem "govuk_design_system_formbuilder", "~> 5.7.1"
+gem "govuk-components", "~> 5.7.1"
 
 gem "govuk_publishing_components"
-
-gem "govuk-components", "~> 5.6.1"
 
 # See https://github.com/typhoeus/ethon/issues/185
 gem "ethon", "~> 0.16.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,9 @@ GEM
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
+    google-protobuf (4.28.3-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.28.3-x86_64-darwin)
       bigdecimal
       rake (>= 13)
@@ -235,10 +238,10 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (5.6.1)
+    govuk-components (5.7.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
-      view_component (>= 3.9, < 3.15)
+      view_component (>= 3.18, < 3.21)
     govuk_app_config (9.15.1)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.30)
@@ -251,7 +254,7 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_design_system_formbuilder (5.6.0)
+    govuk_design_system_formbuilder (5.7.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -349,6 +352,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
@@ -813,8 +818,8 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    view_component (3.14.0)
-      activesupport (>= 5.2.0, < 8.0)
+    view_component (3.20.0)
+      activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     web-console (4.2.1)
@@ -862,8 +867,8 @@ DEPENDENCIES
   faker (~> 3.4)
   faraday_middleware
   foreman
-  govuk-components (~> 5.6.1)
-  govuk_design_system_formbuilder (~> 5.6)
+  govuk-components (~> 5.7.1)
+  govuk_design_system_formbuilder (~> 5.7.1)
   govuk_publishing_components
   httpclient
   jbuilder (~> 2.13)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "a11y-dialog": "^8.1.1",
     "accessible-autocomplete": "^3.0.1",
-    "govuk-frontend": "^5.6.0",
+    "govuk-frontend": "^5.7.1",
     "govuk-one-login-service-header": "https://github.com/govuk-one-login/service-header.git"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,15 @@ focusable-selectors@^0.8.0:
   resolved "https://registry.yarnpkg.com/focusable-selectors/-/focusable-selectors-0.8.4.tgz#2ee34129b29371766ce201499e3b88c6f79ea4c1"
   integrity sha512-0XxbkD0KhOnX10qmnfF9U8DkDD8N/e4M77wMYw2Itoi4vdcoRjSkqXLZFIzkrLIOxzmzCGy88fNG1EbeXMD/zw==
 
-govuk-frontend@^5.4.0, govuk-frontend@^5.6.0:
+govuk-frontend@^5.4.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.6.0.tgz#8c0975f0d825ec7192bcfe64e3e97ef3dfa7dea1"
   integrity sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==
+
+govuk-frontend@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.7.1.tgz#d4c561ebf8c0b76130f31df8c2e4d70d340cd63f"
+  integrity sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==
 
 "govuk-one-login-service-header@https://github.com/govuk-one-login/service-header.git":
   version "1.1.0"


### PR DESCRIPTION
# Notes

- This is a prerequisite to upgrading to rails 8