### PR TITLE
Add name / dob fields to analytics for FE only

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -83,6 +83,10 @@ shared:
     - onelogin_uid
     - started_at
     - verified_at
+    - fe_first_name
+    - fe_middle_name
+    - fe_surname
+    - fe_date_of_birth
   :decisions:
     - id
     - result

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,6 +1,10 @@
 ---
 :shared:
   :claims:
+    - fe_first_name
+    - fe_middle_name
+    - fe_surname
+    - fe_date_of_birth
     - onelogin_uid
   :levelling_up_premium_payments_eligibilities:
     - teacher_reference_number

--- a/spec/lib/analytics_importer_spec.rb
+++ b/spec/lib/analytics_importer_spec.rb
@@ -30,7 +30,14 @@ RSpec.describe AnalyticsImporter do
 
   describe ".import" do
     it "sends the entity information to dfe analytics" do
-      claim = create(:claim)
+      claim = create(
+        :claim,
+        first_name: "Homer",
+        middle_name: "J",
+        surname: "Simpson",
+        date_of_birth: Date.new(1956, 5, 12),
+        policy: Policies::FurtherEducationPayments
+      )
 
       AnalyticsImporter.import(Claim)
 
@@ -43,7 +50,28 @@ RSpec.describe AnalyticsImporter do
             "entity_table_name" => "claims",
             "event_tags" => ["20240101000000"],
             "data" => a_hash_including({"key" => "id", "value" => [claim.id]}),
-            "hidden_data" => [{"key" => "onelogin_uid", "value" => []}]
+            "hidden_data" => [
+              {
+                "key" => "onelogin_uid",
+                "value" => []
+              },
+              {
+                "key" => "fe_first_name",
+                "value" => ["Homer"]
+              },
+              {
+                "key" => "fe_middle_name",
+                "value" => ["J"]
+              },
+              {
+                "key" => "fe_surname",
+                "value" => ["Simpson"]
+              },
+              {
+                "key" => "fe_date_of_birth",
+                "value" => ["1956-05-12"]
+              }
+            ]
           }
         ],
         ignore_unknown: true


### PR DESCRIPTION
We want to send over name and date of birth over to DfE analytics for FE
claims only. These attributes are stored on the claim which is shared
between all policies. DfE analaytics gem only gives us coarse grain
control over which attributes to send to big query. This is a hack and
we're not stoked on having to patch internal methods like this but it
should do the trick until we think of a better solution.
