### PR TITLE
Navigator supports changing answers

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -49,8 +49,8 @@ class Form
   end
 
   def url
-    if journey.use_navigator? && params[:change] == "true"
-      claim_path(journey::ROUTING_NAME, params[:slug], change: true)
+    if journey.use_navigator? && params[:change].present?
+      claim_path(journey::ROUTING_NAME, params[:slug], change: params[:change])
     else
       claim_path(journey::ROUTING_NAME, params[:slug])
     end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -4,6 +4,7 @@ class Form
   include ActiveModel::Serialization
   include ActiveModel::Validations::Callbacks
   include FormHelpers
+  include Rails.application.routes.url_helpers
 
   attr_accessor :journey
   attr_accessor :journey_session
@@ -45,6 +46,14 @@ class Form
   # and should be implemented on per form basis
   # if the forms stores data to session
   def clear_answers_from_session
+  end
+
+  def url
+    if journey.use_navigator? && params[:change] == "true"
+      claim_path(journey::ROUTING_NAME, params[:slug], change: true)
+    else
+      claim_path(journey::ROUTING_NAME, params[:slug])
+    end
   end
 
   private

--- a/app/forms/journeys/further_education_payments/building_construction_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/building_construction_courses_form.rb
@@ -52,8 +52,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(building_construction_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("building_construction")
+          journey_session.answers.assign_attributes(building_construction_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/chemistry_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/chemistry_courses_form.rb
@@ -48,8 +48,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(chemistry_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("chemistry")
+          journey_session.answers.assign_attributes(chemistry_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/computing_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/computing_courses_form.rb
@@ -64,8 +64,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(computing_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("computing")
+          journey_session.answers.assign_attributes(computing_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/early_years_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/early_years_courses_form.rb
@@ -48,8 +48,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(early_years_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("early_years")
+          journey_session.answers.assign_attributes(early_years_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/engineering_manufacturing_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/engineering_manufacturing_courses_form.rb
@@ -60,8 +60,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(engineering_manufacturing_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("engineering_manufacturing")
+          journey_session.answers.assign_attributes(engineering_manufacturing_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
@@ -34,11 +34,6 @@ module Journeys
         journey_session.save!
       end
 
-      def clear_answers_from_session
-        journey_session.answers.assign_attributes(further_education_teaching_start_year: nil)
-        journey_session.save!
-      end
-
       def before_year
         academic_year = AcademicYear.current + YEARS_BEFORE
         academic_year.start_year

--- a/app/forms/journeys/further_education_payments/half_teaching_hours_form.rb
+++ b/app/forms/journeys/further_education_payments/half_teaching_hours_form.rb
@@ -22,11 +22,6 @@ module Journeys
         journey_session.answers.assign_attributes(half_teaching_hours:)
         journey_session.save!
       end
-
-      def clear_answers_from_session
-        journey_session.answers.assign_attributes(half_teaching_hours: nil)
-        journey_session.save!
-      end
     end
   end
 end

--- a/app/forms/journeys/further_education_payments/maths_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/maths_courses_form.rb
@@ -40,8 +40,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(maths_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("maths")
+          journey_session.answers.assign_attributes(maths_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/physics_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/physics_courses_form.rb
@@ -48,8 +48,10 @@ module Journeys
       end
 
       def clear_answers_from_session
-        journey_session.answers.assign_attributes(physics_courses: [])
-        journey_session.save!
+        if answers.subjects_taught.exclude?("physics")
+          journey_session.answers.assign_attributes(physics_courses: [])
+          journey_session.save!
+        end
       end
 
       private

--- a/app/forms/journeys/further_education_payments/subjects_taught_form.rb
+++ b/app/forms/journeys/further_education_payments/subjects_taught_form.rb
@@ -23,11 +23,6 @@ module Journeys
         journey_session.save!
       end
 
-      def clear_answers_from_session
-        journey_session.answers.assign_attributes(subjects_taught: [])
-        journey_session.save!
-      end
-
       private
 
       def clean_subjects_taught

--- a/app/forms/journeys/further_education_payments/teaching_qualification_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_qualification_form.rb
@@ -34,11 +34,6 @@ module Journeys
         journey_session.answers.assign_attributes(teaching_qualification:)
         journey_session.save!
       end
-
-      def clear_answers_from_session
-        journey_session.answers.assign_attributes(teaching_qualification: nil)
-        journey_session.save!
-      end
     end
   end
 end

--- a/app/forms/poor_performance_form.rb
+++ b/app/forms/poor_performance_form.rb
@@ -36,12 +36,4 @@ class PoorPerformanceForm < Form
     )
     journey_session.save
   end
-
-  def clear_answers_from_session
-    journey_session.answers.assign_attributes(
-      subject_to_formal_performance_action: nil,
-      subject_to_disciplinary_action: nil
-    )
-    journey_session.save
-  end
 end

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -57,6 +57,12 @@ module Journeys
             return slug
           end
 
+          if changing_answer?
+            return slug if form == forms.last
+
+            next
+          end
+
           if current_slug == slug
             current_index = forms.index(form)
             next_index = current_index + 1
@@ -144,6 +150,10 @@ module Journeys
     end
 
     private
+
+    def changing_answer?
+      params[:change] == "true"
+    end
 
     def impermissible_forms
       all_forms.reject do |form|

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -59,6 +59,7 @@ module Journeys
 
           if changing_answer?
             return slug if form == forms.last
+            return slug if params[:change] == slug
 
             next
           end
@@ -152,7 +153,7 @@ module Journeys
     private
 
     def changing_answer?
-      params[:change] == "true"
+      params[:change].present?
     end
 
     def impermissible_forms

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -4,20 +4,16 @@
   </h2>
 <% end %>
 
-<dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%- answers.each do |(label, answer, slug)| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label %>
-      </dt>
-
-      <dd class="govuk-summary-list__value">
-        <%= answer %>
-      </dd>
-
-      <dd class="govuk-summary-list__actions">
-        <%= link_to('Change', claim_path(current_journey_routing_name, slug), class: 'govuk-link', 'aria-label': "Change #{label.downcase}") unless slug.nil? %>
-      </dd>
-    </div>
+<div class="govuk-!-margin-bottom-9">
+  <%= govuk_summary_list do |summary_list| %>
+    <%- answers.each do |(label, answer, slug)| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { label } %>
+        <% row.with_value { answer } %>
+        <% if slug.present? %>
+          <% row.with_action(text: "Change", href: claim_path(current_journey_routing_name, slug), visually_hidden_text: label.downcase) %>
+        <% end %>
+      <% end %>
+    <% end %>
   <% end %>
-</dl>
+</div>

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -11,7 +11,7 @@
         <% row.with_key { label } %>
         <% row.with_value { answer } %>
         <% if slug.present? %>
-          <% row.with_action(text: "Change", href: claim_path(current_journey_routing_name, slug), visually_hidden_text: label.downcase) %>
+          <% row.with_action(text: "Change", href: claim_path(current_journey_routing_name, slug, change: true), visually_hidden_text: label.downcase) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -4,6 +4,8 @@
   </h2>
 <% end %>
 
+<% change_slug = journey.slug_for_form(form: @form) %>
+
 <div class="govuk-!-margin-bottom-9">
   <%= govuk_summary_list do |summary_list| %>
     <%- answers.each do |(label, answer, slug)| %>
@@ -11,7 +13,7 @@
         <% row.with_key { label } %>
         <% row.with_value { answer } %>
         <% if slug.present? %>
-          <% row.with_action(text: "Change", href: claim_path(current_journey_routing_name, slug, change: true), visually_hidden_text: label.downcase) %>
+          <% row.with_action(text: "Change", href: claim_path(current_journey_routing_name, slug, change: change_slug), visually_hidden_text: label.downcase) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/claims/_confirmation_form.html.erb
+++ b/app/views/claims/_confirmation_form.html.erb
@@ -1,4 +1,4 @@
-  <%= form_for form, url: claim_path(current_journey_routing_name) do |f| %>
+  <%= form_for form, url: @form.url do |f| %>
     <%= f.hidden_field :details_check %>
     <%= f.hidden_field :logged_in_with_tid %>
     <%= form_group_tag f.object do %>

--- a/app/views/claims/_current_school_search.html.erb
+++ b/app/views/claims/_current_school_search.html.erb
@@ -2,7 +2,7 @@
 <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { school_search: "school_search" }) if @form.errors.any? %>
 
 <%= form_for @form,
-             url: claim_path(current_journey_routing_name),
+             url: @form.url,
              method: :get,
              data: {
                "school-id-param": "claim_current_school_id",

--- a/app/views/claims/_current_school_search_results.html.erb
+++ b/app/views/claims/_current_school_search_results.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, page_title(question, journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { "current_school_id": "claim_current_school_id_#{@form.schools.first.id}" }) if @form.errors.any? %>
 
-<%= form_for @form, url: claim_path(current_journey_routing_name), method: :patch do |form| %>
+<%= form_for @form, url: @form.url, method: :patch do |form| %>
   <%= form_group_tag @form do %>
     <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
       <%= render "#{@form.view_path}/claims/current_school_search_results_question", question: question %>

--- a/app/views/claims/_email_address.html.erb
+++ b/app/views/claims/_email_address.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <% caption_settings = { text: t("questions.personal_details"), size: "xl" } if show_caption %>

--- a/app/views/claims/_mobile_number.html.erb
+++ b/app/views/claims/_mobile_number.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <% caption_settings = { text: t("questions.personal_details"), size: "xl" } if show_caption %>

--- a/app/views/claims/_one_time_password.html.erb
+++ b/app/views/claims/_one_time_password.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <% caption_settings = { text: "#{email_or_mobile == "email" ? "Email address" : "Mobile number"} verification", size: "xl" } if show_caption %>

--- a/app/views/claims/_personal_details_page.html.erb
+++ b/app/views/claims/_personal_details_page.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-<%= heading_size %>">

--- a/app/views/claims/_provide_mobile_number.html.erb
+++ b/app/views/claims/_provide_mobile_number.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <% caption_settings = { text: t("questions.personal_details"), size: "xl" } if show_caption %>

--- a/app/views/claims/_sign_in_3_identified.html.erb
+++ b/app/views/claims/_sign_in_3_identified.html.erb
@@ -6,6 +6,6 @@
   You can now continue with your application.
 </p>
 
-<%= form_with model: @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= form_with model: @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: {

--- a/app/views/claims/correct_school.html.erb
+++ b/app/views/claims/correct_school.html.erb
@@ -1,6 +1,6 @@
 <%= render("shared/error_summary", instance: @form) if @form.errors.any? %>
 
-<%= form_for @form, url: claim_path(current_journey_routing_name) do |form| %>
+<%= form_for @form, url: @form.url do |form| %>
   <%= form_group_tag form.object do %>
     <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
       <legend class="govuk-fieldset__legend <%= fieldset_legend_css_class_for_journey(journey) %>">

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(

--- a/app/views/claims/personal_bank_account.html.erb
+++ b/app/views/claims/personal_bank_account.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: {

--- a/app/views/claims/postcode_search.html.erb
+++ b/app/views/claims/postcode_search.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if @form.errors.any? %>

--- a/app/views/claims/reset_claim.erb
+++ b/app/views/claims/reset_claim.erb
@@ -16,7 +16,7 @@
         You can continue to complete an application to check your eligibility and apply for a payment.
       </p>
 
-      <%= form_with model: @form, url: claim_path(current_journey_routing_name) do %>
+      <%= form_with model: @form, url: @form.url do %>
         <div class="govuk-form-group">
           <%= hidden_field_tag :skip_landing_page, 'true' %>
           <%= submit_tag 'Continue', class: 'govuk-button', data: { module: 'govuk-button' }, 'data-disable-with' => 'Continue' %>

--- a/app/views/claims/select_email.html.erb
+++ b/app/views/claims/select_email.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { email_address_check: "claim_email_address_check_true", email_address: "claim_email_address_check_false" }) if @form.errors.any? %>
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
+    <%= form_for @form, url: @form.url do |f| %>
       <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
       <%= form_group_tag @form do %>
 

--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <%= form.govuk_error_summary %>
 
       <div class="govuk-!-margin-bottom-5">

--- a/app/views/claims/select_mobile.html.erb
+++ b/app/views/claims/select_mobile.html.erb
@@ -17,8 +17,8 @@
         }
       ) %>
     <% end %>
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
 
+    <%= form_for @form, url: @form.url do |f| %>
       <span class="govuk-caption-xl"><%= t("questions.personal_details") %></span>
       <%= form_group_tag f.object do %>
 

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :teacher_reference_number,

--- a/app/views/further_education_payments/claims/_courses.html.erb
+++ b/app/views/further_education_payments/claims/_courses.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_check_boxes_fieldset @form.course_field,

--- a/app/views/further_education_payments/claims/contract_type.html.erb
+++ b/app/views/further_education_payments/claims/contract_type.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :contract_type, @form.radio_options, :id, :name, :hint,

--- a/app/views/further_education_payments/claims/fixed_term_contract.html.erb
+++ b/app/views/further_education_payments/claims/fixed_term_contract.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :fixed_term_full_year, @form.radio_options, :id, :name,

--- a/app/views/further_education_payments/claims/further_education_teaching_start_year.html.erb
+++ b/app/views/further_education_payments/claims/further_education_teaching_start_year.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :further_education_teaching_start_year,

--- a/app/views/further_education_payments/claims/half_teaching_hours.html.erb
+++ b/app/views/further_education_payments/claims/half_teaching_hours.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :half_teaching_hours,

--- a/app/views/further_education_payments/claims/hours_teaching_eligible_subjects.html.erb
+++ b/app/views/further_education_payments/claims/hours_teaching_eligible_subjects.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :hours_teaching_eligible_subjects,

--- a/app/views/further_education_payments/claims/poor_performance.html.erb
+++ b/app/views/further_education_payments/claims/poor_performance.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/app/views/further_education_payments/claims/postcode_search.html.erb
+++ b/app/views/further_education_payments/claims/postcode_search.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.hidden_field :skip_postcode_search, value: "false" %>
 
       <%= f.govuk_error_summary %>

--- a/app/views/further_education_payments/claims/subjects_taught.html.erb
+++ b/app/views/further_education_payments/claims/subjects_taught.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_check_boxes_fieldset :subjects_taught,

--- a/app/views/further_education_payments/claims/taught_at_least_one_term.html.erb
+++ b/app/views/further_education_payments/claims/taught_at_least_one_term.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :taught_at_least_one_term, @form.radio_options, :id, :name,

--- a/app/views/further_education_payments/claims/teacher_reference_number.html.erb
+++ b/app/views/further_education_payments/claims/teacher_reference_number.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_for @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/app/views/further_education_payments/claims/teaching_hours_per_week.html.erb
+++ b/app/views/further_education_payments/claims/teaching_hours_per_week.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :teaching_hours_per_week, @form.radio_options, :id, :name,

--- a/app/views/further_education_payments/claims/teaching_hours_per_week_next_term.html.erb
+++ b/app/views/further_education_payments/claims/teaching_hours_per_week_next_term.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :teaching_hours_per_week_next_term, @form.radio_options, :id, :name,

--- a/app/views/further_education_payments/claims/teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/claims/teaching_responsibilities.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: claim_path(current_journey_routing_name), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       slug: "check-your-answers"
     )
 
-    find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught")}']").click
+    click_link "Change which of the following subjects did you teach at #{session.answers.claim_school.name.downcase} between 6 april 2022 and 5 april 2023?"
 
     expect(find("#claim_physics_taught").checked?).to eq(true)
 
@@ -59,7 +59,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       journey_session: session
     )
 
-    find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "qts-year")}']").click
+    click_link "Change when did you complete your initial teacher training (itt)?"
 
     expect(find("#claim_qts_award_year_on_or_after_cut_off_date").checked?).to eq(true)
 
@@ -87,7 +87,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     new_claim_school = create(:school, :student_loans_eligible, name: "Claim School")
 
-    find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "claim-school")}']").click
+    click_link "Change which school were you employed to teach at between 6 april 2022 and 5 april 2023?"
 
     choose_school new_claim_school
 
@@ -136,7 +136,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       journey_session: session
     )
 
-    find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "leadership-position")}']").click
+    click_link "Change were you employed in a leadership position between 6 april 2022 and 5 april 2023?"
 
     choose "Yes"
     click_on "Continue"
@@ -167,7 +167,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       journey_session: session
     )
 
-    find("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught")}']").click
+    click_link "Change which of the following subjects did you teach at #{session.answers.claim_school.name.downcase} between 6 april 2022 and 5 april 2023?"
 
     expect(find("#claim_physics_taught").checked?).to eq(true)
 
@@ -213,7 +213,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       amount: 50
     )
 
-    page.first("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "personal-details")}']", minimum: 1).click
+    click_link "Change what is your national insurance number?"
     fill_in "National Insurance number", with: "AB123456C"
     click_on "Continue"
 
@@ -250,7 +250,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       new_middle_name = "Janet #{old_middle_name}"
 
       expect {
-        page.first("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "personal-details")}']", minimum: 1).click
+        click_link "Change what is your full name?"
         fill_in "Middle names", with: new_middle_name
         click_on "Continue"
       }.to change {
@@ -273,11 +273,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
       expect(page).to have_content(I18n.t("forms.address.questions.your_address"))
       expect(page).to have_content(I18n.t("questions.date_of_birth"))
       expect(page).to have_content(I18n.t("forms.gender.questions.payroll_gender"))
-      expect(page).to have_selector(:css, "a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "personal-details")}']")
-      expect(page).to have_selector(:css, "a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "address")}']")
-      expect(page).to have_selector(:css, "a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "gender")}']")
+      expect(page).to have_link("Change what is your full name?")
+      expect(page).to have_link("Change what is your address?")
+      expect(page).to have_link("Change how is your gender recorded on your school’s payroll system?")
 
-      page.first("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "personal-details")}']", minimum: 1).click
+      click_link "Change what is your full name?"
       fill_in "First name", with: "Bobby"
       click_on "Continue"
 
@@ -319,7 +319,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         new_email = "fiona.adouboux@protonmail.com"
 
         expect {
-          page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "email-address")}']", minimum: 1).click
+          click_link "Change email address"
           fill_in "Email address", with: new_email
           click_on "Continue"
         }.to change {
@@ -345,7 +345,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       end
 
       scenario "entering same email address - passcode email is not sent" do
-        page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "email-address")}']", minimum: 1).click
+        click_link "Change email address"
         click_on "Continue"
 
         expect(page).to have_content("Check your answers before sending your application")
@@ -377,7 +377,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
       scenario "is asked to provide the OTP challenge code for validation" do
         expect {
-          page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "provide-mobile-number")}']", minimum: 1).click
+          click_link "Change would you like to provide your mobile number?"
           choose "Yes"
           click_on "Continue"
         }.to change {
@@ -439,7 +439,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         old_mobile = session.answers.mobile_number
 
         expect {
-          page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "mobile-number")}']", minimum: 1).click
+          click_link "Change mobile number"
           fill_in "Mobile number", with: new_mobile
           click_on "Continue"
         }.to change {
@@ -466,7 +466,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
       end
 
       scenario "entering same mobile number - is not asked to provide the OTP challenge code for validation" do
-        page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "mobile-number")}']", minimum: 1).click
+        click_link "Change mobile number"
         click_on "Continue"
 
         expect(page).to have_content("Check your answers before sending your application")

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -221,6 +221,6 @@ RSpec.feature "Combined journey with Teacher ID mobile check" do
   end
 
   def go_back_to_mobile_selection
-    page.first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "select-mobile")}']", minimum: 1).click
+    click_link "Change which mobile number should we use to contact you?"
   end
 end

--- a/spec/features/early_years_payment/provider/authenticated/changing_answers_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/changing_answers_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Early years payment provider" do
     when_early_years_payment_provider_start_journey_completed
     when_early_years_payment_provider_authenticated_journey_ready_to_submit
 
-    find("a[href='#{claim_path(Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME, "paye-reference")}']").click
+    click_link "Change employer’s paye reference number"
     expect(page).to have_content("What is #{nursery.nursery_name}’s employer PAYE reference?")
     fill_in "claim-paye-reference-field", with: "123/A"
     click_button "Continue"
@@ -65,7 +65,7 @@ RSpec.feature "Early years payment provider" do
     click_button "Continue"
 
     expect(page).to have_content "Check your answers before submitting this claim"
-    find("a[href='#{claim_path(Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME, "returner-worked-with-children")}']").click
+    click_link "Change employee’s previous role in an early years setting involved working mostly with children"
 
     expect(page).to have_content("previous role in an early years setting involve mostly working directly with children?")
     choose "No"
@@ -73,7 +73,7 @@ RSpec.feature "Early years payment provider" do
 
     expect(page).to have_content "Check your answers before submitting this claim"
     expect(page).not_to have_content "Contract type"
-    find("a[href='#{claim_path(Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME, "returner-worked-with-children")}']").click
+    click_link "Change employee’s previous role in an early years setting involved working mostly with children"
 
     expect(page).to have_content("previous role in an early years setting involve mostly working directly with children?")
     choose "Yes"

--- a/spec/features/further_education_payments/change_answers_spec.rb
+++ b/spec/features/further_education_payments/change_answers_spec.rb
@@ -269,10 +269,6 @@ RSpec.feature "Further education change answers" do
     choose "Yes"
     click_button "Continue"
 
-    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to")
-    choose "Yes"
-    click_button "Continue"
-
     expect(page).to have_content("Check your answers")
     click_button "Continue"
 

--- a/spec/features/further_education_payments/change_answers_spec.rb
+++ b/spec/features/further_education_payments/change_answers_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.feature "Further education change answers" do
+  include ActionView::Helpers::NumberHelper
+
+  let(:college) { create(:school, :further_education, :fe_eligible) }
+  let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
+
+  scenario "without side effects redirects back to check answers" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
+    check("Chemistry")
+    check("Computing, including digital and ICT")
+    check("Early years")
+    check("Engineering and manufacturing, including transport engineering and electronics")
+    check("Maths")
+    check("Physics")
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Which chemistry courses do you teach?")
+    check "GCSE chemistry"
+    click_button "Continue"
+
+    expect(page).to have_content("Which computing courses do you teach?")
+    check "T Level in digital support services"
+    click_button "Continue"
+
+    expect(page).to have_content("Which early years courses do you teach?")
+    check "T Level in education and early years (early years educator)"
+    click_button "Continue"
+
+    expect(page).to have_content("Which engineering and manufacturing courses do you teach?")
+    check "T Level in design and development for engineering and manufacturing"
+    click_button "Continue"
+
+    expect(page).to have_content("Which maths courses do you teach?")
+
+    check("claim-maths-courses-approved-level-321-maths-field")
+    click_button "Continue"
+
+    expect(page).to have_content("Which physics courses do you teach?")
+    check "A or AS level physics"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    expect(page).to have_content("T Level in building services engineering for construction")
+    expect(page).to have_content("GCSE chemistry")
+    expect(page).to have_content("T Level in digital support services")
+    expect(page).to have_content("T Level in education and early years (early years educator)")
+    expect(page).to have_content("T Level in design and development for engineering and manufacturing")
+    expect(page).to have_content("Qualifications approved for funding at level 3 and below in the")
+    expect(page).to have_content("A or AS level physics")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you subject to any formal performance measures as a result of continuous poor teaching standards")
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    expect(page).to have_content("Are you currently subject to disciplinary action?")
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a targeted retention incentive payment")
+    expect(page).to have_content(number_to_currency(expected_award_amount, precision: 0))
+    expect(page).to have_content("Apply now")
+    click_button "Apply now"
+
+    sign_in_with_one_login
+
+    expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
+    click_button "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    expect(page).to have_content("What is your home address?")
+    click_button("Enter your address manually")
+
+    expect(page).to have_content("What is your address?")
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    expect(page).to have_content("Email address")
+    fill_in "Email address", with: "john.doe@example.com"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter the 6-digit passcode")
+    mail = ActionMailer::Base.deliveries.last
+    otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
+    fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+    click_on "Confirm"
+
+    expect(page).to have_content("Would you like to provide your mobile number?")
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter your personal bank account details")
+    fill_in "Name on your account", with: "Jo Bloggs"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    expect(page).to have_content("How is your gender recorded on your employer’s payroll system?")
+    choose "Female"
+    click_on "Continue"
+
+    expect(page).to have_content("Teacher reference number (TRN)")
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
+    click_on "Continue"
+
+    expect(page).to have_content("Check your answers before sending your application")
+    click_link("Change how is your gender recorded on your employer’s payroll system?")
+
+    expect(page).to have_content "How is your gender recorded on your employer’s payroll system?"
+    uri = URI.parse(page.current_url)
+    expect(uri.query).to eql "change=true"
+    choose "Male"
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers before sending your application")
+    expect(page).to have_content("Male")
+  end
+
+  def and_college_exists
+    college
+  end
+end

--- a/spec/features/further_education_payments/change_answers_spec.rb
+++ b/spec/features/further_education_payments/change_answers_spec.rb
@@ -182,7 +182,193 @@ RSpec.feature "Further education change answers" do
     expect(page).to have_content("Male")
   end
 
+  scenario "after eligibility check with side effects, answers new questions then redirects back to check answers" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
+    check("Computing, including digital and ICT")
+    check("Early years")
+    check("Engineering and manufacturing, including transport engineering and electronics")
+    check("Maths")
+    check("Physics")
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Which computing courses do you teach?")
+    check "T Level in digital support services"
+    click_button "Continue"
+
+    expect(page).to have_content("Which early years courses do you teach?")
+    check "T Level in education and early years (early years educator)"
+    click_button "Continue"
+
+    expect(page).to have_content("Which engineering and manufacturing courses do you teach?")
+    check "T Level in design and development for engineering and manufacturing"
+    click_button "Continue"
+
+    expect(page).to have_content("Which maths courses do you teach?")
+
+    check("claim-maths-courses-approved-level-321-maths-field")
+    click_button "Continue"
+
+    expect(page).to have_content("Which physics courses do you teach?")
+    check "A or AS level physics"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    expect(page).to have_content("T Level in building services engineering for construction")
+    expect(page).to have_content("T Level in digital support services")
+    expect(page).to have_content("T Level in education and early years (early years educator)")
+    expect(page).to have_content("T Level in design and development for engineering and manufacturing")
+    expect(page).to have_content("Qualifications approved for funding at level 3 and below in the")
+    expect(page).to have_content("A or AS level physics")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you subject to any formal performance measures as a result of continuous poor teaching standards")
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    expect(page).to have_content("Are you currently subject to disciplinary action?")
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a targeted retention incentive payment")
+    expect(page).to have_content(number_to_currency(expected_award_amount, precision: 0))
+    expect(page).to have_content("Apply now")
+    click_button "Apply now"
+
+    sign_in_with_one_login
+
+    expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
+    click_button "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    expect(page).to have_content("What is your home address?")
+    click_button("Enter your address manually")
+
+    expect(page).to have_content("What is your address?")
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    expect(page).to have_content("Email address")
+    fill_in "Email address", with: "john.doe@example.com"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter the 6-digit passcode")
+    mail = ActionMailer::Base.deliveries.last
+    otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
+    fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+    click_on "Confirm"
+
+    expect(page).to have_content("Would you like to provide your mobile number?")
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter your personal bank account details")
+    fill_in "Name on your account", with: "Jo Bloggs"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    expect(page).to have_content("How is your gender recorded on your employer’s payroll system?")
+    choose "Female"
+    click_on "Continue"
+
+    expect(page).to have_content("Teacher reference number (TRN)")
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
+    click_on "Continue"
+
+    expect(page).to have_content("Check your answers before sending your application")
+    click_link "Change would you like to provide your mobile number?"
+
+    expect(page).to have_content("Would you like to provide your mobile number?")
+    choose "Yes"
+    click_button "Continue"
+
+    stub_sms_code
+
+    expect(page).to have_content("To verify your mobile number we will send you a text message with a 6-digit passcode")
+    fill_in "Mobile number", with: "07123456789"
+    click_button "Continue"
+
+    secret = Journeys::FurtherEducationPayments::Session.last.answers.mobile_verification_secret
+    code = OneTimePassword::Generator.new(secret:).code
+
+    expect(page).to have_content "Enter the 6-digit passcode"
+    fill_in "Enter the 6-digit passcode", with: code
+    click_button "Confirm"
+
+    expect(page).to have_content "Check your answers before sending your application"
+    expect(page).to have_content /Mobile number\s?07123456789/
+  end
+
   def and_college_exists
     college
+  end
+
+  def stub_sms_code
+    stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/sms")
+      .to_return(status: 200, body: "{}", headers: {})
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -97,83 +97,83 @@ describe "teacher route: completing the form" do
     assert_on_check_your_answers_part_one_page!
 
     expect(page).to have_text(
-      "What is your employment status? I am employed as a teacher in a school in England"
+      /What is your employment status\?\s?I am employed as a teacher in a school in England/
     )
 
     expect(page).to have_text(
-      "Are you employed by an English state secondary school? Yes"
+      /Are you employed by an English state secondary school\?\s?Yes/
     )
 
     expect(page).to have_text(
-      "Which school are you currently employed to teach at? #{school.name}"
+      /Which school are you currently employed to teach at\?\s?#{school.name}/
     )
 
     expect(page).to have_text(
-      "Enter the name of the headteacher of the school where you are employed as a teacher Seymour Skinner"
+      /Enter the name of the headteacher of the school where you are employed as a teacher\s?Seymour Skinner/
     )
 
     expect(page).to have_text(
-      "Are you employed on a contract lasting at least one year? Yes"
+      /Are you employed on a contract lasting at least one year\?\s?Yes/
     )
 
     expect(page).to have_text(
-      "Enter the start date of your contract #{I18n.l(contract_start_date)}"
+      /Enter the start date of your contract\s?#{I18n.l(contract_start_date)}/
     )
 
     expect(page).to have_text(
-      "What subject are you employed to teach at your school? Physics"
+      /What subject are you employed to teach at your school\?\s?Physics/
     )
 
     expect(page).to have_text(
-      "Select the visa you used to move to England British National (Overseas) visa"
+      /Select the visa you used to move to England\s?British National \(Overseas\) visa/
     )
 
     expect(page).to have_text(
-      "Enter the date you moved to England to start your teaching job #{I18n.l(entry_date)}"
+      /Enter the date you moved to England to start your teaching job\s?#{I18n.l(entry_date)}/
     )
   end
 
   def then_the_check_your_answers_part_page_shows_my_answers(school, mobile_number: false, building_society: false)
     expect(page).to have_text(
-      "What is your full name? Walter Seymour Skinner"
+      /What is your full name\?\s?Walter Seymour Skinner/
     )
 
     expect(page).to have_text(
-      "What is your date of birth? 12 July 1945"
+      /What is your date of birth\?\s?12 July 1945/
     )
 
     expect(page).to have_text(
-      "What is your National Insurance number? QQ123456C"
+      /What is your National Insurance number\?\s?QQ123456C/
     )
 
     expect(page).to have_text(
-      "What is your address? Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX"
+      /What is your address\?\s?Flat 1, Millbrook Tower, Windermere Avenue, Southampton, SO16 9FX/
     )
 
     expect(page).to have_text(
-      "Email address seymour.skinner@springfieldelementary.edu"
+      /Email address\s?seymour.skinner@springfieldelementary.edu/
     )
 
-    expect(page).to have_text("Select your nationality Australian")
+    expect(page).to have_text(/Select your nationality\s?Australian/)
 
     expect(page).to have_text(
-      "Enter your passport number, as it appears on your passport 123456789"
+      /Enter your passport number, as it appears on your passport\s?123456789/
     )
 
     if mobile_number
-      expect(page).to have_text("Mobile number 01234567890")
+      expect(page).to have_text(/Mobile number\s?01234567890/)
     else
       expect(page).to have_text(
-        "Would you like to provide your mobile number? No"
+        /Would you like to provide your mobile number\?\s?No/
       )
     end
 
-    expect(page).to have_text("Name on bank account Walter Skinner")
-    expect(page).to have_text("Bank sort code 123456")
-    expect(page).to have_text("Bank account number 12345678")
+    expect(page).to have_text(/Name on bank account\s?Walter Skinner/)
+    expect(page).to have_text(/Bank sort code\s?123456/)
+    expect(page).to have_text(/Bank account number\s?12345678/)
 
     expect(page).to have_text(
-      "How is your gender recorded on your school’s payroll system? Male"
+      /How is your gender recorded on your school’s payroll system\?\s?Male/
     )
   end
 end

--- a/spec/features/levelling_up_premium_payments_spec.rb
+++ b/spec/features/levelling_up_premium_payments_spec.rb
@@ -309,7 +309,7 @@ RSpec.feature "Levelling up premium payments claims" do
     before do
       claim_up_to_check_your_answers
 
-      first("a[href='#{claim_path(Journeys::AdditionalPaymentsForTeaching::ROUTING_NAME, "personal-details")}']", minimum: 1).click
+      click_link "Change what is your full name?"
       fill_in "Last name", with: new_last_name
     end
 

--- a/spec/features/tslr/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
+++ b/spec/features/tslr/tslr_claim_journey_with_teacher_id_check_mobile_spec.rb
@@ -206,6 +206,6 @@ RSpec.feature "TSLR journey with Teacher ID mobile check" do
   end
 
   def go_back_to_mobile_selection
-    page.first("a[href='#{claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "select-mobile")}']", minimum: 1).click
+    click_link "Change which mobile number should we use to contact you?"
   end
 end

--- a/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
@@ -67,18 +67,4 @@ RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationTeachingStart
       )
     end
   end
-
-  describe "#clear_answers_from_session" do
-    let(:answers_hash) do
-      {
-        further_education_teaching_start_year: "2025"
-      }
-    end
-
-    it "clears relevant answers from session" do
-      expect {
-        subject.clear_answers_from_session
-      }.to change { journey_session.reload.answers.further_education_teaching_start_year }.from("2025").to(nil)
-    end
-  end
 end

--- a/spec/forms/journeys/further_education_payments/half_teaching_hours_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/half_teaching_hours_form_spec.rb
@@ -56,21 +56,4 @@ RSpec.describe Journeys::FurtherEducationPayments::HalfTeachingHoursForm, type: 
       end
     end
   end
-
-  describe "#clear_answers_from_session" do
-    let(:journey_session) { create(:further_education_payments_session, answers:) }
-    let(:answers) { build(:further_education_payments_answers, answers_hash) }
-
-    let(:answers_hash) do
-      {
-        half_teaching_hours: true
-      }
-    end
-
-    it "clears relevant answers from session" do
-      expect {
-        subject.clear_answers_from_session
-      }.to change { journey_session.reload.answers.half_teaching_hours }.from(true).to(nil)
-    end
-  end
 end

--- a/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/subjects_taught_form_spec.rb
@@ -58,16 +58,4 @@ RSpec.describe Journeys::FurtherEducationPayments::SubjectsTaughtForm, type: :mo
       )
     end
   end
-
-  describe "#clear_answers_from_session" do
-    let(:answers_hash) do
-      {subjects_taught: %w[maths physics]}
-    end
-
-    it "clears relevant answers from session" do
-      expect {
-        subject.clear_answers_from_session
-      }.to change { journey_session.reload.answers.subjects_taught }.from(%w[maths physics]).to([])
-    end
-  end
 end

--- a/spec/forms/journeys/further_education_payments/teaching_qualification_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_qualification_form_spec.rb
@@ -58,18 +58,4 @@ RSpec.describe Journeys::FurtherEducationPayments::TeachingQualificationForm, ty
       )
     end
   end
-
-  describe "#clear_answers_from_session" do
-    let(:answers_hash) do
-      {
-        teaching_qualification: "yes"
-      }
-    end
-
-    it "clears relevant answers from session" do
-      expect {
-        subject.clear_answers_from_session
-      }.to change { journey_session.reload.answers.teaching_qualification }.from("yes").to(nil)
-    end
-  end
 end

--- a/spec/forms/poor_performance_form_spec.rb
+++ b/spec/forms/poor_performance_form_spec.rb
@@ -70,23 +70,4 @@ RSpec.describe PoorPerformanceForm do
       end
     end
   end
-
-  describe "#clear_answers_from_session" do
-    let(:journey_session) { create(:further_education_payments_session, answers:) }
-    let(:answers) { build(:further_education_payments_answers, answers_hash) }
-
-    let(:answers_hash) do
-      {
-        subject_to_formal_performance_action: true,
-        subject_to_disciplinary_action: true
-      }
-    end
-
-    it "clears relevant answers from session" do
-      expect {
-        subject.clear_answers_from_session
-      }.to change { journey_session.reload.answers.subject_to_formal_performance_action }.from(true).to(nil)
-        .and change { journey_session.reload.answers.subject_to_disciplinary_action }.from(true).to(nil)
-    end
-  end
 end


### PR DESCRIPTION
# Context

- This allows navigator to support changing answers in a journey
- When a user reaches a changing answers screen and clicks `change answer` link
- we append a param to the url `change=slug-of-check-answers`
- we use the `slug` of check answers page as some journeys have multiple check answer pages and this mechanic supports that
- the `change` param is continually passed forward so we know the user is in the process of changing answer
- if the change of answer does not affect their journey they are sent back the check your answers screen
- otherwise they fill in new forms they now must answer as a consequence of changing answer after which they will then be sent back to check answers page
- Also now using `govuk_summary_list` component on check answers page and removed custom version