### PR TITLE
CAPT 1941/admin date formats

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -38,7 +38,7 @@ module Admin
       [
         [translate("admin.teacher_reference_number"), claim.eligibility.teacher_reference_number.presence || "Not provided"],
         [translate("#{claim.policy.locale_key}.govuk_verify_fields.full_name", default: :"govuk_verify_fields.full_name").capitalize, claim.personal_data_removed? ? personal_data_removed_text : claim.full_name],
-        [translate("govuk_verify_fields.date_of_birth").capitalize, claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year)],
+        [translate("govuk_verify_fields.date_of_birth").capitalize, claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth)],
         [translate("admin.national_insurance_number"), claim.personal_data_removed? ? personal_data_removed_text : claim.national_insurance_number],
         [translate("govuk_verify_fields.address").capitalize, claim.personal_data_removed? ? personal_data_removed_text : sanitize(claim.address("<br>").html_safe, tags: %w[br])],
         [translate("#{claim.policy.locale_key}.admin.email_address", default: :"admin.email_address"), claim.email_address]

--- a/app/helpers/admin/timeline_helper.rb
+++ b/app/helpers/admin/timeline_helper.rb
@@ -32,7 +32,7 @@ module Admin
     def admin_amendment_format_attribute(attribute, value)
       override = case attribute.to_s
       when "payroll_gender" then "don’t know" if value.to_s == "dont_know"
-      when "date_of_birth" then l(value, format: :day_month_year)
+      when "date_of_birth" then l(value)
       when "student_loan_repayment_amount" then number_to_currency(value)
       when "student_loan_plan" then (value.to_s == "not_applicable") ? "not applicable" : value&.humanize
       when "award_amount" then number_to_currency(value)

--- a/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
@@ -40,8 +40,8 @@ module AutomatedChecks
         def note_body(match)
           provider_entered_name = claim.eligibility.practitioner_name
           govuk_one_login_name = claim.onelogin_idv_full_name
-          claimant_entered_dob = claim.date_of_birth
-          gov_uk_one_login_dob = claim.onelogin_idv_date_of_birth
+          claimant_entered_dob = format_date(claim.date_of_birth)
+          gov_uk_one_login_dob = format_date(claim.onelogin_idv_date_of_birth)
 
           name_colour = if provider_entered_name.downcase == govuk_one_login_name.downcase
             "green"
@@ -64,6 +64,12 @@ module AutomatedChecks
             GOV.UK One Login DOB: <span class="#{dob_colour}">"#{gov_uk_one_login_dob}"</span>
           </pre>
           HTML
+        end
+
+        def format_date(date)
+          return if date.blank?
+
+          I18n.l(date.to_date)
         end
       end
     end

--- a/app/models/policies/early_years_payments/admin_claim_details_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_claim_details_presenter.rb
@@ -16,7 +16,7 @@ module Policies
       def personal_details
         [
           [translate("#{claim.policy.locale_key}.govuk_verify_fields.full_name").capitalize, personal_data(claim.full_name)],
-          [translate("govuk_verify_fields.date_of_birth").capitalize, personal_data(formatted_date(claim.date_of_birth, format: :day_month_year))],
+          [translate("govuk_verify_fields.date_of_birth").capitalize, personal_data(formatted_date(claim.date_of_birth))],
           [translate("admin.national_insurance_number"), personal_data(claim.national_insurance_number)],
           [translate("govuk_verify_fields.address").capitalize, personal_data(sanitize(claim.address("<br>").html_safe, tags: %w[br]))],
           [translate("#{claim.policy.locale_key}.admin.email_address"), claim.email_address],

--- a/app/models/policies/early_years_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_tasks_presenter.rb
@@ -25,7 +25,9 @@ module Policies
       end
 
       def practitioner_entered_dob
-        claim.date_of_birth
+        return unless claim.date_of_birth
+
+        I18n.l(claim.date_of_birth)
       end
 
       def one_login_claimant_name
@@ -33,7 +35,9 @@ module Policies
       end
 
       def one_login_claimant_dob
-        claim.onelogin_idv_date_of_birth
+        return unless claim.onelogin_idv_date_of_birth
+
+        I18n.l(claim.onelogin_idv_date_of_birth)
       end
 
       def practitioner_journey_completed?

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -54,7 +54,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year) %>
+        <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth) %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/admin/tasks/_claim_summary_early_years_payments.html.erb
+++ b/app/views/admin/tasks/_claim_summary_early_years_payments.html.erb
@@ -72,7 +72,7 @@
       </dt>
       <dd class="govuk-summary-list__value">
         <% if claim.date_of_birth.present? %>
-          <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year) %>
+          <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth) %>
         <% end %>
       </dd>
     </div>

--- a/app/views/admin/tasks/_claim_summary_further_education_payments.html.erb
+++ b/app/views/admin/tasks/_claim_summary_further_education_payments.html.erb
@@ -53,7 +53,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year) %>
+        <%= claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth) %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/admin/tasks/_claim_summary_international_relocation_payments.html.erb
+++ b/app/views/admin/tasks/_claim_summary_international_relocation_payments.html.erb
@@ -39,7 +39,7 @@
 
       <% summary_list.with_row do |row| %>
         <% row.with_key { "Date of birth" } %>
-        <% row.with_value { claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year) } %>
+        <% row.with_value { claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth) } %>
       <% end %>
 
       <% summary_list.with_row do |row| %>

--- a/spec/features/admin/admin_amend_claim_spec.rb
+++ b/spec/features/admin/admin_amend_claim_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Admin amends a claim" do
     click_on "Claim amendments"
 
     expect(page).to have_content("Teacher reference number\nchanged from 1234567 to 7654321")
-    expect(page).to have_content("Date of birth\nchanged from #{I18n.l(date_of_birth, format: :day_month_year)} to #{I18n.l(new_date_of_birth, format: :day_month_year)}")
+    expect(page).to have_content("Date of birth\nchanged from #{I18n.l(date_of_birth)} to #{I18n.l(new_date_of_birth)}")
     expect(page).to have_content("Student loan repayment plan\nchanged from Plan 1 to Plan 2")
     expect(page).to have_content("Bank sort code\nchanged from 010203 to 111213")
     expect(page).to have_content("Bank account number\nchanged from 47274828 to 18929492")

--- a/spec/features/admin/admin_ey_tasks_spec.rb
+++ b/spec/features/admin/admin_ey_tasks_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe "Admin EY tasks" do
           )
 
           expect(page).to have_content(
-            "Claimant entered DOB 1986-01-01"
+            "Claimant entered DOB 1 January 1986"
           )
 
           expect(page).to have_content(
-            "Claimant DOB from One Login 1986-01-01"
+            "Claimant DOB from One Login 1 January 1986"
           )
 
           expect(page).to have_content(
@@ -109,10 +109,10 @@ RSpec.describe "Admin EY tasks" do
 
             expect(page).to have_content("Confirm claimant date of birth")
 
-            expect(page).to have_content("Claimant entered DOB 1986-01-01")
+            expect(page).to have_content("Claimant entered DOB 1 January 1986")
 
             expect(page).to have_content(
-              "Claimant DOB from One Login 1986-01-01"
+              "Claimant DOB from One Login 1 January 1986"
             )
 
             expect(page).to have_content(
@@ -127,9 +127,9 @@ RSpec.describe "Admin EY tasks" do
               'GOV.UK One Login Name: "Robby Bobberson"'
             )
 
-            expect(page).to have_content('Claimant-entered DOB: "1986-01-01"')
+            expect(page).to have_content('Claimant-entered DOB: "1 January 1986"')
 
-            expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
+            expect(page).to have_content('GOV.UK One Login DOB: "1 January 1986"')
           end
 
           it "allows the admin to mark the task as passed" do
@@ -203,10 +203,10 @@ RSpec.describe "Admin EY tasks" do
 
             expect(page).to have_content("Confirm claimant date of birth")
 
-            expect(page).to have_content("Claimant entered DOB 1986-01-01")
+            expect(page).to have_content("Claimant entered DOB 1 January 1986")
 
             expect(page).to have_content(
-              "Claimant DOB from One Login 1986-01-01"
+              "Claimant DOB from One Login 1 January 1986"
             )
 
             expect(page).to have_content(
@@ -221,9 +221,9 @@ RSpec.describe "Admin EY tasks" do
               'GOV.UK One Login Name: "Robby Robberson"'
             )
 
-            expect(page).to have_content('Claimant-entered DOB: "1986-01-01"')
+            expect(page).to have_content('Claimant-entered DOB: "1 January 1986"')
 
-            expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
+            expect(page).to have_content('GOV.UK One Login DOB: "1 January 1986"')
           end
 
           it "doesn't allow the admin to complete the task" do
@@ -266,9 +266,9 @@ RSpec.describe "Admin EY tasks" do
             'GOV.UK One Login Name: "Bobby Bobberson"'
           )
 
-          expect(page).to have_content('Claimant-entered DOB: "1986-01-11"')
+          expect(page).to have_content('Claimant-entered DOB: "11 January 1986"')
 
-          expect(page).to have_content('GOV.UK One Login DOB: "1986-01-01"')
+          expect(page).to have_content('GOV.UK One Login DOB: "1 January 1986"')
 
           expect(page).not_to have_button("Save and continue")
         end

--- a/spec/features/admin/admin_view_claim_early_years_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_early_years_payments_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Admin view claim for EarlyYearsPayments" do
     expect(page).to have_summary_item(key: "Contact email", value: practitioner_claim.email_address)
     expect(page).to have_summary_item(key: "Provider email", value: practitioner_claim.eligibility.provider_email_address)
     expect(page).to have_summary_item(key: "Start date", value: practitioner_claim.eligibility.start_date.strftime(I18n.t("date.formats.default")))
-    expect(page).to have_summary_item(key: "Date of birth", value: practitioner_claim.date_of_birth.strftime(I18n.t("date.formats.day_month_year")))
+    expect(page).to have_summary_item(key: "Date of birth", value: practitioner_claim.date_of_birth.strftime(I18n.t("date.formats.default")))
     expect(page).to have_summary_item(key: "Mobile number", value: practitioner_claim.mobile_number)
     expect(page).to have_summary_item(key: "Reference", value: practitioner_claim.reference)
     expect(page).to have_summary_item(key: "Submitted", value: practitioner_claim.submitted_at.strftime(I18n.t("time.formats.default")))

--- a/spec/features/admin/admin_view_full_claim_early_years_payments_spec.rb
+++ b/spec/features/admin/admin_view_full_claim_early_years_payments_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Admin views claim details for EarlyYearsPayments" do
 
     it "shows the claim details" do
       expect(summary_row("Applicant name")).to have_content("Bruce Wayne")
-      expect(summary_row("Date of birth")).to have_content("01/01/1901")
+      expect(summary_row("Date of birth")).to have_content("1 January 1901")
       expect(summary_row("National Insurance number")).to have_content("QQ123456C")
       expect(summary_row("Address")).to have_content("Flat 1")
       expect(summary_row("Address")).to have_content("1 Test Road")

--- a/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Admin views claim details for FurtherEducationPayments" do
 
       expect(summary_row("Full name")).to have_content("Edna Krabappel")
 
-      expect(summary_row("Date of birth")).to have_content("03/07/1945")
+      expect(summary_row("Date of birth")).to have_content("3 July 1945")
 
       expect(summary_row("National Insurance number")).to have_content(
         "QQ123456C"

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -25,7 +25,7 @@ describe Admin::ClaimsHelper do
       expected_answers = [
         [I18n.t("admin.teacher_reference_number"), "1234567"],
         [I18n.t("govuk_verify_fields.full_name").capitalize, "Bruce Wayne"],
-        [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "01/01/1901"],
+        [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "1 January 1901"],
         [I18n.t("admin.national_insurance_number"), "QQ123456C"],
         [I18n.t("govuk_verify_fields.address").capitalize, "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
         [I18n.t("admin.email_address"), "test@email.com"]

--- a/spec/helpers/admin/timeline_helper_spec.rb
+++ b/spec/helpers/admin/timeline_helper_spec.rb
@@ -19,7 +19,7 @@ describe Admin::TimelineHelper do
         expect(helper.admin_amendment_details(amendment)).to eq([
           ["Bank account number", "12345678", "87654321"],
           ["Bank sort code", "123456", "654321"],
-          ["Date of birth", "25/02/1995", "25/02/1990"],
+          ["Date of birth", "25 February 1995", "25 February 1990"],
           ["Payroll gender", "male", "don’t know"],
           ["Student loan repayment amount", "£123.00", "£456.00"],
           ["Student loan repayment plan", "not applicable", "Plan 1"],

--- a/spec/models/policies/early_years_payments/admin_claim_details_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_claim_details_presenter_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Policies::EarlyYearsPayments::AdminClaimDetailsPresenter do
       it "returns an array of questions and answers" do
         expected_answers = [
           [I18n.t("early_years_payments.govuk_verify_fields.full_name").capitalize, "Bruce Wayne"],
-          [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "01/01/1901"],
+          [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "1 January 1901"],
           [I18n.t("admin.national_insurance_number"), "QQ123456C"],
           [I18n.t("govuk_verify_fields.address").capitalize, "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
           [I18n.t("early_years_payments.admin.email_address"), "test@example.com"],

--- a/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_tasks_presenter_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
 
     subject { described_class.new(claim).practitioner_entered_dob }
 
-    it { is_expected.to eq Date.new(1990, 1, 1) }
+    it { is_expected.to eq I18n.l(Date.new(1990, 1, 1)) }
   end
 
   describe "#one_login_claimant_dob" do
@@ -63,6 +63,6 @@ RSpec.describe Policies::EarlyYearsPayments::AdminTasksPresenter do
 
     subject { described_class.new(claim).one_login_claimant_dob }
 
-    it { is_expected.to eq Date.new(1990, 2, 1) }
+    it { is_expected.to eq I18n.l(Date.new(1990, 2, 1)) }
   end
 end


### PR DESCRIPTION
Standardise dates in the admin area

Requirement is to standardise on %d/%m/%Y when displaying dates in the
admin area. We've added a new locale format `admin_date` which we now
use throughout the admin area when displaying a date or datetime.

