### PR TITLE
Fix ssl check statuscake monitoring

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -19,6 +19,7 @@
   "enable_monitoring": true,
   "statuscake_contact_groups": [195955, 282453],
   "external_url": "https://www.claim-additional-teaching-payment.service.gov.uk/healthcheck",
+  "apex_url": "https://claim-additional-teaching-payment.service.gov.uk",
   "enable_logit": true,
   "dataset_name": "claim_events_production",
   "enable_dfe_analytics_federated_auth": true

--- a/terraform/application/statuscake.tf
+++ b/terraform/application/statuscake.tf
@@ -4,7 +4,7 @@ module "statuscake" {
   source = "./vendor/modules/aks//monitoring/statuscake"
 
   uptime_urls = compact([module.web_application.probe_url, var.external_url])
-  ssl_urls    = compact([var.external_url])
+  ssl_urls    = compact([var.apex_url])
 
   contact_groups = var.statuscake_contact_groups
 

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -44,6 +44,10 @@ variable "external_url" {
   default     = null
   description = "Healthcheck URL for StatusCake monitoring"
 }
+variable "apex_url" {
+  default     = null
+  description = "Apex URL for StatusCake SSL monitoring"
+}
 variable "statuscake_contact_groups" {
   default     = []
   description = "ID of the contact group in statuscake web UI"


### PR DESCRIPTION
### Context

The prod apex SSL cert should be monitored by statuscake, nothing else.

### Changes proposed in this pull request

- Add apex_url variable
- Change statuscake.tf

### Guidance to review

make env deploy-plan
- will remove test and www ssl cert monitors, and add prod apex

### Link to Trello card

https://trello.com/c/rumvvcay/2198-capt-apex-domain-not-monitored


