### PR TITLE
Ops reports

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -21,6 +21,8 @@ module Admin
         Reports::FeApprovedClaimsWithFailingProviderVerification.new
       when "approved-claims-failing-qualification-task"
         Reports::ApprovedClaimsFailingQualificationTask.new
+      when "duplicate-claims"
+        Reports::DuplicateApprovedClaims.new
       else
         raise ActiveRecord::RecordNotFound
       end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,0 +1,27 @@
+module Admin
+  class ReportsController < BaseAdminController
+    before_action :ensure_service_operator
+
+    def index
+    end
+
+    def show
+      respond_to do |format|
+        format.csv do
+          send_data(report.to_csv, filename: report.filename)
+        end
+      end
+    end
+
+    private
+
+    def report
+      @report ||= case params[:name]
+      when "fe-approved-claims-with-failing-provider-verification"
+        Reports::FeApprovedClaimsWithFailingProviderVerification.new
+      else
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -19,6 +19,8 @@ module Admin
       @report ||= case params[:name]
       when "fe-approved-claims-with-failing-provider-verification"
         Reports::FeApprovedClaimsWithFailingProviderVerification.new
+      when "approved-claims-failing-qualification-task"
+        Reports::ApprovedClaimsFailingQualificationTask.new
       else
         raise ActiveRecord::RecordNotFound
       end

--- a/app/models/admin/reports/approved_claims_failing_qualification_task.rb
+++ b/app/models/admin/reports/approved_claims_failing_qualification_task.rb
@@ -1,0 +1,121 @@
+module Admin
+  module Reports
+    class ApprovedClaimsFailingQualificationTask
+      HEADERS = [
+        "Claim reference",
+        "Teacher reference number",
+        "Policy",
+        "Status",
+        "Decision date",
+        "Decision agent",
+        "Qualification",
+        "ITT start year",
+        "ITT subject",
+        "ITT subjects",
+        "ITT start date",
+        "QTS award date",
+        "Qualification name"
+      ]
+
+      def filename
+        "approved_claims_failing_qualification_task"
+      end
+
+      def to_csv
+        CSV.generate(
+          row_sep: "\r\n",
+          write_headers: true,
+          headers: HEADERS
+        ) do |csv|
+          rows.each { |row| csv << row }
+        end
+      end
+
+      private
+
+      def rows
+        scope.map(&ClaimPresenter.method(:new)).map(&:to_a)
+      end
+
+      def scope
+        Claim
+          .approved
+          .where(academic_year: AcademicYear.current)
+          .joins(:tasks)
+          .merge(Task.where(name: "qualifications", passed: false))
+          .includes(:eligibility, decisions: :created_by)
+      end
+
+      class ClaimPresenter
+        include Admin::ClaimsHelper
+
+        def initialize(claim)
+          @claim = claim
+        end
+
+        def to_a
+          [
+            claim.reference,
+            claim.eligibility.teacher_reference_number,
+            I18n.t("#{claim.policy.locale_key}.policy_acronym"),
+            status(claim),
+            I18n.l(approval.created_at.to_date, format: :day_month_year),
+            approval.created_by.full_name,
+            qualification,
+            itt_academic_year&.to_s,
+            eligible_itt_subject,
+            dqt_teacher_record.itt_subjects.join(", "),
+            I18n.l(dqt_teacher_record.itt_start_date, format: :day_month_year),
+            I18n.l(dqt_teacher_record.qts_award_date, format: :day_month_year),
+            dqt_teacher_record.qualification_name
+          ]
+        end
+
+        private
+
+        attr_reader :claim
+
+        def approval
+          @approval ||= claim.decisions.reject(&:undone).last
+        end
+
+        # StudentLoans doesn't have an eligible_itt_subject
+        def eligible_itt_subject
+          claim.eligibility.try(:eligible_itt_subject)
+        end
+
+        # StudentLoans doesn't have an itt_academic_year
+        def itt_academic_year
+          claim.eligibility.try(:itt_academic_year)
+        end
+
+        # StudentLoans doesn't have a qualification
+        def qualification
+          claim.eligibility.try(:qualification)
+        end
+
+        def itt_subjects
+          dqt_teacher_record&.itt_subjects
+        end
+
+        def itt_start_date
+          dqt_teacher_record&.itt_start_date
+        end
+
+        def qts_award_date
+          dqt_teacher_record&.qts_award_date
+        end
+
+        def qualification_name
+          dqt_teacher_record&.qualification_name
+        end
+
+        def dqt_teacher_record
+          @dqt_teacher_record ||= if claim.has_dqt_record?
+            Dqt::Teacher.new(claim.dqt_teacher_status)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/admin/reports/approved_claims_failing_qualification_task.rb
+++ b/app/models/admin/reports/approved_claims_failing_qualification_task.rb
@@ -18,7 +18,7 @@ module Admin
       ]
 
       def filename
-        "approved_claims_failing_qualification_task"
+        "approved_claims_failing_qualification_task.csv"
       end
 
       def to_csv

--- a/app/models/admin/reports/duplicate_approved_claims.rb
+++ b/app/models/admin/reports/duplicate_approved_claims.rb
@@ -17,7 +17,7 @@ module Admin
       end
 
       def filename
-        "duplicate_approved_claims"
+        "duplicate_approved_claims.csv"
       end
 
       def to_csv

--- a/app/models/admin/reports/duplicate_approved_claims.rb
+++ b/app/models/admin/reports/duplicate_approved_claims.rb
@@ -1,3 +1,5 @@
+# This file is ignored in the brakeman config, be careful not to interpolate
+# any user provided parameters!
 module Admin
   module Reports
     class DuplicateApprovedClaims

--- a/app/models/admin/reports/duplicate_approved_claims.rb
+++ b/app/models/admin/reports/duplicate_approved_claims.rb
@@ -1,0 +1,215 @@
+module Admin
+  module Reports
+    class DuplicateApprovedClaims
+      HEADERS = [
+        "Claim reference",
+        "Full name",
+        "TRN",
+        "Policy",
+        "Claim amount",
+        "Claim status",
+        "Decision date",
+        "Decision agent"
+      ]
+
+      def initialize(academic_year: AcademicYear.current)
+        @academic_year = AcademicYear.wrap(academic_year)
+      end
+
+      def filename
+        "duplicate_approved_claims"
+      end
+
+      def to_csv
+        CSV.generate(
+          row_sep: "\r\n",
+          write_headers: true,
+          headers: HEADERS
+        ) do |csv|
+          rows.each { |row| csv << row }
+        end
+      end
+
+      private
+
+      attr_reader :academic_year
+
+      def rows
+        scope.map(&ClaimPresenter.method(:new)).map(&:to_a)
+      end
+
+      def scope
+        Claim.where(
+          id: Set.new(duplicates_by_eligibility + duplicates_by_attributes)
+        ).includes(decisions: :created_by)
+      end
+
+      def duplicates_by_eligibility
+        ActiveRecord::Base.connection.execute(
+          Policies::POLICIES.map do |policy|
+            policy_with_claimable_policies(policy)
+          end.compact.join("\nUNION\n")
+        ).map { |row| row["id"] }
+      end
+
+      def policy_with_claimable_policies(policy)
+        left_table = policy::Eligibility.table_name
+
+        claimable_policies = claimable_policy_mapping(policy)
+
+        return if claimable_policies.empty?
+
+        claimable_policy_mapping(policy).map do |other_policy, matching_attributes|
+          right_table = other_policy::Eligibility.table_name
+          right_table_alias = "#{right_table}_#{left_table}"
+
+          join_condition = build_join_condition(
+            left_table,
+            right_table_alias,
+            matching_attributes
+          )
+
+          <<~SQL
+            SELECT claims.id
+            FROM #{left_table}
+            JOIN #{right_table} #{right_table_alias}
+            ON #{left_table}.id != #{right_table_alias}.id
+            AND (#{join_condition})
+            JOIN claims ON claims.eligibility_id = #{left_table}.id
+            JOIN claims other_claims ON other_claims.eligibility_id = #{right_table_alias}.id
+            JOIN decisions ON claims.id = decisions.claim_id
+            JOIN decisions other_decisions ON other_claims.id = other_decisions.claim_id
+            WHERE claims.academic_year = '#{academic_year}'
+            AND other_claims.academic_year = '#{academic_year}'
+            AND decisions.result = 0
+            AND other_decisions.result = 0
+          SQL
+        end.join("\nUNION\n")
+      end
+
+      # [["teacher_reference_number"], ["school_id", "nqt_in_academic_year"]]
+      # =>
+      # (
+      #   (
+      #     left_table.teacher_reference_number = right_table.teacher_reference_number
+      #     AND left_table.teacher_reference_number IS NOT NULL
+      #     AND left_table.teacher_reference_number != ''
+      #   )
+      # )
+      # OR
+      # (
+      #   (
+      #     left_table.school_id = right_table.school_id
+      #     AND left_table.school_id IS NOT NULL
+      #     AND left_table.school_id != ''
+      #   )
+      #   AND
+      #   (
+      #     left_table.nqt_in_academic_year = right_table.nqt_in_academic_year
+      #     AND left_table.nqt_in_academic_year IS NOT NULL
+      #     AND left_table.nqt_in_academic_year != ''
+      #   )
+      # )
+      def build_join_condition(left_table, right_table, matching_attributes)
+        matching_attributes.map do |attr_group|
+          "(" + attr_group.map do |attr|
+            "(" \
+            "#{left_table}.#{attr} = #{right_table}.#{attr} " \
+            "AND #{left_table}.#{attr} IS NOT NULL " \
+            "AND #{left_table}.#{attr} != ''" \
+            ")"
+          end.join(" AND ") + ")"
+        end.join(" OR ")
+      end
+
+      # Return a hash of other claimable policies and the attributes we can
+      # use for determining duplicates.
+      # "other_policy" => [["attr_1"], ["attr_2", "attr_3"]]
+      # If other policy is in the list of claimable policies but shares no
+      # matching attributes, we can't compare them, eg EY is in ECP
+      # other claimable policies, but EY doesn't have a
+      # `teacher_reference_number`.
+      def claimable_policy_mapping(policy)
+        policy.policies_claimable.map do |other_policy|
+          shared_matching_attributes = policy.eligibility_matching_attributes.select do |attribute_group|
+            attribute_group.all? do |attr|
+              other_policy::Eligibility.column_names.include?(attr)
+            end
+          end
+
+          [other_policy, shared_matching_attributes]
+        end.to_h.reject { |_, matching_attrs| matching_attrs.empty? }
+      end
+
+      # building_society_roll_number is no longer used, so is always null
+      # we only check the number and sort code when determining duplicates.
+      def claim_matching_attributes
+        Claim::MatchingAttributeFinder::CLAIM_ATTRIBUTE_GROUPS_TO_MATCH.map do |attr_group|
+          attr_group.without("building_society_roll_number")
+        end
+      end
+
+      def duplicates_by_attributes
+        # Limit the claims we're looking at
+        current_claims = <<~SQL
+          WITH current_claims AS (
+            SELECT claims.id, #{claim_matching_attributes.flatten.join(", ")}
+            FROM claims
+            JOIN decisions ON claims.id = decisions.claim_id
+            WHERE claims.academic_year = '#{academic_year}'
+            AND decisions.undone = false
+            AND decisions.result = 0
+          )
+        SQL
+
+        # Make sure to have indexes for the columns we're querying!
+        filter = claim_matching_attributes.flat_map do |attribute_group|
+          join_condition = attribute_group.map do |attr|
+            if Claim.column_for_attribute(attr).type == :string
+              "LOWER(current_claims.#{attr}) = LOWER(other_claims.#{attr})"
+            else
+              "current_claims.#{attr} = other_claims.#{attr}"
+            end
+          end.join(" AND ")
+
+          <<~SQL
+            SELECT current_claims.id
+            FROM current_claims
+            JOIN current_claims other_claims
+            ON #{join_condition}
+            WHERE current_claims.id != other_claims.id
+          SQL
+        end.join("\nUNION\n")
+
+        query = current_claims + "\n" + filter
+
+        ActiveRecord::Base.connection.execute(query).map { |row| row["id"] }
+      end
+
+      class ClaimPresenter
+        include Admin::ClaimsHelper
+
+        def initialize(claim)
+          @claim = claim
+        end
+
+        def to_a
+          [
+            claim.reference,
+            claim.full_name,
+            claim.eligibility.try(:teacher_reference_number),
+            I18n.t("#{claim.policy.locale_key}.policy_acronym"),
+            claim.award_amount,
+            status(claim),
+            claim.decisions.last.created_at.to_date,
+            claim.decisions.last.created_by&.full_name
+          ]
+        end
+
+        private
+
+        attr_reader :claim
+      end
+    end
+  end
+end

--- a/app/models/admin/reports/fe_approved_claims_with_failing_provider_verification.rb
+++ b/app/models/admin/reports/fe_approved_claims_with_failing_provider_verification.rb
@@ -1,0 +1,105 @@
+module Admin
+  module Reports
+    class FeApprovedClaimsWithFailingProviderVerification
+      HEADERS = [
+        "Claim reference",
+        "Full name",
+        "Claim amount",
+        "Claim status",
+        "Decision date",
+        "Decision agent",
+        "Contract of employment",
+        "Teaching responsibilities",
+        "First 5 years of teaching",
+        "One full term",
+        "Timetabled teaching hours",
+        "Age range taught",
+        "Subject",
+        "Course",
+        "2.5 hours weekly teaching",
+        "Performance",
+        "Disciplinary"
+      ]
+
+      def filename
+        "fe_approved_claims_with_failing_provider_verification.csv"
+      end
+
+      def to_csv
+        CSV.generate(
+          row_sep: "\r\n",
+          write_headers: true,
+          headers: HEADERS
+        ) do |csv|
+          rows.each { |row| csv << row }
+        end
+      end
+
+      private
+
+      def rows
+        scope.map(&ClaimPresenter.method(:new)).map(&:to_a)
+      end
+
+      def scope
+        Claim
+          .by_policy(Policies::FurtherEducationPayments)
+          .approved
+          .joins(:tasks)
+          .merge(Task.where(name: "provider_verification", passed: false))
+          .includes(:eligibility, decisions: :created_by)
+      end
+
+      class ClaimPresenter
+        include Admin::ClaimsHelper
+        include ActionView::Helpers::NumberHelper
+
+        def initialize(claim)
+          @claim = claim
+        end
+
+        def to_a
+          [
+            claim.reference,
+            claim.full_name,
+            number_to_currency(claim.award_amount, precision: 0),
+            status(claim),
+            approval_date,
+            approval.created_by.full_name,
+            present_assertion("contract_type"),
+            present_assertion("teaching_responsibilities"),
+            present_assertion("further_education_teaching_start_year"),
+            present_assertion("taught_at_least_one_term"),
+            present_assertion("teaching_hours_per_week"),
+            present_assertion("half_teaching_hours"),
+            present_assertion("subjects_taught"),
+            "??", # FIXME RL: not sure what courses should be
+            present_assertion("teaching_hours_per_week_next_term"),
+            present_assertion("subject_to_formal_performance_action"),
+            present_assertion("subject_to_disciplinary_action")
+          ]
+        end
+
+        private
+
+        attr_reader :claim
+
+        def approval_date
+          I18n.l(approval.created_at.to_date, format: :day_month_year)
+        end
+
+        def approval
+          @approval ||= claim.decisions.reject(&:undone).last
+        end
+
+        def present_assertion(name)
+          case claim.eligibility.verification_assertion(name)
+          when true then "Yes"
+          when false then "No"
+          else "N/A" # fixed and variable contracts have different assertions
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -94,6 +94,10 @@ module Policies
         nil
       end
 
+      def verification_assertion(name)
+        assertion_hash[name]
+      end
+
       private
 
       def provider_and_claimant_names_match?
@@ -115,6 +119,12 @@ module Policies
 
       def provider_last_name
         verification.dig("verifier", "last_name")
+      end
+
+      def assertion_hash
+        @assertion_hash ||= verification.fetch("assertions").map do |assertion|
+          [assertion["name"], assertion["outcome"]]
+        end.to_h
       end
     end
   end

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -16,6 +16,7 @@
     <%= link_to "Upload TPS data", new_admin_tps_data_upload_path, class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" }, role: :button %>
     <%= link_to "Upload SLC data", new_admin_student_loans_data_upload_path, class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" }, role: :button %>
     <%= link_to "Upload fraud prevention data", new_admin_fraud_risk_csv_upload_path, class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" }, role: :button %>
+    <%= link_to "Reports", admin_reports_path, class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" }, role: :button %>
 
     <%= render "allocations_form" %>
 

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -1,0 +1,17 @@
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claims_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      Reports
+    </h1>
+
+    <%= govuk_button_link_to(
+      "FE TRI approved claims whereby the provider check status is 'failed'",
+      admin_report_path("fe-approved-claims-with-failing-provider-verification", format: :csv),
+      secondary: true
+    ) %>
+  </div>
+</div>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -7,6 +7,11 @@
     <h1 class="govuk-heading-xl">
       Reports
     </h1>
+    <%= govuk_button_link_to(
+      "Duplicate claims",
+      admin_report_path("duplicate-claims", format: :csv),
+      secondary: true
+    ) %>
 
     <%= govuk_button_link_to(
       "FE TRI approved claims whereby the provider check status is 'failed'",

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -13,5 +13,11 @@
       admin_report_path("fe-approved-claims-with-failing-provider-verification", format: :csv),
       secondary: true
     ) %>
+
+    <%= govuk_button_link_to(
+      "Approved claims failing qualification task",
+      admin_report_path("approved-claims-failing-qualification-task", format: :csv),
+      secondary: true
+    ) %>
   </div>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -141,6 +141,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "b0269286fd1ea8251ec5b7680edd39187adb72c1ed2c4bc61e6eec7e14ed24f7",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/admin/reports/duplicate_approved_claims.rb",
+      "line": 191,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(((\"WITH current_claims AS (\\n  SELECT claims.id, #{claim_matching_attributes.flatten.join(\", \")}\\n  FROM claims\\n  JOIN decisions ON claims.id = decisions.claim_id\\n  WHERE claims.academic_year = '#{academic_year}'\\n  AND decisions.undone = false\\n  AND decisions.result = 0\\n)\\n\" + \"\\n\") + claim_matching_attributes.flat_map do\n join_condition = attribute_group.map do\n if (Claim.column_for_attribute(attr).type == :string) then\n  \"LOWER(current_claims.#{attr}) = LOWER(other_claims.#{attr})\"\nelse\n  \"current_claims.#{attr} = other_claims.#{attr}\"\nend\n end.join(\" AND \")\n\"SELECT current_claims.id, other_claims.id AS other_claim_id\\nFROM current_claims\\nJOIN current_claims other_claims\\nON #{attribute_group.map do\n if (Claim.column_for_attribute(attr).type == :string) then\n  \"LOWER(current_claims.#{attr}) = LOWER(other_claims.#{attr})\"\nelse\n  \"current_claims.#{attr} = other_claims.#{attr}\"\nend\n end.join(\" AND \")}\\nWHERE current_claims.id != other_claims.id\\n\"\n end.join(\"\\nUNION\\n\")))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::Reports::DuplicateApprovedClaims",
+        "method": "duplicates_by_attributes"
+      },
+      "user_input": "claim_matching_attributes.flatten.join(\", \")",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "cddc34b96e07d19510d574438a1ce61b69d9c1f28c0d4e5eee631d17a9b38ba6",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -185,6 +208,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-11-20 17:38:36 +0000",
+  "updated": "2024-12-16 15:02:51 +0000",
   "brakeman_version": "6.2.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
     resources :tps_data_uploads, only: [:new, :create]
     resources :fraud_risk_csv_uploads, only: [:new, :create]
     resource :fraud_risk_csv_download, only: :show
+    resources :reports, only: [:index, :show], param: :name
 
     resources :payroll_runs, only: [:index, :new, :create, :show, :destroy] do
       resources :payment_confirmation_report_uploads, only: [:new, :create]

--- a/db/migrate/20241213142806_add_indexes_for_ops_report.rb
+++ b/db/migrate/20241213142806_add_indexes_for_ops_report.rb
@@ -1,0 +1,30 @@
+class AddIndexesForOpsReport < ActiveRecord::Migration[8.0]
+  def change
+    add_index(
+      :claims,
+      "LOWER(email_address)",
+      name: "index_claims_on_lower_email_address"
+    )
+
+    add_index(
+      :claims,
+      "LOWER(national_insurance_number)",
+      name: "index_claims_on_lower_national_insurance_number"
+    )
+
+    # Even though bank details are "numbers" they're stored in a string column
+    # we call lower on these so we don't have to treat them differently to
+    # other string columns when building the query.
+    add_index(
+      :claims,
+      "LOWER(bank_account_number), LOWER(bank_sort_code)",
+      name: "index_claims_on_bank_details"
+    )
+
+    add_index(
+      :claims,
+      "LOWER(first_name), LOWER(surname), date_of_birth",
+      name: "index_claims_on_personal_details"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_26_105650) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_13_142806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -113,6 +113,10 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_26_105650) do
     t.date "onelogin_idv_date_of_birth"
     t.datetime "started_at", precision: nil, null: false
     t.datetime "verified_at"
+    t.index "lower((bank_account_number)::text), lower((bank_sort_code)::text)", name: "index_claims_on_bank_details"
+    t.index "lower((email_address)::text)", name: "index_claims_on_lower_email_address"
+    t.index "lower((first_name)::text), lower((surname)::text), date_of_birth", name: "index_claims_on_personal_details"
+    t.index "lower((national_insurance_number)::text)", name: "index_claims_on_lower_national_insurance_number"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -395,5 +395,10 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :random_name do
+      first_name { Faker::Name.first_name }
+      surname { Faker::Name.last_name }
+    end
   end
 end

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "Admin reports" do
+  around do |example|
+    travel_to Date.new(2024, 12, 6) do
+      example.run
+    end
+  end
+
+  describe "Approved FE claims with failing provider verification" do
+    it "returns a CSV report" do
+      claim = create(
+        :claim,
+        :approved,
+        policy: Policies::FurtherEducationPayments,
+        first_name: "Elizabeth",
+        surname: "Hoover",
+        qa_required: true,
+        eligibility_attributes: {
+          award_amount: 2_000,
+          contract_type: "permanent",
+          verification: {
+            assertions: [
+              {
+                name: "contract_type",
+                outcome: true
+              },
+              {
+                name: "teaching_responsibilities",
+                outcome: true
+              },
+              {
+                name: "further_education_teaching_start_year",
+                outcome: true
+              },
+              {
+                name: "teaching_hours_per_week",
+                outcome: true
+              },
+              {
+                name: "half_teaching_hours",
+                outcome: false
+              },
+              {
+                name: "subjects_taught",
+                outcome: false
+              },
+              {
+                name: "subject_to_formal_performance_action",
+                outcome: true
+              },
+              {
+                name: "subject_to_disciplinary_action",
+                outcome: true
+              }
+            ]
+          }
+        }
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "provider_verification",
+        claim: claim
+      )
+
+      sign_in_as_service_operator
+
+      visit admin_claims_path
+
+      click_on "Reports"
+
+      click_on(
+        "FE TRI approved claims whereby the provider check status is 'failed'"
+      )
+
+      csv_data = page.body
+
+      csv = CSV.parse(csv_data, headers: true)
+      row = csv.first
+
+      expect(row.fetch("Claim reference")).to eq(claim.reference)
+      expect(row.fetch("Full name")).to eq("Elizabeth Hoover")
+      expect(row.fetch("Claim amount")).to eq("£2,000")
+      expect(row.fetch("Claim status")).to eq("Approved awaiting QA")
+      expect(row.fetch("Decision date")).to eq("06/12/2024")
+      expect(row.fetch("Decision agent")).to eq("Aaron Admin")
+      expect(row.fetch("Contract of employment")).to eq("Yes")
+      expect(row.fetch("Teaching responsibilities")).to eq("Yes")
+      expect(row.fetch("First 5 years of teaching")).to eq("Yes")
+      expect(row.fetch("One full term")).to eq("N/A")
+      expect(row.fetch("Timetabled teaching hours")).to eq("Yes")
+      expect(row.fetch("Age range taught")).to eq("No")
+      expect(row.fetch("Subject")).to eq("No")
+      expect(row.fetch("Course")).to eq("??")
+      expect(row.fetch("2.5 hours weekly teaching")).to eq("N/A")
+      expect(row.fetch("Performance")).to eq("Yes")
+      expect(row.fetch("Disciplinary")).to eq("Yes")
+    end
+  end
+end

--- a/spec/models/admin/reports/approved_claims_failing_qualification_task_spec.rb
+++ b/spec/models/admin/reports/approved_claims_failing_qualification_task_spec.rb
@@ -1,0 +1,261 @@
+require "rails_helper"
+
+RSpec.describe Admin::Reports::ApprovedClaimsFailingQualificationTask do
+  around do |example|
+    travel_to Date.new(2024, 11, 1) do
+      example.run
+    end
+  end
+
+  describe "to_csv" do
+    it "returns a csv of the claims" do
+      # excluded, claim not approved
+      ecp_claim_unapporved_failed_qualification_task = create(
+        :claim,
+        policy: Policies::EarlyCareerPayments,
+        academic_year: AcademicYear.new(2024)
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "qualifications",
+        claim: ecp_claim_unapporved_failed_qualification_task
+      )
+
+      # excluded, task passed
+      lup_claim_approved_passed_qualification_task = create(
+        :claim,
+        :approved,
+        policy: Policies::LevellingUpPremiumPayments,
+        academic_year: AcademicYear.new(2024)
+      )
+
+      create(
+        :task,
+        :passed,
+        name: "qualifications",
+        claim: lup_claim_approved_passed_qualification_task
+      )
+
+      # excluded, claim not approved
+      tslr_claim_rejected = create(
+        :claim,
+        :rejected,
+        policy: Policies::StudentLoans,
+        academic_year: AcademicYear.new(2024)
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "qualifications",
+        claim: tslr_claim_rejected
+      )
+
+      # excluded, wrong policy!
+      _fe_claim = create(
+        :claim,
+        :approved,
+        policy: Policies::FurtherEducationPayments,
+        academic_year: AcademicYear.new(2024)
+      )
+
+      # excluded, previous academic year
+      ecp_claim_unapporved_failed_qualification_task = create(
+        :claim,
+        :approved,
+        policy: Policies::EarlyCareerPayments,
+        academic_year: AcademicYear.new(2023)
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "qualifications",
+        claim: ecp_claim_unapporved_failed_qualification_task
+      )
+
+      # included
+      ecp_claim_approved_failed_qualification_task = create(
+        :claim,
+        :approved,
+        :flagged_for_qa,
+        policy: Policies::EarlyCareerPayments,
+        academic_year: AcademicYear.new(2024),
+        decision_creator: create(
+          :dfe_signin_user,
+          given_name: "Some",
+          family_name: "admin"
+        ),
+        eligibility_attributes: {
+          teacher_reference_number: "1111111",
+          eligible_itt_subject: :mathematics,
+          itt_academic_year: AcademicYear.new(2021),
+          qualification: :postgraduate_itt
+        },
+        dqt_teacher_status: {
+          qualified_teacher_status: {
+            qts_date: "2023-09-01",
+            name: "Qualified teacher (trained)"
+          },
+          initial_teacher_training: {
+            programme_start_date: "2022-08-01",
+            subject1: "mathematics",
+            subject1_code: "100403",
+            subject2: "physics",
+            subject3_code: "F300",
+            qualification: "Graduate Diploma"
+          }
+        }
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "qualifications",
+        claim: ecp_claim_approved_failed_qualification_task
+      )
+
+      # included
+      lup_claim_approved_failed_qualification_task = create(
+        :claim,
+        :approved,
+        policy: Policies::LevellingUpPremiumPayments,
+        academic_year: AcademicYear.new(2024),
+        decision_creator: create(
+          :dfe_signin_user,
+          given_name: "Some",
+          family_name: "admin"
+        ),
+        eligibility_attributes: {
+          teacher_reference_number: "2222222",
+          eligible_itt_subject: :physics,
+          itt_academic_year: AcademicYear.new(2021),
+          qualification: :postgraduate_itt
+        },
+        dqt_teacher_status: {
+          qualified_teacher_status: {
+            qts_date: "2023-10-01",
+            name: "Qualified teacher (trained)"
+          },
+          initial_teacher_training: {
+            programme_start_date: "2022-08-02",
+            subject1: "physics",
+            subject1_code: "F300",
+            qualification: "Graduate Diploma"
+          }
+        }
+      )
+
+      create(:payment, claims: [lup_claim_approved_failed_qualification_task])
+
+      create(
+        :task,
+        :failed,
+        name: "qualifications",
+        claim: lup_claim_approved_failed_qualification_task
+      )
+
+      # included
+      tslr_claim_approved_failed_qualification_task = create(
+        :claim,
+        :approved,
+        policy: Policies::StudentLoans,
+        academic_year: AcademicYear.new(2024),
+        decision_creator: create(
+          :dfe_signin_user,
+          given_name: "Some",
+          family_name: "admin"
+        ),
+        eligibility_attributes: {
+          teacher_reference_number: "3333333"
+        },
+        dqt_teacher_status: {
+          qualified_teacher_status: {
+            qts_date: "2023-10-01",
+            name: "Qualified teacher (trained)"
+          },
+          initial_teacher_training: {
+            programme_start_date: "2022-08-02",
+            subject1: "physics",
+            subject1_code: "F300",
+            qualification: "Graduate Diploma"
+          }
+        }
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "qualifications",
+        claim: tslr_claim_approved_failed_qualification_task
+      )
+
+      csv = CSV.parse(described_class.new.to_csv, headers: true)
+
+      expect(csv.to_a).to match_array([
+        [
+          "Claim reference",
+          "Teacher reference number",
+          "Policy",
+          "Status",
+          "Decision date",
+          "Decision agent",
+          "Qualification",
+          "ITT start year",
+          "ITT subject",
+          "ITT subjects",
+          "ITT start date",
+          "QTS award date",
+          "Qualification name"
+        ],
+        [
+          ecp_claim_approved_failed_qualification_task.reference,
+          "1111111",
+          "ECP",
+          "Approved awaiting QA",
+          "01/11/2024",
+          "Some admin",
+          "postgraduate_itt",
+          "2021/2022",
+          "mathematics",
+          "mathematics, physics",
+          "01/08/2022",
+          "01/09/2023",
+          "Graduate Diploma"
+        ],
+        [
+          lup_claim_approved_failed_qualification_task.reference,
+          "2222222",
+          "STRI",
+          "Payrolled",
+          "01/11/2024",
+          "Some admin",
+          "postgraduate_itt",
+          "2021/2022",
+          "physics",
+          "physics",
+          "02/08/2022",
+          "01/10/2023",
+          "Graduate Diploma"
+        ],
+        [
+          tslr_claim_approved_failed_qualification_task.reference,
+          "3333333",
+          "TSLR",
+          "Approved awaiting payroll",
+          "01/11/2024",
+          "Some admin",
+          nil,
+          nil,
+          nil,
+          "physics",
+          "02/08/2022",
+          "01/10/2023",
+          "Graduate Diploma"
+        ]
+      ])
+    end
+  end
+end

--- a/spec/models/admin/reports/duplicate_approved_claims_spec.rb
+++ b/spec/models/admin/reports/duplicate_approved_claims_spec.rb
@@ -1,0 +1,249 @@
+require "rails_helper"
+
+RSpec.describe Admin::Reports::DuplicateApprovedClaims do
+  describe "#to_csv" do
+    it "includes claims with duplicate details, excludes claims that aren't duplicates" do
+      claim_1 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        email_address: "duplicate@example.com",
+        reference: "claim 1"
+      )
+
+      claim_2 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        email_address: "duplicate@example.com",
+        reference: "claim 2"
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        email_address: "non-duplicate@example.com",
+        reference: "nondupe1"
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        national_insurance_number: "AB123456D",
+        reference: "nondupe2"
+      )
+
+      claim_3 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        bank_account_number: "12345678",
+        bank_sort_code: "123456",
+        reference: "claim 3"
+      )
+
+      claim_4 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        bank_account_number: "12345678",
+        bank_sort_code: "123456",
+        reference: "claim 4"
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        bank_account_number: "12345679",
+        bank_sort_code: "123456",
+        reference: "nondupe3"
+      )
+
+      claim_5 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        first_name: "SEYMOUR",
+        surname: "Skinner",
+        date_of_birth: Date.new(1960, 1, 1),
+        reference: "claim 5"
+      )
+
+      claim_6 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        first_name: "Seymour",
+        surname: "Skinner",
+        date_of_birth: Date.new(1960, 1, 1),
+        reference: "claim 6"
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        first_name: "Seymour",
+        surname: "Skinner",
+        date_of_birth: Date.new(1960, 1, 2),
+        reference: "nondupe4"
+      )
+
+      csv = CSV.parse(described_class.new.to_csv, headers: true)
+
+      claim_references = csv.map { |row| row["Claim reference"] }
+
+      expect(claim_references).to match_array([
+        claim_1.reference,
+        claim_2.reference,
+        claim_3.reference,
+        claim_4.reference,
+        claim_5.reference,
+        claim_6.reference
+      ])
+    end
+
+    it "includes claims with duplicate eligibility details" do
+      claim_1 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        reference: "claim 1",
+        policy: Policies::EarlyCareerPayments,
+        eligibility_attributes: {
+          teacher_reference_number: "1234567"
+        }
+      )
+
+      claim_2 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        reference: "claim 2",
+        policy: Policies::LevellingUpPremiumPayments,
+        eligibility_attributes: {
+          teacher_reference_number: "1234567"
+        }
+      )
+
+      claim_3 = create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        reference: "claim 3",
+        policy: Policies::FurtherEducationPayments,
+        eligibility_attributes: {
+          teacher_reference_number: "1234567"
+        }
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        reference: "nondupe1",
+        policy: Policies::InternationalRelocationPayments
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        :random_name,
+        reference: "nondupe2",
+        policy: Policies::StudentLoans,
+        eligibility_attributes: {
+          teacher_reference_number: "1234568"
+        }
+      )
+
+      csv = CSV.parse(described_class.new.to_csv, headers: true)
+
+      claim_references = csv.map { |row| row["Claim reference"] }
+
+      expect(claim_references).to match_array([
+        claim_1.reference,
+        claim_2.reference,
+        claim_3.reference
+      ])
+    end
+
+    it "excludes claims with duplicate details that are not approved" do
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        email_address: "duplicate@example.com",
+        reference: "claim 1"
+      )
+
+      create(
+        :claim,
+        :current_academic_year,
+        email_address: "duplicate@example.com",
+        reference: "claim 2"
+      )
+
+      create(
+        :claim,
+        :approved,
+        :random_name,
+        :current_academic_year,
+        policy: Policies::EarlyCareerPayments,
+        eligibility_attributes: {
+          teacher_reference_number: "1234567"
+        },
+        reference: "claim 3"
+      )
+
+      create(
+        :claim,
+        :random_name,
+        :current_academic_year,
+        policy: Policies::EarlyCareerPayments,
+        eligibility_attributes: {
+          teacher_reference_number: "1234567"
+        },
+        reference: "claim 4"
+      )
+
+      csv = CSV.parse(described_class.new.to_csv, headers: true)
+
+      expect(csv.count).to eq(0)
+    end
+
+    it "excludes claims with duplicate details across academic years" do
+      create(
+        :claim,
+        :approved,
+        email_address: "duplicate@example.com",
+        academic_year: AcademicYear.new(2021)
+      )
+
+      create(
+        :claim,
+        :approved,
+        :current_academic_year,
+        email_address: "duplicate@example.com"
+      )
+
+      csv = CSV.parse(described_class.new.to_csv, headers: true)
+
+      expect(csv.count).to eq(0)
+    end
+  end
+end

--- a/spec/models/admin/reports/fe_approved_claims_with_failing_provider_verification_spec.rb
+++ b/spec/models/admin/reports/fe_approved_claims_with_failing_provider_verification_spec.rb
@@ -1,0 +1,207 @@
+require "rails_helper"
+
+RSpec.describe Admin::Reports::FeApprovedClaimsWithFailingProviderVerification do
+  around do |example|
+    travel_to Date.new(2024, 11, 1) do
+      example.run
+    end
+  end
+
+  describe "#to_csv" do
+    it "returns a csv of approved fe claims with failing provider verification" do
+      fe_claim_with_passing_provider_check = create(
+        :claim,
+        :approved,
+        policy: Policies::FurtherEducationPayments
+      )
+
+      create(
+        :task,
+        :passed,
+        name: "provider_verification",
+        claim: fe_claim_with_passing_provider_check
+      )
+
+      fe_fixed_claim_with_failing_provider_check = create(
+        :claim,
+        :approved,
+        policy: Policies::FurtherEducationPayments,
+        first_name: "Elizabeth",
+        surname: "Hoover",
+        qa_required: true,
+        eligibility_attributes: {
+          award_amount: 2_000,
+          contract_type: "permanent",
+          verification: {
+            assertions: [
+              {
+                name: "contract_type",
+                outcome: true
+              },
+              {
+                name: "teaching_responsibilities",
+                outcome: true
+              },
+              {
+                name: "further_education_teaching_start_year",
+                outcome: true
+              },
+              {
+                name: "teaching_hours_per_week",
+                outcome: true
+              },
+              {
+                name: "half_teaching_hours",
+                outcome: false
+              },
+              {
+                name: "subjects_taught",
+                outcome: false
+              },
+              {
+                name: "subject_to_formal_performance_action",
+                outcome: true
+              },
+              {
+                name: "subject_to_disciplinary_action",
+                outcome: true
+              }
+            ]
+          }
+        }
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "provider_verification",
+        claim: fe_fixed_claim_with_failing_provider_check
+      )
+
+      fe_variable_claim_with_failing_provider_check = create(
+        :claim,
+        :approved,
+        policy: Policies::FurtherEducationPayments,
+        first_name: "Edna",
+        surname: "Krabappel",
+        eligibility_attributes: {
+          award_amount: 3_000,
+          contract_type: "variable_hours",
+          verification: {
+            assertions: [
+              {
+                name: "contract_type",
+                outcome: true
+              },
+              {
+                name: "teaching_responsibilities",
+                outcome: true
+              },
+              {
+                name: "further_education_teaching_start_year",
+                outcome: true
+              },
+              {
+                name: "taught_at_least_one_term",
+                outcome: true
+              },
+              {
+                name: "teaching_hours_per_week",
+                outcome: true
+              },
+              {
+                name: "half_teaching_hours",
+                outcome: true
+              },
+              {
+                name: "subjects_taught",
+                outcome: true
+              },
+              {
+                name: "teaching_hours_per_week_next_term",
+                outcome: true
+              },
+              {
+                name: "subject_to_formal_performance_action",
+                outcome: true
+              },
+              {
+                name: "subject_to_disciplinary_action",
+                outcome: false
+              }
+            ]
+          }
+        }
+      )
+
+      create(
+        :task,
+        :failed,
+        name: "provider_verification",
+        claim: fe_variable_claim_with_failing_provider_check
+      )
+
+      csv = CSV.parse(described_class.new.to_csv, headers: true)
+
+      expect(csv.to_a).to match_array([
+        [
+          "Claim reference",
+          "Full name",
+          "Claim amount",
+          "Claim status",
+          "Decision date",
+          "Decision agent",
+          "Contract of employment",
+          "Teaching responsibilities",
+          "First 5 years of teaching",
+          "One full term",
+          "Timetabled teaching hours",
+          "Age range taught",
+          "Subject",
+          "Course",
+          "2.5 hours weekly teaching",
+          "Performance",
+          "Disciplinary"
+        ],
+        [
+          fe_fixed_claim_with_failing_provider_check.reference,
+          "Elizabeth Hoover",
+          "£2,000",
+          "Approved awaiting QA",
+          "01/11/2024",
+          "Aaron Admin",
+          "Yes", # contract of employment
+          "Yes", # teaching responsibilities
+          "Yes", # first 5 years of teaching
+          "N/A", # one full term - not a question for fixed term contracts
+          "Yes", # timetabled teaching hours
+          "No", # age range taught
+          "No", # subject
+          "??", # course
+          "N/A", # 2.5 hours weekly teaching
+          "Yes", # performance
+          "Yes" # disciplinary
+        ],
+        [
+          fe_variable_claim_with_failing_provider_check.reference,
+          "Edna Krabappel",
+          "£3,000",
+          "Approved awaiting payroll",
+          "01/11/2024",
+          "Aaron Admin",
+          "Yes", # contract of employment
+          "Yes", # teaching responsibilities
+          "Yes", # first 5 years of teaching
+          "Yes", # one full term
+          "Yes", # timetabled teaching hours
+          "Yes", # age range taught
+          "Yes", # subject
+          "??", # course
+          "Yes", # 2.5 hours weekly teaching
+          "Yes", # performance
+          "No" # disciplinary
+        ]
+      ])
+    end
+  end
+end


### PR DESCRIPTION
Ops reports

This PR introduces some new reporting functionality for the ops team.
We've added a new button on the admin claims index page that links to the
`/admin/reports` page where the ops team can download various reports.

Initially there are three reports:
1. Duplicate approved claims
2. Approved claims failing qualification task
3. FE approved claims failing provider verification

Reports 2 and 3 are fairly straight forward, we just need to join to the
appropriate tasks and present the data. Report 1 is involved! For report 1 we
need to duplicate the functionality of the `Claim::MatchingAttributeFinder` but
rather than checking for duplicates of a single claim, it needs to work across
all claims. Running the claim matching attribute finder in a loop over all
claims takes a _long_ time (6 minuets to check 1000 claims), even with moving
generating the report into a background job it would be tanning the DB and who
wants to wait for an 1hr 30 for a report to generate! To avoid this we've
re implemented all the duplicate checking in SQL.

Having the report in SQL feels a little less maintainable, so something we
might want to consider is:
* when a claim is created kick off a background job to check for duplicates
  using claim matching attribute finder
* if duplicates are found associate them with the "source" claim using some
  new join model
* duplicate claims are then claims which can be joined with the source model

However we'd need to back fill the duplicate records for existing claims on
production using something like the logic we've written here for finding the
duplicates.

If we do decide to keep the version of the claim duplicate checking from this
pr then we probably want to update the `Claim::MatchingAttributeFinder` to use
the logic introduced in this PR so we don't have two definitions of what
constitutes a duplicate claim.

Open for suggestions of the namespacing of these reports.

NOTE for reviewers: probably worth reviewing each commit separately.
