### PR TITLE
Add security recommendations to maint page

### DIFF
--- a/maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl
+++ b/maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl
@@ -20,6 +20,9 @@ spec:
       containers:
       - name: claim-additional-payments-for-teaching-maintenance
         image: ghcr.io/dfe-digital/claim-additional-payments-for-teaching-maintenance:#MAINTENANCE_IMAGE_TAG#
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
## Context
As per ITHC, set below for maintenance app deployment
- allowPrivilegeEscalation: false
- runAsNonRoot: true

## Changes proposed in this pull request
Update to deployment file

## Guidance to review
Tested in another service which has the same config (GIT) 

