### PR TITLE
Fix date format

### DIFF
--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -57,7 +57,7 @@ module Journeys
       def start_date_details
         [
           t("get_a_teacher_relocation_payment.forms.start_date.question"),
-          answers.start_date.strftime("%d-%m-%Y"),
+          l(answers.start_date),
           "start-date"
         ]
       end
@@ -81,7 +81,7 @@ module Journeys
       def entry_date
         [
           t("get_a_teacher_relocation_payment.forms.entry_date.question"),
-          answers.date_of_entry.strftime("%d-%m-%Y"),
+          l(answers.date_of_entry),
           "entry-date"
         ]
       end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -117,7 +117,7 @@ describe "teacher route: completing the form" do
     )
 
     expect(page).to have_text(
-      "Enter the start date of your contract #{contract_start_date.strftime("%d-%m-%Y")}"
+      "Enter the start date of your contract #{I18n.l(contract_start_date)}"
     )
 
     expect(page).to have_text(
@@ -129,7 +129,7 @@ describe "teacher route: completing the form" do
     )
 
     expect(page).to have_text(
-      "Enter the date you moved to England to start your teaching job #{entry_date.strftime("%d-%m-%Y")}"
+      "Enter the date you moved to England to start your teaching job #{I18n.l(entry_date)}"
     )
   end
 

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
         ],
         [
           "Enter the start date of your contract",
-          answers.start_date.strftime("%d-%m-%Y"),
+          I18n.l(answers.start_date),
           "start-date"
         ],
         [
@@ -70,7 +70,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
         ],
         [
           "Enter the date you moved to England to start your teaching job",
-          answers.date_of_entry.strftime("%d-%m-%Y"),
+          I18n.l(answers.date_of_entry),
           "entry-date"
         ]
       )


### PR DESCRIPTION
The dates displayed on the check your answers page weren't in the
standard govuk format.
