### PR TITLE
Block all head requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery except: :handle_unwanted_requests
 
   def handle_unwanted_requests
-    render file: Rails.root.join("public", "404.html"), status: :not_found, layout: false
+    if request.head?
+      head :bad_request
+    else
+      render file: Rails.root.join("public", "404.html"), status: :not_found, layout: false
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,10 +196,8 @@ Rails.application.routes.draw do
     req.path =~ %r{^/(wordpress|wp)}i
   }
 
-  # 404 - misc head requests
-  match "*path", to: "application#handle_unwanted_requests", via: :head, constraints: lambda { |req|
-    req.path =~ %r{^/(backup|bc|bk|home|main|new|old)}i
-  }
+  # 400 - any head requests
+  match "*path", to: "application#handle_unwanted_requests", via: :head
 
   # 404 - root requests
   options "/", to: "application#handle_unwanted_requests"

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -99,17 +99,25 @@ describe "Routes", type: :routing do
     end
 
     context "misc head requests" do
-      it "returns a 404" do
-        %w[
-          backup
-          bc
-          bk
-          home
-          main
-          new
-          old
+      before { create(:journey_configuration, :additional_payments) }
+
+      let(:some_app_url) do
+        Journeys::AdditionalPaymentsForTeaching::SlugSequence.start_page_url
+      end
+
+      it "returns a 400" do
+        [
+          "backup",
+          "bc",
+          "bk",
+          "home",
+          "main",
+          "new",
+          "old",
+          some_app_url
         ].each do |path|
-          expect(head: path).to route_to(controller: "application", action: "handle_unwanted_requests", path: path)
+          expected_path = path.remove(/\A\//)
+          expect(head: path).to route_to(controller: "application", action: "handle_unwanted_requests", path: expected_path)
         end
       end
     end


### PR DESCRIPTION
Previously we were blocking some specific head requests however rollback is triggering on head requests from email clients. We want to just return a 400 rather than generate an error.

Not sure how we want to QA this one, curl does what we'd expect
```
curl -I https://localhost:3000/additional-payments/landing-page
HTTP/1.1 400 Bad Request
```