### PR TITLE
Payments show

### DIFF
--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -1,11 +1,18 @@
 module Admin
   class PaymentsController < BaseAdminController
     before_action :ensure_service_operator
-    before_action :find_payroll_run, except: [:index]
-    before_action :find_payment, except: [:index]
+    before_action :find_payroll_run, except: [:index, :show]
+    before_action :find_payment, except: [:index, :show]
 
     def index
       @claim = Claim.find(params[:claim_id])
+    end
+
+    def show
+      @payment = Payment.includes(
+        non_topup_claims: :eligibility,
+        topups: [:created_by, {claim: :eligibility}]
+      ).find(params[:id])
     end
 
     def remove

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -3,6 +3,16 @@ class Payment < ApplicationRecord
   has_many :claims, through: :claim_payments
   has_many :topups, dependent: :nullify
 
+  # When creating a payment for a topup both the topup and the topup's claim
+  # are associated with the payment, so `Payment#claims` includes topup
+  # claims, see PayrollRunJob#perform
+  has_many(
+    :non_topup_claims,
+    ->(payment) { where.not(id: payment.topups.select(:claim_id)) },
+    through: :claim_payments,
+    source: :claim
+  )
+
   belongs_to :payroll_run
   belongs_to :confirmation, class_name: "PaymentConfirmation", optional: true
 

--- a/app/views/admin/payments/index.html.erb
+++ b/app/views/admin/payments/index.html.erb
@@ -34,7 +34,7 @@
         <tbody class="govuk-table__body">
           <% @claim.payments.each do |payment| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= payment.id %></td>
+              <td class="govuk-table__cell"><%= govuk_link_to payment.id, admin_payment_path(payment) %></td>
               <td class="govuk-table__cell"><%= number_to_currency(payment.award_amount) %></td>
               <td class="govuk-table__cell"><%= payment.claims.size %></td>
               <td class="govuk-table__cell"><%= link_to(payment.payroll_run.created_at.strftime("%B %Y"), admin_payroll_run_path(payment.payroll_run)) %></td>
@@ -69,7 +69,7 @@
             <% @claim.topups.each do |topup| %>
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell"><%= number_to_currency(topup.award_amount) %></td>
-                <td class="govuk-table__cell"><%= topup.payment_id? ? topup.payment_id : "Awaiting payroll" %></td>
+                <td class="govuk-table__cell"><%= topup.payment_id? ? govuk_link_to(topup.payment_id, admin_payment_path(topup.payment)) : "Awaiting payroll" %></td>
                 <td class="govuk-table__cell"><%= user_details(topup.created_by) %></td>
                 <td class="govuk-table__cell"><%= l(topup.created_at) %></td>
                 <td class="govuk-table__cell">

--- a/app/views/admin/payments/show.html.erb
+++ b/app/views/admin/payments/show.html.erb
@@ -1,0 +1,160 @@
+<% content_for(:page_title) do %>
+  <%= "Payment #{@payment.id}" %>
+<% end %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: request.referrer || admin_claim_payments_path(@payment.claims.first) %>
+<% end %>
+
+<article id="<%= dom_id(@payment) %>">
+  <header>
+    <h1 class="govuk-heading-xl govuk-heading--navigation">
+      Payment <%= @payment.id %>
+    </h1>
+  </header>
+
+  <section id="payment-details">
+    <h2 class="govuk-heading-l">Details</h2>
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Payroll run</th>
+          <td class="govuk-table__cell">
+            <%= govuk_link_to(
+              l(@payment.payroll_run.created_at.to_date, format: :month_year),
+              admin_payroll_run_path(@payment.payroll_run)
+            )%>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Payment amount</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.award_amount) %>
+          </td>
+        </tr>
+        <% if @payment.confirmed? %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Gross value</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.gross_value).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">NI</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.national_insurance).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Employers NI</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.employers_national_insurance).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Student loan repayment</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.student_loan_repayment).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Tax</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.tax).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Net pay</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.net_pay).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Gross pay</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.gross_pay).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Postgraduate loan repayment</th>
+          <td class="govuk-table__cell">
+            <%= number_to_currency(@payment.postgraduate_loan_repayment).presence || "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Scheduled payment date</th>
+          <td class="govuk-table__cell">
+            <%= @payment.scheduled_payment_date ? l(@payment.scheduled_payment_date) : "-" %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Confirmed by</th>
+          <td class="govuk-table__cell">
+            <%= user_details(@payment.confirmation.created_by) %>
+          </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </section>
+
+  <% if @payment.non_topup_claims.any? %>
+    <section id="claims">
+      <h2 class="govuk-heading-l">Claims</h2>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <th scope="col" class="govuk-table__header">Claim Reference</th>
+          <th scope="col" class="govuk-table__header">Service</th>
+          <th scope="col" class="govuk-table__header">Claim Amount</th>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @payment.non_topup_claims.each do |claim| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= govuk_link_to claim.reference, admin_claim_payments_path(claim) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= claim.policy.short_name %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= number_to_currency(claim.award_amount) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+  <% end %>
+
+  <% if @payment.topups.any? %>
+    <section id="topups">
+      <h2 class="govuk-heading-l">Topups</h2>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <th scope="col" class="govuk-table__header">Claim Reference</th>
+          <th scope="col" class="govuk-table__header">Service</th>
+          <th scope="col" class="govuk-table__header">Top Up Amount</th>
+          <th scope="col" class="govuk-table__header">Created by</th>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @payment.topups.each do |topup| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= govuk_link_to topup.claim.reference, admin_claim_payments_path(topup.claim) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= topup.claim.policy.short_name %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= number_to_currency(topup.award_amount) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= user_details(topup.created_by) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+  <% end %>
+</article>

--- a/app/views/admin/payroll_runs/_complete.html.erb
+++ b/app/views/admin/payroll_runs/_complete.html.erb
@@ -129,7 +129,7 @@
 
           <tr class="govuk-table__row">
             <% if index == 0 %>
-              <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= payment.id %></th>
+              <th scope="row" rowspan="<%= number_of_claims %>" class="govuk-table__header"><%= govuk_link_to payment.id, admin_payment_path(payment) %></th>
               <td class="govuk-table__cell" rowspan="<%= number_of_claims %>"><%= payment.banking_name %></td>
             <% end %>
             <td class="govuk-table__cell"><%= link_to claim.reference, admin_claim_path(claim), class: "govuk-link" %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :payments, only: :show
+
     resources :journey_configurations, only: [:index, :edit, :update]
     resources :levelling_up_premium_payments_awards, only: [:index, :create]
     resource :eligible_ey_providers, only: [:create, :show], path: "eligible-early-years-providers"

--- a/spec/features/admin/admin_views_payment_spec.rb
+++ b/spec/features/admin/admin_views_payment_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+RSpec.describe "Admin views payment spec" do
+  around do |example|
+    travel_to Date.new(2025, 1, 1) do
+      example.run
+    end
+  end
+
+  before do
+    create(:journey_configuration, :student_loans)
+    create(:journey_configuration, :further_education_payments)
+    create(:journey_configuration, :levelling_up_premium_payments)
+  end
+
+  it "shows the payment details" do
+    payroll_run = create(
+      :payroll_run,
+      created_at: DateTime.new(2025, 1, 1, 12, 0, 0)
+    )
+
+    claim_1 = create(
+      :claim,
+      :approved,
+      policy: Policies::FurtherEducationPayments,
+      eligibility_attributes: {
+        award_amount: 111.11
+      }
+    )
+
+    personal_details = Payment::PERSONAL_CLAIM_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES.map do |attr|
+      [attr, claim_1.send(attr)]
+    end.to_h
+
+    claim_2 = create(
+      :claim,
+      :approved,
+      **personal_details,
+      eligibility_attributes: {
+        student_loan_repayment_amount: 222.22
+      }
+    )
+
+    create(:levelling_up_premium_payments_award, award_amount: 9999)
+
+    topup_1 = create(
+      :topup,
+      award_amount: 333.33,
+      claim: create(
+        :claim,
+        :current_academic_year,
+        policy: Policies::LevellingUpPremiumPayments,
+        **personal_details
+      )
+    )
+
+    topup_2 = create(
+      :topup,
+      award_amount: 444.44,
+      claim: create(
+        :claim,
+        :current_academic_year,
+        policy: Policies::LevellingUpPremiumPayments,
+        **personal_details
+      )
+    )
+
+    payment = create(
+      :payment,
+      payroll_run: payroll_run,
+      claims: [claim_1, claim_2, topup_1.claim, topup_2.claim],
+      topups: [topup_1, topup_2],
+      award_amount: 1111.10 # 111.11 + 222.22 + 333.33 + 444.44
+    )
+
+    sign_in_as_service_operator
+
+    visit admin_payment_path(payment)
+
+    expect(page).to have_content("Payment #{payment.id}")
+    expect(page).to have_content("£1,111.10")
+    expect(page).to have_link(
+      "January 2025", href: admin_payroll_run_path(payroll_run)
+    )
+
+    expect(page).not_to have_content("Gross value")
+
+    claim_rows = find_all("#claims table tbody tr").to_a
+
+    expect(claim_rows.map(&:text)).to match_array([
+      "#{claim_1.reference} Further Education Targeted Retention Incentive £111.11",
+      "#{claim_2.reference} Student Loans £222.22"
+    ])
+
+    topup_rows = find_all("#topups table tbody tr").to_a
+
+    expect(topup_rows.map(&:text)).to match_array([
+      "#{topup_1.claim.reference} School Targeted Retention Incentive £333.33 Aaron Admin",
+      "#{topup_2.claim.reference} School Targeted Retention Incentive £444.44 Aaron Admin"
+    ])
+  end
+
+  it "shows additional payment details if the payment is confirmed" do
+    payment = create(:payment, :with_figures, :confirmed, award_amount: 1337.33)
+
+    sign_in_as_service_operator
+
+    visit admin_payment_path(payment)
+
+    payment_rows = find_all("#payment-details table tbody tr").to_a
+
+    expect(payment_rows.map(&:text)).to match_array([
+      "Payroll run January 2025",
+      "Payment amount £1,337.33",
+      "Gross value £1,925.76",
+      "NI £160.48",
+      "Employers NI £160.48",
+      "Student loan repayment £0.00",
+      "Tax £267.47",
+      "Net pay £1,337.33",
+      "Gross pay £1,765.28",
+      "Postgraduate loan repayment -",
+      "Scheduled payment date 1 January 2025",
+      "Confirmed by Aaron Admin"
+    ])
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -3,6 +3,26 @@ require "rails_helper"
 RSpec.describe Payment do
   subject { build(:payment) }
 
+  describe ".non_topup_claims" do
+    it "returns claims that are not associated with topups" do
+      create(:journey_configuration, :levelling_up_premium_payments)
+      create(:levelling_up_premium_payments_award, award_amount: 9999)
+
+      claim = create(:claim, :approved)
+
+      personal_details = Payment::PERSONAL_CLAIM_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES.map do |attr|
+        [attr, claim.send(attr)]
+      end.to_h
+
+      topup_claim = create(:claim, :current_academic_year, **personal_details)
+      topup = create(:topup, claim: topup_claim)
+
+      payment = create(:payment, claims: [claim, topup_claim], topups: [topup])
+
+      expect(payment.reload.non_topup_claims).to eq([claim])
+    end
+  end
+
   context "when validating in the :upload context" do
     it "is invalid" do
       expect(subject).not_to be_valid(:upload)


### PR DESCRIPTION
Add payments show resource

The claim payments index shows the payments belonging to a specific
claim, however a payment can contain multiple claims and topups, this
commit adds a payment show page where admins can view all the claims and
topups belonging to a payment along with a summary of the various
payment amounts.

