### PR TITLE
Remove accessibility statment for EY

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -101,9 +101,11 @@
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers">Privacy notice</a>
               </li>
-              <li class="govuk-footer__inline-list-item">
-                <%= link_to "Accessibility statement", accessibility_statement_path(current_journey_routing_name), class: "govuk-footer__link" %>
-              </li>
+              <% unless current_journey_routing_name == "early-years-payment" %>
+                <li class="govuk-footer__inline-list-item">
+                  <%= link_to "Accessibility statement", accessibility_statement_path(current_journey_routing_name), class: "govuk-footer__link" %>
+                </li>
+              <% end %>
             </ul>
 
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">


### PR DESCRIPTION
The EY service hasn't been accessibility tested yet so we want to
temporarily remove the link to the accessibility statement.
