### PR TITLE
[CAPT-2051] Better OL name

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -92,13 +92,14 @@ class OmniauthCallbacksController < ApplicationController
       return redirect_to "/auth/failure?strategy=onelogin&message=access_denied&origin=#{origin}"
     end
 
-    first_name, last_name, date_of_birth = extract_data_from_jwt(core_identity_jwt)
+    first_name, last_name, full_name, date_of_birth = extract_data_from_jwt(core_identity_jwt)
 
     journey_session.answers.assign_attributes(
       identity_confirmed_with_onelogin: true,
       onelogin_idv_at: Time.now,
       onelogin_idv_first_name: first_name,
       onelogin_idv_last_name: last_name,
+      onelogin_idv_full_name: full_name,
       onelogin_idv_date_of_birth: date_of_birth
     )
     journey_session.answers.first_name ||= first_name
@@ -124,16 +125,18 @@ class OmniauthCallbacksController < ApplicationController
     if OneLoginSignIn.bypass?
       first_name = ONE_LOGIN_TEST_USER[:first_name]
       last_name = ONE_LOGIN_TEST_USER[:last_name]
+      full_name = "#{first_name} #{last_name}"
       date_of_birth = ONE_LOGIN_TEST_USER[:date_of_birth]
     else
       validator = OneLogin::CoreIdentityValidator.new(jwt:)
       validator.call
       first_name = validator.first_name
       last_name = validator.last_name
+      full_name = validator.full_name
       date_of_birth = validator.date_of_birth
     end
 
-    [first_name, last_name, date_of_birth]
+    [first_name, last_name, full_name, date_of_birth]
   end
 
   def test_user_auth_hash

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -93,7 +93,8 @@ class Claim < ApplicationRecord
     practitioner_email_address: true,
     provider_contact_name: true,
     started_at: false,
-    verified_at: false
+    verified_at: false,
+    onelogin_idv_full_name: true
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks
@@ -246,10 +247,6 @@ class Claim < ApplicationRecord
   scope :require_in_progress_update_emails, -> {
     by_policies(Policies.all.select { |p| p.require_in_progress_update_emails? })
   }
-
-  def onelogin_idv_full_name
-    "#{onelogin_idv_first_name} #{onelogin_idv_last_name}"
-  end
 
   def hold!(reason:, user:)
     if holdable? && !held?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -475,12 +475,12 @@ class Claim < ApplicationRecord
     end
   end
 
-  def one_login_idv_mismatch?
-    !one_login_idv_name_match? || !one_login_idv_dob_match?
-  end
-
   def one_login_idv_match?
     one_login_idv_name_match? && one_login_idv_dob_match?
+  end
+
+  def one_login_idv_mismatch?
+    !one_login_idv_match?
   end
 
   def awaiting_provider_verification?
@@ -500,7 +500,8 @@ class Claim < ApplicationRecord
   private
 
   def one_login_idv_name_match?
-    onelogin_idv_full_name.downcase == "#{first_name.downcase} #{surname.downcase}"
+    /\A#{first_name.strip.downcase} /.match?(onelogin_idv_full_name.strip.downcase) &&
+      / #{surname.strip.downcase}\z/.match?(onelogin_idv_full_name.strip.downcase)
   end
 
   def one_login_idv_dob_match?

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -44,6 +44,7 @@ module Journeys
 
     attribute :onelogin_idv_first_name, :string
     attribute :onelogin_idv_last_name, :string
+    attribute :onelogin_idv_full_name, :string
     attribute :onelogin_idv_date_of_birth, :date
 
     attribute :onelogin_auth_at, :datetime

--- a/app/models/one_login/core_identity_validator.rb
+++ b/app/models/one_login/core_identity_validator.rb
@@ -21,6 +21,10 @@ class OneLogin::CoreIdentityValidator
     Date.parse(decoded_jwt[0]["vc"]["credentialSubject"]["birthDate"][0]["value"])
   end
 
+  def full_name
+    name_parts.map { |hash| hash["value"] }.join(" ")
+  end
+
   private
 
   def name_parts

--- a/app/models/one_login/core_identity_validator.rb
+++ b/app/models/one_login/core_identity_validator.rb
@@ -22,7 +22,15 @@ class OneLogin::CoreIdentityValidator
   end
 
   def full_name
-    name_parts.map { |hash| hash["value"] }.join(" ")
+    given_names = name_parts
+      .select { |hash| hash["type"] == "GivenName" }
+      .map { |hash| hash["value"] }
+
+    family_names = name_parts
+      .select { |hash| hash["type"] == "FamilyName" }
+      .map { |hash| hash["value"] }
+
+    (given_names + family_names).join(" ")
   end
 
   private

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -34,6 +34,7 @@
   - onelogin_uid
   - onelogin_idv_first_name
   - onelogin_idv_last_name
+  - onelogin_idv_full_name
   - onelogin_idv_date_of_birth
   :claim_decisions:
   - trn

--- a/db/migrate/20241205121421_add_ol_full_name_to_claims.rb
+++ b/db/migrate/20241205121421_add_ol_full_name_to_claims.rb
@@ -1,0 +1,15 @@
+class AddOlFullNameToClaims < ActiveRecord::Migration[8.0]
+  def up
+    add_column :claims, :onelogin_idv_full_name, :text
+
+    execute <<-SQL
+      UPDATE claims
+      SET onelogin_idv_full_name = CONCAT(claims.onelogin_idv_first_name, ' ', claims.onelogin_idv_last_name)
+      WHERE claims.onelogin_idv_full_name IS NULL
+    SQL
+  end
+
+  def down
+    remove_column :claims, :onelogin_idv_full_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_26_105650) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_05_121421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_26_105650) do
     t.date "onelogin_idv_date_of_birth"
     t.datetime "started_at", precision: nil, null: false
     t.datetime "verified_at"
+    t.text "onelogin_idv_full_name"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -57,6 +57,7 @@ FactoryBot.define do
       onelogin_idv_at { (onelogin_auth_at + 1.hour) }
       onelogin_idv_first_name { first_name }
       onelogin_idv_last_name { surname }
+      onelogin_idv_full_name { [first_name, surname].join(" ") }
       onelogin_idv_date_of_birth { date_of_birth }
     end
 

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -180,6 +180,7 @@ RSpec.feature "Further education payments" do
 
     expect(claim.first_name).to eql("John")
     expect(claim.surname).to eql("Doe")
+    expect(claim.onelogin_idv_full_name).to eql("TEST USER")
     expect(claim.student_loan_plan).to eq "plan_1"
 
     eligibility = Policies::FurtherEducationPayments::Eligibility.last

--- a/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
       logged_in_with_onelogin: true,
       onelogin_idv_first_name: "John",
       onelogin_idv_last_name: "Doe",
+      onelogin_idv_full_name: "John Doe",
       onelogin_idv_date_of_birth: Date.new(1970, 1, 1),
       first_name: "John",
       surname: "Doe",
@@ -47,6 +48,7 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
       expect(claim.onelogin_idv_at).to eql(answers.onelogin_idv_at)
       expect(claim.onelogin_idv_first_name).to eql(answers.onelogin_idv_first_name)
       expect(claim.onelogin_idv_last_name).to eql(answers.onelogin_idv_last_name)
+      expect(claim.onelogin_idv_full_name).to eql(answers.onelogin_idv_full_name)
       expect(claim.onelogin_idv_date_of_birth).to eql(answers.onelogin_idv_date_of_birth)
 
       expect(eligibility.award_amount).to eq(answers.award_amount)
@@ -141,6 +143,7 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
           logged_in_with_onelogin: true,
           onelogin_idv_first_name: "John",
           onelogin_idv_last_name: "Doe",
+          onelogin_idv_full_name: "John Doe",
           onelogin_idv_date_of_birth: Date.new(1970, 1, 1),
           first_name: "Jack",
           surname: "Doe",

--- a/spec/models/automated_checks/claim_verifiers/identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/identity_spec.rb
@@ -90,7 +90,8 @@ module AutomatedChecks
               first_name: "John",
               surname: "Doe",
               onelogin_idv_first_name: "Tom",
-              onelogin_idv_last_name: "Jones"
+              onelogin_idv_last_name: "Jones",
+              onelogin_idv_full_name: "Tom Jones"
             )
           end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1478,4 +1478,51 @@ RSpec.describe Claim, type: :model do
       expect(policy).to have_received(:decision_deadline_date).with(claim)
     end
   end
+
+  describe "#one_login_idv_match?" do
+    context "space in first name" do
+      before do
+        subject.onelogin_idv_full_name = "A B C"
+        subject.first_name = "A B"
+        subject.surname = "C"
+
+        subject.onelogin_idv_date_of_birth = Date.today
+        subject.date_of_birth = Date.today
+      end
+
+      it "matches" do
+        expect(subject).to be_one_login_idv_match
+      end
+    end
+
+    context "close match" do
+      before do
+        subject.onelogin_idv_full_name = "A B C"
+        subject.first_name = "AA B"
+        subject.surname = "C"
+
+        subject.onelogin_idv_date_of_birth = Date.today
+        subject.date_of_birth = Date.today
+      end
+
+      it "does not match" do
+        expect(subject).not_to be_one_login_idv_match
+      end
+    end
+
+    context "not a match" do
+      before do
+        subject.onelogin_idv_full_name = "A B"
+        subject.first_name = "Z"
+        subject.surname = "B"
+
+        subject.onelogin_idv_date_of_birth = Date.today
+        subject.date_of_birth = Date.today
+      end
+
+      it "does not match" do
+        expect(subject).not_to be_one_login_idv_match
+      end
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -653,6 +653,7 @@ RSpec.describe Claim, type: :model do
         :onelogin_uid,
         :onelogin_idv_first_name,
         :onelogin_idv_last_name,
+        :onelogin_idv_full_name,
         :onelogin_idv_date_of_birth,
         :paye_reference,
         :practitioner_email_address,

--- a/spec/models/one_login/core_identity_validator_spec.rb
+++ b/spec/models/one_login/core_identity_validator_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe OneLogin::CoreIdentityValidator do
     end
   end
 
+  describe "#full_name" do
+    before do
+      stub_normal_did
+
+      travel_to(Time.at(1723548751)) do
+        subject.call
+      end
+    end
+
+    it "returns whole name" do
+      expect(subject.full_name).to eql("KENNETH DECERQUEIRA")
+    end
+  end
+
   let(:stub_normal_did) do
     return_headers = {
       "Cache-Control" => "max-age=3600, private"

--- a/spec/models/one_login/core_identity_validator_spec.rb
+++ b/spec/models/one_login/core_identity_validator_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe OneLogin::CoreIdentityValidator do
     it "returns whole name" do
       expect(subject.full_name).to eql("KENNETH DECERQUEIRA")
     end
+
+    context "if name parts is out of order" do
+      it "ensures family name is used as last name" do
+        out_of_order = [
+          {"value" => "DECERQUEIRA", "type" => "FamilyName"},
+          {"value" => "KENNETH", "type" => "GivenName"}
+        ]
+
+        allow(subject).to receive(:name_parts).and_return(out_of_order)
+
+        expect(subject.full_name).to eql("KENNETH DECERQUEIRA")
+      end
+    end
   end
 
   let(:stub_normal_did) do

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
           call: nil,
           first_name: "John",
           last_name: "Doe",
+          full_name: "John Doe",
           date_of_birth: Date.new(1970, 12, 13)
         )
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2051
- We are only storing from OL the first and last name

# Changes

-  Persist all the names that OL returns
- When checking against OL name we match entered name matches the start and end of returned OL name
- `onelogin_idv_full_name` is no longer a virtual attribute and returns the full name OL returns
- We backfill `onelogin_idv_full_name` with data we have which is concatenation of first and last name

# Notes

- Once this is complete we can work to remove `onelogin_idv_first_name` and `onelogin_idv_last_name` as these will become redundant