### PR TITLE
[CAPT-1335] Copy tweak: update info provided with SLC

### DIFF
--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -13,6 +13,7 @@
       <li>the school you are currently employed to teach at</li>
       <li>the Department for Education’s (DfE) database of qualified teachers</li>
       <li>the Teacher Pension Scheme</li>
+      <li>the Student Loans Company</li>
     </ul>
 
     <h2 class="govuk-heading-m">To pay you</h2>

--- a/app/views/further_education_payments/claims/information_provided.html.erb
+++ b/app/views/further_education_payments/claims/information_provided.html.erb
@@ -12,7 +12,8 @@
 
     <%= govuk_list [
       "further education provider where you currently teach",
-      "Teacher’s Pension Scheme, if you have a teacher reference number (TRN) and choose to provide it"
+      "Teacher’s Pension Scheme, if you have a teacher reference number (TRN) and choose to provide it",
+      "the Student Loans Company"
     ], type: :bullet %>
 
     <%= govuk_details(summary_text: "Where to find your TRN") do %>

--- a/spec/features/early_career_payments/early_career_payments_claim_spec.rb
+++ b/spec/features/early_career_payments/early_career_payments_claim_spec.rb
@@ -113,6 +113,7 @@ RSpec.feature "Teacher Early-Career Payments claims", slow: true do
     # - How will we use the information you provide
     expect(page).to have_text("How we will use the information you provide")
     expect(page).to have_text("For more details, you can read about payments and deductions for the early-career payment")
+    expect(page).to have_text("the Student Loans Company")
     click_on "Continue"
 
     # - Personal details

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -118,6 +118,7 @@ RSpec.feature "Further education payments" do
     sign_in_with_one_login
 
     expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
     click_button "Continue"
 
     expect(page).to have_content("Personal details")

--- a/spec/features/tslr/tslr_claim_journey_with_teacher_id_check_email_spec.rb
+++ b/spec/features/tslr/tslr_claim_journey_with_teacher_id_check_email_spec.rb
@@ -162,6 +162,7 @@ RSpec.feature "TSLR journey with Teacher ID email check" do
 
     # - How we will use the information you provide
     expect(page).to have_text("How we will use the information you provide")
+    expect(page).to have_text("the Student Loans Company")
     click_on "Continue"
 
     # - Personal details - skipped


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1335
- Update `information provided` pages to include SLC