### PR TITLE
Make email address validation notify compliant

### DIFF
--- a/app/forms/email_address_form.rb
+++ b/app/forms/email_address_form.rb
@@ -7,8 +7,7 @@ class EmailAddressForm < Form
       message: ->(form, _) { form.i18n_errors_path("presence") }
     }
   validates :email_address,
-    format: {
-      with: Rails.application.config.email_regexp,
+    email_address_format: {
       message: ->(form, _) { form.i18n_errors_path("format") }
     },
     length: {

--- a/app/forms/reminders/personal_details_form.rb
+++ b/app/forms/reminders/personal_details_form.rb
@@ -19,8 +19,7 @@ module Reminders
 
     validates :reminder_email_address,
       if: -> { reminder_email_address.present? },
-      format: {
-        with: Rails.application.config.email_regexp,
+      email_address_format: {
         message: i18n_error_message("email_address.invalid")
       },
       length: {

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -5,7 +5,7 @@ class SelectEmailForm < Form
 
   validates :email_address_check, inclusion: {in: [true, false], message: i18n_error_message(:select_email)}
   validates :email_address, presence: {message: i18n_error_message(:invalid_email)}, if: -> { email_address_check == true }
-  validates :email_address, format: {with: Rails.application.config.email_regexp, message: i18n_error_message(:invalid_email)},
+  validates :email_address, email_address_format: {message: i18n_error_message(:invalid_email)},
     length: {maximum: Rails.application.config.email_max_length, message: i18n_error_message(:invalid_email)}, if: -> { email_address.present? }
 
   before_validation :determine_dependant_attributes

--- a/app/models/eligible_fe_provider.rb
+++ b/app/models/eligible_fe_provider.rb
@@ -3,7 +3,7 @@ class EligibleFeProvider < ApplicationRecord
 
   validates :primary_key_contact_email_address,
     presence: true,
-    format: {with: Rails.application.config.email_regexp},
+    email_address_format: true,
     length: {maximum: Rails.application.config.email_max_length}
 
   def self.csv_for_academic_year(academic_year)

--- a/app/validators/email_address_format_validator.rb
+++ b/app/validators/email_address_format_validator.rb
@@ -1,0 +1,85 @@
+# Implementation of this validation:
+# https://github.com/alphagov/notifications-utils/blob/e89dcc53c7f88ef23053d1efb2c00b8ef2ea377e/notifications_utils/recipient_validation/email_address.py#L1
+# though lacking the punycode support.
+class EmailAddressFormatValidator < ActiveModel::EachValidator
+  VALID_LOCAL_CHARS = "a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\\-"
+  EMAIL_REGEX_PATTERN = /\A[#{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+)\z/
+  HOSTNAME_PART = /\A(xn|[a-z0-9]+)(-?-[a-z0-9]+)*\z/i
+  TLD_PART = /\A([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)\z/i
+
+  def validate_each(record, attribute, value)
+    return unless value
+
+    match = EMAIL_REGEX_PATTERN.match(value)
+
+    if match.nil?
+      record.errors.add(
+        attribute,
+        :invalid,
+        message: options.fetch(:message, "is not a valid email address"),
+        value: value
+      )
+
+      return
+    end
+
+    if value.length > 320
+      record.errors.add(
+        attribute,
+        :invalid,
+        message: options.fetch(:message, "is not a valid email address"),
+        value: value
+      )
+
+      return
+    end
+
+    if value.include?("..")
+      record.errors.add(
+        attribute,
+        :invalid,
+        message: options.fetch(:message, "is not a valid email address"),
+        value: value
+      )
+
+      return
+    end
+
+    hostname = match[1]
+
+    parts = hostname.split(".")
+
+    if hostname.length > 253 || parts.size < 2
+      record.errors.add(
+        attribute,
+        :invalid,
+        message: options.fetch(:message, "is not a valid email address"),
+        value: value
+      )
+
+      return
+    end
+
+    if parts.any? { |part| part.length > 63 || !HOSTNAME_PART.match?(part) }
+      record.errors.add(
+        attribute,
+        :invalid,
+        message: options.fetch(:message, "is not a valid email address"),
+        value: value
+      )
+
+      return
+    end
+
+    tld = parts.last
+
+    if !TLD_PART.match?(tld)
+      record.errors.add(
+        attribute,
+        :invalid,
+        message: options.fetch(:message, "is not a valid email address"),
+        value: value
+      )
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,8 +72,6 @@ module DfeTeachersPaymentService
 
     config.active_record.yaml_column_permitted_classes = [BigDecimal, Date, Symbol]
 
-    config.email_regexp = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+\z/
-
     # Max length is based on the lowest requirement on services Claim interacts, in this case Payroll
     # https://www.gov.uk/government/publications/real-time-information-internet-submissions-2024-to-2025-technical-specifications
     config.email_max_length = 129

--- a/spec/validators/email_address_format_validator_spec.rb
+++ b/spec/validators/email_address_format_validator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe EmailAddressFormatValidator do
         record = TestRecord.new
         record.email = string
 
-        expect(record.valid?).to be false
+        expect(record).not_to be_valid
 
         expect(record.errors[:email]).to include("no good")
       end
@@ -47,7 +47,7 @@ RSpec.describe EmailAddressFormatValidator do
         record = TestRecord.new
         record.email = string
 
-        expect(record.valid?).to be true
+        expect(record).to be_valid
 
         expect(record.errors[:email]).to be_empty
       end

--- a/spec/validators/email_address_format_validator_spec.rb
+++ b/spec/validators/email_address_format_validator_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+class TestRecord
+  include ActiveModel::Validations
+
+  attr_accessor :email
+
+  validates :email, email_address_format: {message: "no good"}
+end
+
+RSpec.describe EmailAddressFormatValidator do
+  context "with an invalid email address" do
+    [
+      "noatsign.domain",
+      "@nolocal.com",
+      "contains space@example.com",
+      "too@many@signs.com",
+      "double..dot@example.com",
+      "doubledot-in-domain@sub..domain.com",
+      "tldonly@com",
+      "trailingdot@subdomain.",
+      "test@-badlabel.co",
+      "test@bad_domain.com",
+      "toolong-dmain@#{"a" * 64}.com",
+      "bad-tld@example.c",
+      "bad-tld@example.com1"
+    ].each do |string|
+      it "rejects #{string}" do
+        record = TestRecord.new
+        record.email = string
+
+        expect(record.valid?).to be false
+
+        expect(record.errors[:email]).to include("no good")
+      end
+    end
+  end
+
+  context "with a valid email address" do
+    [
+      "test@example.com",
+      "first.o'surname+123@sub.domain.co.uk",
+      "abc@my-long-subdomain.gov.uk",
+      "someone@domain.org"
+    ].each do |string|
+      it "accepts #{string}" do
+        record = TestRecord.new
+        record.email = string
+
+        expect(record.valid?).to be true
+
+        expect(record.errors[:email]).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updates our email address validation to, mostly, match the validation
logic in notify. To avoid pulling in a gem to the project we're not
converting to puny code so some domains like `müller-büromöbel.de` won't
be permitted. If we want to support these domains we can convert them to
puny code and validate that
`https://github.com/alphagov/notifications-utils/blob/e89dcc53c7f88ef23053d1efb2c00b8ef2ea377e/notifications_utils/recipient_validation/email_address.py#L38`

The email validation code in notify seems pretty stable, having last
changed in 2022.

**Other option is to just rescue notify api errors and add a validation error** might be simpler.