### PR TITLE
[CAPT-1862] Add unsubscribe functionality

### DIFF
--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -1,0 +1,37 @@
+class UnsubscribeController < ApplicationController
+  skip_forgery_protection
+
+  def show
+    @form = Unsubscribe::ConfirmationForm.new(form_params)
+
+    if @form.reminder.nil?
+      render "subscription_not_found"
+    end
+  end
+
+  def create
+    @form = Unsubscribe::ConfirmationForm.new(form_params)
+
+    if @form.reminder.nil?
+      head :bad_request
+    else
+      @form.reminder.destroy
+    end
+  end
+
+  private
+
+  def form_params
+    params.permit([:id])
+  end
+
+  def current_journey_routing_name
+    params[:journey]
+  end
+  helper_method :current_journey_routing_name
+
+  def current_journey
+    Journeys.for_routing_name(params[:journey])
+  end
+  helper_method :current_journey
+end

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -15,7 +15,7 @@ class UnsubscribeController < ApplicationController
     if @form.reminder.nil?
       head :bad_request
     else
-      @form.reminder.destroy
+      @form.reminder.soft_delete!
     end
   end
 

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -15,7 +15,7 @@ class UnsubscribeController < ApplicationController
     if @form.reminder.nil?
       head :bad_request
     else
-      @form.reminder.soft_delete!
+      @form.reminder.mark_as_deleted!
     end
   end
 

--- a/app/forms/reminders/email_verification_form.rb
+++ b/app/forms/reminders/email_verification_form.rb
@@ -25,6 +25,8 @@ module Reminders
         journey_class: journey.to_s
       )
 
+      reminder.update!(deleted_at: nil)
+
       ReminderMailer.reminder_set(reminder).deliver_now
     end
 
@@ -34,7 +36,9 @@ module Reminders
     private
 
     def itt_subject
-      journey_session.answers.eligible_itt_subject
+      if journey_session.answers.respond_to?(:eligible_itt_subject)
+        journey_session.answers.eligible_itt_subject
+      end
     end
 
     def next_academic_year

--- a/app/forms/reminders/email_verification_form.rb
+++ b/app/forms/reminders/email_verification_form.rb
@@ -25,7 +25,7 @@ module Reminders
         journey_class: journey.to_s
       )
 
-      reminder.update!(deleted_at: nil)
+      reminder.undelete!
 
       ReminderMailer.reminder_set(reminder).deliver_now
     end

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -53,6 +53,8 @@ module Reminders
           journey_class: journey.to_s
         )
 
+        reminder.update!(deleted_at: nil)
+
         ReminderMailer.reminder_set(reminder).deliver_now
       else
         false

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -53,7 +53,7 @@ module Reminders
           journey_class: journey.to_s
         )
 
-        reminder.update!(deleted_at: nil)
+        reminder.undelete!
 
         ReminderMailer.reminder_set(reminder).deliver_now
       else

--- a/app/forms/unsubscribe/confirmation_form.rb
+++ b/app/forms/unsubscribe/confirmation_form.rb
@@ -23,7 +23,8 @@ module Unsubscribe
     end
 
     def journey_name
-      I18n.t("journey_name", scope: reminder.journey::I18N_NAMESPACE).downcase
+      default = I18n.t("journey_name", scope: reminder.journey::I18N_NAMESPACE).downcase
+      I18n.t("policy_short_name", scope: reminder.journey::I18N_NAMESPACE, default:).downcase
     end
   end
 end

--- a/app/forms/unsubscribe/confirmation_form.rb
+++ b/app/forms/unsubscribe/confirmation_form.rb
@@ -1,0 +1,29 @@
+module Unsubscribe
+  class ConfirmationForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :id, :string
+
+    def reminder
+      @reminder ||= Reminder.find_by(id:)
+    end
+
+    def obfuscasted_email
+      head, tail = reminder.email_address.split("@")
+
+      mask = case head.size
+      when 1, 2, 3
+        "*" * head.size
+      else
+        [head[0], "*" * (head.length - 2), head[-1]].join
+      end
+
+      [mask, "@", tail].join
+    end
+
+    def journey_name
+      I18n.t("journey_name", scope: reminder.journey::I18N_NAMESPACE).downcase
+    end
+  end
+end

--- a/app/forms/unsubscribe/confirmation_form.rb
+++ b/app/forms/unsubscribe/confirmation_form.rb
@@ -6,7 +6,7 @@ module Unsubscribe
     attribute :id, :string
 
     def reminder
-      @reminder ||= Reminder.find_by(id:)
+      @reminder ||= Reminder.not_deleted.find_by(id:)
     end
 
     def obfuscasted_email

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -19,7 +19,13 @@ class ReminderMailer < ApplicationMailer
       journey_name:
     }
 
-    send_mail(OTP_EMAIL_NOTIFY_TEMPLATE_ID, personalisation)
+    template_mail(
+      OTP_EMAIL_NOTIFY_TEMPLATE_ID,
+      to: @reminder.email_address,
+      reply_to_id: GENERIC_NOTIFY_REPLY_TO_ID,
+      subject: @subject,
+      personalisation:
+    )
   end
 
   def reminder_set(reminder)
@@ -29,10 +35,17 @@ class ReminderMailer < ApplicationMailer
     personalisation = {
       first_name: extract_first_name(@reminder.full_name),
       support_email_address: support_email_address,
-      next_application_window: @reminder.send_year
+      next_application_window: @reminder.send_year,
+      unsubscribe_url: unsubscribe_url(reminder:)
     }
 
-    send_mail(REMINDER_SET_NOTIFY_TEMPLATE_ID, personalisation)
+    template_mail(
+      REMINDER_SET_NOTIFY_TEMPLATE_ID,
+      to: @reminder.email_address,
+      reply_to_id: GENERIC_NOTIFY_REPLY_TO_ID,
+      subject: @subject,
+      personalisation:
+    )
   end
 
   # TODO: This template only accommodates LUP/ECP claims currently. Needs to
@@ -47,22 +60,22 @@ class ReminderMailer < ApplicationMailer
       support_email_address: support_email_address
     }
 
-    send_mail(REMINDER_APPLICATION_WINDOW_OPEN_NOTIFY_TEMPLATE_ID, personalisation)
-  end
-
-  private
-
-  def extract_first_name(fullname)
-    (fullname || "").split(" ").first
-  end
-
-  def send_mail(template_id, personalisation)
     template_mail(
-      template_id,
+      REMINDER_APPLICATION_WINDOW_OPEN_NOTIFY_TEMPLATE_ID,
       to: @reminder.email_address,
       reply_to_id: GENERIC_NOTIFY_REPLY_TO_ID,
       subject: @subject,
       personalisation:
     )
+  end
+
+  private
+
+  def unsubscribe_url(reminder:)
+    "https://#{ENV["CANONICAL_HOSTNAME"]}/#{reminder.journey::ROUTING_NAME}/unsubscribe/reminders/#{reminder.id}"
+  end
+
+  def extract_first_name(fullname)
+    (fullname || "").split(" ").first
   end
 end

--- a/app/models/concerns/deletable.rb
+++ b/app/models/concerns/deletable.rb
@@ -16,4 +16,8 @@ module Deletable
 
     update!(deleted_at: Time.zone.now)
   end
+
+  def undelete!
+    update!(deleted_at: nil)
+  end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -7,6 +7,7 @@ class Reminder < ApplicationRecord
   scope :by_journey, ->(journey) { where(journey_class: journey.to_s) }
   scope :inside_academic_year, -> { where(itt_academic_year: AcademicYear.current.to_s) }
   scope :to_be_sent, -> { email_verified.not_yet_sent.inside_academic_year }
+  scope :not_deleted, -> { where(deleted_at: nil) }
 
   def journey
     journey_class.constantize
@@ -20,5 +21,9 @@ class Reminder < ApplicationRecord
     AcademicYear.new(
       read_attribute(:itt_academic_year)
     )
+  end
+
+  def soft_delete!
+    update!(deleted_at: Time.now)
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,4 +1,6 @@
 class Reminder < ApplicationRecord
+  include Deletable
+
   attribute :sent_one_time_password_at, :datetime
   attribute :one_time_password, :string, limit: 6
 
@@ -7,7 +9,6 @@ class Reminder < ApplicationRecord
   scope :by_journey, ->(journey) { where(journey_class: journey.to_s) }
   scope :inside_academic_year, -> { where(itt_academic_year: AcademicYear.current.to_s) }
   scope :to_be_sent, -> { email_verified.not_yet_sent.inside_academic_year }
-  scope :not_deleted, -> { where(deleted_at: nil) }
 
   def journey
     journey_class.constantize

--- a/app/views/reminders/confirmation.html.erb
+++ b/app/views/reminders/confirmation.html.erb
@@ -9,7 +9,7 @@
       <h2 class="govuk-heading-m">What happens next</h2>
 
       <p class="govuk-body">
-        We will send you a verification email now. If you don’t receive one,
+        We will send you a confirmation email now. If you don’t receive one,
         contact us on <%= mail_to t("support_email_address", scope: journey::I18N_NAMESPACE), t("support_email_address", scope: journey::I18N_NAMESPACE), class: "govuk-link" %>.
       </p>
 

--- a/app/views/unsubscribe/create.html.erb
+++ b/app/views/unsubscribe/create.html.erb
@@ -1,0 +1,11 @@
+<%= content_for(:page_title) { "Unsubscribe" } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text: "Unsubscribe complete") %>
+
+    <p class="govuk-body">
+    You will no longer receive your <%= @form.journey_name %> reminder to <%= @form.obfuscasted_email %>.
+    </p>
+  </div>
+</div>

--- a/app/views/unsubscribe/show.html.erb
+++ b/app/views/unsubscribe/show.html.erb
@@ -10,7 +10,7 @@
       <%= f.hidden_field :id %>
 
       <h1 class="govuk-heading-l">
-        Are you sure you wish to unsubscribe from your <%= @form.journey_name %> reminder?
+        Are you sure you wish to unsubscribe from your reminder?
       </h1>
 
       <p class="govuk-body">
@@ -19,6 +19,10 @@
 
       <p class="govuk-body">
         However, you will still continue to receive updates about your claim as it progresses.
+      <p>
+
+      <p class="govuk-body">
+        You will also continue to receive communications related to the claim service, please contact <%= govuk_mail_to I18n.t(:support_email_address) %> if you no longer wish these kinds of updates.
       <p>
 
       <%= f.govuk_submit "Unsubscribe" %>

--- a/app/views/unsubscribe/show.html.erb
+++ b/app/views/unsubscribe/show.html.erb
@@ -14,15 +14,15 @@
       </h1>
 
       <p class="govuk-body">
-        You will no longer receive your reminder to <%= @form.obfuscasted_email %>.
+        You will no longer receive reminders regarding future application windows for targeted retention incentive payments from the Department for Education.
       <p>
 
       <p class="govuk-body">
-        However, you will still continue to receive updates about your claim as it progresses.
+        However, if you have already submitted a claim for a targeted retention incentive payment, you will still continue to receive updates about the progress of your claim.
       <p>
 
       <p class="govuk-body">
-        You will also continue to receive communications related to the claim service, please contact <%= govuk_mail_to I18n.t(:support_email_address) %> if you no longer wish these kinds of updates.
+        You may also continue to receive communications related to the Claim Additional Payments service. Please email <%= govuk_mail_to I18n.t(:support_email_address) %> if you no longer want to receive emails.
       <p>
 
       <%= f.govuk_submit "Unsubscribe" %>

--- a/app/views/unsubscribe/show.html.erb
+++ b/app/views/unsubscribe/show.html.erb
@@ -1,0 +1,27 @@
+<%= content_for(:page_title) { "Unsubscribe" } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form,
+      url: unsubscribe_index_path,
+      scope: "",
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+
+      <%= f.hidden_field :id %>
+
+      <h1 class="govuk-heading-l">
+        Are you sure you wish to unsubscribe from your <%= @form.journey_name %> reminder?
+      </h1>
+
+      <p class="govuk-body">
+        You will no longer receive your reminder to <%= @form.obfuscasted_email %>.
+      <p>
+
+      <p class="govuk-body">
+        However, you will still continue to receive updates about your claim as it progresses.
+      <p>
+
+      <%= f.govuk_submit "Unsubscribe" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/unsubscribe/subscription_not_found.html.erb
+++ b/app/views/unsubscribe/subscription_not_found.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      We can’t find your subscription
+    </h1>
+
+    <p class="govuk-body">
+      You may have already unsubscribed. If you haven’t, check your email and copy the link again.
+    </p>
+
+    <p class="govuk-body">
+      If you need more help, contact support at <%= govuk_mail_to I18n.t("support_email_address", scope: [current_journey::I18N_NAMESPACE]), I18n.t("support_email_address", scope: [current_journey::I18N_NAMESPACE]) %>
+    </p>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -18,6 +18,7 @@ shared:
     - itt_subject
     - sent_one_time_password_at
     - journey_class
+    - deleted_at
   :tasks:
     - id
     - name

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,8 +60,7 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  # Raise an exception if parameters that are not explicitly permitted are found
-  config.action_controller.action_on_unpermitted_parameters = :raise
+  config.action_controller.action_on_unpermitted_parameters = :log
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,8 +33,7 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Raise an exception if parameters that are not explicitly permitted are found
-  config.action_controller.action_on_unpermitted_parameters = :raise
+  config.action_controller.action_on_unpermitted_parameters = :log
 
   config.action_mailer.perform_caching = false
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
       format:
         unit: "£"
   service_name: "Claim additional payments for teaching"
-  support_email_address: "additionalteachingpayment@digital.education.gov.uk"
+  support_email_address: "additional.teachingpayment@education.gov.uk"
   check_your_answers:
     heading_send_application: Confirm and send your application
     statement:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,11 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :unsubscribe,
+      path: "/unsubscribe/:resource_class",
+      constraints: {resource_class: /reminders/},
+      only: [:create, :show]
+
     scope constraints: {journey: /further-education-payments|additional-payments/} do
       resources :reminders,
         only: [:show, :update],

--- a/db/migrate/20241206105631_add_deleted_at_to_reminders.rb
+++ b/db/migrate/20241206105631_add_deleted_at_to_reminders.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToReminders < ActiveRecord::Migration[7.2]
+  def change
+    add_column :reminders, :deleted_at, :datetime
+  end
+end

--- a/db/migrate/20241206105631_add_deleted_at_to_reminders.rb
+++ b/db/migrate/20241206105631_add_deleted_at_to_reminders.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToReminders < ActiveRecord::Migration[7.2]
+class AddDeletedAtToReminders < ActiveRecord::Migration[8.0]
   def change
     add_column :reminders, :deleted_at, :datetime
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_05_121421) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_06_105631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -429,6 +429,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_121421) do
     t.string "itt_academic_year", limit: 9
     t.string "itt_subject"
     t.text "journey_class", null: false
+    t.datetime "deleted_at"
     t.index ["journey_class"], name: "index_reminders_on_journey_class"
   end
 

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     trait :with_fe_reminder do
       journey_class { Journeys::FurtherEducationPayments.to_s }
     end
+
+    trait :soft_deleted do
+      deleted_at { 1.second.ago }
+    end
   end
 end

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "unsubscribe from reminders" do
+  let(:reminder) do
+    create(
+      :reminder,
+      journey_class: Journeys::FurtherEducationPayments.to_s
+    )
+  end
+
+  scenario "happy path" do
+    visit "/#{reminder.journey::ROUTING_NAME}/unsubscribe/reminders/#{reminder.id}"
+    expect(page).to have_content "Are you sure you wish to unsub"
+
+    expect {
+      click_button("Unsubscribe")
+    }.to change(Reminder, :count).by(-1)
+
+    expect(page).to have_content "Unsubscribe complete"
+  end
+
+  scenario "when reminder does not exist" do
+    visit "/#{reminder.journey::ROUTING_NAME}/unsubscribe/reminders/idonotexist"
+    expect(page).to have_content "We can’t find your subscription"
+  end
+end

--- a/spec/forms/current_school_form_spec.rb
+++ b/spec/forms/current_school_form_spec.rb
@@ -19,14 +19,6 @@ RSpec.describe CurrentSchoolForm do
       )
     end
 
-    context "unpermitted claim param" do
-      let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
-
-      it "raises an error" do
-        expect { form }.to raise_error ActionController::UnpermittedParameters
-      end
-    end
-
     describe "#schools" do
       context "new form" do
         let(:params) { ActionController::Parameters.new({slug: slug, claim: {}}) }

--- a/spec/forms/employed_directly_form_spec.rb
+++ b/spec/forms/employed_directly_form_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EmployedDirectlyForm do
     )
   end
 
-  context "unpermitted claim param" do
-    let(:params) { ActionController::Parameters.new({slug:, claim: {random_param: 1}}) }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "#employed_directly" do
     let(:params) { ActionController::Parameters.new({slug:, claim: {}}) }
 

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -48,14 +48,6 @@ RSpec.describe Form, type: :model do
   let(:claim_params) { {first_name: "test-name"} }
 
   describe "#initialize" do
-    context "with unpermitted params" do
-      let(:claim_params) { {unpermitted: "my-name"} }
-
-      it "raises an error" do
-        expect { form }.to raise_error(ActionController::UnpermittedParameters)
-      end
-    end
-
     context "with valid params" do
       let(:claim_params) { {first_name: "my-name"} }
 
@@ -216,14 +208,6 @@ RSpec.describe Form, type: :model do
     context "with params containing attributes defined on the form" do
       it "permits the attributes in the params" do
         expect(form.permitted_params).to eql(ActionController::Parameters.new(claim_params.stringify_keys).permit!)
-      end
-    end
-
-    context "with params containing attributes not defined on the form" do
-      let(:claim_params) { super().merge(unpermitted_attribute: "test-value") }
-
-      it "raises an error" do
-        expect { form.permitted_params }.to raise_error(ActionController::UnpermittedParameters)
       end
     end
   end

--- a/spec/forms/gender_form_spec.rb
+++ b/spec/forms/gender_form_spec.rb
@@ -25,14 +25,6 @@ RSpec.describe GenderForm do
       )
     end
 
-    context "unpermitted claim param" do
-      let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
-
-      it "raises an error" do
-        expect { form }.to raise_error ActionController::UnpermittedParameters
-      end
-    end
-
     describe "#payroll_gender" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {}}) }
 

--- a/spec/forms/journeys/additional_payments_for_teaching/entire_term_contract_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/entire_term_contract_form_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::EntireTermContractForm d
     )
   end
 
-  context "unpermitted claim param" do
-    let(:params) { ActionController::Parameters.new({slug:, claim: {random_param: 1}}) }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "#has_entire_term_contract" do
     let(:params) { ActionController::Parameters.new({slug:, claim: {}}) }
 

--- a/spec/forms/journeys/additional_payments_for_teaching/induction_completed_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/induction_completed_form_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::InductionCompletedForm d
     )
   end
 
-  context "unpermitted claim param" do
-    let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "#save" do
     let(:params) { ActionController::Parameters.new({slug: slug, claim: {induction_completed: true}}) }
 

--- a/spec/forms/journeys/additional_payments_for_teaching/itt_academic_year_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/itt_academic_year_form_spec.rb
@@ -31,14 +31,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::IttAcademicYearForm do
     )
   end
 
-  context "unpermitted claim param" do
-    let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "#itt_academic_year" do
     let(:params) { ActionController::Parameters.new({slug: slug, claim: {}}) }
 

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/claim_school_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/claim_school_form_spec.rb
@@ -34,14 +34,6 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSchoolForm do
     )
   end
 
-  context "unpermitted claim param" do
-    let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "#schools" do
     context "new form" do
       let(:params) { ActionController::Parameters.new({slug: slug, claim: {}}) }

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -30,16 +30,6 @@ RSpec.describe PersonalDetailsForm, type: :model do
       )
     end
 
-    context "unpermitted claim param" do
-      let(:params) { {nonsense_id: 1} }
-      let(:logged_in_with_tid) { nil }
-      let(:teacher_id_user_info) { {} }
-
-      it "raises an error" do
-        expect { form }.to raise_error ActionController::UnpermittedParameters
-      end
-    end
-
     describe "#show_name_section?" do
       context "when not logged_in_with_tid" do
         let(:logged_in_with_tid) { nil }

--- a/spec/forms/poor_performance_form_spec.rb
+++ b/spec/forms/poor_performance_form_spec.rb
@@ -11,14 +11,6 @@ RSpec.describe PoorPerformanceForm do
 
   it { expect(form).to be_a(Form) }
 
-  context "with unpermitted params" do
-    let(:claim_params) { {unpermitted_param: ""} }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "validations" do
     context "subject_to_formal_performance_action" do
       it "cannot be nil" do

--- a/spec/forms/provide_mobile_number_form_spec.rb
+++ b/spec/forms/provide_mobile_number_form_spec.rb
@@ -29,16 +29,6 @@ RSpec.describe ProvideMobileNumberForm, type: :model do
       )
     end
 
-    context "unpermitted claim param" do
-      let(:provide_mobile_number) { nil }
-
-      let(:params) { ActionController::Parameters.new({slug: slug, claim: {nonsense_id: 1}}) }
-
-      it "raises an error" do
-        expect { form }.to raise_error ActionController::UnpermittedParameters
-      end
-    end
-
     describe "validations" do
       let(:provide_mobile_number) { nil }
 

--- a/spec/forms/reminders/email_verification_form_spec.rb
+++ b/spec/forms/reminders/email_verification_form_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Reminders::EmailVerificationForm do
+  let!(:journey_configuration) do
+    create(:journey_configuration, :further_education_payments)
+  end
+
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) do
+    create(
+      :further_education_payments_session,
+      answers: {
+        reminder_full_name: "John Doe",
+        reminder_email_address: "john.doe@example.com"
+      }
+    )
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params: ActionController::Parameters.new,
+      session: {}
+    )
+  end
+
+  describe "#save!" do
+    let(:fake_passing_validator) { OpenStruct.new(valid?: true) }
+
+    before do
+      allow(OneTimePassword::Validator).to receive(:new).and_return(fake_passing_validator)
+    end
+
+    context "when reminder previously soft deleted" do
+      let!(:reminder) do
+        create(
+          :reminder,
+          :soft_deleted,
+          full_name: "John Doe",
+          email_address: "john.doe@example.com",
+          email_verified: true,
+          itt_subject: nil,
+          itt_academic_year: journey_configuration.current_academic_year.succ,
+          journey_class: journey.to_s
+        )
+      end
+
+      it "becomes undeleted" do
+        expect {
+          subject.save!
+        }.to change { reminder.reload.deleted_at }.to(nil)
+      end
+    end
+  end
+end

--- a/spec/forms/reminders/personal_details_form_spec.rb
+++ b/spec/forms/reminders/personal_details_form_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Reminders::PersonalDetailsForm do
+  let!(:journey_configuration) do
+    create(:journey_configuration, :further_education_payments)
+  end
+
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session) }
+  let(:claim) { create(:claim, :submitted) }
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params: ActionController::Parameters.new,
+      session: {"submitted_claim_id" => claim.id}
+    )
+  end
+
+  describe "#set_reminder_from_claim" do
+    context "when reminder previously soft deleted" do
+      let!(:reminder) do
+        create(
+          :reminder,
+          :soft_deleted,
+          full_name: claim.full_name,
+          email_address: claim.email_address,
+          email_verified: true,
+          itt_subject: claim.eligible_itt_subject,
+          itt_academic_year: journey_configuration.current_academic_year.succ,
+          journey_class: journey.to_s
+        )
+      end
+
+      it "becomes undeleted" do
+        expect {
+          subject.set_reminder_from_claim
+        }.to change { reminder.reload.deleted_at }.to(nil)
+      end
+    end
+  end
+end

--- a/spec/forms/supply_teacher_form_spec.rb
+++ b/spec/forms/supply_teacher_form_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SupplyTeacherForm do
     )
   end
 
-  context "unpermitted claim param" do
-    let(:params) { ActionController::Parameters.new({slug:, claim: {random_param: 1}}) }
-
-    it "raises an error" do
-      expect { form }.to raise_error ActionController::UnpermittedParameters
-    end
-  end
-
   describe "#employed_as_supply_teacher" do
     let(:params) { ActionController::Parameters.new({slug:, claim: {}}) }
 

--- a/spec/forms/unsubscribe/confirmation_form_spec.rb
+++ b/spec/forms/unsubscribe/confirmation_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Unsubscribe::ConfirmationForm do
+  describe "#obfuscasted_email" do
+    let(:reminder) {
+      create(
+        :reminder,
+        email_address:
+      )
+    }
+
+    subject { described_class.new(id: reminder.id) }
+
+    context "happy path" do
+      let(:email_address) { "hello@example.com" }
+
+      it "obfuscates" do
+        expect(subject.obfuscasted_email).to eql "h***o@example.com"
+      end
+    end
+
+    context "1 char email" do
+      let(:email_address) { "h@example.com" }
+
+      it "obfuscates" do
+        expect(subject.obfuscasted_email).to eql "*@example.com"
+      end
+    end
+
+    context "2 char email" do
+      let(:email_address) { "hh@example.com" }
+
+      it "obfuscates" do
+        expect(subject.obfuscasted_email).to eql "**@example.com"
+      end
+    end
+
+    context "3 char email" do
+      let(:email_address) { "hah@example.com" }
+
+      it "obfuscates" do
+        expect(subject.obfuscasted_email).to eql "***@example.com"
+      end
+    end
+  end
+end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe ReminderMailer do
+  let(:reminder) {
+    create(:reminder, :with_fe_reminder)
+  }
+
+  describe "#reminder_set" do
+    it "includes unsubscribe_url in personalisation" do
+      mail = described_class.reminder_set(reminder)
+
+      expect(mail.personalisation[:unsubscribe_url]).to eql("https://www.example.com/further-education-payments/unsubscribe/reminders/#{reminder.id}")
+    end
+  end
+end

--- a/spec/requests/admin/admin_amendments_spec.rb
+++ b/spec/requests/admin/admin_amendments_spec.rb
@@ -87,15 +87,11 @@ RSpec.describe "Admin claim amendments" do
         expect(response.body).to include("To amend the claim you must change at least one value")
       end
 
-      it "raises an error and does not create an amendment or update the claim when attempting to modify an attribute that isn't in the allowed list" do
+      it "does not create an amendment or update the claim when attempting to modify an attribute that isn't in the allowed list" do
         original_counts = [claim.reference, claim.amendments.size]
 
-        expect {
-          post admin_claim_amendments_url(claim, amendment: {claim: {reference: "REF12345"},
-                                                             notes: "Claimant made a typo"})
-        }.to raise_error(
-          ActionController::UnpermittedParameters
-        )
+        post admin_claim_amendments_url(claim, amendment: {claim: {reference: "REF12345"},
+                                                           notes: "Claimant made a typo"})
 
         expect([claim.reference, claim.amendments.size]).to eq(original_counts)
       end

--- a/spec/requests/unsubscribe_spec.rb
+++ b/spec/requests/unsubscribe_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "unsubscribe", type: :request do
-  let!(:reminder) { create(:reminder, :with_fe_reminder) }
+  let(:reminder) { create(:reminder, :with_fe_reminder) }
 
   describe "POST #create" do
     context "happy path" do
-      it "unsubscribes from reminder via one click unsubscribe" do
-        expect {
-          post "/further-education-payments/unsubscribe/reminders", params: {id: reminder.id}
-        }.to change(Reminder, :count).by(-1)
+      it "sets deleted_at from reminder via one click unsubscribe" do
+        post "/further-education-payments/unsubscribe/reminders", params: {id: reminder.id}
+
+        expect(reminder.reload.deleted_at).to be_present
 
         expect(response).to be_successful
       end
@@ -17,6 +17,16 @@ RSpec.describe "unsubscribe", type: :request do
     context "when no such reminder" do
       it "returns 400 error" do
         post "/further-education-payments/unsubscribe/reminders", params: {id: "idonotexist"}
+
+        expect(response).to be_bad_request
+      end
+    end
+
+    context "when already soft deleted" do
+      let(:reminder) { create(:reminder, :with_fe_reminder, :soft_deleted) }
+
+      it "returns 400 error" do
+        post "/further-education-payments/unsubscribe/reminders", params: {id: reminder.id}
 
         expect(response).to be_bad_request
       end

--- a/spec/requests/unsubscribe_spec.rb
+++ b/spec/requests/unsubscribe_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "unsubscribe", type: :request do
+  let!(:reminder) { create(:reminder, :with_fe_reminder) }
+
+  describe "POST #create" do
+    context "happy path" do
+      it "unsubscribes from reminder via one click unsubscribe" do
+        expect {
+          post "/further-education-payments/unsubscribe/reminders", params: {id: reminder.id}
+        }.to change(Reminder, :count).by(-1)
+
+        expect(response).to be_successful
+      end
+    end
+
+    context "when no such reminder" do
+      it "returns 400 error" do
+        post "/further-education-payments/unsubscribe/reminders", params: {id: "idonotexist"}
+
+        expect(response).to be_bad_request
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1862
- Add unsubscribe link to reminder emails
- NOTE: notify templates must to be updated AFTER this change has been deployed

# Changes

- Send `unsubscribe_url` as part of reminder emails in the `personalisation` section so they can be appended to emails sent to users
- Should a user click on this link they are sent to the send to confirm if they wish to unsubscribe
- As recommended by notify https://docs.notifications.service.gov.uk/ruby.html#unsubscribe-link-at-the-bottom-of-the-email-recommended
- Upon success they get show the confirmation panel that transaction is complete
- Should user visit invalid link or if they are already unsubscribed they are show a page with copy explaining the situation
- `config.action_controller.action_on_unpermitted_parameters` has been changed back to the rails default setting which happens to also be the setting used in production. not sure why this was ever changed in the first place as it makes development and test behave differently to how production would behave

# Notes

- One click unsubscribe is not present in this change, however the server side mechanism has been added
- This is because the library we are using at the moment does not support this notify feature see https://github.com/dxw/mail-notify/issues/166
- We either need to switch to official library or add the needed functionality to support this feature

# Screenshots

## After user click unsubscribe link in email
![Screenshot 2025-01-09 at 14 18 23](https://github.com/user-attachments/assets/39b1ddfd-fa7c-41fb-b1db-af0f879b88b2)

---

## Upon successfully unsubscribing
![complete](https://github.com/user-attachments/assets/22d59afd-efca-4e35-8824-0f5d344082cb)


---

## Wrong link or user already unsubscribed
![404](https://github.com/user-attachments/assets/ca23cb3d-f52d-4446-b226-aec449ede204)
