### PR TITLE
[CAPT-2090] Add nil guard where eligible_itt_subject is nil

### DIFF
--- a/app/models/policies/early_career_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_career_payments/admin_tasks_presenter.rb
@@ -26,7 +26,7 @@ module Policies
 
       def census_subjects_taught
         [
-          ["Subject", eligibility.eligible_itt_subject.titleize]
+          ["Subject", eligibility.eligible_itt_subject&.titleize]
         ]
       end
 

--- a/spec/models/policies/early_career_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/early_career_payments/admin_tasks_presenter_spec.rb
@@ -2,4 +2,16 @@ require "rails_helper"
 
 RSpec.describe Policies::EarlyCareerPayments::AdminTasksPresenter do
   it_behaves_like "ECP and LUP Combined Journey Admin Tasks Presenter", Policies::EarlyCareerPayments
+
+  describe "#census_subjects_taught" do
+    let(:claim) { build(:claim) }
+
+    subject { described_class.new(claim) }
+
+    context "when eligible_itt_subject is nil" do
+      it "returns nil value" do
+        expect(subject.census_subjects_taught).to eql([["Subject", nil]])
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2090
- Add nil guard where `eligible_itt_subject` is nil in admin area otherwise throws an error