### PR TITLE
Navigator FE

### DIFF
--- a/app/assets/stylesheets/components/button_to.scss
+++ b/app/assets/stylesheets/components/button_to.scss
@@ -1,3 +1,7 @@
+.one-login-header__nav__link.button-to-as-link {
+  color: inherit;
+}
+
 .button-to-as-link {
   padding: 0;
   background: none;
@@ -5,7 +9,7 @@
   outline: none;
   box-shadow: none;
 
-  color: inherit;
+  color: #1d70b8;
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -4,6 +4,7 @@ class ClaimsController < BasePublicController
   skip_before_action :send_unstarted_claimants_to_the_start, only: [:new, :create]
   before_action :initialize_session_slug_history
   before_action :check_page_is_in_sequence, only: [:show, :update]
+  before_action :check_page_is_permissible, only: [:show]
   before_action :set_backlink_path, only: [:show, :update]
   before_action :check_claim_not_in_progress, only: [:new]
   before_action :clear_claim_session, only: [:new], unless: -> { journey.start_with_magic_link? }
@@ -118,6 +119,14 @@ class ClaimsController < BasePublicController
     raise ActionController::RoutingError.new("Not Found for #{params[:slug]}") unless page_sequence.in_sequence?(params[:slug])
 
     redirect_to claim_path(current_journey_routing_name, next_required_slug) unless page_sequence.has_completed_journey_until?(params[:slug])
+  end
+
+  def check_page_is_permissible
+    return unless journey.use_navigator?
+
+    unless navigator.permissible_slug?
+      redirect_to claim_path(current_journey_routing_name, navigator.furthest_permissible_slug)
+    end
   end
 
   def initialize_session_slug_history

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -137,6 +137,10 @@ module FormSubmittable
       log_event(__method__)
 
       if @form.present?
+        if journey.use_navigator?
+          navigator.clear_furthest_ineligible_answer
+        end
+
         if @form.save
           return if execute_callback_if_exists(:after_form_save_success)
           redirect_to_next_slug

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -137,12 +137,17 @@ module FormSubmittable
       log_event(__method__)
 
       if @form.present?
-        if journey.use_navigator?
-          navigator.clear_furthest_ineligible_answer
-        end
-
         if @form.save
           return if execute_callback_if_exists(:after_form_save_success)
+
+          if journey.use_navigator?
+            navigator.clear_impermissible_answers
+          end
+
+          if journey.use_navigator?
+            navigator.clear_furthest_ineligible_answer
+          end
+
           redirect_to_next_slug
         else
           return if execute_callback_if_exists(:after_form_save_failure)

--- a/app/forms/email_verification_form.rb
+++ b/app/forms/email_verification_form.rb
@@ -8,7 +8,7 @@ class EmailVerificationForm < Form
   validate :otp_must_be_valid, if: :sent_one_time_password_at?
 
   before_validation do
-    self.one_time_password = one_time_password.gsub(/\D/, "")
+    self.one_time_password = (one_time_password || "").gsub(/\D/, "")
   end
 
   def save

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -39,6 +39,14 @@ class Form
     true
   end
 
+  # for this particular form
+  # clear all associated answers from the session
+  # does nothing by default
+  # and should be implemented on per form basis
+  # if the forms stores data to session
+  def clear_answers_from_session
+  end
+
   private
 
   def permitted_attributes

--- a/app/forms/journeys/further_education_payments/building_construction_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/building_construction_courses_form.rb
@@ -51,6 +51,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(building_construction_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/check_your_answers_part_one_form.rb
+++ b/app/forms/journeys/further_education_payments/check_your_answers_part_one_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    class CheckYourAnswersPartOneForm < Form
+      def save
+        true
+      end
+    end
+  end
+end

--- a/app/forms/journeys/further_education_payments/chemistry_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/chemistry_courses_form.rb
@@ -47,6 +47,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(chemistry_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/computing_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/computing_courses_form.rb
@@ -63,6 +63,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(computing_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/contract_type_form.rb
+++ b/app/forms/journeys/further_education_payments/contract_type_form.rb
@@ -31,8 +31,6 @@ module Journeys
       def save
         return if invalid?
 
-        reset_dependent_answers
-
         journey_session.answers.assign_attributes(contract_type:)
         journey_session.save!
       end
@@ -44,31 +42,6 @@ module Journeys
       def clear_answers_from_session
         journey_session.answers.assign_attributes(contract_type: nil)
         journey_session.save!
-      end
-
-      private
-
-      def reset_dependent_answers
-        if changing_answer? && old_answer == "fixed_term"
-          journey_session.answers.assign_attributes(
-            fixed_term_full_year: nil,
-            taught_at_least_one_term: nil
-          )
-        end
-
-        if changing_answer? && old_answer == "variable_hours"
-          journey_session.answers.assign_attributes(
-            taught_at_least_one_term: nil
-          )
-        end
-      end
-
-      def changing_answer?
-        journey_session.answers.contract_type.present? && (contract_type != journey_session.answers.contract_type)
-      end
-
-      def old_answer
-        journey_session.answers.contract_type
       end
     end
   end

--- a/app/forms/journeys/further_education_payments/contract_type_form.rb
+++ b/app/forms/journeys/further_education_payments/contract_type_form.rb
@@ -41,6 +41,11 @@ module Journeys
         journey_session.answers.school
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(contract_type: nil)
+        journey_session.save!
+      end
+
       private
 
       def reset_dependent_answers

--- a/app/forms/journeys/further_education_payments/early_years_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/early_years_courses_form.rb
@@ -47,6 +47,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(early_years_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/eligible_form.rb
+++ b/app/forms/journeys/further_education_payments/eligible_form.rb
@@ -6,6 +6,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(award_amount: nil)
+        journey_session.save!
+      end
+
       def award_amount
         journey_session.answers.calculate_award_amount
       end

--- a/app/forms/journeys/further_education_payments/engineering_manufacturing_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/engineering_manufacturing_courses_form.rb
@@ -59,6 +59,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(engineering_manufacturing_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/fixed_term_contract_form.rb
+++ b/app/forms/journeys/further_education_payments/fixed_term_contract_form.rb
@@ -32,6 +32,11 @@ module Journeys
       def current_academic_year
         @current_academic_year ||= AcademicYear.current.to_s(:long)
       end
+
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(fixed_term_full_year: nil)
+        journey_session.save!
+      end
     end
   end
 end

--- a/app/forms/journeys/further_education_payments/fixed_term_contract_form.rb
+++ b/app/forms/journeys/further_education_payments/fixed_term_contract_form.rb
@@ -29,13 +29,13 @@ module Journeys
         journey_session.save!
       end
 
-      def current_academic_year
-        @current_academic_year ||= AcademicYear.current.to_s(:long)
-      end
-
       def clear_answers_from_session
         journey_session.answers.assign_attributes(fixed_term_full_year: nil)
         journey_session.save!
+      end
+
+      def current_academic_year
+        @current_academic_year ||= AcademicYear.current.to_s(:long)
       end
     end
   end

--- a/app/forms/journeys/further_education_payments/further_education_provision_search_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_provision_search_form.rb
@@ -34,6 +34,15 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(
+          possible_school_id: nil,
+          provision_search: nil
+        )
+
+        journey_session.save!
+      end
+
       private
 
       def validate_no_results

--- a/app/forms/journeys/further_education_payments/further_education_provision_search_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_provision_search_form.rb
@@ -56,7 +56,7 @@ module Journeys
       end
 
       def has_results
-        School.search(provision_search).count > 0
+        @has_results ||= School.search(provision_search).count > 0
       end
 
       def changed_possible_school?

--- a/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
@@ -34,6 +34,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(further_education_teaching_start_year: nil)
+        journey_session.save!
+      end
+
       def before_year
         academic_year = AcademicYear.current + YEARS_BEFORE
         academic_year.start_year

--- a/app/forms/journeys/further_education_payments/half_teaching_hours_form.rb
+++ b/app/forms/journeys/further_education_payments/half_teaching_hours_form.rb
@@ -22,6 +22,11 @@ module Journeys
         journey_session.answers.assign_attributes(half_teaching_hours:)
         journey_session.save!
       end
+
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(half_teaching_hours: nil)
+        journey_session.save!
+      end
     end
   end
 end

--- a/app/forms/journeys/further_education_payments/hours_teaching_eligible_subjects_form.rb
+++ b/app/forms/journeys/further_education_payments/hours_teaching_eligible_subjects_form.rb
@@ -31,6 +31,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(hours_teaching_eligible_subjects: nil)
+        journey_session.save!
+      end
+
       private
 
       def course_descriptions(course_field)

--- a/app/forms/journeys/further_education_payments/information_provided_form.rb
+++ b/app/forms/journeys/further_education_payments/information_provided_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module FurtherEducationPayments
+    class InformationProvidedForm < Form
+      def save
+        true
+      end
+    end
+  end
+end

--- a/app/forms/journeys/further_education_payments/maths_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/maths_courses_form.rb
@@ -39,6 +39,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(maths_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/physics_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/physics_courses_form.rb
@@ -47,6 +47,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(physics_courses: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_courses

--- a/app/forms/journeys/further_education_payments/select_provision_form.rb
+++ b/app/forms/journeys/further_education_payments/select_provision_form.rb
@@ -13,10 +13,13 @@ module Journeys
         return unless valid?
 
         journey_session.answers.assign_attributes(
-          possible_school_id:,
           school_id: possible_school_id
         )
         journey_session.save!
+      end
+
+      def completed?
+        journey_session.answers.school_id.present?
       end
 
       private

--- a/app/forms/journeys/further_education_payments/subjects_taught_form.rb
+++ b/app/forms/journeys/further_education_payments/subjects_taught_form.rb
@@ -19,8 +19,6 @@ module Journeys
       def save
         return false if invalid?
 
-        reset_dependent_answers
-
         journey_session.answers.assign_attributes(subjects_taught:)
         journey_session.save!
       end
@@ -34,16 +32,6 @@ module Journeys
 
       def clean_subjects_taught
         subjects_taught.reject!(&:blank?)
-      end
-
-      def reset_dependent_answers
-        unchecked_subjects.each do |subject|
-          journey_session.answers.assign_attributes("#{subject}_courses" => [])
-        end
-      end
-
-      def unchecked_subjects
-        journey_session.answers.subjects_taught - subjects_taught - ["none"]
       end
     end
   end

--- a/app/forms/journeys/further_education_payments/subjects_taught_form.rb
+++ b/app/forms/journeys/further_education_payments/subjects_taught_form.rb
@@ -25,6 +25,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(subjects_taught: [])
+        journey_session.save!
+      end
+
       private
 
       def clean_subjects_taught

--- a/app/forms/journeys/further_education_payments/taught_at_least_one_term_form.rb
+++ b/app/forms/journeys/further_education_payments/taught_at_least_one_term_form.rb
@@ -29,6 +29,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(taught_at_least_one_term: nil)
+        journey_session.save!
+      end
+
       def school
         journey_session.answers.school
       end

--- a/app/forms/journeys/further_education_payments/teacher_reference_number_form.rb
+++ b/app/forms/journeys/further_education_payments/teacher_reference_number_form.rb
@@ -24,6 +24,14 @@ module Journeys
 
         journey_session.save!
       end
+
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(
+          teacher_reference_number: nil
+        )
+
+        journey_session.save!
+      end
     end
   end
 end

--- a/app/forms/journeys/further_education_payments/teaching_hours_per_week_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_hours_per_week_form.rb
@@ -33,6 +33,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(teaching_hours_per_week: nil)
+        journey_session.save!
+      end
+
       def school
         journey_session.answers.school
       end

--- a/app/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form.rb
@@ -29,6 +29,11 @@ module Journeys
         journey_session.save!
       end
 
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(teaching_hours_per_week_next_term: nil)
+        journey_session.save!
+      end
+
       def school
         journey_session.answers.school
       end

--- a/app/forms/journeys/further_education_payments/teaching_qualification_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_qualification_form.rb
@@ -34,6 +34,11 @@ module Journeys
         journey_session.answers.assign_attributes(teaching_qualification:)
         journey_session.save!
       end
+
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(teaching_qualification: nil)
+        journey_session.save!
+      end
     end
   end
 end

--- a/app/forms/journeys/further_education_payments/teaching_responsibilities_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_responsibilities_form.rb
@@ -22,6 +22,11 @@ module Journeys
         journey_session.answers.assign_attributes(teaching_responsibilities:)
         journey_session.save!
       end
+
+      def clear_answers_from_session
+        journey_session.answers.assign_attributes(teaching_responsibilities: nil)
+        journey_session.save!
+      end
     end
   end
 end

--- a/app/forms/mobile_verification_form.rb
+++ b/app/forms/mobile_verification_form.rb
@@ -7,7 +7,7 @@ class MobileVerificationForm < Form
   validate :otp_validate
 
   before_validation do
-    self.one_time_password = one_time_password.gsub(/\D/, "")
+    self.one_time_password = (one_time_password || "").gsub(/\D/, "")
   end
 
   def save

--- a/app/forms/mobile_verification_form.rb
+++ b/app/forms/mobile_verification_form.rb
@@ -14,7 +14,6 @@ class MobileVerificationForm < Form
     return false unless valid?
 
     journey_session.answers.assign_attributes(mobile_verified: true)
-
     journey_session.save!
   end
 

--- a/app/forms/poor_performance_form.rb
+++ b/app/forms/poor_performance_form.rb
@@ -36,4 +36,12 @@ class PoorPerformanceForm < Form
     )
     journey_session.save
   end
+
+  def clear_answers_from_session
+    journey_session.answers.assign_attributes(
+      subject_to_formal_performance_action: nil,
+      subject_to_disciplinary_action: nil
+    )
+    journey_session.save
+  end
 end

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -3,7 +3,8 @@ class SelectHomeAddressForm < Form
   attribute :address_line_1, :string
   attribute :postcode, :string
 
-  validates :address, presence: true
+  validates :address, presence: true, unless: -> { skip_postcode_search? }
+  validate :address_selected, if: -> { skip_postcode_search? }
 
   def address_data
     return [] if postcode.blank?
@@ -28,5 +29,19 @@ class SelectHomeAddressForm < Form
     })
 
     journey_session.save!
+  end
+
+  def completed?
+    skip_postcode_search? || valid?
+  end
+
+  private
+
+  def skip_postcode_search?
+    journey_session.answers.skip_postcode_search
+  end
+
+  def address_selected
+    errors.add(:address) if journey_session.answers.address_line_1.blank?
   end
 end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -37,9 +37,17 @@ module Journeys
     end
 
     def form(journey_session:, params:, session:)
-      form = SHARED_FORMS.deep_merge(forms).dig(params[:controller].split("/").last, params[:slug])
+      form = all_forms.dig(params[:controller].split("/").last, params[:slug])
 
       form&.new(journey: self, journey_session:, params:, session:)
+    end
+
+    def form_class_for_slug(slug:)
+      all_forms.dig("claims", slug)
+    end
+
+    def slug_for_form(form:)
+      all_forms["claims"].invert[form.class]
     end
 
     def forms
@@ -77,6 +85,16 @@ module Journeys
 
     def pii_attributes
       SessionAnswers.pii_attributes
+    end
+
+    def use_navigator?
+      false
+    end
+
+    private
+
+    def all_forms
+      SHARED_FORMS.deep_merge(forms)
     end
   end
 end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -26,6 +26,8 @@ module Journeys
         "engineering-manufacturing-courses" => EngineeringManufacturingCoursesForm,
         "maths-courses" => MathsCoursesForm,
         "physics-courses" => PhysicsCoursesForm,
+        "check-your-answers-part-one" => CheckYourAnswersPartOneForm,
+        "information-provided" => InformationProvidedForm,
         "teaching-qualification" => TeachingQualificationForm,
         "poor-performance" => PoorPerformanceForm,
         "check-your-answers" => CheckYourAnswersForm,
@@ -38,6 +40,10 @@ module Journeys
     }
 
     def requires_student_loan_details?
+      true
+    end
+
+    def use_navigator?
       true
     end
   end

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -89,7 +89,7 @@ module Journeys
       def eligible_fe_provider?
         return unless school
 
-        EligibleFeProvider
+        @eligible_fe_provider ||= EligibleFeProvider
           .where(academic_year: AcademicYear.current)
           .where(ukprn: school.ukprn)
           .exists?

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -131,6 +131,10 @@ module Journeys
           0
         end
       end
+
+      def performing_poorly?
+        subject_to_formal_performance_action || subject_to_disciplinary_action
+      end
     end
   end
 end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -143,6 +143,13 @@ module Journeys
           if !eligibility_checker.ineligible?
             sequence.delete("ineligible")
           end
+
+          if answers.performing_poorly?
+            sequence.delete("check-your-answers-part-one")
+            sequence.delete("eligible")
+            sequence.delete("sign-in")
+            sequence.delete("information-provided")
+          end
         end
       end
 

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -115,12 +115,28 @@ module Journeys
             sequence.delete("physics-courses")
           end
 
+          if answers.school_id.present?
+            sequence.delete("select-provision")
+          end
+
+          if answers.email_verified == true
+            sequence.delete("email-verification")
+          end
+
           if answers.provide_mobile_number == false
             sequence.delete("mobile-number")
             sequence.delete("mobile-verification")
           end
 
+          if answers.mobile_verified == true
+            sequence.delete("mobile-verification")
+          end
+
           if answers.ordnance_survey_error == true
+            sequence.delete("select-home-address")
+          end
+
+          if answers.skip_postcode_search == true
             sequence.delete("select-home-address")
           end
         end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -139,7 +139,21 @@ module Journeys
           if answers.skip_postcode_search == true
             sequence.delete("select-home-address")
           end
+
+          if !eligibility_checker.ineligible?
+            sequence.delete("ineligible")
+          end
         end
+      end
+
+      private
+
+      def eligibility_checker
+        @eligibility_checker ||= journey::EligibilityChecker.new(journey_session:)
+      end
+
+      def journey
+        Journeys.for_routing_name(journey_session.journey)
       end
     end
   end

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -43,20 +43,6 @@ module Journeys
     def next_slug
       return "ineligible" if eligibility_checker.ineligible?
 
-      forms = slug_sequence.slugs.map do |slug|
-        form_class = journey.form_class_for_slug(slug:)
-
-        raise "Form not found for journey: #{journey} slug: #{slug}" if form_class.nil?
-
-        form = form_class.new(
-          journey:,
-          journey_session:,
-          params:,
-          session:
-        )
-        form
-      end
-
       if current_slug.nil?
         forms.first
       else

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -168,13 +168,15 @@ module Journeys
     end
 
     def permissible_forms
+      return @permissible_forms if @permissible_forms
+
       index = forms.find_index do |form|
         slug = journey.slug_for_form(form:)
 
         slug == furthest_permissible_slug
       end
 
-      forms.take(index)
+      @permissible_forms ||= forms.take(index)
     end
 
     def forms

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -146,7 +146,9 @@ module Journeys
     private
 
     def impermissible_forms
-      @impermissible_forms ||= all_forms - permissible_forms
+      all_forms.reject do |form|
+        permissible_forms.map { |f| f.class }.include?(form.class)
+      end
     end
 
     def all_forms

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -123,8 +123,10 @@ module Journeys
     # an existing answer might no longer be applicable
     # if so we clear all those inaccessbile answers
     def clear_impermissible_answers
-      impermissible_forms.each do |form|
-        form.clear_answers_from_session
+      ApplicationRecord.transaction do
+        impermissible_forms.each do |form|
+          form.clear_answers_from_session
+        end
       end
     end
 

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -1,0 +1,95 @@
+module Journeys
+  class Navigator
+    attr_reader :current_slug, :slug_sequence, :params, :session
+
+    def initialize(current_slug:, slug_sequence:, params:, session:)
+      @current_slug = current_slug
+      @slug_sequence = slug_sequence
+      @params = params
+      @session = session
+    end
+
+    def previous_slug
+      last_valid_slug = nil
+
+      slug_sequence.slugs.each do |slug|
+        form_class = journey.form_class_for_slug(slug:)
+        form = form_class.new(
+          journey:,
+          journey_session:,
+          params:,
+          session:
+        )
+
+        if current_slug == slug
+          return last_valid_slug
+        elsif form.respond_to?(:completed?)
+          if form.completed?
+            last_valid_slug = slug
+          end
+        elsif form.valid?
+          last_valid_slug = slug
+        else
+          return last_valid_slug
+        end
+      end
+    end
+
+    def next_slug
+      return "ineligible" if eligibility_checker.ineligible?
+
+      forms = slug_sequence.slugs.map do |slug|
+        form_class = journey.form_class_for_slug(slug:)
+
+        raise "Form not found for journey: #{journey} slug: #{slug}" if form_class.nil?
+
+        form = form_class.new(
+          journey:,
+          journey_session:,
+          params:,
+          session:
+        )
+        form
+      end
+
+      if current_slug.nil?
+        forms.first
+      else
+        forms.each_with_index do |form, index|
+          slug = journey.slug_for_form(form:)
+
+          if form.respond_to?(:completed?)
+            if !form.completed?
+              return slug
+            end
+          elsif form.invalid?
+            return slug
+          end
+
+          if current_slug == slug
+            current_index = forms.index(form)
+            next_index = current_index + 1
+            next_form = forms[next_index]
+            next_slug = journey.slug_for_form(form: next_form)
+
+            return next_slug
+          end
+        end
+      end
+    end
+
+    private
+
+    def journey
+      Journeys.for_routing_name(slug_sequence.journey_session.journey)
+    end
+
+    def journey_session
+      slug_sequence.journey_session
+    end
+
+    def eligibility_checker
+      @eligibility_checker ||= journey::EligibilityChecker.new(journey_session:)
+    end
+  end
+end

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -128,6 +128,19 @@ module Journeys
       end
     end
 
+    # should we clear the furthest most inelgible answer
+    # we do so if we are changing answer of a previous page
+    def clear_furthest_ineligible_answer
+      return unless eligibility_checker.ineligible?
+
+      furthest_form = permissible_forms.last
+      furthest_slug = journey.slug_for_form(form: furthest_form)
+
+      if current_slug != furthest_slug
+        furthest_form.clear_answers_from_session
+      end
+    end
+
     private
 
     def impermissible_forms

--- a/app/models/journeys/page_sequence.rb
+++ b/app/models/journeys/page_sequence.rb
@@ -3,7 +3,7 @@
 # Used to model the sequence of pages that make up the claim process.
 module Journeys
   class PageSequence
-    attr_reader :current_slug
+    attr_reader :current_slug, :slug_sequence
 
     DEAD_END_SLUGS = %w[complete existing-session eligible-later future-eligibility ineligible check-your-email expired-link unauthorised]
     OPTIONAL_SLUGS = %w[postcode-search select-home-address reset-claim]

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -12,6 +12,8 @@ module Journeys
     attribute :address_line_3, :string, pii: true
     attribute :address_line_4, :string, pii: true
     attribute :postcode, :string, pii: true
+    attribute :skip_postcode_search, :boolean, pii: false
+
     attribute :date_of_birth, :date, pii: false
     attribute :teacher_reference_number, :string, pii: true
     attribute :national_insurance_number, :string, pii: true
@@ -52,6 +54,7 @@ module Journeys
 
     attribute :onelogin_auth_at, :datetime, pii: false
     attribute :onelogin_idv_at, :datetime, pii: false
+
     attribute :email_address_check, :boolean, pii: false
     attribute :mobile_check, :string, pii: false
     attribute :qualifications_details_check, :boolean, pii: false
@@ -61,8 +64,8 @@ module Journeys
     attribute :submitted_using_slc_data, :boolean, pii: false
     attribute :sent_one_time_password_at, :datetime, pii: false
     attribute :hmrc_validation_attempt_count, :integer, default: 0, pii: false
-    attribute :reminder_id, :string, pii: false
 
+    attribute :reminder_id, :string, pii: false
     attribute :reminder_full_name, :string, pii: true
     attribute :reminder_email_address, :string, pii: true
     attribute :reminder_otp_secret, :string, pii: true

--- a/app/views/further_education_payments/claims/_ineligible_courses.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_courses.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_lack_teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_lack_teaching_responsibilities.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_lacks_teacher_qualification_or_enrolment.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_lacks_teacher_qualification_or_enrolment.html.erb
@@ -19,7 +19,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_less_than_half_hours_teaching_eligible_courses.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_less_than_half_hours_teaching_eligible_courses.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_must_at_least_half_hours_teaching_fe.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_must_at_least_half_hours_teaching_fe.html.erb
@@ -18,7 +18,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_must_be_recent_further_education_teacher.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_must_be_recent_further_education_teacher.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_must_teach_at_least_one_term.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_must_teach_at_least_one_term.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_subject.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_subject.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_subject_to_problematic_actions.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_subject_to_problematic_actions.html.erb
@@ -19,7 +19,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5_next_term.html.erb
+++ b/app/views/further_education_payments/claims/_ineligible_teaching_less_than_2_5_next_term.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, session[:slugs].last) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
+      If you are unsure your information is correct, you can <%= govuk_link_to "go back", claim_path(current_journey_routing_name, navigator.previous_slug) %> and review your answers. You can also <%= govuk_link_to "start the application again", claim_path(current_journey_routing_name, "landing-page") %>.
     </p>
   </div>
 </div>

--- a/app/views/further_education_payments/claims/ineligible.html.erb
+++ b/app/views/further_education_payments/claims/ineligible.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_title, page_title(@form.t("#{@form.journey_eligibility_checker.ineligibility_reason}.heading"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
-<% @backlink_path = claim_path(current_journey_routing_name, session[:slugs].last) %>
+<% @backlink_path = claim_path(current_journey_routing_name, navigator.previous_slug) %>
 
 <%= render "ineligible_#{@form.journey_eligibility_checker.ineligibility_reason}" %>

--- a/app/views/further_education_payments/claims/postcode_search.html.erb
+++ b/app/views/further_education_payments/claims/postcode_search.html.erb
@@ -3,6 +3,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.hidden_field :skip_postcode_search, value: "false" %>
+
       <%= f.govuk_error_summary %>
 
       <% if @form.errors.any? %>
@@ -44,13 +46,19 @@
         <% end %>
 
         <p class="govuk-body">
-          <%= govuk_link_to I18n.t("questions.address.home.link_to_manual_address"), claim_path(current_journey_routing_name, "address"), "aria-label": I18n.t("questions.address.home.link_to_manual_address") %>
+          <button form="skip-postcode-search" class="govuk-link govuk-link--no-visited-state button-to-as-link">
+            <%= I18n.t("questions.address.home.link_to_manual_address") %>
+          </button>
         </p>
 
         <p class="govuk-!-padding-top-6">
           <%= f.govuk_submit "Search" %>
         </p>
       <% end %>
+    <% end %>
+
+    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { id: "skip-postcode-search" } do |f| %>
+      <%= f.hidden_field :skip_postcode_search, value: true %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1161,6 +1161,10 @@ en:
             IBO level 3 in SL and HL physics, taught as part of a diploma or career related programme or as a standalone
             certificate
           none: I do not teach any of these courses
+      email_verification:
+        errors:
+          one_time_password:
+            invalid: An error occured while validating the passcode, please try generating a new one
       teaching_qualification:
         question: Do you have a teaching qualification?
         hint_html: >

--- a/spec/features/further_education_payments/back_link_spec.rb
+++ b/spec/features/further_education_payments/back_link_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.feature "Further education back link" do
+  let(:school) { create(:school, :fe_eligible) }
+
+  scenario "are correct" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: school.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose school.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have")
+    choose "Permanent contract"
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach")
+    choose "12 hours or more per week"
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose "September 2024 to August 2025"
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check "Chemistry"
+    click_button "Continue"
+
+    expect(page).to have_content("Which chemistry courses do you teach?")
+    check "GCSE chemistry"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Tell us if you are currently under any performance measures or disciplinary action")
+    choose "claim-subject-to-formal-performance-action-true-field"
+    choose "claim-subject-to-disciplinary-action-true-field"
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    click_link "Back"
+
+    expect(page).to have_content("Tell us if you are currently under any performance measures or disciplinary action")
+  end
+end

--- a/spec/features/further_education_payments/happy_js_path_spec.rb
+++ b/spec/features/further_education_payments/happy_js_path_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     click_button "Continue"
 
     expect(page).to have_content("Select where you are employed")
-    expect(page).to have_selector "input[type=radio][value='#{college.id}']", visible: false
     choose college.name
     click_button "Continue"
 
@@ -93,7 +92,7 @@ RSpec.feature "Further education payments", js: true, flaky: true do
     click_on "Continue"
 
     expect(page).to have_content("What is your home address?")
-    click_link("Enter your address manually")
+    click_button("Enter your address manually")
 
     expect(page).to have_content("What is your address?")
     fill_in "House number or name", with: "57"

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature "Further education payments" do
     click_on "Continue"
 
     expect(page).to have_content("What is your home address?")
-    click_link("Enter your address manually")
+    click_button("Enter your address manually")
 
     expect(page).to have_content("What is your address?")
     fill_in "House number or name", with: "57"

--- a/spec/features/further_education_payments/jump_around_spec.rb
+++ b/spec/features/further_education_payments/jump_around_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments" do
+  scenario "visiting impermissible slug redirects back to last permissible slug" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+
+    visit claim_path(Journeys::FurtherEducationPayments::ROUTING_NAME, slug: "address")
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+  end
+end

--- a/spec/features/further_education_payments/jump_around_spec.rb
+++ b/spec/features/further_education_payments/jump_around_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Further education payments" do
+  let(:school) { create(:school, :fe_eligible) }
+
   scenario "visiting impermissible slug redirects back to last permissible slug" do
     when_further_education_payments_journey_configuration_exists
 
     visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
-    expect(page).to have_link("Start now")
     click_link "Start now"
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
@@ -13,5 +14,48 @@ RSpec.feature "Further education payments" do
     visit claim_path(Journeys::FurtherEducationPayments::ROUTING_NAME, slug: "address")
 
     expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+  end
+
+  # user reaches an ineligible state
+  # hits back button more than once
+  # changes an answer that does not change pathway
+  # ie they are still inelgibile
+  # we remove the ineligible answer
+  # so they can continue with their current journey
+  # rather than still showing an ineligible page again
+  scenario "changing answer on a previous page that maintains pathway" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: school.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose school.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have")
+    choose "Permanent contract"
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach")
+    choose "Less than 2.5 hours per week"
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+
+    visit claim_path(Journeys::FurtherEducationPayments::ROUTING_NAME, "contract-type")
+    expect(page).to have_content("What type of contract do you have")
+    choose "Fixed-term contract"
+    click_button "Continue"
+
+    expect(page).not_to have_content "You are not eligible"
   end
 end

--- a/spec/features/further_education_payments/jump_around_spec.rb
+++ b/spec/features/further_education_payments/jump_around_spec.rb
@@ -58,4 +58,61 @@ RSpec.feature "Further education payments" do
 
     expect(page).not_to have_content "You are not eligible"
   end
+
+  scenario "changing subjects" do
+    when_further_education_payments_journey_configuration_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: school.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose school.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have")
+    choose "Permanent contract"
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach")
+    choose "12 hours or more per week"
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose "September 2024 to August 2025"
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check "Chemistry"
+    check "Computing, including digital and ICT"
+    click_button "Continue"
+
+    expect(Journeys::FurtherEducationPayments::Session.last.answers.chemistry_courses).to be_empty
+
+    expect(page).to have_content("Which chemistry courses do you teach?")
+    check "GCSE chemistry"
+    click_button "Continue"
+
+    expect(Journeys::FurtherEducationPayments::Session.last.answers.chemistry_courses).not_to be_empty
+
+    expect(page).to have_content("Which computing courses do you teach?")
+    check "T Level in digital support services"
+    click_button "Continue"
+
+    visit claim_path(Journeys::FurtherEducationPayments::ROUTING_NAME, slug: "subjects-taught")
+    uncheck "Chemistry"
+    click_button "Continue"
+
+    expect(Journeys::FurtherEducationPayments::Session.count).to eql(1)
+    expect(Journeys::FurtherEducationPayments::Session.last.answers.chemistry_courses).to be_empty
+
+    expect(page).to have_content("Which computing courses do you teach?")
+  end
 end

--- a/spec/forms/journeys/additional_payments_for_teaching/supply_teacher_form_spec.rb
+++ b/spec/forms/journeys/additional_payments_for_teaching/supply_teacher_form_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Journeys::AdditionalPaymentsForTeaching::SupplyTeacherForm do
   before { create(:journey_configuration, :additional_payments) }
 
   let(:journey) { Journeys::AdditionalPaymentsForTeaching }
-
   let(:journey_session) { build(:"#{journey::I18N_NAMESPACE}_session") }
-
   let(:slug) { "supply-teacher" }
 
   subject(:form) do

--- a/spec/forms/journeys/further_education_payments/building_construction_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/building_construction_courses_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::BuildingConstructionCoursesForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:building_construction_courses) { [""] }
 
   let(:params) do
@@ -50,6 +52,20 @@ RSpec.describe Journeys::FurtherEducationPayments::BuildingConstructionCoursesFo
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.building_construction_courses }.to(building_construction_courses)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        building_construction_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.building_construction_courses }.from(%w[none]).to([])
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/chemistry_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/chemistry_courses_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::ChemistryCoursesForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:chemistry_courses) { [""] }
 
   let(:params) do
@@ -50,6 +52,20 @@ RSpec.describe Journeys::FurtherEducationPayments::ChemistryCoursesForm, type: :
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.chemistry_courses }.to(chemistry_courses)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        chemistry_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.chemistry_courses }.from(%w[none]).to([])
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/computing_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/computing_courses_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::ComputingCoursesForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:computing_courses) { [""] }
 
   let(:params) do
@@ -50,6 +52,20 @@ RSpec.describe Journeys::FurtherEducationPayments::ComputingCoursesForm, type: :
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.computing_courses }.to(computing_courses)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        computing_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.computing_courses }.from(%w[none]).to([])
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/contract_type_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/contract_type_form_spec.rb
@@ -87,4 +87,20 @@ RSpec.describe Journeys::FurtherEducationPayments::ContractTypeForm, type: :mode
       end
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:answers) do
+      build(
+        :further_education_payments_answers,
+        school_id: college.id,
+        contract_type: "permanent"
+      )
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.contract_type }.from("permanent").to(nil)
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/contract_type_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/contract_type_form_spec.rb
@@ -44,48 +44,6 @@ RSpec.describe Journeys::FurtherEducationPayments::ContractTypeForm, type: :mode
         .to(contract_type)
       )
     end
-
-    context "when changing answers from fixed term contract" do
-      let(:answers) do
-        build(
-          :further_education_payments_answers,
-          school_id: college.id,
-          contract_type: "fixed_term",
-          fixed_term_full_year: false,
-          taught_at_least_one_term: true
-        )
-      end
-
-      it "resets fixed_term_full_year + taught_at_least_one_term" do
-        subject.contract_type = "permanent"
-
-        expect { expect(subject.save).to be(true) }.to(
-          change { journey_session.reload.answers.contract_type }.to("permanent")
-          .and(change { journey_session.answers.fixed_term_full_year }.to(nil)
-          .and(change { journey_session.answers.taught_at_least_one_term }.to(nil)))
-        )
-      end
-    end
-
-    context "when changing answers from variable contract" do
-      let(:answers) do
-        build(
-          :further_education_payments_answers,
-          school_id: college.id,
-          contract_type: "variable_hours",
-          taught_at_least_one_term: true
-        )
-      end
-
-      it "resets taught_at_least_one_term" do
-        subject.contract_type = "permanent"
-
-        expect { expect(subject.save).to be(true) }.to(
-          change { journey_session.reload.answers.contract_type }.to("permanent")
-          .and(change { journey_session.answers.taught_at_least_one_term }.to(nil))
-        )
-      end
-    end
   end
 
   describe "#clear_answers_from_session" do

--- a/spec/forms/journeys/further_education_payments/early_years_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/early_years_courses_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::EarlyYearsCoursesForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:early_years_courses) { [""] }
 
   let(:params) do
@@ -50,6 +52,20 @@ RSpec.describe Journeys::FurtherEducationPayments::EarlyYearsCoursesForm, type: 
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.early_years_courses }.to(early_years_courses)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        early_years_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.early_years_courses }.from(%w[none]).to([])
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/eligible_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/eligible_form_spec.rb
@@ -30,4 +30,21 @@ RSpec.describe Journeys::FurtherEducationPayments::EligibleForm, type: :model do
       )
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:answers) do
+      build(
+        :further_education_payments_answers,
+        teaching_hours_per_week: "more_than_12",
+        school_id: school.id,
+        award_amount: 6_000
+      )
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.award_amount }.from(6_000).to(nil)
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/engineering_manufacturing_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/engineering_manufacturing_courses_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::EngineeringManufacturingCoursesForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:engineering_manufacturing_courses) { [""] }
 
   let(:params) do
@@ -50,6 +52,20 @@ RSpec.describe Journeys::FurtherEducationPayments::EngineeringManufacturingCours
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.engineering_manufacturing_courses }.to(engineering_manufacturing_courses)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        engineering_manufacturing_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.engineering_manufacturing_courses }.from(%w[none]).to([])
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/fixed_term_contract_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/fixed_term_contract_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::FixedTermContractForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:fixed_term_full_year) { nil }
 
   let(:params) do
@@ -40,6 +42,20 @@ RSpec.describe Journeys::FurtherEducationPayments::FixedTermContractForm, type: 
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.fixed_term_full_year }.to(true)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        fixed_term_full_year: true
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.fixed_term_full_year }.from(true).to(nil)
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/further_education_provision_search_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/further_education_provision_search_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationProvisionSearchForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:college) { create(:school) }
 
   let(:provision_search) { nil }
@@ -70,6 +72,22 @@ RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationProvisionSear
           change { journey_session.reload.answers.possible_school_id }.to(possible_school_id)
         )
       end
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        possible_school_id: college.id,
+        provision_search: college.name
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.possible_school_id }.from(college.id).to(nil)
+        .and change { journey_session.reload.answers.provision_search }.from(college.name).to(nil)
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/further_education_provision_search_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/further_education_provision_search_form_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationProvisionSear
     context "when possible_school_id supplied" do
       let(:possible_school_id) { college.id }
 
-      it "updates the journey session with possible_school_id" do
+      it "updates the journey session with school_id" do
         expect { expect(subject.save).to be(true) }.to(
           change { journey_session.reload.answers.possible_school_id }.to(possible_school_id)
         )

--- a/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationTeachingStartYearForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:further_education_teaching_start_year) { nil }
 
   let(:params) do
@@ -63,6 +65,20 @@ RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationTeachingStart
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.further_education_teaching_start_year }.to(further_education_teaching_start_year)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        further_education_teaching_start_year: "2025"
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.further_education_teaching_start_year }.from("2025").to(nil)
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/half_teaching_hours_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/half_teaching_hours_form_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Journeys::FurtherEducationPayments::HalfTeachingHoursForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
   let(:journey_session) { create(:further_education_payments_session) }
+  let(:half_teaching_hours) { nil }
 
   let(:params) do
     ActionController::Parameters.new(
@@ -53,6 +54,23 @@ RSpec.describe Journeys::FurtherEducationPayments::HalfTeachingHoursForm, type: 
           .to(false)
         )
       end
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:journey_session) { create(:further_education_payments_session, answers:) }
+    let(:answers) { build(:further_education_payments_answers, answers_hash) }
+
+    let(:answers_hash) do
+      {
+        half_teaching_hours: true
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.half_teaching_hours }.from(true).to(nil)
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/hours_teaching_eligible_subjects_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/hours_teaching_eligible_subjects_form_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Journeys::FurtherEducationPayments::HoursTeachingEligibleSubjectsForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
   let(:journey_session) { create(:further_education_payments_session) }
+  let(:hours_teaching_eligible_subjects) { nil }
 
   let(:params) do
     ActionController::Parameters.new(
@@ -53,6 +54,23 @@ RSpec.describe Journeys::FurtherEducationPayments::HoursTeachingEligibleSubjects
           .to(false)
         )
       end
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:journey_session) { create(:further_education_payments_session, answers:) }
+    let(:answers) { build(:further_education_payments_answers, answers_hash) }
+
+    let(:answers_hash) do
+      {
+        hours_teaching_eligible_subjects: true
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.hours_teaching_eligible_subjects }.from(true).to(nil)
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/maths_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/maths_courses_form_spec.rb
@@ -52,4 +52,21 @@ RSpec.describe Journeys::FurtherEducationPayments::MathsCoursesForm, type: :mode
       )
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:journey_session) { create(:further_education_payments_session, answers:) }
+    let(:answers) { build(:further_education_payments_answers, answers_hash) }
+
+    let(:answers_hash) do
+      {
+        maths_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.maths_courses }.from(%w[none]).to([])
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/physics_courses_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/physics_courses_form_spec.rb
@@ -52,4 +52,21 @@ RSpec.describe Journeys::FurtherEducationPayments::PhysicsCoursesForm, type: :mo
       )
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:journey_session) { create(:further_education_payments_session, answers:) }
+    let(:answers) { build(:further_education_payments_answers, answers_hash) }
+
+    let(:answers_hash) do
+      {
+        physics_courses: ["none"]
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.physics_courses }.from(%w[none]).to([])
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
@@ -57,69 +57,11 @@ RSpec.describe Journeys::FurtherEducationPayments::SubjectsTaughtForm, type: :mo
         change { journey_session.reload.answers.subjects_taught }.to(["chemistry", "maths"])
       )
     end
-
-    context "when changing some answers" do
-      let(:answers_hash) do
-        {
-          subjects_taught: %w[maths physics],
-          maths_courses: %w[approved_level_321_maths],
-          physics_courses: %w[alevel_physics]
-        }
-      end
-
-      let(:subjects_taught) { %w[chemistry maths] }
-
-      it "resets dependent answers" do
-        expect { expect(subject.save).to be(true) }.to(
-          change { journey_session.reload.answers.subjects_taught }.to(subjects_taught)
-          .and(change { journey_session.reload.answers.physics_courses }.to([])
-          .and(not_change { journey_session.reload.answers.maths_courses }))
-        )
-      end
-    end
-
-    context "when changing all answers" do
-      let(:answers_hash) do
-        {
-          subjects_taught: %w[
-            building_construction
-            chemistry
-            computing
-            early_years
-            engineering_manufacturing
-            maths
-            physics
-          ],
-          building_construction_courses: %w[none],
-          chemistry_courses: %w[none],
-          computing_courses: %w[none],
-          early_years_courses: %w[none],
-          engineering_manufacturing_courses: %w[none],
-          maths_courses: %w[none],
-          physics_courses: %w[none]
-        }
-      end
-
-      let(:subjects_taught) { %w[none] }
-
-      it "resets dependent answers" do
-        expect { expect(subject.save).to be(true) }.to(
-          change { journey_session.reload.answers.subjects_taught }.to(subjects_taught)
-          .and(change { journey_session.reload.answers.building_construction_courses }.to([])
-          .and(change { journey_session.reload.answers.chemistry_courses }.to([])
-          .and(change { journey_session.reload.answers.computing_courses }.to([])
-          .and(change { journey_session.reload.answers.early_years_courses }.to([])
-          .and(change { journey_session.reload.answers.engineering_manufacturing_courses }.to([])
-          .and(change { journey_session.reload.answers.maths_courses }.to([])
-          .and(change { journey_session.reload.answers.physics_courses }.to([]))))))))
-        )
-      end
-    end
   end
 
   describe "#clear_answers_from_session" do
     let(:answers_hash) do
-      { subjects_taught: %w[maths physics] }
+      {subjects_taught: %w[maths physics]}
     end
 
     it "clears relevant answers from session" do

--- a/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
@@ -116,4 +116,16 @@ RSpec.describe Journeys::FurtherEducationPayments::SubjectsTaughtForm, type: :mo
       end
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      { subjects_taught: %w[maths physics] }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.subjects_taught }.from(%w[maths physics]).to([])
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/taught_at_least_one_term_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/taught_at_least_one_term_form_spec.rb
@@ -45,4 +45,18 @@ RSpec.describe Journeys::FurtherEducationPayments::TaughtAtLeastOneTermForm, typ
       )
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        taught_at_least_one_term: true
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.taught_at_least_one_term }.from(true).to(nil)
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/teacher_reference_number_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teacher_reference_number_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Journeys::FurtherEducationPayments::TeacherReferenceNumberForm, t
   let(:answers_hash) { {} }
 
   let(:params) do
-    ActionController::Parameters.new()
+    ActionController::Parameters.new
   end
 
   subject do

--- a/spec/forms/journeys/further_education_payments/teacher_reference_number_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teacher_reference_number_form_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Journeys::FurtherEducationPayments::TeacherReferenceNumberForm, type: :model do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
+
+  let(:params) do
+    ActionController::Parameters.new()
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        teacher_reference_number: "1234567"
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.teacher_reference_number }.from("1234567").to(nil)
+    end
+  end
+end

--- a/spec/forms/journeys/further_education_payments/teaching_hours_per_week_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_hours_per_week_form_spec.rb
@@ -47,4 +47,18 @@ RSpec.describe Journeys::FurtherEducationPayments::TeachingHoursPerWeekForm, typ
       )
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        teaching_hours_per_week: "more_than_12"
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.teaching_hours_per_week }.from("more_than_12").to(nil)
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form_spec.rb
@@ -45,4 +45,18 @@ RSpec.describe Journeys::FurtherEducationPayments::TeachingHoursPerWeekNextTermF
       )
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        teaching_hours_per_week_next_term: "at_least_2_5"
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.teaching_hours_per_week_next_term }.from("at_least_2_5").to(nil)
+    end
+  end
 end

--- a/spec/forms/journeys/further_education_payments/teaching_qualification_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_qualification_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::TeachingQualificationForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
   let(:teaching_qualification) { nil }
 
   let(:params) do
@@ -54,6 +56,20 @@ RSpec.describe Journeys::FurtherEducationPayments::TeachingQualificationForm, ty
       expect { expect(subject.save).to be(true) }.to(
         change { journey_session.reload.answers.teaching_qualification }.to("yes")
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:answers_hash) do
+      {
+        teaching_qualification: "yes"
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.teaching_qualification }.from("yes").to(nil)
     end
   end
 end

--- a/spec/forms/journeys/further_education_payments/teaching_responsibilities_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_responsibilities_form_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::TeachingResponsibilitiesForm, type: :model do
   let(:journey) { Journeys::FurtherEducationPayments }
-  let(:journey_session) { create(:further_education_payments_session) }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:answers_hash) { {} }
 
   let(:params) do
     ActionController::Parameters.new(
@@ -40,6 +42,22 @@ RSpec.describe Journeys::FurtherEducationPayments::TeachingResponsibilitiesForm,
         change { journey_session.reload.answers.teaching_responsibilities }
         .to(true)
       )
+    end
+  end
+
+  describe "#clear_answers_from_session" do
+    let(:teaching_responsibilities) { nil }
+
+    let(:answers_hash) do
+      {
+        teaching_responsibilities: true
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.teaching_responsibilities }.from(true).to(nil)
     end
   end
 end

--- a/spec/forms/poor_performance_form_spec.rb
+++ b/spec/forms/poor_performance_form_spec.rb
@@ -70,4 +70,23 @@ RSpec.describe PoorPerformanceForm do
       end
     end
   end
+
+  describe "#clear_answers_from_session" do
+    let(:journey_session) { create(:further_education_payments_session, answers:) }
+    let(:answers) { build(:further_education_payments_answers, answers_hash) }
+
+    let(:answers_hash) do
+      {
+        subject_to_formal_performance_action: true,
+        subject_to_disciplinary_action: true
+      }
+    end
+
+    it "clears relevant answers from session" do
+      expect {
+        subject.clear_answers_from_session
+      }.to change { journey_session.reload.answers.subject_to_formal_performance_action }.from(true).to(nil)
+        .and change { journey_session.reload.answers.subject_to_disciplinary_action }.from(true).to(nil)
+    end
+  end
 end

--- a/spec/forms/select_home_address_form_spec.rb
+++ b/spec/forms/select_home_address_form_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe SelectHomeAddressForm, type: :model do
       )
     end
     let(:journey) { Journeys::TeacherStudentLoanReimbursement }
-    let(:journey_session) { build(:student_loans_session) }
+    let(:journey_session) { build(:student_loans_session, answers:) }
+    let(:answers) do
+      attributes_for(
+        :"#{journey::I18N_NAMESPACE}_answers",
+        skip_postcode_search: false
+      )
+    end
     let(:params) { ActionController::Parameters.new(claim: {address:}) }
 
     it { is_expected.to be_truthy }

--- a/spec/models/journeys/navigator_spec.rb
+++ b/spec/models/journeys/navigator_spec.rb
@@ -74,4 +74,83 @@ RSpec.describe Journeys::Navigator do
       end
     end
   end
+
+  describe "#permissible_slug?" do
+    context "when permissible" do
+      let(:answers) do
+        build(
+          :further_education_payments_answers
+        )
+      end
+
+      it "returns truthy" do
+        expect(subject.permissible_slug?).to be_truthy
+      end
+    end
+
+    context "when not permissible" do
+      let(:current_slug) { "address" }
+      let(:answers) do
+        build(
+          :further_education_payments_answers
+        )
+      end
+
+      it "returns falsey" do
+        expect(subject.permissible_slug?).to be_falsey
+      end
+    end
+  end
+
+  describe "#furthest_permissible_slug" do
+    context "when new journey" do
+      let(:answers) do
+        build(
+          :further_education_payments_answers
+        )
+      end
+
+      it "returns first slug" do
+        expect(subject.furthest_permissible_slug).to eql("teaching-responsibilities")
+      end
+    end
+
+    context "when mid-journey" do
+      let(:current_slug) { "foo" }
+
+      let(:answers) do
+        build(
+          :further_education_payments_answers,
+          teaching_responsibilities: true,
+          provision_search: "ply"
+        )
+      end
+
+      before do
+        create(:school, name: "Plymouth")
+      end
+
+      it "returns relevant slug" do
+        expect(subject.furthest_permissible_slug).to eql("select-provision")
+      end
+    end
+
+    context "when about to submit" do
+      let(:current_slug) { "foo" }
+      let(:school) { create(:school) }
+
+      let(:answers) do
+        build(
+          :further_education_payments_answers,
+          :submittable,
+          provision_search: school.name,
+          skip_postcode_search: true
+        )
+      end
+
+      it "returns check-answers slug" do
+        expect(subject.furthest_permissible_slug).to eql("check-your-answers")
+      end
+    end
+  end
 end

--- a/spec/models/journeys/navigator_spec.rb
+++ b/spec/models/journeys/navigator_spec.rb
@@ -153,4 +153,26 @@ RSpec.describe Journeys::Navigator do
       end
     end
   end
+
+  describe "#clear_impermissible_answers" do
+    let(:current_slug) { "foo" }
+    let(:school) { create(:school) }
+
+    let(:answers) do
+      build(
+        :further_education_payments_answers,
+        teaching_responsibilities: "true",
+        provision_search: school.name,
+        school_id: school.id,
+        contract_type: "permanent",
+        fixed_term_full_year: true
+      )
+    end
+
+    it "clears impermissible answers from session" do
+      expect {
+        subject.clear_impermissible_answers
+      }.to change { journey_session.reload.answers.fixed_term_full_year }.from(true).to(nil)
+    end
+  end
 end

--- a/spec/models/journeys/navigator_spec.rb
+++ b/spec/models/journeys/navigator_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe Journeys::Navigator do
+  subject { described_class.new(current_slug:, slug_sequence:, params:, session:) }
+
+  let(:current_slug) { "teaching-responsibilities" }
+  let(:slug_sequence) { Journeys::FurtherEducationPayments::SlugSequence.new(journey_session) }
+  let(:params) { ActionController::Parameters.new }
+  let(:session) { {} }
+  let(:journey_session) do
+    create(:further_education_payments_session, answers: answers)
+  end
+
+  describe "#next_slug" do
+    context "starting journey" do
+      let(:answers) do
+        build(
+          :further_education_payments_answers
+        )
+      end
+
+      it "returns first slug" do
+        expect(subject.next_slug).to eql("teaching-responsibilities")
+      end
+    end
+
+    context "when on first slug" do
+      let(:current_slug) { "teaching-responsibilities" }
+
+      let(:answers) do
+        build(
+          :further_education_payments_answers,
+          teaching_responsibilities: "true"
+        )
+      end
+
+      it "returns second slug" do
+        expect(subject.next_slug).to eql("further-education-provision-search")
+      end
+    end
+
+    context "when on second slug" do
+      let(:current_slug) { "further-education-provision-search" }
+
+      let(:answers) do
+        build(
+          :further_education_payments_answers,
+          teaching_responsibilities: true,
+          provision_search: "ply"
+        )
+      end
+
+      before do
+        create(:school, name: "Plymouth")
+      end
+
+      it "returns third slug" do
+        expect(subject.next_slug).to eql("select-provision")
+      end
+    end
+
+    context "when should be ineligible" do
+      let(:current_slug) { "teaching-responsibilities" }
+
+      let(:answers) do
+        build(
+          :further_education_payments_answers,
+          teaching_responsibilities: false
+        )
+      end
+
+      it "returns ineligible" do
+        expect(subject.next_slug).to eql("ineligible")
+      end
+    end
+  end
+end

--- a/spec/support/steps/further_education_journey.rb
+++ b/spec/support/steps/further_education_journey.rb
@@ -48,7 +48,7 @@ def when_further_education_journey_ready_to_submit
   fill_in "National Insurance number", with: "PX321499A"
   click_on "Continue"
 
-  click_link("Enter your address manually")
+  click_button("Enter your address manually")
   fill_in "House number or name", with: "57"
   fill_in "Building and street", with: "Walthamstow Drive"
   fill_in "Town or city", with: "Derby"


### PR DESCRIPTION
# Context

- The goal of this PR is to focus on a stateful representation a journey
- Given a set of answers, a pointer to what page the user is on or wants load:
  - are they allowed on the page, not be able to jump to a future page without answering preceding pages ✅ 
  - determine what the next page should be when they hit continue ✅ 
  - what the previous page should be when they hit the back link, therefore remove and backlink overrides ✅ 
  - if a user changes answer retrospectively mid-way thru a journey clear all answers no longer in the "tree" ✅ 
  - if a user changes answer retrospectively mid-way thru a journey where a later page causes ineligibility clear the last answer in the tree that caused ineligibility ✅ 
  - this process needs to be deterministic and repeatable ✅ 
- To limit the amount of work the changes have been constrained to a single journey, FE
- Things to keep in mind but probably out of scope:
  - changing answers on the check answers page affecting state

# Notes:

- Every page must now be a form even though that page is simply content
- I've attempted to make the slug sequence additive rather than subtractive. which i think is more logical and easier to reason with. but found this to be more work than is probably worth
- Also resolves https://dfedigital.atlassian.net/browse/CAPT-1912