### PR TITLE
Include claim reference in rollbar errors

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,14 @@
 class ApplicationJob < ActiveJob::Base
+  around_perform do |job, block|
+    claim = job.arguments.find { |arg| arg.is_a?(Claim) }
+
+    if claim
+      Rollbar.scope!(claim: {reference: claim.reference})
+    end
+
+    block.call
+  end
+
   def priority
     10
   end


### PR DESCRIPTION
When a job errors we want to be able to easily identify which claim it
was working with, if there is one.

Example [rollbar error with claim reference](https://app.rollbar.com/a/dfe-digital/fix/item/dfe-claims/1529?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification)
