### PR TITLE
Don't render link if no email

### DIFF
--- a/app/views/admin/support_tickets/_widget.html.erb
+++ b/app/views/admin/support_tickets/_widget.html.erb
@@ -3,7 +3,10 @@
   <h2 class="govuk-heading-m">Support ticket</h2>
 
   <ul class="govuk-body">
-    <li><%= govuk_link_to "View all suppport tickets in Zendesk", zendesk_email_search_url(@claim.email_address), new_tab: "" %></li>
+    <%# EY journey without a practitioner will not have an email address yet %>
+    <% if @claim.email_address %>
+      <li><%= govuk_link_to "View all suppport tickets in Zendesk", zendesk_email_search_url(@claim.email_address), new_tab: "" %></li>
+    <% end %>
     <li><%= govuk_link_to claim.support_ticket.url, claim.support_ticket.url, new_tab: ""  %></li>
   </ul>
 


### PR DESCRIPTION
EY claims that are awaiting the practitioner to complete their half of
the claim don't have an email address, so we can't link to the zendesk
search by email page.
