### PR TITLE
[CAPT-650] Enable OTP autocomplete

### DIFF
--- a/app/views/claims/_one_time_password.html.erb
+++ b/app/views/claims/_one_time_password.html.erb
@@ -8,7 +8,7 @@
       <% caption_settings = { text: "#{email_or_mobile == "email" ? "Email address" : "Mobile number"} verification", size: "xl" } if show_caption %>
       <%= f.govuk_text_field :one_time_password,
         width: 5,
-        autocomplete: "off",
+        autocomplete: "one-time-code",
         inputmode: "numeric",
         label: {
           text: t("one_time_password.title"),


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-650
- Enable iOS autocomplete for mobile OTPs

# Notes

- Tested on iOS safari
- MDN for `autocomplete=one-time-code` https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#one-time-code
- Apple documentation on the feature https://developer.apple.com/news/?id=z0i801mg