### PR TITLE
CAPT-2189/closed service access

### DIFF
--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -11,7 +11,7 @@ module PartOfClaimJourney
   private
 
   def check_whether_closed_for_submissions
-    unless journey.open_for_submissions?(access_code)
+    unless journey.accessible?(access_code)
       @availability_message = journey_configuration.availability_message
       render "static_pages/closed_for_submissions", status: :service_unavailable
     end

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -11,9 +11,20 @@ module PartOfClaimJourney
   private
 
   def check_whether_closed_for_submissions
-    unless journey_configuration.open_for_submissions?
+    unless journey.open_for_submissions?(access_code)
       @availability_message = journey_configuration.availability_message
       render "static_pages/closed_for_submissions", status: :service_unavailable
+    end
+  end
+
+  def access_code
+    if journey_session
+      journey_session.answers.service_access_code
+    else
+      # We've been redirected from the landing page and this callback
+      # is running before the new action, so we're yet to create the
+      # journey session.
+      params.fetch(:answers, {})[:service_access_code]
     end
   end
 

--- a/app/controllers/journeys/early_years_payment/provider/start/static_pages_controller.rb
+++ b/app/controllers/journeys/early_years_payment/provider/start/static_pages_controller.rb
@@ -4,7 +4,7 @@ module Journeys
       module Start
         class StaticPagesController < BasePublicController
           def guidance
-            @journey_open = journey.open_for_submissions?(params[:service_access_code])
+            @journey_open = journey.accessible?(params[:service_access_code])
             render "#{journey::VIEW_PATH}/guidance"
           end
         end

--- a/app/controllers/journeys/early_years_payment/provider/start/static_pages_controller.rb
+++ b/app/controllers/journeys/early_years_payment/provider/start/static_pages_controller.rb
@@ -4,7 +4,7 @@ module Journeys
       module Start
         class StaticPagesController < BasePublicController
           def guidance
-            @journey_open = journey.configuration.open_for_submissions?
+            @journey_open = journey.open_for_submissions?(params[:service_access_code])
             render "#{journey::VIEW_PATH}/guidance"
           end
         end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -13,7 +13,8 @@ class StaticPagesController < BasePublicController
 
   def landing_page
     @academic_year = journey.configuration.current_academic_year
-    @journey_open = journey.configuration.open_for_submissions?
+
+    @journey_open = journey.open_for_submissions?(params[:service_access_code])
 
     render "#{journey::VIEW_PATH}/landing_page"
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -14,7 +14,7 @@ class StaticPagesController < BasePublicController
   def landing_page
     @academic_year = journey.configuration.current_academic_year
 
-    @journey_open = journey.open_for_submissions?(params[:service_access_code])
+    @journey_open = journey.accessible?(params[:service_access_code])
 
     render "#{journey::VIEW_PATH}/landing_page"
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,6 +3,7 @@ class SubmissionsController < BasePublicController
   include ClaimSubmission
 
   skip_before_action :send_unstarted_claimants_to_the_start, only: [:show]
+  skip_before_action :check_whether_closed_for_submissions, only: [:show]
 
   def create
     create_and_save_claim_form

--- a/app/forms/claim_submission_base_form.rb
+++ b/app/forms/claim_submission_base_form.rb
@@ -22,6 +22,7 @@ class ClaimSubmissionBaseForm
     ApplicationRecord.transaction do
       set_attributes_for_claim_submission
       claim.save!
+      mark_service_access_code_as_used!
     end
 
     claim.policy.mailer.submitted(claim).deliver_later
@@ -72,6 +73,14 @@ class ClaimSubmissionBaseForm
     claim.policy_options_provided = generate_policy_options_provided
     claim.reference ||= generate_reference
     set_submitted_at_attributes
+  end
+
+  def mark_service_access_code_as_used!
+    access_code = Journeys::ServiceAccessCode.find_by(
+      code: answers.service_access_code,
+      journey: journey_session.journey_class
+    )
+    access_code&.mark_as_used!
   end
 
   def set_submitted_at_attributes

--- a/app/forms/journeys/session_form.rb
+++ b/app/forms/journeys/session_form.rb
@@ -3,6 +3,8 @@ module Journeys
     include ActiveModel::Model
     include ActiveModel::Attributes
 
+    attribute :service_access_code, :string
+
     def self.create!(params)
       new(params).tap(&:save!).journey_session
     end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -91,6 +91,11 @@ module Journeys
       false
     end
 
+    def open_for_submissions?(code = nil)
+      configuration.open_for_submissions? ||
+        ServiceAccessCode.permits_access?(code: code, journey: self)
+    end
+
     private
 
     def all_forms

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -91,7 +91,7 @@ module Journeys
       false
     end
 
-    def open_for_submissions?(code = nil)
+    def accessible?(code = nil)
       configuration.open_for_submissions? ||
         ServiceAccessCode.permits_access?(code: code, journey: self)
     end

--- a/app/models/journeys/service_access_code.rb
+++ b/app/models/journeys/service_access_code.rb
@@ -1,0 +1,35 @@
+module Journeys
+  class ServiceAccessCode < ApplicationRecord
+    scope :for_journey, ->(journey) { where(journey: journey) }
+
+    scope :used, -> do
+      joins(
+        <<~SQL
+          JOIN journeys_sessions
+          ON journeys_service_access_codes.code = journeys_sessions.answers ->> 'service_access_code'
+        SQL
+      ).merge(Journeys::Session.submitted)
+    end
+
+    scope :unused, -> { where.not(id: used) }
+
+    after_initialize -> { self.code = generate_code if code.blank? }
+
+    normalizes :journey, with: -> { it.to_s }
+
+    validates :code, presence: true, uniqueness: true
+
+    def self.permits_access?(code:, journey:)
+      code.present? && for_journey(journey).unused.exists?(code: code)
+    end
+
+    private
+
+    def generate_code
+      loop {
+        code = Reference.new.to_s
+        break code unless self.class.exists?(code: code)
+      }
+    end
+  end
+end

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -15,6 +15,8 @@ module Journeys
 
     scope :unsubmitted, -> { where.missing(:claim) }
 
+    scope :submitted, -> { joins(:claim) }
+
     scope :purgeable, -> do
       unsubmitted.where(journeys_sessions: {updated_at: ..24.hours.ago})
     end

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -7,7 +7,7 @@ module Journeys
     include Sessions::PiiAttributes
     include BooleanAttributes
 
-    attribute :service_access_code, :string, pii: true
+    attribute :service_access_code, :string, pii: false
 
     attribute :current_school_id, :string, pii: false # UUID
     attribute :address_line_1, :string, pii: true

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -7,6 +7,8 @@ module Journeys
     include Sessions::PiiAttributes
     include BooleanAttributes
 
+    attribute :service_access_code, :string, pii: true
+
     attribute :current_school_id, :string, pii: false # UUID
     attribute :address_line_1, :string, pii: true
     attribute :address_line_2, :string, pii: true

--- a/app/views/additional_payments/landing_page.html.erb
+++ b/app/views/additional_payments/landing_page.html.erb
@@ -37,7 +37,7 @@
       </p>
 
       <p class="govuk-!-margin-top-8">
-        <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="<%= claim_path(current_journey_routing_name, "claim", answers: { service_access_code: params[:service_access_code] }) %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>

--- a/app/views/early_years_payment/provider/start/landing_page.html.erb
+++ b/app/views/early_years_payment/provider/start/landing_page.html.erb
@@ -92,7 +92,7 @@
 
     <%# TODO: There isn't any journey closed content, for now hide the button %>
     <% if @journey_open %>
-      <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>
+      <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim", answers: { service_access_code: params[:service_access_code] })) %>
     <% end %>
   </div>
 </div>

--- a/app/views/further_education_payments/landing_page.html.erb
+++ b/app/views/further_education_payments/landing_page.html.erb
@@ -34,7 +34,7 @@
 
     <%# TODO: There isn't any journey closed content, for now hide the button %>
     <% if @journey_open %>
-      <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim")) %>
+      <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim", answers: { service_access_code: params[:service_access_code] })) %>
     <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">Eligibility criteria</h2>

--- a/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/landing_page.html.erb
@@ -61,7 +61,7 @@
      <%# TODO: There isn't any journey closed content, for now hide the button %>
      <% if @journey_open %>
      <p class="govuk-body">
-       <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      <a href="<%= claim_path(current_journey_routing_name, "claim", answers: { service_access_code: params[:service_access_code] }) %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
          Start
          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>

--- a/app/views/student_loans/landing_page.html.erb
+++ b/app/views/student_loans/landing_page.html.erb
@@ -32,7 +32,7 @@
     <%# TODO: There isn't any journey closed content, for now hide the button %>
     <% if @journey_open %>
     <p class="govuk-!-margin-top-8">
-        <a href="<%= claim_path(current_journey_routing_name, "claim") %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      <a href="<%= claim_path(current_journey_routing_name, "claim", answers: { service_access_code: params[:service_access_code] }) %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -121,3 +121,9 @@
   - number_of_rows
   :targeted_retention_incentive_payments_awards:
   - file_upload_id
+  :journeys_service_access_codes:
+  - id
+  - code
+  - journey
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -124,6 +124,7 @@
   :journeys_service_access_codes:
   - id
   - code
+  - used
   - journey
   - created_at
   - updated_at

--- a/db/migrate/20250207140932_create_journeys_service_access_codes.rb
+++ b/db/migrate/20250207140932_create_journeys_service_access_codes.rb
@@ -1,0 +1,10 @@
+class CreateJourneysServiceAccessCodes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :journeys_service_access_codes, id: :uuid do |t|
+      t.string :code, null: false, index: {unique: true}
+      t.string :journey, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250226151104_add_used_to_journeys_service_access_codes.rb
+++ b/db/migrate/20250226151104_add_used_to_journeys_service_access_codes.rb
@@ -1,0 +1,5 @@
+class AddUsedToJourneysServiceAccessCodes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :journeys_service_access_codes, :used, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -314,6 +314,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_150905) do
     t.index ["created_at"], name: "index_journey_configurations_on_created_at"
   end
 
+  create_table "journeys_service_access_codes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "code", null: false
+    t.string "journey", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_journeys_service_access_codes_on_code", unique: true
+  end
+
   create_table "journeys_sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.jsonb "answers", default: {}
     t.string "journey", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_18_150905) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_26_151104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -319,6 +319,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_150905) do
     t.string "journey", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "used", default: false, null: false
     t.index ["code"], name: "index_journeys_service_access_codes_on_code", unique: true
   end
 

--- a/spec/factories/journeys/service_access_code.rb
+++ b/spec/factories/journeys/service_access_code.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :service_access_code, class: "Journeys::ServiceAccessCode" do
+    journey { Journeys::FurtherEducationPayments }
+  end
+end

--- a/spec/factories/journeys/service_access_code.rb
+++ b/spec/factories/journeys/service_access_code.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :service_access_code, class: "Journeys::ServiceAccessCode" do
     journey { Journeys::FurtherEducationPayments }
+    used { false }
   end
 end

--- a/spec/features/accessing_closed_service_spec.rb
+++ b/spec/features/accessing_closed_service_spec.rb
@@ -1,0 +1,191 @@
+require "rails_helper"
+
+RSpec.describe "Accessing a closed service" do
+  before do
+    create(
+      :journey_configuration,
+      :further_education_payments,
+      :closed,
+      availability_message: "This service is closed for submissions"
+    )
+  end
+
+  context "without a service access link" do
+    it "doesn't allow access to the start of the journey" do
+      visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+
+      expect(page).not_to have_content("Start now")
+    end
+
+    it "doesn't allow access to pages in the journey" do
+      visit claim_path(
+        Journeys::FurtherEducationPayments::ROUTING_NAME,
+        "teaching-responsibilities"
+      )
+
+      expect(page).to have_content("This service is closed for submissions")
+    end
+  end
+
+  context "with a service access link" do
+    it "allows the claimant to submit a claim" do
+      service_access_code = create(
+        :service_access_code,
+        journey: Journeys::FurtherEducationPayments
+      )
+
+      visit landing_page_path(
+        Journeys::FurtherEducationPayments::ROUTING_NAME,
+        service_access_code: service_access_code.code
+      )
+
+      click_on "Start now"
+
+      complete_fe_practitioner_journey
+
+      expect(page).to have_content(
+        "You applied for a further education targeted retention incentive payment"
+      )
+
+      # Check we don't permit code reused
+      visit landing_page_path(
+        Journeys::FurtherEducationPayments::ROUTING_NAME,
+        service_access_code: service_access_code.code
+      )
+
+      expect(page).not_to have_content("Start now")
+    end
+  end
+
+  context "with a service access link for a different journey" do
+    it "doesn't allow access to the journey" do
+      service_access_code = create(
+        :service_access_code,
+        journey: Journeys::GetATeacherRelocationPayment
+      )
+
+      visit landing_page_path(
+        Journeys::FurtherEducationPayments::ROUTING_NAME,
+        service_access_code: service_access_code.code
+      )
+
+      expect(page).not_to have_content("Start now")
+    end
+  end
+
+  def complete_fe_practitioner_journey
+    college = create(:school, :further_education, :fe_eligible)
+    # teaching-responsibilities
+    choose "Yes"
+    click_button "Continue"
+
+    # further-education-provision-search
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    # select-provision
+    choose college.name
+    click_button "Continue"
+
+    # contract-type
+    choose("Permanent contract")
+    click_button "Continue"
+
+    # teaching-hours-per-week
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    # further-education-teaching-start-year
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    # subjects-taught
+    check("Building and construction")
+    click_button "Continue"
+
+    # building-construction-courses
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    # hours-teaching-eligible-subjects
+    choose("Yes")
+    click_button "Continue"
+
+    # half-teaching-hours
+    choose "Yes"
+    click_button "Continue"
+
+    # teaching-qualification
+    choose("Yes")
+    click_button "Continue"
+
+    # poor-performance
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    # check-your-answers-part-one
+    click_button "Continue"
+
+    # eligible
+    click_button "Apply now"
+
+    sign_in_with_one_login
+
+    click_button "Continue"
+
+    # personal-details
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    click_button("Enter your address manually")
+
+    # address
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    # email-address
+    fill_in "Email address", with: "john.doe@example.com"
+    click_on "Continue"
+
+    # email-verification
+    mail = ActionMailer::Base.deliveries.last
+    otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
+    fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+    click_on "Confirm"
+
+    # provide-mobile-number
+    choose "No"
+    click_on "Continue"
+
+    # personal-bank-account
+    fill_in "Name on your account", with: "Jo Bloggs"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    # gender
+    choose "Female"
+    click_on "Continue"
+
+    # teacher-reference-number
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
+    click_on "Continue"
+
+    # check-your-answers
+    click_on "Accept and send"
+  end
+end

--- a/spec/models/journeys/service_access_code_spec.rb
+++ b/spec/models/journeys/service_access_code_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Journeys::ServiceAccessCode, type: :model do
+  describe ".unused" do
+    it "returns the used service access codes" do
+      unused_service_access_code = create(:service_access_code)
+
+      used_service_access_code = create(:service_access_code)
+
+      journey_session = create(
+        :further_education_payments_session,
+        answers: {
+          service_access_code: used_service_access_code.code
+        }
+      )
+
+      create(:claim, journey_session: journey_session)
+
+      expect(described_class.unused).to eq([unused_service_access_code])
+    end
+  end
+
+  describe "#permits_access?" do
+    context "when the code is blank" do
+      it "returns false" do
+        journey = Journeys::FurtherEducationPayments
+
+        code = ""
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be false
+      end
+    end
+
+    context "when the code is for a different journey" do
+      it "returns false" do
+        code = create(
+          :service_access_code,
+          journey: Journeys::FurtherEducationPayments
+        ).code
+
+        journey = Journeys::GetATeacherRelocationPayment
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be false
+      end
+    end
+
+    context "when the code is used" do
+      it "returns false" do
+        journey = Journeys::FurtherEducationPayments
+
+        service_access_code = create(:service_access_code, journey: journey)
+
+        code = service_access_code.code
+
+        journey_session = create(
+          :further_education_payments_session,
+          answers: {
+            service_access_code: service_access_code.code
+          }
+        )
+
+        create(:claim, journey_session: journey_session)
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be false
+      end
+    end
+
+    context "when the code is for the correct journey and unused" do
+      it "returns true" do
+        journey = Journeys::FurtherEducationPayments
+
+        code = create(:service_access_code, journey: journey).code
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be true
+      end
+    end
+  end
+end

--- a/spec/models/journeys/service_access_code_spec.rb
+++ b/spec/models/journeys/service_access_code_spec.rb
@@ -1,22 +1,67 @@
 require "rails_helper"
 
 RSpec.describe Journeys::ServiceAccessCode, type: :model do
-  describe ".unused" do
-    it "returns the used service access codes" do
-      unused_service_access_code = create(:service_access_code)
+  describe "scopes" do
+    describe ".used" do
+      it "returns access codes marked as used" do
+        used_code = create(:service_access_code, used: true)
+        unused_code = create(:service_access_code, used: false)
 
-      used_service_access_code = create(:service_access_code)
+        expect(described_class.used).to include(used_code)
+        expect(described_class.used).not_to include(unused_code)
+      end
+    end
+
+    describe ".unused" do
+      it "returns access codes not marked as used" do
+        used_code = create(:service_access_code, used: true)
+        unused_code = create(:service_access_code, used: false)
+
+        expect(described_class.unused).not_to include(used_code)
+        expect(described_class.unused).to include(unused_code)
+      end
+    end
+  end
+
+  describe "#mark_as_used!" do
+    it "marks the access code as used" do
+      code = create(:service_access_code)
+
+      expect { code.mark_as_used! }.to(
+        change { code.reload.used }.from(false).to(true)
+      )
+    end
+  end
+
+  describe "claim submission with service access code" do
+    it "marks the service access code as used when a claim is submitted" do
+      service_access_code = create(
+        :service_access_code,
+        journey: Journeys::FurtherEducationPayments
+      )
+
+      answers = attributes_for(
+        :further_education_payments_answers,
+        :submittable,
+        logged_in_with_onelogin: true,
+        onelogin_idv_first_name: "John",
+        onelogin_idv_last_name: "Doe",
+        onelogin_idv_full_name: "John Doe",
+        onelogin_idv_date_of_birth: Date.new(1970, 1, 1)
+      ).merge(service_access_code: service_access_code.code)
 
       journey_session = create(
         :further_education_payments_session,
-        answers: {
-          service_access_code: used_service_access_code.code
-        }
+        answers: answers
       )
 
-      create(:claim, journey_session: journey_session)
+      form = Journeys::FurtherEducationPayments::ClaimSubmissionForm.new(
+        journey_session: journey_session
+      )
 
-      expect(described_class.unused).to eq([unused_service_access_code])
+      expect(form.save).to be true
+
+      expect(service_access_code.reload.used?).to be true
     end
   end
 
@@ -52,18 +97,13 @@ RSpec.describe Journeys::ServiceAccessCode, type: :model do
       it "returns false" do
         journey = Journeys::FurtherEducationPayments
 
-        service_access_code = create(:service_access_code, journey: journey)
-
-        code = service_access_code.code
-
-        journey_session = create(
-          :further_education_payments_session,
-          answers: {
-            service_access_code: service_access_code.code
-          }
+        service_access_code = create(
+          :service_access_code,
+          journey: journey,
+          used: true
         )
 
-        create(:claim, journey_session: journey_session)
+        code = service_access_code.code
 
         expect(
           described_class.permits_access?(code: code, journey: journey)


### PR DESCRIPTION
Adds service access code

Service access codes are a mechanism for allowing claimants to access
the service outside of the claim window.
These links will be created adhoc by developers in the console

```rb
Journeys::ServiceAccessCode.create!(
  journey: Journeys::FurtherEducationPayments
)
```

Some of the journeys are started via an email link
* FE provider
* EY provider authenticated
* EY practition

For these journeys we can either
* open the journey as needed (should be ok as they're not generally
  accessible)
* manually construct the links to include a service access code and tell
  the users to ignore links received by email
* update the code to include service access codes in any emails if the
  emails were triggered by a session containing a service access code

For now we've not implemented any specific code to handle these journeys
as we may not need it / can get by with work arounds.

