### PR TITLE
Don't cache admin pages

### DIFF
--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -6,6 +6,7 @@ module Admin
     layout "admin"
 
     before_action :end_expired_admin_sessions, :ensure_authenticated_user
+    before_action :set_cache_headers
     after_action :update_last_seen_at
     helper_method :admin_signed_in?, :admin_timeout_in_minutes, :service_operator_signed_in?
 
@@ -57,6 +58,11 @@ module Admin
       session.delete(:organisation_id)
       session.delete(:role_codes)
       session.delete(:claims_backlink_path)
+    end
+
+    def set_cache_headers
+      response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+      response.headers["Pragma"] = "no-cache"
     end
   end
 end


### PR DESCRIPTION
We already set the max-age=0, private, must-revalidate directives but we
need to add no-store so the pages don't show up in the BF cache.
ITHC picked up an issue where after logging out of the admin area
hitting the back button renders a logged in page, seems like it's BF
cache doing this.
