### PR TITLE
CAPT 1797/qualification report tweak

### DIFF
--- a/app/models/reports/failed_qualification_claims.rb
+++ b/app/models/reports/failed_qualification_claims.rb
@@ -29,7 +29,7 @@ module Reports
             Task.qualifications.claim_verifier_match_none
           )
         )
-        .includes(:eligibility, decisions: :created_by)
+        .includes(:eligibility, :notes, decisions: :created_by)
     end
 
     def to_csv
@@ -58,10 +58,10 @@ module Reports
           qualification,
           itt_academic_year,
           eligible_itt_subject,
-          itt_subjects,
-          itt_start_date,
-          qts_award_date,
-          qualification_name
+          parse_note("ITT subjects"),
+          parse_note("ITT start date"),
+          parse_note("QTS award date"),
+          parse_note("Qualification name")
         ]
       end
 
@@ -88,34 +88,18 @@ module Reports
         claim.eligibility.try(:qualification)
       end
 
-      def itt_subjects
-        dqt_teacher_record&.itt_subjects&.join(", ")
+      # dqt information isn't stored on any claims on production.
+      # We don't want to make an API call for each claim in this report, so
+      # instead we parse the note to get the information for the report.
+      def parse_note(label)
+        return unless dqt_note
+
+        match = dqt_note.body.match(/#{label}: (.*)/)
+        match ? match[1].strip : nil
       end
 
-      def itt_start_date
-        date = dqt_teacher_record&.itt_start_date
-
-        return unless date
-
-        I18n.l(date, format: :day_month_year)
-      end
-
-      def qts_award_date
-        date = dqt_teacher_record&.qts_award_date
-
-        return unless date
-
-        I18n.l(date, format: :day_month_year)
-      end
-
-      def qualification_name
-        dqt_teacher_record&.qualification_name
-      end
-
-      def dqt_teacher_record
-        @dqt_teacher_record ||= if claim.has_dqt_record?
-          Dqt::Teacher.new(claim.dqt_teacher_status)
-        end
+      def dqt_note
+        @dqt_note ||= claim.notes.find_by(label: "qualifications")
       end
     end
   end

--- a/app/models/reports/failed_qualification_claims.rb
+++ b/app/models/reports/failed_qualification_claims.rb
@@ -24,7 +24,11 @@ module Reports
       @claims = Claim
         .approved
         .where(academic_year: AcademicYear.current)
-        .joins(:tasks).merge(Task.where(name: "qualifications", passed: false))
+        .joins(:tasks).merge(
+          Task.qualifications.where(passed: false).or(
+            Task.qualifications.claim_verifier_match_none
+          )
+        )
         .includes(:eligibility, decisions: :created_by)
     end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -30,6 +30,8 @@ class Task < ApplicationRecord
     payroll_gender
   ].freeze
 
+  NAMES.each { |name| scope name.to_sym, -> { where(name: name) } }
+
   belongs_to :claim
   belongs_to :created_by, class_name: "DfeSignIn::User", optional: true
 
@@ -44,7 +46,6 @@ class Task < ApplicationRecord
   scope :automated, -> { where(manual: false) }
   scope :passed_automatically, -> { automated.where(passed: true) }
 
-  scope :census_subjects_taught, -> { where(name: "census_subjects_taught") }
   scope :no_data_census_subjects_taught, -> { census_subjects_taught.where(passed: nil, claim_verifier_match: nil) }
 
   def to_param

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -30,5 +30,9 @@ FactoryBot.define do
     trait :automated do
       manual { false }
     end
+
+    trait :claim_verifier_context do
+      to_create { it.save!(context: :claim_verifier) }
+    end
   end
 end

--- a/spec/models/reports/failed_qualification_claims_spec.rb
+++ b/spec/models/reports/failed_qualification_claims_spec.rb
@@ -93,20 +93,6 @@ RSpec.describe Reports::FailedQualificationClaims do
           eligible_itt_subject: :mathematics,
           itt_academic_year: AcademicYear.new(2021),
           qualification: :postgraduate_itt
-        },
-        dqt_teacher_status: {
-          qualified_teacher_status: {
-            qts_date: "2023-09-01",
-            name: "Qualified teacher (trained)"
-          },
-          initial_teacher_training: {
-            programme_start_date: "2022-08-01",
-            subject1: "mathematics",
-            subject1_code: "100403",
-            subject2: "physics",
-            subject3_code: "F300",
-            qualification: "Graduate Diploma"
-          }
         }
       )
 
@@ -115,6 +101,23 @@ RSpec.describe Reports::FailedQualificationClaims do
         :failed,
         name: "qualifications",
         claim: ecp_claim_approved_failed_qualification_task
+      )
+
+      create(
+        :note,
+        label: "qualifications",
+        claim: ecp_claim_approved_failed_qualification_task,
+        body: <<~HTML
+          [DQT Qualification] - Ineligible:
+          <pre>
+            ITT subjects: mathematics, physics
+            ITT subject codes:  100403, F300
+            Degree codes:       456
+            ITT start date:     01/08/2022
+            QTS award date:     01/09/2023
+            Qualification name: Graduate Diploma
+          </pre>
+        HTML
       )
 
       # included
@@ -133,18 +136,6 @@ RSpec.describe Reports::FailedQualificationClaims do
           eligible_itt_subject: :physics,
           itt_academic_year: AcademicYear.new(2021),
           qualification: :postgraduate_itt
-        },
-        dqt_teacher_status: {
-          qualified_teacher_status: {
-            qts_date: "2023-10-01",
-            name: "Qualified teacher (trained)"
-          },
-          initial_teacher_training: {
-            programme_start_date: "2022-08-02",
-            subject1: "physics",
-            subject1_code: "F300",
-            qualification: "Graduate Diploma"
-          }
         }
       )
 
@@ -155,6 +146,23 @@ RSpec.describe Reports::FailedQualificationClaims do
         :failed,
         name: "qualifications",
         claim: lup_claim_approved_failed_qualification_task
+      )
+
+      create(
+        :note,
+        label: "qualifications",
+        claim: lup_claim_approved_failed_qualification_task,
+        body: <<~HTML
+          [DQT Qualification] - Ineligible:
+          <pre>
+            ITT subjects: physics
+            ITT subject codes:  F300
+            Degree codes:       456
+            ITT start date:     02/08/2022
+            QTS award date:     01/10/2023
+            Qualification name: Graduate Diploma
+          </pre>
+        HTML
       )
 
       # included
@@ -170,18 +178,6 @@ RSpec.describe Reports::FailedQualificationClaims do
         ),
         eligibility_attributes: {
           teacher_reference_number: "3333333"
-        },
-        dqt_teacher_status: {
-          qualified_teacher_status: {
-            qts_date: "2023-10-01",
-            name: "Qualified teacher (trained)"
-          },
-          initial_teacher_training: {
-            programme_start_date: "2022-08-02",
-            subject1: "physics",
-            subject1_code: "F300",
-            qualification: "Graduate Diploma"
-          }
         }
       )
 
@@ -190,6 +186,23 @@ RSpec.describe Reports::FailedQualificationClaims do
         :failed,
         name: "qualifications",
         claim: tslr_claim_approved_failed_qualification_task
+      )
+
+      create(
+        :note,
+        label: "qualifications",
+        claim: tslr_claim_approved_failed_qualification_task,
+        body: <<~HTML
+          [DQT Qualification] - Ineligible:
+          <pre>
+            ITT subjects: physics
+            ITT subject codes:  F300
+            Degree codes:       456
+            ITT start date:     02/08/2022
+            QTS award date:     01/10/2023
+            Qualification name: Graduate Diploma
+          </pre>
+        HTML
       )
 
       # included "no match" on the task
@@ -208,20 +221,6 @@ RSpec.describe Reports::FailedQualificationClaims do
           eligible_itt_subject: :mathematics,
           itt_academic_year: AcademicYear.new(2021),
           qualification: :postgraduate_itt
-        },
-        dqt_teacher_status: {
-          qualified_teacher_status: {
-            qts_date: "2023-09-01",
-            name: "Qualified teacher (trained)"
-          },
-          initial_teacher_training: {
-            programme_start_date: "2022-08-01",
-            subject1: "mathematics",
-            subject1_code: "100403",
-            subject2: "physics",
-            subject3_code: "F300",
-            qualification: "Graduate Diploma"
-          }
         }
       )
 
@@ -232,6 +231,23 @@ RSpec.describe Reports::FailedQualificationClaims do
         passed: nil,
         name: "qualifications",
         claim: ecp_claim_approved_no_match_qualification_task
+      )
+
+      create(
+        :note,
+        label: "qualifications",
+        claim: ecp_claim_approved_no_match_qualification_task,
+        body: <<~HTML
+          [DQT Qualification] - Ineligible:
+          <pre>
+            ITT subjects: mathematics, physics
+            ITT subject codes:  100403, F300
+            Degree codes:       456
+            ITT start date:     01/08/2022
+            QTS award date:     01/09/2023
+            Qualification name: Graduate Diploma
+          </pre>
+        HTML
       )
 
       # included "Ineligible" DQT status - task passed
@@ -250,20 +266,6 @@ RSpec.describe Reports::FailedQualificationClaims do
           eligible_itt_subject: :mathematics,
           itt_academic_year: AcademicYear.new(2021),
           qualification: :postgraduate_itt
-        },
-        dqt_teacher_status: {
-          qualified_teacher_status: {
-            qts_date: "2023-09-01",
-            name: "Qualified teacher (trained)"
-          },
-          initial_teacher_training: {
-            programme_start_date: "2022-08-01",
-            subject1: "mathematics",
-            subject1_code: "100403",
-            subject2: "physics",
-            subject3_code: "F300",
-            qualification: "Graduate Diploma"
-          }
         }
       )
 
@@ -277,6 +279,7 @@ RSpec.describe Reports::FailedQualificationClaims do
 
       create(
         :note,
+        label: "qualifications",
         claim: ecp_claim_approved_ineligibile_note,
         body: <<~HTML
           [DQT Qualification] - Ineligible:
@@ -284,8 +287,8 @@ RSpec.describe Reports::FailedQualificationClaims do
             ITT subjects: mathematics, physics
             ITT subject codes:  100403, F300
             Degree codes:       456
-            ITT start date:     2022-08-01
-            QTS award date:     2023-09-01
+            ITT start date:     01/08/2022
+            QTS award date:     01/09/2023
             Qualification name: Graduate Diploma
           </pre>
         HTML
@@ -307,20 +310,6 @@ RSpec.describe Reports::FailedQualificationClaims do
           eligible_itt_subject: :mathematics,
           itt_academic_year: AcademicYear.new(2021),
           qualification: :postgraduate_itt
-        },
-        dqt_teacher_status: {
-          qualified_teacher_status: {
-            qts_date: "2023-09-01",
-            name: "Qualified teacher (trained)"
-          },
-          initial_teacher_training: {
-            programme_start_date: "2022-08-01",
-            subject1: "mathematics",
-            subject1_code: "100403",
-            subject2: "physics",
-            subject3_code: "F300",
-            qualification: "Graduate Diploma"
-          }
         }
       )
 
@@ -334,6 +323,7 @@ RSpec.describe Reports::FailedQualificationClaims do
 
       create(
         :note,
+        label: "qualifications",
         claim: ecp_claim_approved_not_eligible_note,
         body: "[DQT Qualification] - Not eligible"
       )
@@ -441,10 +431,10 @@ RSpec.describe Reports::FailedQualificationClaims do
           "postgraduate_itt",
           "2021/2022",
           "mathematics",
-          "mathematics, physics",
-          "01/08/2022",
-          "01/09/2023",
-          "Graduate Diploma"
+          nil,
+          nil,
+          nil,
+          nil
         ]
       ])
     end


### PR DESCRIPTION
Some tweaks to the DQT qualifications report:
- **Include claims which failed dqt checks**
- **Pull dqt data from notes**

Might be easier to review each commit separately.
