### PR TITLE
[CAPT-2195] OL return codes

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -136,7 +136,7 @@ class OmniauthCallbacksController < ApplicationController
     journey_session.save!
 
     one_login_return_codes.each do |code|
-      Stat.create!(one_login_return_code: code)
+      Stats::OneLogin.create!(one_login_return_code: code)
     end
 
     redirect_to(

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,6 +2,7 @@ class OmniauthCallbacksController < ApplicationController
   include JourneyConcern
 
   ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY = "https://vocab.account.gov.uk/v1/coreIdentityJWT".freeze
+  ONELOGIN_JWT_RETURN_CODE_HASH_KEY = "https://vocab.account.gov.uk/v1/returnCode".freeze
 
   def callback
     auth = request.env["omniauth.auth"]
@@ -44,13 +45,25 @@ class OmniauthCallbacksController < ApplicationController
     end
   end
 
+  # unfortunely this method has dual responsibilites
+  # handles both auth callback + idv callback
+  # logic must be included to handle this shortcoming
   def onelogin
-    core_identity_jwt = omniauth_hash.extra.raw_info[ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY]
     return process_one_login_identity_verification_callback(core_identity_jwt) if core_identity_jwt
+    return process_one_login_return_codes_callback if one_login_return_codes.present?
+
     process_one_login_authentication_callback
   end
 
   private
+
+  def core_identity_jwt
+    omniauth_hash.extra.raw_info[ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY]
+  end
+
+  def one_login_return_codes
+    omniauth_hash.extra.raw_info.fetch(ONELOGIN_JWT_RETURN_CODE_HASH_KEY, []).map { |hash| hash["code"] }
+  end
 
   def current_journey_routing_name
     if session[:current_journey_routing_name].present?
@@ -106,6 +119,25 @@ class OmniauthCallbacksController < ApplicationController
     journey_session.answers.surname ||= last_name
     journey_session.answers.date_of_birth ||= date_of_birth
     journey_session.save!
+
+    redirect_to(
+      claim_path(
+        journey: current_journey_routing_name,
+        slug: "sign-in"
+      )
+    )
+  end
+
+  def process_one_login_return_codes_callback
+    journey_session.answers.assign_attributes(
+      identity_confirmed_with_onelogin: false,
+      onelogin_idv_at: Time.now
+    )
+    journey_session.save!
+
+    one_login_return_codes.each do |code|
+      Stat.create!(one_login_return_code: code)
+    end
 
     redirect_to(
       claim_path(

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -1,0 +1,2 @@
+class Stat < ApplicationRecord
+end

--- a/app/models/stats/one_login.rb
+++ b/app/models/stats/one_login.rb
@@ -1,0 +1,2 @@
+class Stats::OneLogin < Stat
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -361,3 +361,4 @@ shared:
     - one_login_return_code
     - created_at
     - updated_at
+    - type

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -356,3 +356,8 @@ shared:
     - created_at
     - updated_at
     - gender_digit
+  :stats:
+    - id
+    - one_login_return_code
+    - created_at
+    - updated_at

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -145,7 +145,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       discovery: true,
       extra_authorize_params: {
         vtr: '["Cl.Cm.P2"]',
-        claims: {userinfo: {"https://vocab.account.gov.uk/v1/coreIdentityJWT": nil}}.to_json
+        claims: {userinfo: {"https://vocab.account.gov.uk/v1/coreIdentityJWT": nil, "https://vocab.account.gov.uk/v1/returnCode": nil}}.to_json
       },
       issuer: ENV["ONELOGIN_SIGN_IN_ISSUER"],
       response_type: :code,

--- a/db/migrate/20250213153245_create_stats_table.rb
+++ b/db/migrate/20250213153245_create_stats_table.rb
@@ -1,0 +1,9 @@
+class CreateStatsTable < ActiveRecord::Migration[8.0]
+  def change
+    create_table :stats, id: :uuid do |t|
+      t.text :one_login_return_code
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250214095211_add_type_to_stats.rb
+++ b/db/migrate/20250214095211_add_type_to_stats.rb
@@ -1,0 +1,5 @@
+class AddTypeToStats < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stats, :type, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -505,6 +505,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_150905) do
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
+  create_table "stats", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "one_login_return_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "student_loans_data", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "claim_reference"
     t.string "nino"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -509,6 +509,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_150905) do
     t.text "one_login_return_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "type"
   end
 
   create_table "student_loans_data", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -240,5 +240,44 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
           .and change { journey_session.reload.answers.onelogin_idv_date_of_birth }.from(nil).to(Date.new(1970, 12, 13))
       end
     end
+
+    context "idv step with return code present" do
+      let(:omniauth_hash) do
+        OmniAuth::AuthHash.new(
+          "uid" => "12345",
+          "extra" => {
+            "raw_info" => {
+              "https://vocab.account.gov.uk/v1/returnCode" => [{"code" => "ABC"}]
+            }
+          }
+        )
+      end
+
+      it "updates session vars" do
+        journey_session = Journeys::FurtherEducationPayments::Session.last
+        journey_session.answers.onelogin_uid = "12345"
+        journey_session.save!
+
+        expect {
+          get auth_onelogin_path
+        }.to change { journey_session.reload.answers.onelogin_idv_at }.from(nil).to(be_within(10.seconds).of(Time.now))
+          .and change { journey_session.reload.answers.identity_confirmed_with_onelogin }.from(nil).to(false)
+          .and not_change { journey_session.reload.answers.onelogin_idv_first_name }
+          .and not_change { journey_session.reload.answers.onelogin_idv_last_name }
+          .and not_change { journey_session.reload.answers.onelogin_idv_date_of_birth }
+      end
+
+      it "updates return codes stats" do
+        journey_session = Journeys::FurtherEducationPayments::Session.last
+        journey_session.answers.onelogin_uid = "12345"
+        journey_session.save!
+
+        expect {
+          get auth_onelogin_path
+        }.to change { Stat.count }.by(1)
+
+        expect(Stat.last.one_login_return_code).to eql("ABC")
+      end
+    end
   end
 end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -274,9 +274,9 @@ RSpec.describe "OmniauthCallbacksControllers", type: :request do
 
         expect {
           get auth_onelogin_path
-        }.to change { Stat.count }.by(1)
+        }.to change { Stats::OneLogin.count }.by(1)
 
-        expect(Stat.last.one_login_return_code).to eql("ABC")
+        expect(Stats::OneLogin.last.one_login_return_code).to eql("ABC")
       end
     end
   end


### PR DESCRIPTION
# IMPORTANT

- ~Prior to merge MUST enable return codes in OL first + enable claim `returnCode` otherwise this feature will not work~
- This has been completed

# Context

- https://dfedigital.atlassian.net/browse/CAPT-2195
- This adds the `returnCode` claim to the OL idv check
- Create a new db backed `Stat` model to store arbitrary stat data points
- Store any OL return codes into this `Stat` model