### PR TITLE
Show the ol and claimant entered DOB

### DIFF
--- a/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
@@ -11,39 +11,15 @@ module AutomatedChecks
           elsif one_login_idv_partial_match?
             create_task(match: :any, passed: nil)
 
-            create_note(
-              body: <<-HTML
-              [GOV UK One Login Name] - Names partially match:
-              <pre>
-                Provider: "#{claim.eligibility.practitioner_name}"
-                GOV.UK One Login: "#{claim.onelogin_idv_full_name}"
-              </pre>
-              HTML
-            )
+            create_note(body: note_body("Names partially match"))
           elsif claim.one_login_idv_match?
             create_task(match: nil, passed: false)
 
-            create_note(
-              body: <<-HTML
-              [GOV UK One Login Name] - Names do not match:
-              <pre>
-                Provider: "#{claim.eligibility.practitioner_name}"
-                GOV.UK One Login: "#{claim.onelogin_idv_full_name}"
-              </pre>
-              HTML
-            )
+            create_note(body: note_body("Names do not match"))
           else
             create_task(match: :none, passed: false)
 
-            create_note(
-              body: <<-HTML
-              [GOV UK One Login] - IDV mismatch:
-              <pre>
-                GOV.UK One Login Name: "#{claim.onelogin_idv_full_name}"
-                GOV.UK One Login DOB: "#{claim.onelogin_idv_date_of_birth}"
-              </pre>
-              HTML
-            )
+            create_note(body: note_body("IDV mismatch"))
           end
         end
 
@@ -59,6 +35,35 @@ module AutomatedChecks
           return false unless claim.one_login_idv_match?
 
           claim.eligibility.practitioner_and_provider_entered_names_partial_match?
+        end
+
+        def note_body(match)
+          provider_entered_name = claim.eligibility.practitioner_name
+          govuk_one_login_name = claim.onelogin_idv_full_name
+          claimant_entered_dob = claim.date_of_birth
+          gov_uk_one_login_dob = claim.onelogin_idv_date_of_birth
+
+          name_colour = if provider_entered_name.downcase == govuk_one_login_name.downcase
+            "green"
+          else
+            "red"
+          end
+
+          dob_colour = if claimant_entered_dob == gov_uk_one_login_dob
+            "green"
+          else
+            "red"
+          end
+
+          <<-HTML.strip_heredoc
+          [GOV UK One Login] - #{match}:
+          <pre>
+            Provider-entered name: <span class="#{name_colour}">"#{provider_entered_name}"</span>
+            GOV.UK One Login Name: <span class="#{name_colour}">"#{govuk_one_login_name}"</span>
+            Claimant-entered DOB: <span class="#{dob_colour}">"#{claimant_entered_dob}"</span>
+            GOV.UK One Login DOB: <span class="#{dob_colour}">"#{gov_uk_one_login_dob}"</span>
+          </pre>
+          HTML
         end
       end
     end

--- a/app/models/policies/early_years_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_tasks_presenter.rb
@@ -24,8 +24,16 @@ module Policies
         claim.eligibility.practitioner_name
       end
 
+      def practitioner_entered_dob
+        claim.date_of_birth
+      end
+
       def one_login_claimant_name
         claim.onelogin_idv_full_name
+      end
+
+      def one_login_claimant_dob
+        claim.onelogin_idv_date_of_birth
       end
 
       def practitioner_journey_completed?

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -34,6 +34,7 @@ module Policies
         Date.today >= employment_task_available_at
       end
 
+      # This is the practioner name that the provider entered
       def practitioner_name
         [practitioner_first_name, practitioner_surname].join(" ")
       end

--- a/app/views/admin/tasks/early_years_payments/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/early_years_payments/identity_confirmation.html.erb
@@ -14,46 +14,59 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m">
-      <%= I18n.t(
-        "admin.tasks.identity_confirmation.title",
-        claim_full_name: @claim.full_name
-      ) %>
-    </h3>
+    <section>
+      <h3 class="govuk-heading-m">
+        Confirm claimant name
+      </h3>
 
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell">Claimant identity check</th>
-          <th class="govuk-table__cell">Full name</th>
-          <th class="govuk-table__cell">Date of birth</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header">
-            One Login identity verification (IDV)
-          </th>
-          <td class="govuk-table__cell">
-            <%= @tasks_presenter.one_login_claimant_name %>
-          </td>
-          <td class="govuk-table__cell">
-            <%= @tasks_presenter.one_login_claimant_dob %>
-          </td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header">
-            Provider entered claimant name
-          </th>
-          <td class="govuk-table__cell">
-            <%= @tasks_presenter.provider_entered_claimant_name %>
-          </td>
-          <td class="govuk-table__cell">
-            <%= @tasks_presenter.practitioner_entered_dob %>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <table class="govuk-table">
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              Provider entered claimant name
+            </th>
+            <td class="govuk-table__cell">
+              <%= @tasks_presenter.provider_entered_claimant_name %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              Claimant name from One Login
+            </th>
+            <td class="govuk-table__cell">
+              <%= @tasks_presenter.one_login_claimant_name.presence || "-" %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h3 class="govuk-heading-m">
+        Confirm claimant date of birth
+      </h3>
+
+      <table class="govuk-table">
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              Claimant entered DOB
+            </th>
+            <td class="govuk-table__cell">
+              <%= @tasks_presenter.practitioner_entered_dob.presence || "-" %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              Claimant DOB from One Login
+            </th>
+            <td class="govuk-table__cell">
+              <%= @tasks_presenter.one_login_claimant_dob.presence || "-" %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
     <% if @tasks_presenter.practitioner_journey_completed? %>
       <% if @task.claim_verifier_match_any? && @task.passed.nil? %>

--- a/app/views/admin/tasks/early_years_payments/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/early_years_payments/identity_confirmation.html.erb
@@ -22,7 +22,25 @@
     </h3>
 
     <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell">Claimant identity check</th>
+          <th class="govuk-table__cell">Full name</th>
+          <th class="govuk-table__cell">Date of birth</th>
+        </tr>
+      </thead>
       <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            One Login identity verification (IDV)
+          </th>
+          <td class="govuk-table__cell">
+            <%= @tasks_presenter.one_login_claimant_name %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= @tasks_presenter.one_login_claimant_dob %>
+          </td>
+        </tr>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">
             Provider entered claimant name
@@ -30,13 +48,8 @@
           <td class="govuk-table__cell">
             <%= @tasks_presenter.provider_entered_claimant_name %>
           </td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header">
-            Claimant name from One login
-          </th>
           <td class="govuk-table__cell">
-            <%= @tasks_presenter.one_login_claimant_name %>
+            <%= @tasks_presenter.practitioner_entered_dob %>
           </td>
         </tr>
       </tbody>

--- a/spec/features/admin/admin_ey_tasks_spec.rb
+++ b/spec/features/admin/admin_ey_tasks_spec.rb
@@ -52,11 +52,19 @@ RSpec.describe "Admin EY tasks" do
           click_on "Confirm the claimant made the claim"
 
           expect(page).to have_content(
-            "Provider entered claimant name Bobby Bobberson 1986-01-01"
+            "Provider entered claimant name Bobby Bobberson"
           )
 
           expect(page).to have_content(
-            "One Login identity verification (IDV) Bobby Bobberson 1986-01-01"
+            "Claimant name from One Login Bobby Bobberson"
+          )
+
+          expect(page).to have_content(
+            "Claimant entered DOB 1986-01-01"
+          )
+
+          expect(page).to have_content(
+            "Claimant DOB from One Login 1986-01-01"
           )
 
           expect(page).to have_content(
@@ -89,21 +97,31 @@ RSpec.describe "Admin EY tasks" do
 
             click_on "Confirm the claimant made the claim"
 
+            expect(page).to have_content("Confirm claimant name")
+
             expect(page).to have_content(
-              "Provider entered claimant name Bobby Bobberson 1986-01-01"
+              "Provider entered claimant name Bobby Bobberson"
             )
 
             expect(page).to have_content(
-              "One Login identity verification (IDV) Robby Bobberson 1986-01-01"
+              "Claimant name from One Login Robby Bobberson"
+            )
+
+            expect(page).to have_content("Confirm claimant date of birth")
+
+            expect(page).to have_content("Claimant entered DOB 1986-01-01")
+
+            expect(page).to have_content(
+              "Claimant DOB from One Login 1986-01-01"
             )
 
             expect(page).to have_content(
-              "[GOV UK One Login Name] - Names partially match"
+              "[GOV UK One Login Name] - Names partially match:"
             )
 
-            expect(page).to have_content('Provider: "Bobby Bobberson"')
-
-            expect(page).to have_content('GOV.UK One Login: "Robby Bobberson"')
+            expect(page).to have_content(
+              'Provider: "Bobby Bobberson" GOV.UK One Login: "Robby Bobberson"'
+            )
           end
 
           it "allows the admin to mark the task as passed" do
@@ -165,16 +183,26 @@ RSpec.describe "Admin EY tasks" do
 
             click_on "Confirm the claimant made the claim"
 
+            expect(page).to have_content("Confirm claimant name")
+
             expect(page).to have_content(
-              "Provider entered claimant name Bobby Bobberson 1986-01-01"
+              "Provider entered claimant name Bobby Bobberson"
             )
 
             expect(page).to have_content(
-              "One Login identity verification (IDV) Robby Robberson 1986-01-01"
+              "Claimant name from One Login Robby Robberson"
+            )
+
+            expect(page).to have_content("Confirm claimant date of birth")
+
+            expect(page).to have_content("Claimant entered DOB 1986-01-01")
+
+            expect(page).to have_content(
+              "Claimant DOB from One Login 1986-01-01"
             )
 
             expect(page).to have_content(
-              "[GOV UK One Login Name] - Names do not match"
+              "[GOV UK One Login Name] - Names do not match:"
             )
 
             expect(page).to have_content('Provider: "Bobby Bobberson"')

--- a/spec/features/admin/admin_ey_tasks_spec.rb
+++ b/spec/features/admin/admin_ey_tasks_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe "Admin EY tasks" do
           click_on "Confirm the claimant made the claim"
 
           expect(page).to have_content(
-            "Provider entered claimant name Bobby Bobberson"
+            "Provider entered claimant name Bobby Bobberson 1986-01-01"
           )
 
           expect(page).to have_content(
-            "Claimant name from One login Bobby Bobberson"
+            "One Login identity verification (IDV) Bobby Bobberson 1986-01-01"
           )
 
           expect(page).to have_content(
@@ -90,11 +90,11 @@ RSpec.describe "Admin EY tasks" do
             click_on "Confirm the claimant made the claim"
 
             expect(page).to have_content(
-              "Provider entered claimant name Bobby Bobberson"
+              "Provider entered claimant name Bobby Bobberson 1986-01-01"
             )
 
             expect(page).to have_content(
-              "Claimant name from One login Robby Bobberson"
+              "One Login identity verification (IDV) Robby Bobberson 1986-01-01"
             )
 
             expect(page).to have_content(
@@ -166,11 +166,11 @@ RSpec.describe "Admin EY tasks" do
             click_on "Confirm the claimant made the claim"
 
             expect(page).to have_content(
-              "Provider entered claimant name Bobby Bobberson"
+              "Provider entered claimant name Bobby Bobberson 1986-01-01"
             )
 
             expect(page).to have_content(
-              "Claimant name from One login Robby Robberson"
+              "One Login identity verification (IDV) Robby Robberson 1986-01-01"
             )
 
             expect(page).to have_content(

--- a/spec/features/admin/admin_ey_tasks_spec.rb
+++ b/spec/features/admin/admin_ey_tasks_spec.rb
@@ -116,12 +116,20 @@ RSpec.describe "Admin EY tasks" do
             )
 
             expect(page).to have_content(
-              "[GOV UK One Login Name] - Names partially match:"
+              "[GOV UK One Login] - Names partially match:"
             )
 
             expect(page).to have_content(
-              'Provider: "Bobby Bobberson" GOV.UK One Login: "Robby Bobberson"'
+              'Provider-entered name: "Bobby Bobberson"'
             )
+
+            expect(page).to have_content(
+              'GOV.UK One Login Name: "Robby Bobberson"'
+            )
+
+            expect(page).to have_content('Claimant-entered DOB: "1986-01-01"')
+
+            expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
           end
 
           it "allows the admin to mark the task as passed" do
@@ -202,12 +210,20 @@ RSpec.describe "Admin EY tasks" do
             )
 
             expect(page).to have_content(
-              "[GOV UK One Login Name] - Names do not match:"
+              "[GOV UK One Login] - Names do not match:"
             )
 
-            expect(page).to have_content('Provider: "Bobby Bobberson"')
+            expect(page).to have_content(
+              'Provider-entered name: "Bobby Bobberson"'
+            )
 
-            expect(page).to have_content('GOV.UK One Login: "Robby Robberson"')
+            expect(page).to have_content(
+              'GOV.UK One Login Name: "Robby Robberson"'
+            )
+
+            expect(page).to have_content('Claimant-entered DOB: "1986-01-01"')
+
+            expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
           end
 
           it "doesn't allow the admin to complete the task" do
@@ -242,7 +258,15 @@ RSpec.describe "Admin EY tasks" do
             "[GOV UK One Login] - IDV mismatch:"
           )
 
-          expect(page).to have_content('GOV.UK One Login Name: "Bobby Bobberson"')
+          expect(page).to have_content(
+            'Provider-entered name: "Bobby Bobberson"'
+          )
+
+          expect(page).to have_content(
+            'GOV.UK One Login Name: "Bobby Bobberson"'
+          )
+
+          expect(page).to have_content('Claimant-entered DOB: "1986-01-11"')
 
           expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
 

--- a/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
@@ -35,4 +35,34 @@ RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
       expect(subject[1][1]).to eq "1 January 2018"
     end
   end
+
+  describe "#practitioner_entered_dob" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::EarlyYearsPayments,
+        date_of_birth: Date.new(1990, 1, 1)
+      )
+    end
+
+    subject { described_class.new(claim).practitioner_entered_dob }
+
+    it { is_expected.to eq Date.new(1990, 1, 1) }
+  end
+
+  describe "#one_login_claimant_dob" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::EarlyYearsPayments,
+        onelogin_idv_date_of_birth: Date.new(1990, 2, 1)
+      )
+    end
+
+    subject { described_class.new(claim).one_login_claimant_dob }
+
+    it { is_expected.to eq Date.new(1990, 2, 1) }
+  end
 end


### PR DESCRIPTION
In order to highlight why the IDV task might have failed we want to
display the DOB returned from one login and the DOB entered by the
claimant.
A quirk of the designs is that we show the claimant entered DOB in the
"Provider entered claimant name" row.
