### PR TITLE
Allow searching by payment id

### DIFF
--- a/app/models/claim/search.rb
+++ b/app/models/claim/search.rb
@@ -26,7 +26,13 @@ class Claim
         }
       }.flatten.map(&:id)
 
-      claim_match_query.or(Claim.where(eligibility_id: eligibility_ids))
+      claims_matched_on_payment_ids = Claim.joins(:payments).merge(
+        Payment.where(id: search_term)
+      )
+
+      claim_match_query
+        .or(Claim.where(eligibility_id: eligibility_ids))
+        .or(Claim.where(id: claims_matched_on_payment_ids))
     end
 
     private

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -12,7 +12,7 @@
 
     <%= form_with url: search_admin_claims_path, method: :get do |form| %>
       <div class="govuk-form-group">
-        <%= form.label :query, "Enter a reference, email address, Teacher Reference Number, or surname", class: "govuk-label" %>
+        <%= form.label :query, "Enter a reference, email address, Teacher Reference Number, surname, or payment ID", class: "govuk-label" %>
         <%= form.text_field :query, class: "govuk-input govuk-input--width-20" %>
       </div>
 

--- a/spec/models/claim/search_spec.rb
+++ b/spec/models/claim/search_spec.rb
@@ -115,4 +115,61 @@ RSpec.describe Claim::Search do
       specify { expect(search.claims).to contain_exactly(claim, historical_matching_claim) }
     end
   end
+
+  context "search by payment id" do
+    let!(:claim_1) do
+      create(
+        :claim,
+        :submitted,
+        bank_account_number: "12345678",
+        bank_sort_code: "123456",
+        national_insurance_number: "QQ123456C"
+      )
+    end
+
+    let!(:claim_2) do
+      create(
+        :claim,
+        :submitted,
+        bank_account_number: "12345678",
+        bank_sort_code: "123456",
+        national_insurance_number: "QQ123456C"
+      )
+    end
+
+    let!(:claim_3) do
+      create(
+        :claim,
+        :submitted,
+        bank_account_number: "12345678",
+        bank_sort_code: "123456",
+        national_insurance_number: "QQ123456C"
+      )
+    end
+
+    let!(:claim_4) do
+      create(
+        :claim,
+        :submitted,
+        bank_account_number: "12345678",
+        bank_sort_code: "123456",
+        national_insurance_number: "QQ123456C"
+      )
+    end
+
+    let!(:payment_1) { create(:payment, claims: [claim_1, claim_2]) }
+
+    let!(:payment_2) do
+      create(:payment, claims: [claim_3], payroll_run: payment_1.payroll_run)
+    end
+
+    let(:query) { payment_1.id }
+
+    subject { search.claims }
+
+    it { is_expected.to include(claim_1) }
+    it { is_expected.to include(claim_2) }
+    it { is_expected.not_to include(claim_3) }
+    it { is_expected.not_to include(claim_4) }
+  end
 end


### PR DESCRIPTION
When reconciling payroll issues the ops team would like the ability to
search for claims by payment id, as this is what's in the payroll CSV.
