### PR TITLE
Move fields to the "clear" config

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -80,6 +80,7 @@ shared:
     - logged_in_with_onelogin
     - onelogin_auth_at
     - onelogin_idv_at
+    - onelogin_uid
     - started_at
     - verified_at
   :decisions:
@@ -160,6 +161,7 @@ shared:
     - had_leadership_position
     - mostly_performed_leadership_duties
     - claim_school_somewhere_else
+    - teacher_reference_number
   :early_career_payments_eligibilities:
     - id
     - nqt_in_academic_year_after_itt
@@ -178,6 +180,7 @@ shared:
     - award_amount
     - induction_completed
     - school_somewhere_else
+    - teacher_reference_number
   :levelling_up_premium_payments_eligibilities:
     - id
     - created_at
@@ -197,6 +200,7 @@ shared:
     - eligible_degree_subject
     - induction_completed
     - school_somewhere_else
+    - teacher_reference_number
   :international_relocation_payments_eligibilities:
     - id
     - created_at
@@ -306,6 +310,7 @@ shared:
     - flagged_as_duplicate
     - provider_verification_email_last_sent_at
     - provider_verification_chase_email_last_sent_at
+    - teacher_reference_number
   :eligible_fe_providers:
     - id
     - ukprn
@@ -327,3 +332,26 @@ shared:
     - updated_at
     - provider_claim_submitted_at
     - practitioner_claim_started_at
+  :school_workforce_censuses:
+    - id
+    - teacher_reference_number
+    - school_urn
+    - totfte
+    - contract_agreement_type
+    - subject_description_sfr
+    - general_subject_code
+    - hours_taught
+    - created_at
+    - updated_at
+  :teachers_pensions_service:
+    - id
+    - teacher_reference_number
+    - start_date
+    - end_date
+    - la_urn
+    - school_urn
+    - employer_id
+    - nino
+    - created_at
+    - updated_at
+    - gender_digit

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -31,15 +31,10 @@
   - paye_reference
   - practitioner_email_address
   - provider_contact_name
-  - onelogin_uid
   - onelogin_idv_first_name
   - onelogin_idv_last_name
   - onelogin_idv_full_name
   - onelogin_idv_date_of_birth
-  :claim_decisions:
-  - trn
-  - claimant_age
-  - claimant_gender
   :delayed_jobs:
   - id
   - priority
@@ -95,40 +90,10 @@
   - amount
   - created_at
   - updated_at
-  :school_workforce_censuses:
-  - id
-  - teacher_reference_number
-  - school_urn
-  - totfte
-  - contract_agreement_type
-  - subject_description_sfr
-  - general_subject_code
-  - hours_taught
-  - created_at
-  - updated_at
-  :teachers_pensions_service:
-  - id
-  - teacher_reference_number
-  - start_date
-  - end_date
-  - la_urn
-  - school_urn
-  - employer_id
-  - nino
-  - created_at
-  - updated_at
-  - gender_digit
   :international_relocation_payments_eligibilities:
   - passport_number
   - school_headteacher_name
-  :levelling_up_premium_payments_eligibilities:
-  - teacher_reference_number
-  :early_career_payments_eligibilities:
-  - teacher_reference_number
-  :student_loans_eligibilities:
-  - teacher_reference_number
   :further_education_payments_eligibilities:
-  - teacher_reference_number
   - verification
   :journeys_sessions:
   - answers

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,2 +1,35 @@
 ---
-shared: {}
+:shared:
+  :claims:
+    - onelogin_uid
+  :levelling_up_premium_payments_eligibilities:
+    - teacher_reference_number
+  :early_career_payments_eligibilities:
+    - teacher_reference_number
+  :student_loans_eligibilities:
+    - teacher_reference_number
+  :further_education_payments_eligibilities:
+    - teacher_reference_number
+  :school_workforce_censuses:
+    - id
+    - teacher_reference_number
+    - school_urn
+    - totfte
+    - contract_agreement_type
+    - subject_description_sfr
+    - general_subject_code
+    - hours_taught
+    - created_at
+    - updated_at
+  :teachers_pensions_service:
+    - id
+    - teacher_reference_number
+    - start_date
+    - end_date
+    - la_urn
+    - school_urn
+    - employer_id
+    - nino
+    - created_at
+    - updated_at
+    - gender_digit

--- a/spec/lib/analytics_importer_spec.rb
+++ b/spec/lib/analytics_importer_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe AnalyticsImporter do
             "event_type" => "import_entity",
             "entity_table_name" => "claims",
             "event_tags" => ["20240101000000"],
-            "data" => a_hash_including({"key" => "id", "value" => [claim.id]})
+            "data" => a_hash_including({"key" => "id", "value" => [claim.id]}),
+            "hidden_data" => [{"key" => "onelogin_uid", "value" => []}]
           }
         ],
         ignore_unknown: true


### PR DESCRIPTION
Data and Insights have informed us that BigQuery is now allowed to
handle storing PII. This commit moves the requested fields from the
block list to the "clear" analytics config to allow them to be synced
over.

## Upon merging
- [ ] Inform Sophie the fields will be pulled over
- [ ] Kick off an analytics reimport - `bin/rake dfe:analytics:import_all_entities`
