### PR TITLE
CAPT 1473/convert decision enum to boolean part 2

### DIFF
--- a/app/models/claim_auto_approval.rb
+++ b/app/models/claim_auto_approval.rb
@@ -13,7 +13,7 @@ class ClaimAutoApproval
     return unless eligible?
 
     claim.transaction do
-      claim.decisions.create!(result: :approved, notes: "Auto-approved")
+      claim.decisions.create!(approved: true, notes: "Auto-approved")
       claim.notes.create!(
         body: <<~TEXT
           This claim was auto-approved because it passed all automated checks

--- a/app/models/policies/claim_personal_data_scrubber.rb
+++ b/app/models/policies/claim_personal_data_scrubber.rb
@@ -82,18 +82,10 @@ module Policies
     end
 
     def claims_rejected_before(date)
-      rejected_claims.where(
+      claim_scope.rejected.where(
         "decisions.created_at < :minimum_time",
         minimum_time: date
       )
-    end
-
-    def rejected_claims
-      claim_scope.joins(:decisions)
-        .where(
-          "(decisions.undone = false AND decisions.result = :rejected)",
-          rejected: Decision.results.fetch(:rejected)
-        )
     end
 
     def old_paid_claims

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -55,14 +55,14 @@
         </h2>
       </legend>
 
-      <%= errors_tag decision, :result %>
+      <%= errors_tag decision, :approved %>
 
       <div class="govuk-radios" data-module="govuk-radios">
-        <%= form.hidden_field :result %>
+        <%= form.hidden_field :approved %>
         <div class="govuk-radios__item">
-          <%= form.radio_button(:result, "approved", class: "govuk-radios__input", disabled: !claim.approvable?) %>
+          <%= form.radio_button(:approved, true, class: "govuk-radios__input", disabled: !claim.approvable?) %>
           <%= form.label(
-            "result_approved",
+            "approved_true",
             (
               @qa_decision_task && claim.rejected? ? "Claim meets eligibility criteria. Approve claim for payment" : "Approve"
             ),
@@ -71,9 +71,9 @@
         </div>
 
         <div class="govuk-radios__item">
-          <%= form.radio_button(:result, "rejected", class: "govuk-radios__input", disabled: !claim.rejectable?, data: { aria_controls: "conditional-rejected-reasons" }) %>
+          <%= form.radio_button(:approved, false, class: "govuk-radios__input", disabled: !claim.rejectable?, data: { aria_controls: "conditional-rejected-reasons" }) %>
           <%= form.label(
-            "result_rejected",
+            "approved_false",
             (
               @qa_decision_task && claim.rejected? ? "Claim does not meet eligibility criteria. Reject claim" : "Reject"
             ),

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
+  <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "approved": "decision_approved_true" }) if @decision.errors.any? %>
 
   <%= render "admin/tasks/#{claim_summary_view}", claim: @claim, heading: "Claim decision" %>
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -85,7 +85,6 @@ shared:
     - verified_at
   :decisions:
     - id
-    - result
     - claim_id
     - created_at
     - updated_at

--- a/db/migrate/20250210161815_make_approved_non_null.rb
+++ b/db/migrate/20250210161815_make_approved_non_null.rb
@@ -1,0 +1,5 @@
+class MakeApprovedNonNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :decisions, :approved, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,7 +133,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_150905) do
     t.uuid "created_by_id"
     t.boolean "undone", default: false
     t.jsonb "rejected_reasons", default: {}
-    t.boolean "approved"
+    t.boolean "approved", null: false
     t.index ["claim_id"], name: "index_decisions_on_claim_id"
     t.index ["created_at"], name: "index_decisions_on_created_at"
     t.index ["created_by_id"], name: "index_decisions_on_created_by_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -157,14 +157,14 @@ FactoryBot.define do
       submitted
       after(:create) do |claim, evaluator|
         if evaluator.decision_creator
-          create(:decision, claim: claim, result: "approved", created_by: evaluator.decision_creator)
+          create(:decision, claim: claim, approved: true, created_by: evaluator.decision_creator)
         elsif claim.policy == Policies::EarlyYearsPayments
           claim.tasks.find_or_create_by(name: "employment") do |c|
             c.passed = true
           end
-          create(:decision, claim: claim, result: "approved")
+          create(:decision, claim: claim, approved: true)
         else
-          create(:decision, claim: claim, result: "approved")
+          create(:decision, claim: claim, approved: true)
         end
       end
     end

--- a/spec/factories/decisions.rb
+++ b/spec/factories/decisions.rb
@@ -4,11 +4,11 @@ FactoryBot.define do
     claim { build(:claim, :submitted) }
 
     trait :approved do
-      result { :approved }
+      approved { true }
     end
 
     trait :rejected do
-      result { :rejected }
+      approved { false }
       rejected_reasons { {policy::ADMIN_DECISION_REJECTED_REASONS.first => "1"} }
     end
 
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :auto_approved do
-      approved
+      approved { true }
       created_by_id { nil }
       notes { "Auto-approved" }
     end

--- a/spec/features/admin/admin_claim_check_spec.rb
+++ b/spec/features/admin/admin_claim_check_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Admin checks a claim" do
 
     scenario "User can see existing decision details" do
       claim_with_decision = create(:claim, :submitted)
-      create(:decision, claim: claim_with_decision, result: :approved, notes: "Everything matches")
+      create(:decision, claim: claim_with_decision, approved: true, notes: "Everything matches")
 
       visit admin_claim_path(claim_with_decision)
 

--- a/spec/features/admin/admin_fraud_prevention_spec.rb
+++ b/spec/features/admin/admin_fraud_prevention_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Admin fraud prevention" do
 
       visit new_admin_claim_decision_path(flagged_claim_trn)
 
-      approval_option = find("input[type=radio][value=approved]")
+      approval_option = find("#decision_approved_true")
 
       expect(approval_option).to be_disabled
 
@@ -74,7 +74,7 @@ RSpec.feature "Admin fraud prevention" do
 
       visit new_admin_claim_decision_path(flagged_claim_nino)
 
-      approval_option = find("input[type=radio][value=approved]")
+      approval_option = find("#decision_approved_true")
 
       expect(approval_option).to be_disabled
 
@@ -85,7 +85,7 @@ RSpec.feature "Admin fraud prevention" do
 
       visit new_admin_claim_decision_path(flagged_claim_trn_and_nino)
 
-      approval_option = find("input[type=radio][value=approved]")
+      approval_option = find("#decision_approved_true")
 
       expect(approval_option).to be_disabled
 

--- a/spec/features/admin/admin_hold_claim_spec.rb
+++ b/spec/features/admin/admin_hold_claim_spec.rb
@@ -39,8 +39,8 @@ RSpec.feature "Admin holds a claim" do
     end
 
     expect(page).to have_text "You cannot approve or reject a claim that is on hold"
-    expect(page.find("#decision_result_approved")).to be_disabled
-    expect(page.find("#decision_result_rejected")).to be_disabled
+    expect(page.find("#decision_approved_true")).to be_disabled
+    expect(page.find("#decision_approved_false")).to be_disabled
 
     click_on "Back"
     click_on "Notes and support"

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -97,7 +97,7 @@ describe Admin::ClaimsHelper do
   describe "#admin_decision_details" do
     let(:claim) { create(:claim, :submitted) }
     let(:user) { create(:dfe_signin_user) }
-    let(:decision) { Decision.create!(claim: claim, created_by: user, result: :approved) }
+    let(:decision) { Decision.create!(claim: claim, created_by: user, approved: true) }
 
     it "includes an array of details about the decision" do
       expect(helper.admin_decision_details(decision)).to eq([
@@ -108,7 +108,7 @@ describe Admin::ClaimsHelper do
     end
 
     context "when notes are saved with the decision" do
-      let(:decision) { Decision.create!(claim: claim, created_by: user, result: :approved, notes: "abc\nxyz") }
+      let(:decision) { Decision.create!(claim: claim, created_by: user, approved: true, notes: "abc\nxyz") }
 
       it "includes the notes" do
         expect(helper.admin_decision_details(decision)).to include([I18n.t("admin.decision.notes"), simple_format(decision.notes, class: "govuk-body")])

--- a/spec/jobs/auto_approve_claim_job_spec.rb
+++ b/spec/jobs/auto_approve_claim_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AutoApproveClaimJob do
 
       it "creates an approval decision" do
         expect { run_job }.to change { claim.reload.latest_decision }.from(nil)
-          .to have_attributes(result: "approved", notes: "Auto-approved")
+          .to have_attributes(approved: true, notes: "Auto-approved")
       end
     end
 

--- a/spec/models/claim_auto_approval_spec.rb
+++ b/spec/models/claim_auto_approval_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe ClaimAutoApproval do
       let(:eligible?) { true }
       let(:expected_decision_attributes) do
         {
-          result: "approved",
+          approved: true,
           notes: "Auto-approved",
           created_by_id: nil
         }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Claim, type: :model do
     it "returns false when a claim has already been approved" do
       claim_with_decision = create(:claim, :submitted)
       expect(claim_with_decision.approvable?).to eq true
-      create(:decision, claim: claim_with_decision, result: :approved)
+      create(:decision, claim: claim_with_decision, approved: true)
 
       expect(claim_with_decision.approvable?).to eq false
     end
@@ -511,7 +511,7 @@ RSpec.describe Claim, type: :model do
   describe "#decision" do
     it "returns the latest decision on a claim" do
       claim = create(:claim, :submitted)
-      create(:decision, result: "approved", claim: claim, created_at: 7.days.ago)
+      create(:decision, approved: true, claim: claim, created_at: 7.days.ago)
       create(:decision, :rejected, claim: claim, created_at: DateTime.now)
 
       expect(claim.latest_decision.result).to eq "rejected"
@@ -1036,20 +1036,20 @@ RSpec.describe Claim, type: :model do
     it "returns true for a claim that had a decison made, undone, then been approved" do
       claim = create(:claim, :submitted)
       create(:decision, :undone, :rejected, claim: claim)
-      create(:decision, result: "approved", claim: claim)
+      create(:decision, approved: true, claim: claim)
       expect(claim.decision_made?).to eq(true)
     end
 
     it "returns true for a claim that had a decison made, undone, then been rejected" do
       claim = create(:claim, :submitted)
-      create(:decision, :undone, result: "approved", claim: claim)
+      create(:decision, :undone, approved: true, claim: claim)
       create(:decision, :rejected, claim: claim)
       expect(claim.decision_made?).to eq(true)
     end
 
     it "returns false for a claim that had a decison made, then undone" do
       claim = create(:claim, :submitted)
-      create(:decision, :undone, result: "approved", claim: claim)
+      create(:decision, :undone, approved: true, claim: claim)
       expect(claim.decision_made?).to eq(false)
     end
   end
@@ -1072,7 +1072,7 @@ RSpec.describe Claim, type: :model do
 
     it "returns false for a claim that had a decison made, then undone" do
       claim = create(:claim, :submitted)
-      create(:decision, :undone, result: "approved", claim: claim)
+      create(:decision, :undone, approved: true, claim: claim)
       expect(claim.decision_made?).to eq(false)
     end
 

--- a/spec/requests/admin/admin_decisions_spec.rb
+++ b/spec/requests/admin/admin_decisions_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Admin decisions", type: :request do
 
       context "when a claim is being flagged for QA" do
         it "can approve the claim and flag it for QA", :aggregate_failures do
-          post admin_claim_decisions_path(claim_id: claim.id, decision: {result: "approved"})
+          post admin_claim_decisions_path(claim_id: claim.id, decision: {approved: true})
 
           follow_redirect!
 
@@ -83,7 +83,7 @@ RSpec.describe "Admin decisions", type: :request do
           expect(ClaimMailer).not_to have_received(:approved).with(claim)
 
           expect(claim.latest_decision.created_by).to eq(@signed_in_user)
-          expect(claim.latest_decision.result).to eq("approved")
+          expect(claim.latest_decision).to be_approved
 
           expect(claim.reload.qa_required).to eq(true)
           expect(claim.reload.qa_completed_at).to be_nil
@@ -94,7 +94,7 @@ RSpec.describe "Admin decisions", type: :request do
           let(:claim) { create(:claim, :approved, :flagged_for_qa, policy: Policies::StudentLoans) }
 
           it "can undo the previous decision and approve the claim", :aggregate_failures do
-            post admin_claim_decisions_path(qa: true, claim_id: claim.id, decision: {result: "approved"})
+            post admin_claim_decisions_path(qa: true, claim_id: claim.id, decision: {approved: true})
 
             follow_redirect!
 
@@ -105,12 +105,12 @@ RSpec.describe "Admin decisions", type: :request do
 
             expect(claim.previous_decision.undone).to eq(true)
             expect(claim.latest_decision.created_by).to eq(@signed_in_user)
-            expect(claim.latest_decision.result).to eq("approved")
+            expect(claim.latest_decision).to be_approved
             expect(claim.reload.qa_completed_at).not_to be_nil
           end
 
           it "can undo the previous decision and reject a claim", :aggregate_failures do
-            post admin_claim_decisions_path(qa: true, claim_id: claim.id, decision: {result: "rejected", rejected_reasons_ineligible_subject: "1"})
+            post admin_claim_decisions_path(qa: true, claim_id: claim.id, decision: {approved: false, rejected_reasons_ineligible_subject: "1"})
 
             follow_redirect!
 
@@ -120,7 +120,7 @@ RSpec.describe "Admin decisions", type: :request do
 
             expect(claim.previous_decision.undone).to eq(true)
             expect(claim.latest_decision.created_by).to eq(@signed_in_user)
-            expect(claim.latest_decision.result).to eq("rejected")
+            expect(claim.latest_decision).to be_rejected
             expect(claim.reload.qa_completed_at).not_to be_nil
           end
         end
@@ -130,7 +130,7 @@ RSpec.describe "Admin decisions", type: :request do
         before { disable_claim_qa_flagging }
 
         it "can approve the claim", :aggregate_failures do
-          post admin_claim_decisions_path(claim_id: claim.id, decision: {result: "approved"})
+          post admin_claim_decisions_path(claim_id: claim.id, decision: {approved: true})
 
           follow_redirect!
 
@@ -139,11 +139,11 @@ RSpec.describe "Admin decisions", type: :request do
           expect(ClaimMailer).to have_received(:approved).with(claim)
 
           expect(claim.latest_decision.created_by).to eq(@signed_in_user)
-          expect(claim.latest_decision.result).to eq("approved")
+          expect(claim.latest_decision).to be_approved
         end
 
         it "can reject the claim", :aggregate_failures do
-          post admin_claim_decisions_path(claim_id: claim.id, decision: {result: "rejected", rejected_reasons_ineligible_subject: "1"})
+          post admin_claim_decisions_path(claim_id: claim.id, decision: {approved: false, rejected_reasons_ineligible_subject: "1"})
 
           follow_redirect!
 
@@ -152,7 +152,7 @@ RSpec.describe "Admin decisions", type: :request do
           expect(ClaimMailer).to have_received(:rejected).with(claim)
 
           expect(claim.latest_decision.created_by).to eq(@signed_in_user)
-          expect(claim.latest_decision.result).to eq("rejected")
+          expect(claim.latest_decision).to be_rejected
         end
       end
 
@@ -169,7 +169,7 @@ RSpec.describe "Admin decisions", type: :request do
         let(:claim) { create(:claim, :approved, policy: Policies::EarlyCareerPayments) }
 
         it "shows an error" do
-          post admin_claim_decisions_path(claim_id: claim.id, decision: {result: "approved"})
+          post admin_claim_decisions_path(claim_id: claim.id, decision: {approved: true})
 
           follow_redirect!
 
@@ -181,7 +181,7 @@ RSpec.describe "Admin decisions", type: :request do
         let(:claim) { create(:claim, :approved, :qa_completed, policy: Policies::EarlyCareerPayments) }
 
         it "shows an error" do
-          post admin_claim_decisions_path(qa: true, claim_id: claim.id, decision: {result: "approved"})
+          post admin_claim_decisions_path(qa: true, claim_id: claim.id, decision: {approved: true})
 
           follow_redirect!
 
@@ -193,12 +193,12 @@ RSpec.describe "Admin decisions", type: :request do
         let(:claim) { create(:claim, :submitted, payroll_gender: :dont_know, policy: Policies::EarlyCareerPayments) }
 
         before do
-          post admin_claim_decisions_path(claim_id: claim.id, decision: {result: result, rejected_reasons_ineligible_subject: "1"})
+          post admin_claim_decisions_path(claim_id: claim.id, decision: {approved: approved, rejected_reasons_ineligible_subject: "1"})
           follow_redirect!
         end
 
         context "and the user attempts to approve" do
-          let(:result) { "approved" }
+          let(:approved) { true }
 
           it "shows an error" do
             expect(response.body).to include("Claim cannot be approved")
@@ -206,7 +206,7 @@ RSpec.describe "Admin decisions", type: :request do
         end
 
         context "and the user attempts to reject" do
-          let(:result) { "rejected" }
+          let(:approved) { false }
 
           it "doesn’t show an error and rejects successfully" do
             expect(response.body).not_to include("Claim cannot be approved")
@@ -232,19 +232,19 @@ RSpec.describe "Admin decisions", type: :request do
         let!(:approved_claim) { create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823", policy: Policies::EarlyCareerPayments)) }
 
         before do
-          post admin_claim_decisions_path(claim_id: claim.id, decision: {result: result, rejected_reasons_ineligible_subject: "1"})
+          post admin_claim_decisions_path(claim_id: claim.id, decision: {approved: approved, rejected_reasons_ineligible_subject: "1"})
           follow_redirect!
         end
 
         context "and the user attempts to approve" do
-          let(:result) { "approved" }
+          let(:approved) { true }
           it "shows an error" do
             expect(response.body).to include("Claim cannot be approved because there are inconsistent claims")
           end
         end
 
         context "and the user attempts to reject" do
-          let(:result) { "rejected" }
+          let(:approved) { false }
           it "doesn’t show an error and rejects successfully" do
             expect(response.body).not_to include("Claim cannot be approved")
             expect(response.body).to include("Claim has been rejected successfully")
@@ -261,7 +261,7 @@ RSpec.describe "Admin decisions", type: :request do
       [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
         it "does not allow a claim to be approved" do
           sign_in_to_admin_with_role(role)
-          post admin_claim_decisions_path(claim_id: claim.id, result: "approved")
+          post admin_claim_decisions_path(claim_id: claim.id, approved: true)
 
           expect(response.code).to eq("401")
         end


### PR DESCRIPTION
Make the approved column non nullable

Now the backfill has run and we've checked the data on prod we can make
the approved column non nullable as it doesn't make sense to create a
decision without out a value for approved.

Now we've backfilled the existing records we can remove the enum
definition and reference the `approved` column.
We'll drop the `result` column in a future PR.
