### PR TITLE
CAPT 2083/slc upload audit

### DIFF
--- a/app/jobs/import_student_loans_data_job.rb
+++ b/app/jobs/import_student_loans_data_job.rb
@@ -1,9 +1,9 @@
 class ImportStudentLoansDataJob < FileImporterJob
-  import_with StudentLoansDataImporter do
+  import_with StudentLoansDataImporter do |uploaded_by|
     Rails.logger.info "SLC data imported; student loan verifiers will re-run where necessary"
 
-    StudentLoanAmountCheckJob.perform_later
-    StudentLoanPlanCheckJob.perform_later
+    StudentLoanAmountCheckJob.perform_later(uploaded_by)
+    StudentLoanPlanCheckJob.perform_later(uploaded_by)
   end
   rescue_with -> do
     StudentLoansData.delete_all

--- a/app/jobs/student_loan_amount_check_job.rb
+++ b/app/jobs/student_loan_amount_check_job.rb
@@ -1,10 +1,10 @@
 class StudentLoanAmountCheckJob < ApplicationJob
-  def perform
+  def perform(admin)
     delete_no_data_student_loan_amount_tasks
     claims = current_year_tslr_claims_awaiting_decision.awaiting_task("student_loan_amount")
 
     claims.each do |claim|
-      ClaimStudentLoanDetailsUpdater.call(claim)
+      ClaimStudentLoanDetailsUpdater.call(claim, admin)
       AutomatedChecks::ClaimVerifiers::StudentLoanAmount.new(claim:).perform
     rescue => e
       # If something goes wrong, log the error and continue

--- a/app/jobs/student_loan_plan_check_job.rb
+++ b/app/jobs/student_loan_plan_check_job.rb
@@ -6,11 +6,11 @@ class StudentLoanPlanCheckJob < ApplicationJob
     Policies::EarlyYearsPayments
   ].freeze
 
-  def perform
+  def perform(admin)
     delete_no_data_student_loan_plan_tasks
     claims = current_year_claims_awaiting_decision.awaiting_task("student_loan_plan")
     claims.each do |claim|
-      ClaimStudentLoanDetailsUpdater.call(claim)
+      ClaimStudentLoanDetailsUpdater.call(claim, admin)
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan.new(claim:).perform
     rescue => e
       # If something goes wrong, log the error and continue

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -8,6 +8,7 @@ class Claim < ApplicationRecord
     national_insurance_number
     date_of_birth
     student_loan_plan
+    has_student_loan
     bank_sort_code
     bank_account_number
     building_society_roll_number

--- a/app/models/claim_student_loan_details_updater.rb
+++ b/app/models/claim_student_loan_details_updater.rb
@@ -1,25 +1,38 @@
 class ClaimStudentLoanDetailsUpdater
-  def self.call(claim)
-    new(claim).update_claim_with_latest_data
+  class StudentLoanUpdateError < StandardError; end
+
+  def self.call(claim, admin)
+    new(claim, admin).update_claim_with_latest_data
   end
 
-  def initialize(claim)
+  def initialize(claim, admin)
     @claim = claim
+    @admin = admin
   end
 
   def update_claim_with_latest_data
-    claim.transaction do
-      eligibility.update!(eligibility_student_loan_attributes) if claim.has_tslr_policy?
+    claim_changes = {}
 
-      claim.assign_attributes(claim_student_loan_attributes)
-
-      claim.save!(context: :"student-loan")
+    if claim.has_student_loan != student_loans_data.has_student_loan?
+      claim_changes[:has_student_loan] = student_loans_data.has_student_loan?
     end
+
+    if claim.student_loan_plan != student_loans_data.student_loan_plan
+      claim_changes[:student_loan_plan] = student_loans_data.student_loan_plan
+    end
+
+    if student_loan_repayment_amount_changed?
+      claim_changes[:eligibility_attributes] = {
+        student_loan_repayment_amount: student_loans_data.total_repayment_amount
+      }
+    end
+
+    amend_claim(claim_changes) if claim_changes.present?
   end
 
   private
 
-  attr_reader :claim
+  attr_reader :claim, :admin
 
   delegate :eligibility, to: :claim
   delegate :national_insurance_number, :date_of_birth, to: :claim
@@ -40,5 +53,32 @@ class ClaimStudentLoanDetailsUpdater
       national_insurance_number: national_insurance_number,
       date_of_birth: date_of_birth
     )
+  end
+
+  def student_loan_repayment_amount_changed?
+    return false unless claim.has_tslr_policy?
+
+    claim.eligibility.student_loan_repayment_amount != student_loans_data.total_repayment_amount
+  end
+
+  def amend_claim(claim_changes)
+    amendment = Amendment.amend_claim(
+      claim,
+      claim_changes,
+      {
+        notes: "Student loan details updated from SLC data",
+        created_by: admin
+      }
+    )
+
+    if amendment.errors.any?
+      msg = [
+        "Failed to update claim #{claim.id} student loan data.",
+        "amendment_error: \"#{amendment.errors.full_messages.to_sentence}\"",
+        "SLC data: #{claim_changes}"
+      ].join(" ")
+
+      raise StudentLoanUpdateError, msg
+    end
   end
 end

--- a/app/models/policies/student_loans/eligibility.rb
+++ b/app/models/policies/student_loans/eligibility.rb
@@ -43,7 +43,7 @@ module Policies
       validates :had_leadership_position, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}
       validates :mostly_performed_leadership_duties, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
       validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99999
-      validates :student_loan_repayment_amount, on: :amendment, award_range: {max: 5_000}
+      validates :student_loan_repayment_amount, on: :amendment, award_range: {max: 5_000}, if: :student_loan_repayment_amount_changed?
       validates :teacher_reference_number, on: :amendment, presence: {message: "Enter your teacher reference number"}
       validate :validate_teacher_reference_number_length
 

--- a/app/views/admin/amendments/index.html.erb
+++ b/app/views/admin/amendments/index.html.erb
@@ -32,7 +32,7 @@
                   <% admin_amendment_details(amendment).each do |details| %>
                     <h3 class="hmcts-timeline__title"><%= details[0] %></h3>
                     <% if details.count > 1 %>
-                      <p class="hmcts-timeline__by">changed from <%= details[1] %> to <%= details[2] %></p>
+                      <p class="hmcts-timeline__by">changed from <%= details[1].presence || "[no details]" %> to <%= details[2].presence || "[no details]" %></p>
                     <% else %>
                       <p class="hmcts-timeline__by">changed</p>
                     <% end %>

--- a/spec/models/claim_student_loan_details_updater_spec-old.rb
+++ b/spec/models/claim_student_loan_details_updater_spec-old.rb
@@ -1,0 +1,236 @@
+require "rails_helper"
+
+RSpec.describe ClaimStudentLoanDetailsUpdater do
+  let(:updater) { described_class.new(claim, admin) }
+  let(:claim) { create(:claim, policy:) }
+  let(:policy) { Policies::StudentLoans }
+  let(:admin) { create(:dfe_signin_user) }
+
+  describe ".call" do
+    let(:updater_mock) { instance_double(described_class) }
+
+    before do
+      allow(described_class).to receive(:new).with(claim, admin).and_return(updater_mock)
+    end
+
+    it "invokes the `update_claim_with_latest_data` instance method" do
+      expect(updater_mock).to receive(:update_claim_with_latest_data)
+      described_class.call(claim, admin)
+    end
+  end
+
+  describe "#update_claim_with_latest_data" do
+    subject(:call) { updater.update_claim_with_latest_data }
+
+    context "when no existing SLC data is found for the claimant" do
+      it "returns true" do
+        expect(call).to eq(true)
+      end
+
+      context "when the policy is StudentLoans" do
+        let(:policy) { Policies::StudentLoans }
+
+        it "does not update the claim student plan and zero repayment total" do
+          expect { call }.not_to change { claim.reload.has_student_loan }
+        end
+
+        it "keeps the `submitted_using_slc_data` flag to `false` (default)" do
+          expect { call }.not_to change { claim.submitted_using_slc_data }.from(false)
+        end
+
+        it "does not create an amendment" do
+          expect { call }.not_to change { claim.amendments.count }
+        end
+      end
+
+      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].each do |policy|
+        context "when the policy is #{policy}" do
+          let(:policy) { policy }
+
+          it "does not update the claim" do
+            expect { call }.not_to change { claim.reload }
+          end
+
+          it "does not create an amendment" do
+            expect { call }.not_to change { claim.amendments.count }
+          end
+        end
+      end
+    end
+
+    context "when SLC data is found with student loan information for the claimant" do
+      before do
+        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 1, amount: 50)
+        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 2, amount: 60)
+      end
+
+      it "returns true" do
+        expect(call).to eq(true)
+      end
+
+      context "when the policy is StudentLoans" do
+        it "updates the claim with the student plan and the repayment total" do
+          expect { call }.to change { claim.reload.has_student_loan }.to(true)
+            .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1_AND_2)
+            .and change { claim.eligibility.student_loan_repayment_amount }.to(110)
+        end
+
+        it "creates an amendment" do
+          expect { call }.to change { claim.amendments.count }.by(1)
+
+          amendment = claim.amendments.last
+
+          expect(amendment.claim_changes).to eq({
+            "has_student_loan" => [false, true],
+            "student_loan_plan" => [Claim::NO_STUDENT_LOAN, StudentLoan::PLAN_1_AND_2],
+            "student_loan_repayment_amount" => [0, 110]
+          })
+
+          expect(amendment.notes).to eq(
+            "Student loan details updated from SLC data"
+          )
+
+          expect(amendment.created_by).to eq(admin)
+        end
+      end
+
+      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].each do |policy|
+        context "when the policy is #{policy}" do
+          let(:policy) { policy }
+
+          it "updates the claim with the student plan only" do
+            expect { call }.to change { claim.reload.has_student_loan }.to(true)
+              .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1_AND_2)
+          end
+
+          it "creates an amendment" do
+            expect { call }.to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "has_student_loan" => [false, true],
+              "student_loan_plan" => [Claim::NO_STUDENT_LOAN, StudentLoan::PLAN_1_AND_2]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
+          end
+        end
+      end
+    end
+
+    context "when SLC data is found with no student loan information for the claimant" do
+      before do
+        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: nil, amount: nil)
+      end
+
+      it "returns true" do
+        expect(call).to eq(true)
+      end
+
+      context "when the policy is StudentLoans" do
+        it "updates the claim with the student plan and the repayment total" do
+          expect { call }.to change { claim.reload.has_student_loan }.to(false)
+            .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
+            .and change { claim.eligibility.student_loan_repayment_amount }.to(0)
+        end
+
+        it "creates an amendment with the student plan change" do
+          expect { call }.to change { claim.amendments.count }.by(1)
+
+          amendment = claim.amendments.last
+
+          expect(amendment.claim_changes).to eq({
+            "has_student_loan" => [true, false],
+            "student_loan_plan" => [StudentLoan::PLAN_1_AND_2, Claim::NO_STUDENT_LOAN],
+            "student_loan_repayment_amount" => [110, 0]
+          })
+
+          expect(amendment.notes).to eq(
+            "Student loan details updated from SLC data"
+          )
+
+          expect(amendment.created_by).to eq(admin)
+        end
+      end
+
+      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].each do |policy|
+        context "when the policy is #{policy}" do
+          let(:policy) { policy }
+
+          it "updates the claim with the student plan only" do
+            expect { call }.to change { claim.reload.has_student_loan }.to(false)
+              .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
+          end
+
+          it "creates an amendment with the student plan change" do
+            expect { call }.to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "has_student_loan" => [true, false],
+              "student_loan_plan" => [StudentLoan::PLAN_1_AND_2, Claim::NO_STUDENT_LOAN]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
+          end
+        end
+      end
+    end
+
+    context "when updating a claim after submission" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          :with_no_student_loan,
+          policy:,
+          eligibility_attributes: {
+            student_loan_repayment_amount: 0
+          }
+        )
+      end
+
+      before do
+        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 1, amount: 50)
+      end
+
+      it "updates the claim with the student plan and the repayment total" do
+        expect { call }.to change { claim.reload.has_student_loan }.to(true)
+          .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1)
+          .and change { claim.eligibility.student_loan_repayment_amount }.to(50)
+      end
+
+      it "creates an amendment" do
+        expect { call }.to change { claim.amendments.count }.by(1)
+
+        amendment = claim.amendments.last
+
+        expect(amendment.claim_changes).to eq({
+          "has_student_loan" => [false, true],
+          "student_loan_plan" => [nil, StudentLoan::PLAN_1],
+          "student_loan_repayment_amount" => [0, 50]
+        })
+
+        expect(amendment.notes).to eq(
+          "Student loan details updated from SLC data"
+        )
+
+        expect(amendment.created_by).to eq(admin)
+      end
+
+      it "does not change the `submitted_using_slc_data` flag" do
+        expect { call }.to not_change { claim.submitted_using_slc_data }
+      end
+    end
+  end
+end

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -1,24 +1,28 @@
 require "rails_helper"
 
 RSpec.describe ClaimStudentLoanDetailsUpdater do
+  let(:admin) { create(:dfe_signin_user) }
+
   describe ".call" do
-    let(:updater) { described_class.new(claim) }
+    let(:updater) { described_class.new(claim, admin) }
     let(:claim) { create(:claim, policy:) }
     let(:policy) { Policies::StudentLoans }
 
     let(:updater_mock) { instance_double(described_class) }
 
     before do
-      allow(described_class).to receive(:new).with(claim).and_return(updater_mock)
+      allow(described_class).to receive(:new).with(claim, admin).and_return(updater_mock)
     end
 
     it "invokes the `update_claim_with_latest_data` instance method" do
       expect(updater_mock).to receive(:update_claim_with_latest_data)
-      described_class.call(claim)
+      described_class.call(claim, admin)
     end
   end
 
   describe "#update_claim_with_latest_data" do
+    before { claim.reload }
+
     context "when the claim has no student loan data" do
       let(:claim) do
         create(
@@ -40,10 +44,15 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "doesn't change the claim attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to not_change { claim.reload.has_student_loan }
               .and not_change { claim.student_loan_plan }
               .and not_change { claim.eligibility.student_loan_repayment_amount }
+          end
+
+          it "doesn't create an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .not_to change { claim.amendments.count }
           end
         end
 
@@ -55,9 +64,14 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "doesn't change the claim attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to not_change { claim.reload.has_student_loan }
               .and not_change { claim.student_loan_plan }
+          end
+
+          it "doesn't create an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .not_to change { claim.amendments.count }
           end
         end
       end
@@ -82,10 +96,29 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "updates the claim's attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to change { claim.reload.has_student_loan }.from(nil).to(true)
               .and change { claim.student_loan_plan }.from(nil).to(StudentLoan::PLAN_1)
               .and change { claim.eligibility.student_loan_repayment_amount }.from(0).to(50)
+          end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "has_student_loan" => [nil, true],
+              "student_loan_plan" => [nil, StudentLoan::PLAN_1],
+              "student_loan_repayment_amount" => [0, 50]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
           end
         end
 
@@ -97,9 +130,27 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "updates the claim's attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to change { claim.reload.has_student_loan }.from(nil).to(true)
               .and change { claim.student_loan_plan }.from(nil).to(StudentLoan::PLAN_1)
+          end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "has_student_loan" => [nil, true],
+              "student_loan_plan" => [nil, StudentLoan::PLAN_1]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
           end
         end
       end
@@ -114,38 +165,6 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           student_loan_plan: StudentLoan::PLAN_1,
           **policy_attributes
         )
-      end
-
-      context "when no student loan data is found" do
-        context "when the claim is a tslr claim" do
-          let(:policy_attributes) do
-            {
-              policy: Policies::StudentLoans,
-              eligibility_attributes: {student_loan_repayment_amount: 100}
-            }
-          end
-
-          it "resets the student loan attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
-              .to change { claim.reload.has_student_loan }.from(true).to(nil)
-              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(nil)
-              .and change { claim.eligibility.student_loan_repayment_amount }.from(100).to(0)
-          end
-        end
-
-        context "when the claim is not a tslr claim" do
-          let(:policy_attributes) do
-            {
-              policy: Policies::EarlyYearsPayments
-            }
-          end
-
-          it "resets the student loan attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
-              .to change { claim.reload.has_student_loan }.from(true).to(nil)
-              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(nil)
-          end
-        end
       end
 
       context "when student loan data is found" do
@@ -168,10 +187,28 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "replaces the student loan attributes with the latest values" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to not_change { claim.reload.has_student_loan }
               .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_2)
-              .and change { claim.eligibility.student_loan_repayment_amount }.from(50).to(300)
+              .and change { claim.eligibility.student_loan_repayment_amount }.from(50).to(100)
+          end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "student_loan_plan" => [StudentLoan::PLAN_1, StudentLoan::PLAN_2],
+              "student_loan_repayment_amount" => [50, 100]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
           end
         end
 
@@ -183,9 +220,26 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "replaces the student loan attributes with the latest values" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to not_change { claim.reload.has_student_loan }
               .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_2)
+          end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "student_loan_plan" => [StudentLoan::PLAN_1, StudentLoan::PLAN_2]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
           end
         end
       end
@@ -218,20 +272,156 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
           end
 
           it "combines the data and replaces the existing claim attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to not_change { claim.reload.has_student_loan }
               .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_1_AND_2)
               .and change { claim.eligibility.student_loan_repayment_amount }.from(50).to(300)
           end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "student_loan_plan" => [StudentLoan::PLAN_1, StudentLoan::PLAN_1_AND_2],
+              "student_loan_repayment_amount" => [50, 300]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
+          end
         end
 
         context "when the claim is not a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::FurtherEducationPayments
+            }
+          end
+
           it "combines the data and replaces the existing claim attributes" do
-            expect { described_class.new(claim).update_claim_with_latest_data }
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
               .to not_change { claim.reload.has_student_loan }
               .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_1_AND_2)
           end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "student_loan_plan" => [StudentLoan::PLAN_1, StudentLoan::PLAN_1_AND_2]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
+          end
         end
+      end
+
+      # This class should only be called with claims that are awaiting the
+      # either the student_loan_plan or student_loan_amount task.
+      # StudentLoans::Eligibility#student_loan_repayment_amount is validated
+      # when an SLC claim is amended. This test is documenting the current
+      # behaviour, we may want to do something else like return early if
+      # attempting to amend the `student_loan_repayment_amount` from some
+      # amount to £0.
+      context "when no student loan data is found" do
+        context "when the claim is a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::StudentLoans,
+              eligibility_attributes: {student_loan_repayment_amount: 100}
+            }
+          end
+
+          it "raises an error" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to raise_error(described_class::StudentLoanUpdateError).with_message(
+                a_string_including(
+                  "Eligibility student loan repayment amount Enter a positive amount up to £5,000.00"
+                )
+              )
+              .and not_change { claim.reload.has_student_loan }
+              .and not_change { claim.student_loan_plan }
+              .and not_change { claim.eligibility.student_loan_repayment_amount }
+          end
+        end
+
+        context "when the claim is not a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::EarlyYearsPayments
+            }
+          end
+
+          it "resets the student loan attributes" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.reload.has_student_loan }.from(true).to(nil)
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(nil)
+          end
+
+          it "creates an ammendment" do
+            expect { described_class.new(claim, admin).update_claim_with_latest_data }
+              .to change { claim.amendments.count }.by(1)
+
+            amendment = claim.amendments.last
+
+            expect(amendment.claim_changes).to eq({
+              "has_student_loan" => [true, nil],
+              "student_loan_plan" => [StudentLoan::PLAN_1, nil]
+            })
+
+            expect(amendment.notes).to eq(
+              "Student loan details updated from SLC data"
+            )
+
+            expect(amendment.created_by).to eq(admin)
+          end
+        end
+      end
+    end
+
+    context "when creating the amendment fails" do
+      before do
+        create(
+          :student_loans_data,
+          nino: claim.national_insurance_number,
+          date_of_birth: claim.date_of_birth,
+          plan_type_of_deduction: 2,
+          amount: 200
+        )
+      end
+
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          has_student_loan: true,
+          student_loan_plan: StudentLoan::PLAN_1,
+          policy: Policies::StudentLoans,
+          eligibility_attributes: {student_loan_repayment_amount: 50},
+          personal_data_removed_at: DateTime.now # make the claim unaamendable
+        )
+      end
+
+      it "raises an error and doesn't update the claim" do
+        expect { described_class.new(claim, admin).update_claim_with_latest_data }
+          .to raise_error(described_class::StudentLoanUpdateError).with_message(
+            "Failed to update claim #{claim.id} student loan data. " \
+            "amendment_error: \"Claim must be amendable\" " \
+            "SLC data: {student_loan_plan: \"plan_2\", eligibility_attributes: {student_loan_repayment_amount: 200.0}}"
+          )
       end
     end
   end

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ClaimStudentLoanDetailsUpdater do
-  let(:updater) { described_class.new(claim) }
-  let(:claim) { create(:claim, policy:) }
-  let(:policy) { Policies::StudentLoans }
-
   describe ".call" do
+    let(:updater) { described_class.new(claim) }
+    let(:claim) { create(:claim, policy:) }
+    let(:policy) { Policies::StudentLoans }
+
     let(:updater_mock) { instance_double(described_class) }
 
     before do
@@ -19,110 +19,219 @@ RSpec.describe ClaimStudentLoanDetailsUpdater do
   end
 
   describe "#update_claim_with_latest_data" do
-    subject(:call) { updater.update_claim_with_latest_data }
-
-    context "when no existing SLC data is found for the claimant" do
-      it "returns true" do
-        expect(call).to eq(true)
+    context "when the claim has no student loan data" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          has_student_loan: nil,
+          student_loan_plan: nil,
+          **policy_attributes
+        )
       end
 
-      context "when the policy is StudentLoans" do
-        let(:policy) { Policies::StudentLoans }
+      context "when no student loan data is found" do
+        context "when the claim is a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::StudentLoans,
+              eligibility_attributes: {student_loan_repayment_amount: 0}
+            }
+          end
 
-        it "does not update the claim student plan and zero repayment total" do
-          expect { call }.not_to change { claim.reload.has_student_loan }
+          it "doesn't change the claim attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to not_change { claim.reload.has_student_loan }
+              .and not_change { claim.student_loan_plan }
+              .and not_change { claim.eligibility.student_loan_repayment_amount }
+          end
         end
 
-        it "keeps the `submitted_using_slc_data` flag to `false` (default)" do
-          expect { call }.not_to change { claim.submitted_using_slc_data }.from(false)
+        context "when the claim is not a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::FurtherEducationPayments
+            }
+          end
+
+          it "doesn't change the claim attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to not_change { claim.reload.has_student_loan }
+              .and not_change { claim.student_loan_plan }
+          end
         end
       end
 
-      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].each do |policy|
-        context "when the policy is #{policy}" do
-          let(:policy) { policy }
+      context "when student loan data is found" do
+        before do
+          create(
+            :student_loans_data,
+            nino: claim.national_insurance_number,
+            date_of_birth: claim.date_of_birth,
+            plan_type_of_deduction: 1,
+            amount: 50
+          )
+        end
 
-          it "does not update the claim" do
-            expect { call }.not_to change { claim.reload }
+        context "when the claim is a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::StudentLoans,
+              eligibility_attributes: {student_loan_repayment_amount: 0}
+            }
+          end
+
+          it "updates the claim's attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to change { claim.reload.has_student_loan }.from(nil).to(true)
+              .and change { claim.student_loan_plan }.from(nil).to(StudentLoan::PLAN_1)
+              .and change { claim.eligibility.student_loan_repayment_amount }.from(0).to(50)
+          end
+        end
+
+        context "when the claim is not a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::LevellingUpPremiumPayments
+            }
+          end
+
+          it "updates the claim's attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to change { claim.reload.has_student_loan }.from(nil).to(true)
+              .and change { claim.student_loan_plan }.from(nil).to(StudentLoan::PLAN_1)
           end
         end
       end
     end
 
-    context "when SLC data is found with student loan information for the claimant" do
-      before do
-        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 1, amount: 50)
-        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 2, amount: 60)
+    context "when the claim has student loan data" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          has_student_loan: true,
+          student_loan_plan: StudentLoan::PLAN_1,
+          **policy_attributes
+        )
       end
 
-      it "returns true" do
-        expect(call).to eq(true)
-      end
+      context "when no student loan data is found" do
+        context "when the claim is a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::StudentLoans,
+              eligibility_attributes: {student_loan_repayment_amount: 100}
+            }
+          end
 
-      context "when the policy is StudentLoans" do
-        it "updates the claim with the student plan and the repayment total" do
-          expect { call }.to change { claim.reload.has_student_loan }.to(true)
-            .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1_AND_2)
-            .and change { claim.eligibility.student_loan_repayment_amount }.to(110)
+          it "resets the student loan attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to change { claim.reload.has_student_loan }.from(true).to(nil)
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(nil)
+              .and change { claim.eligibility.student_loan_repayment_amount }.from(100).to(0)
+          end
         end
-      end
 
-      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments, Policies::FurtherEducationPayments].each do |policy|
-        context "when the policy is #{policy}" do
-          let(:policy) { policy }
+        context "when the claim is not a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::EarlyYearsPayments
+            }
+          end
 
-          it "updates the claim with the student plan only" do
-            expect { call }.to change { claim.reload.has_student_loan }.to(true)
-              .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1_AND_2)
+          it "resets the student loan attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to change { claim.reload.has_student_loan }.from(true).to(nil)
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(nil)
           end
         end
       end
-    end
 
-    context "when SLC data is found with no student loan information for the claimant" do
-      before do
-        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: nil, amount: nil)
-      end
-
-      it "returns true" do
-        expect(call).to eq(true)
-      end
-
-      context "when the policy is StudentLoans" do
-        it "updates the claim with the student plan and the repayment total" do
-          expect { call }.to change { claim.reload.has_student_loan }.to(false)
-            .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
-            .and change { claim.eligibility.student_loan_repayment_amount }.to(0)
+      context "when student loan data is found" do
+        before do
+          create(
+            :student_loans_data,
+            nino: claim.national_insurance_number,
+            date_of_birth: claim.date_of_birth,
+            plan_type_of_deduction: 2,
+            amount: 100
+          )
         end
-      end
 
-      [Policies::EarlyCareerPayments, Policies::LevellingUpPremiumPayments].each do |policy|
-        context "when the policy is #{policy}" do
-          let(:policy) { policy }
+        context "when the claim is a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::StudentLoans,
+              eligibility_attributes: {student_loan_repayment_amount: 50}
+            }
+          end
 
-          it "updates the claim with the student plan only" do
-            expect { call }.to change { claim.reload.has_student_loan }.to(false)
-              .and change { claim.student_loan_plan }.to(Claim::NO_STUDENT_LOAN)
+          it "replaces the student loan attributes with the latest values" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to not_change { claim.reload.has_student_loan }
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_2)
+              .and change { claim.eligibility.student_loan_repayment_amount }.from(50).to(300)
+          end
+        end
+
+        context "when the claim is not a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::FurtherEducationPayments
+            }
+          end
+
+          it "replaces the student loan attributes with the latest values" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to not_change { claim.reload.has_student_loan }
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_2)
           end
         end
       end
-    end
 
-    context "when updating a claim after submission" do
-      let(:claim) { create(:claim, :submitted, :with_no_student_loan, policy:) }
+      context "when multiple student loan data is found" do
+        before do
+          create(
+            :student_loans_data,
+            nino: claim.national_insurance_number,
+            date_of_birth: claim.date_of_birth,
+            plan_type_of_deduction: 1,
+            amount: 100
+          )
 
-      before do
-        create(:student_loans_data, nino: claim.national_insurance_number, date_of_birth: claim.date_of_birth, plan_type_of_deduction: 1, amount: 50)
-      end
+          create(
+            :student_loans_data,
+            nino: claim.national_insurance_number,
+            date_of_birth: claim.date_of_birth,
+            plan_type_of_deduction: 2,
+            amount: 200
+          )
+        end
 
-      it "updates the claim with the student plan and the repayment total" do
-        expect { call }.to change { claim.reload.has_student_loan }.to(true)
-          .and change { claim.student_loan_plan }.to(StudentLoan::PLAN_1)
-          .and change { claim.eligibility.student_loan_repayment_amount }.to(50)
-      end
+        context "when the claim is a tslr claim" do
+          let(:policy_attributes) do
+            {
+              policy: Policies::StudentLoans,
+              eligibility_attributes: {student_loan_repayment_amount: 50}
+            }
+          end
 
-      it "does not change the `submitted_using_slc_data` flag" do
-        expect { call }.to not_change { claim.submitted_using_slc_data }
+          it "combines the data and replaces the existing claim attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to not_change { claim.reload.has_student_loan }
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_1_AND_2)
+              .and change { claim.eligibility.student_loan_repayment_amount }.from(50).to(300)
+          end
+        end
+
+        context "when the claim is not a tslr claim" do
+          it "combines the data and replaces the existing claim attributes" do
+            expect { described_class.new(claim).update_claim_with_latest_data }
+              .to not_change { claim.reload.has_student_loan }
+              .and change { claim.student_loan_plan }.from(StudentLoan::PLAN_1).to(StudentLoan::PLAN_1_AND_2)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Create audit trail when SLC upload runs

When the SLC data upload runs we want to use the existing amendments
mechanism to record any changes to the claim. As amending a claim
requires a user to be associated with the amendment we need to pass who
triggered the SLC upload down to the `ClaimStudentLoanDetailsUpdater`.

We've had to slightly change the validation on
`StudentLoans::Eligibility` to check if the repayment amount has changed
as there's one test (`spec/features/admin/upload_slc_data_spec.rb`)
where:
* No SLC data is found for a claim
* The claim has a student_loan_repayment_amount of `0`
* The claim's plan is expected to change from `not_applicable` to `nil`
* The claim's `has_student_loan` is expected to change from `false` to
  `nil`
Without changing the validation on the eligibility we can't pass this
test as amending the claim errors due to the `0` student loan repayment
amount.

<img width="1158" alt="Screenshot 2025-01-13 at 14 51 59" src="https://github.com/user-attachments/assets/2c142354-5cb5-4822-ba30-b9cd023a1edf" />

