### PR TITLE
FE address fix

### DIFF
--- a/app/forms/postcode_search_form.rb
+++ b/app/forms/postcode_search_form.rb
@@ -24,7 +24,7 @@ class PostcodeSearchForm < Form
   end
 
   def completed?
-    journey_session.answers.skip_postcode_search || journey_session.answers.ordnance_survey_error
+    journey_session.answers.skip_postcode_search || journey_session.answers.ordnance_survey_error || valid?
   end
 
   def skip_postcode_search?

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -2,6 +2,7 @@ class SelectHomeAddressForm < Form
   attribute :address, :string
   attribute :address_line_1, :string
   attribute :postcode, :string
+  attribute :skip_postcode_search, :boolean
 
   validate :validate_address_selected, unless: -> { skip_postcode_search? }
   validate :validate_address_entered, if: -> { skip_postcode_search? }
@@ -19,14 +20,20 @@ class SelectHomeAddressForm < Form
   def save
     return false unless valid?
 
-    address_parts = address.split(":")
+    if skip_postcode_search?
+      journey_session.answers.assign_attributes(
+        skip_postcode_search:
+      )
+    else
+      address_parts = address.split(":")
 
-    journey_session.answers.assign_attributes({
-      address_line_1: address_parts[1].titleize,
-      address_line_2: address_parts[2].titleize,
-      address_line_3: address_parts[3].titleize,
-      postcode: address_parts[4]
-    })
+      journey_session.answers.assign_attributes({
+        address_line_1: address_parts[1].titleize,
+        address_line_2: address_parts[2].titleize,
+        address_line_3: address_parts[3].titleize,
+        postcode: address_parts[4]
+      })
+    end
 
     journey_session.save!
   end
@@ -38,7 +45,7 @@ class SelectHomeAddressForm < Form
   private
 
   def skip_postcode_search?
-    journey_session.answers.skip_postcode_search
+    journey_session.answers.skip_postcode_search || skip_postcode_search
   end
 
   def validate_address_selected
@@ -50,12 +57,12 @@ class SelectHomeAddressForm < Form
       return
     end
 
-    errors.add(:address)
+    errors.add(:address, "Select an address")
   end
 
   def validate_address_entered
     if journey_session.answers.address_line_1.blank? && journey_session.answers.postcode.blank?
-      errors.add(:address) if journey_session.answers.address_line_1.blank?
+      errors.add(:address, "Enter an address") if journey_session.answers.address_line_1.blank?
     end
   end
 end

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -3,8 +3,8 @@ class SelectHomeAddressForm < Form
   attribute :address_line_1, :string
   attribute :postcode, :string
 
-  validates :address, presence: true, unless: -> { skip_postcode_search? }
-  validate :address_selected, if: -> { skip_postcode_search? }
+  validate :validate_address_selected, unless: -> { skip_postcode_search? }
+  validate :validate_address_entered, if: -> { skip_postcode_search? }
 
   def address_data
     return [] if postcode.blank?
@@ -41,7 +41,21 @@ class SelectHomeAddressForm < Form
     journey_session.answers.skip_postcode_search
   end
 
-  def address_selected
-    errors.add(:address) if journey_session.answers.address_line_1.blank?
+  def validate_address_selected
+    if journey_session.answers.address_line_1.present? && journey_session.answers.postcode.present?
+      return
+    end
+
+    if address.present?
+      return
+    end
+
+    errors.add(:address)
+  end
+
+  def validate_address_entered
+    if journey_session.answers.address_line_1.blank? && journey_session.answers.postcode.blank?
+      errors.add(:address) if journey_session.answers.address_line_1.blank?
+    end
   end
 end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -140,6 +140,10 @@ module Journeys
             sequence.delete("select-home-address")
           end
 
+          if answers.address_line_1.present? && answers.postcode.present?
+            sequence.delete("address")
+          end
+
           if !eligibility_checker.ineligible?
             sequence.delete("ineligible")
           end

--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { "address": "#{@address_data.first[:address].gsub(",", "").gsub(" ", "_").downcase}"}) if @form.errors.any? %>
-
     <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form.govuk_error_summary %>
+
       <div class="govuk-!-margin-bottom-5">
         <h1 class="govuk-heading-xl"><%= t("questions.address.home.title") %></h1>
         <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Postcode</h2>
@@ -37,7 +37,16 @@
             </div>
           </fieldset>
         <% end %>
-        <%= link_to I18n.t("questions.address.home.i_cannot_find"), claim_path(current_journey_routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.i_cannot_find") %>
+
+        <p class="govuk-body">
+          <% if journey.use_navigator? %>
+            <button form="skip-postcode-search" class="govuk-link govuk-link--no-visited-state button-to-as-link">
+              <%= I18n.t("questions.address.home.i_cannot_find") %>
+            </button>
+          <% else %>
+            <%= link_to I18n.t("questions.address.home.i_cannot_find"), claim_path(current_journey_routing_name, "address"), class: "govuk-link", "aria-label": I18n.t("questions.address.home.i_cannot_find") %>
+          <% end %>
+        </p>
       </div>
       <p class="govuk-!-padding-top-3">
         <%= form.submit "Continue", class: "govuk-button" %>
@@ -45,3 +54,7 @@
     <% end %>
   </div>
 </div>
+
+<%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { id: "skip-postcode-search" } do |f| %>
+  <%= f.hidden_field :skip_postcode_search, value: true %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,7 @@ en:
       home:
         title: "What is your home address?"
         link_to_manual_address: "Enter your address manually"
-        i_cannot_find: "I can't find my address in the list"
+        i_cannot_find: "I can’t find my address in the list"
         no_address_found: "No addresses found matching those details"
     date_of_birth: "What is your date of birth?"
     email_address: "Email address"

--- a/spec/features/further_education_payments/jump_around_spec.rb
+++ b/spec/features/further_education_payments/jump_around_spec.rb
@@ -221,7 +221,113 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Email address")
   end
 
-  scenario "postcode search address but result not in list"
+  scenario "postcode search address but result not in list" do
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: school.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    expect(page).to have_content("T Level in building services engineering for construction")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you subject to any formal performance measures as a result of continuous poor teaching standards")
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    expect(page).to have_content("Are you currently subject to disciplinary action?")
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a targeted retention incentive payment")
+    expect(page).to have_content(number_to_currency(expected_award_amount, precision: 0))
+    expect(page).to have_content("Apply now")
+    click_button "Apply now"
+
+    sign_in_with_one_login
+
+    expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
+    click_button "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    stub_search_places_index(claim: OpenStruct.new(postcode: "SO16 9FX"))
+
+    expect(page).to have_content("What is your home address?")
+    fill_in "Postcode", with: "SO16 9FX"
+    click_on "Search"
+
+    expect(page).to have_text "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    expect(page).to have_text "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    expect(page).to have_text "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    click_button "I can’t find my address in the list"
+
+    expect(page).to have_content("What is your address?")
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    expect(page).to have_content("Email address")
+  end
 
   def and_college_exists
     school

--- a/spec/features/further_education_payments/jump_around_spec.rb
+++ b/spec/features/further_education_payments/jump_around_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Further education payments" do
+  include ActionView::Helpers::NumberHelper
+
   let(:school) { create(:school, :fe_eligible) }
+  let(:college) { school }
+  let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
 
   scenario "visiting impermissible slug redirects back to last permissible slug" do
     when_further_education_payments_journey_configuration_exists
@@ -114,5 +118,112 @@ RSpec.feature "Further education payments" do
     expect(Journeys::FurtherEducationPayments::Session.last.answers.chemistry_courses).to be_empty
 
     expect(page).to have_content("Which computing courses do you teach?")
+  end
+
+  scenario "postcode search address and selects a result" do
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: school.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    expect(page).to have_content("T Level in building services engineering for construction")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you subject to any formal performance measures as a result of continuous poor teaching standards")
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    expect(page).to have_content("Are you currently subject to disciplinary action?")
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a targeted retention incentive payment")
+    expect(page).to have_content(number_to_currency(expected_award_amount, precision: 0))
+    expect(page).to have_content("Apply now")
+    click_button "Apply now"
+
+    sign_in_with_one_login
+
+    expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
+    click_button "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    stub_search_places_index(claim: OpenStruct.new(postcode: "SO16 9FX"))
+
+    expect(page).to have_content("What is your home address?")
+    fill_in "Postcode", with: "SO16 9FX"
+    click_on "Search"
+
+    expect(page).to have_text "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    expect(page).to have_text "Flat 10, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    expect(page).to have_text "Flat 11, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    choose "Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+    click_on "Continue"
+
+    expect(page).to have_content("Email address")
+  end
+
+  scenario "postcode search address but result not in list"
+
+  def and_college_exists
+    school
   end
 end


### PR DESCRIPTION
# Context

- As part of the navigator/state.machine work applied to FE journey there was a regression where for the FE journey searching for postcode then either choosing an address result or then opting to manually enter address was not working as desired. This PR should address these issues with extra coverage to ensure no future regressions