### PR TITLE
CAPT-1953 - Initial attempt to silence repeated unwanted requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
 
   helper_method :timeout_warning_in_minutes
 
+  def handle_unwanted_requests
+    render file: Rails.root.join("public", "404.html"), status: :not_found, layout: false
+  end
+
   private
 
   def timeout_warning_in_minutes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,4 +165,29 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  # We still want to know about 404s in case of missing a route, but silence a whitelist instead to reduce the noise in Rollbar
+  # This is not exhastive, so add more if there are obvious requests to ignore
+
+  # 404 - extensions we don't expect
+  match "*path", to: "application#handle_unwanted_requests", via: :all, constraints: lambda { |req|
+    req.path =~ %r{\.(axd|asp|aspx|cgi|htm|html|php|php7|pl|txt|xml)$}i
+  }
+
+  # 404 - folders
+  match "*path", to: "application#handle_unwanted_requests", via: :all, constraints: lambda { |req|
+    req.path =~ %r{^/\.git/config$}i ||
+      req.path =~ %r{^/cgi-bin}i ||
+      req.path =~ %r{^/webui}i
+  }
+
+  # 404 - hard-coded apple icons - gov uk seems to 404 these as well
+  match "*path", to: "application#handle_unwanted_requests", via: :all, constraints: lambda { |req|
+    req.path =~ %r{^/apple-touch-icon(-120x120)?(-precomposed)?\.png$}i
+  }
+
+  # 404 - wordpress
+  match "*path", to: "application#handle_unwanted_requests", via: :all, constraints: lambda { |req|
+    req.path =~ %r{^/(wordpress|wp)}i
+  }
 end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -47,4 +47,55 @@ describe "Routes", type: :routing do
       expect(get: "admin/claims/#{claim.id}/tasks/foo").not_to be_routable
     end
   end
+
+  describe "Silence unwanted request from causing a Rollbar error and render a 404" do
+    context "unwanted extensions" do
+      it "returns a 404" do
+        %w[axd asp aspx cgi htm html php php7 pl txt xml].each do |extension|
+          expect(get: "foo.#{extension}").to route_to(controller: "application", action: "handle_unwanted_requests", path: "foo", format: extension)
+        end
+      end
+    end
+
+    context "folders" do
+      it "returns a 404 for .git/config" do
+        expect(get: ".git/config").to route_to(controller: "application", action: "handle_unwanted_requests", path: ".git/config")
+      end
+
+      it "returns a 404 for cgi-bin" do
+        expect(get: "cgi-bin/").to route_to(controller: "application", action: "handle_unwanted_requests", path: "cgi-bin")
+      end
+
+      it "returns a 404 for webui" do
+        expect(get: "webui/").to route_to(controller: "application", action: "handle_unwanted_requests", path: "webui")
+      end
+    end
+
+    context "apple icons" do
+      it "returns a 404" do
+        %w[
+          apple-touch-icon
+          apple-touch-icon-120x120-precomposed
+          apple-touch-icon-120x120
+          apple-touch-icon-precomposed
+        ].each do |path|
+          expect(get: "#{path}.png").to route_to(controller: "application", action: "handle_unwanted_requests", path: path, format: "png")
+        end
+      end
+    end
+
+    context "wordpress" do
+      it "returns a 404" do
+        %w[
+          wordpress
+          wp
+          wp-admin
+          wp-content
+          wp-includes
+        ].each do |path|
+          expect(get: path).to route_to(controller: "application", action: "handle_unwanted_requests", path: path)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Catch unwanted request patterns to stop to them alerting in Rollbar and force them to be a 404.

Tested in Review App seems to work.

Here are the ones that do come through that are deliberately incorrect:

![Screenshot 2024-12-16 at 15 22 22](https://github.com/user-attachments/assets/c3b752cf-e637-4dc1-933c-778d6737da59)
