### PR TITLE
Don't allow admins to enter (most) html

### DIFF
--- a/app/views/admin/notes/_note.html.erb
+++ b/app/views/admin/notes/_note.html.erb
@@ -1,6 +1,10 @@
 <div class="hmcts-timeline__item">
   <section<%= " class=banner" if note.important %>>
-    <%= simple_format note.body, class: "govuk-body" %>
+    <%= simple_format(
+      note.body,
+      { class: "govuk-body" },
+      { sanitize_options: { attributes: %w[class], tags: %w[span pre] } }
+    ) %>
   </section>
 
   <% if display_description %>


### PR DESCRIPTION
ITHC flagged this one. We still need to be able to render `span` and
`pre` tags as these are generated by some automated notes, we also need
to be able to set the `class` attribute as CAPT-2033 introduced some
colours to some of the automated notes.
