### PR TITLE
Display the urn on the employment task

### DIFF
--- a/app/models/policies/early_years_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_tasks_presenter.rb
@@ -51,7 +51,9 @@ module Policies
       def nursery_name
         [
           eligible_ey_provider.nursery_name,
-          "(#{eligible_ey_provider.urn})"
+          "(#{eligible_ey_provider.urn})",
+          "-",
+          eligible_ey_provider.local_authority.name
         ].join(" ")
       end
     end

--- a/app/models/policies/early_years_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_tasks_presenter.rb
@@ -11,7 +11,7 @@ module Policies
 
       def employment
         [
-          ["Current employment", claim.eligibility.eligible_ey_provider.nursery_name],
+          ["Current employment", nursery_name],
           ["Start date", l(claim.eligibility.start_date)]
         ]
       end
@@ -40,6 +40,19 @@ module Policies
         [
           ["Student loan plan", claim.student_loan_plan&.humanize]
         ]
+      end
+
+      private
+
+      def eligible_ey_provider
+        claim.eligibility.eligible_ey_provider
+      end
+
+      def nursery_name
+        [
+          eligible_ey_provider.nursery_name,
+          "(#{eligible_ey_provider.urn})"
+        ].join(" ")
       end
     end
   end

--- a/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
   describe "#employment" do
-    let(:claim) {
+    let(:claim) do
       create(:claim,
         :submitted,
         policy: Policies::EarlyYearsPayments,
@@ -10,12 +10,16 @@ RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
           nursery_urn: eligible_ey_provider.urn,
           start_date: Date.new(2018, 1, 1)
         })
-    }
+    end
+
+    let(:local_authority) { create(:local_authority, name: "Some LA") }
+
     let(:eligible_ey_provider) do
       create(
         :eligible_ey_provider,
         nursery_name: "Some Nursery",
-        urn: "EY123456"
+        urn: "EY123456",
+        local_authority: local_authority
       )
     end
 
@@ -23,7 +27,7 @@ RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
 
     it "shows current employment" do
       expect(subject[0]).to eq(
-        ["Current employment", "Some Nursery (EY123456)"]
+        ["Current employment", "Some Nursery (EY123456) - Some LA"]
       )
     end
 

--- a/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
@@ -11,12 +11,20 @@ RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
           start_date: Date.new(2018, 1, 1)
         })
     }
-    let(:eligible_ey_provider) { create(:eligible_ey_provider) }
+    let(:eligible_ey_provider) do
+      create(
+        :eligible_ey_provider,
+        nursery_name: "Some Nursery",
+        urn: "EY123456"
+      )
+    end
 
     subject { described_class.new(claim).employment }
 
     it "shows current employment" do
-      expect(subject[0][1]).to eq claim.eligibility.eligible_ey_provider.nursery_name
+      expect(subject[0]).to eq(
+        ["Current employment", "Some Nursery (EY123456)"]
+      )
     end
 
     it "shows start date" do


### PR DESCRIPTION
Displays the urn as part of the nursery name on the admin employment
task view.
