### PR TITLE
CAPT-2235/qa rejected claims

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -218,8 +218,16 @@ class Claim < ApplicationRecord
     decision_made? && below_min_qa_threshold? && !awaiting_qa? && !qa_completed?
   end
 
+  def approved?
+    decision_made? && latest_decision.approved?
+  end
+
+  def rejected?
+    decision_made? && latest_decision.rejected?
+  end
+
   def below_min_qa_threshold?
-    if latest_decision.approved?
+    if approved?
       below_min_qa_threshold_for_approval?
     else
       below_min_qa_threshold_for_rejection?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -222,26 +222,26 @@ class Claim < ApplicationRecord
   # be flagged for QA or not. These criteria need to be met for each academic year:
   #
   # 1. the first claim to be approved should always be flagged for QA
-  # 2. subsequently approved claims should be flagged for QA, 1 in 100/MIN_QA_THRESHOLD.
+  # 2. subsequently approved claims should be flagged for QA, 1 in 100/APPROVED_MIN_QA_THRESHOLD.
   #
   # This method should be used every time a new approval decision is being made;
   # when used retrospectively, i.e. when several claims have been approved,
   # the method returns:
   #
   # 1. `true` if none of then claims have been flagged for QA
-  # 2. `true` if some claims have been flagged for QA using a lower MIN_QA_THRESHOLD
-  # 3. `false` if some claims have been flagged for QA using a higher MIN_QA_THRESHOLD
+  # 2. `true` if some claims have been flagged for QA using a lower APPROVED_MIN_QA_THRESHOLD
+  # 3. `false` if some claims have been flagged for QA using a higher APPROVED_MIN_QA_THRESHOLD
   #
   # Newly approved claims should not be flagged for QA for as long as the method
   # returns `false`; they should be flagged for QA otherwise.
   def below_min_qa_threshold?
-    return false if policy::MIN_QA_THRESHOLD.zero?
+    return false if policy::APPROVED_MIN_QA_THRESHOLD.zero?
 
     approved_claims = Claim.by_policy(policy).by_academic_year(academic_year).approved
     claims_approved_so_far = approved_claims.count
     return true if claims_approved_so_far.zero?
 
-    (approved_claims.qa_required.count.to_f / claims_approved_so_far) * 100 <= policy::MIN_QA_THRESHOLD
+    (approved_claims.qa_required.count.to_f / claims_approved_so_far) * 100 <= policy::APPROVED_MIN_QA_THRESHOLD
   end
 
   def qa_completed?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -215,7 +215,19 @@ class Claim < ApplicationRecord
   end
 
   def flaggable_for_qa?
-    decision_made? && latest_decision.approved? && below_min_qa_threshold? && !awaiting_qa? && !qa_completed?
+    decision_made? && below_min_qa_threshold? && !awaiting_qa? && !qa_completed?
+  end
+
+  def below_min_qa_threshold?
+    if latest_decision.approved?
+      below_min_qa_threshold_for_approval?
+    else
+      below_min_qa_threshold_for_rejection?
+    end
+  end
+
+  def below_min_qa_threshold_for_rejection?
+    Random.new.rand(100) < policy::REJECTED_MIN_QA_THRESHOLD
   end
 
   # This method's intention is to help make a decision on whether a claim should
@@ -234,7 +246,7 @@ class Claim < ApplicationRecord
   #
   # Newly approved claims should not be flagged for QA for as long as the method
   # returns `false`; they should be flagged for QA otherwise.
-  def below_min_qa_threshold?
+  def below_min_qa_threshold_for_approval?
     return false if policy::APPROVED_MIN_QA_THRESHOLD.zero?
 
     approved_claims = Claim.by_policy(policy).by_academic_year(academic_year).approved

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -30,8 +30,8 @@ module Policies
 
     SEARCHABLE_ELIGIBILITY_ATTRIBUTES = %w[teacher_reference_number].freeze
 
-    # Percentage of claims to QA
-    MIN_QA_THRESHOLD = 10
+    # Percentage of approved claims to QA
+    APPROVED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/early_career_payments.rb
+++ b/app/models/policies/early_career_payments.rb
@@ -32,6 +32,8 @@ module Policies
 
     # Percentage of approved claims to QA
     APPROVED_MIN_QA_THRESHOLD = 10
+    # Percentage of rejected claims to QA
+    REJECTED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -8,6 +8,8 @@ module Policies
 
     # Percentage of approved claims to QA
     APPROVED_MIN_QA_THRESHOLD = 10
+    # Percentage of rejected claims to QA
+    REJECTED_MIN_QA_THRESHOLD = 10
 
     VERIFIERS = [
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan,

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -6,8 +6,8 @@ module Policies
     POLICY_START_DATE = Date.new(2024, 11, 11)
     RETENTION_PERIOD = 6.months
 
-    # Percentage of claims to QA
-    MIN_QA_THRESHOLD = 10
+    # Percentage of approved claims to QA
+    APPROVED_MIN_QA_THRESHOLD = 10
 
     VERIFIERS = [
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan,

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -7,6 +7,8 @@ module Policies
 
     # Percentage of approved claims to QA
     APPROVED_MIN_QA_THRESHOLD = 10
+    # Percentage of rejected claims to QA
+    REJECTED_MIN_QA_THRESHOLD = 10
 
     VERIFIERS = [
       AutomatedChecks::ClaimVerifiers::Identity,

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -5,8 +5,8 @@ module Policies
 
     ELIGIBILITY_MATCHING_ATTRIBUTES = [["teacher_reference_number"]].freeze
 
-    # Percentage of claims to QA
-    MIN_QA_THRESHOLD = 10
+    # Percentage of approved claims to QA
+    APPROVED_MIN_QA_THRESHOLD = 10
 
     VERIFIERS = [
       AutomatedChecks::ClaimVerifiers::Identity,

--- a/app/models/policies/international_relocation_payments.rb
+++ b/app/models/policies/international_relocation_payments.rb
@@ -11,6 +11,8 @@ module Policies
 
     # Percentage of approved claims to QA
     APPROVED_MIN_QA_THRESHOLD = 100
+    # Percentage of rejected claims to QA
+    REJECTED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/international_relocation_payments.rb
+++ b/app/models/policies/international_relocation_payments.rb
@@ -9,8 +9,8 @@ module Policies
 
     ELIGIBILITY_MATCHING_ATTRIBUTES = [["passport_number"]].freeze
 
-    # Percentage of claims to QA
-    MIN_QA_THRESHOLD = 100
+    # Percentage of approved claims to QA
+    APPROVED_MIN_QA_THRESHOLD = 100
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -30,8 +30,8 @@ module Policies
 
     SEARCHABLE_ELIGIBILITY_ATTRIBUTES = %w[teacher_reference_number].freeze
 
-    # Percentage of claims to QA
-    MIN_QA_THRESHOLD = 10
+    # Percentage of approved claims to QA
+    APPROVED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -32,6 +32,8 @@ module Policies
 
     # Percentage of approved claims to QA
     APPROVED_MIN_QA_THRESHOLD = 10
+    # Percentage of rejected claims to QA
+    REJECTED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/targeted_retention_incentive_payments.rb
+++ b/app/models/policies/targeted_retention_incentive_payments.rb
@@ -21,8 +21,8 @@ module Policies
     POLICY_END_YEAR = AcademicYear.new(2025).freeze
     POLICY_RANGE = POLICY_START_YEAR..POLICY_END_YEAR
 
-    # Percentage of claims to QA
-    MIN_QA_THRESHOLD = 10
+    # Percentage of approved claims to QA
+    APPROVED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/models/policies/targeted_retention_incentive_payments.rb
+++ b/app/models/policies/targeted_retention_incentive_payments.rb
@@ -23,6 +23,8 @@ module Policies
 
     # Percentage of approved claims to QA
     APPROVED_MIN_QA_THRESHOLD = 10
+    # Percentage of rejected claims to QA
+    REJECTED_MIN_QA_THRESHOLD = 10
 
     # Options shown to admins when rejecting a claim
     ADMIN_DECISION_REJECTED_REASONS = [

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -61,12 +61,24 @@
         <%= form.hidden_field :result %>
         <div class="govuk-radios__item">
           <%= form.radio_button(:result, "approved", class: "govuk-radios__input", disabled: !claim.approvable?) %>
-          <%= form.label "result_approved", "Approve", class: "govuk-label govuk-radios__label" %>
+          <%= form.label(
+            "result_approved",
+            (
+              @qa_decision_task && claim.rejected? ? "Claim meets eligibility criteria. Approve claim for payment" : "Approve"
+            ),
+            class: "govuk-label govuk-radios__label"
+          ) %>
         </div>
 
         <div class="govuk-radios__item">
           <%= form.radio_button(:result, "rejected", class: "govuk-radios__input", disabled: !claim.rejectable?, data: { aria_controls: "conditional-rejected-reasons" }) %>
-          <%= form.label "result_rejected", "Reject", class: "govuk-label govuk-radios__label" %>
+          <%= form.label(
+            "result_rejected",
+            (
+              @qa_decision_task && claim.rejected? ? "Claim does not meet eligibility criteria. Reject claim" : "Reject"
+            ),
+            class: "govuk-label govuk-radios__label"
+          ) %>
         </div>
 
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-rejected-reasons">

--- a/spec/features/admin/admin_reject_claim_spec.rb
+++ b/spec/features/admin/admin_reject_claim_spec.rb
@@ -157,4 +157,106 @@ RSpec.feature "Admin rejects a claim" do
       end
     end
   end
+
+  context "QA required for a rejected claim" do
+    let(:policy) { Policies::FurtherEducationPayments }
+
+    let(:claim) { create(:claim, :submitted, policy: policy) }
+
+    around do |example|
+      perform_enqueued_jobs { example.run }
+    end
+
+    before do
+      stub_const("Policies::#{policy}::REJECTED_MIN_QA_THRESHOLD", 100)
+    end
+
+    context "when rejecting during QA" do
+      it "rejects the claim" do
+        visit admin_claim_tasks_path(claim)
+
+        click_on "Approve or reject this claim"
+
+        choose "Reject"
+
+        check "No teaching responsibilities"
+
+        click_button "Confirm decision"
+
+        expect(claim.email_address).not_to have_received_email(
+          ApplicationMailer::FURTHER_EDUCATION_PAYMENTS[:CLAIM_REJECTED_NOTIFY_TEMPLATE_ID]
+        )
+
+        expect(page).to have_content(
+          "This claim has been marked for a quality assurance review"
+        )
+
+        visit admin_claim_tasks_path(claim)
+
+        click_on "Approve or reject quality assurance of this claim"
+
+        choose "Reject"
+
+        check "Identity check failed"
+
+        fill_in "Decision notes", with: "QA failed"
+
+        click_button "Confirm decision"
+
+        expect(page).to have_content("Claim has been rejected successfully")
+
+        expect(claim.email_address).to have_received_email(
+          ApplicationMailer::FURTHER_EDUCATION_PAYMENTS[:CLAIM_REJECTED_NOTIFY_TEMPLATE_ID]
+        )
+
+        visit admin_claim_decisions_path(claim)
+
+        expect(page).to have_content("Result Rejected").twice
+      end
+    end
+
+    context "when approving during QA" do
+      it "approves the claim" do
+        visit admin_claim_tasks_path(claim)
+
+        click_on "Approve or reject this claim"
+
+        choose "Reject"
+
+        check "No teaching responsibilities"
+
+        click_button "Confirm decision"
+
+        expect(claim.email_address).not_to have_received_email(
+          ApplicationMailer::FURTHER_EDUCATION_PAYMENTS[:CLAIM_REJECTED_NOTIFY_TEMPLATE_ID]
+        )
+
+        expect(page).to have_content(
+          "This claim has been marked for a quality assurance review"
+        )
+
+        visit admin_claim_tasks_path(claim)
+
+        click_on "Approve or reject quality assurance of this claim"
+
+        choose "Approve"
+
+        fill_in "Decision notes", with: "QA passed"
+
+        click_button "Confirm decision"
+
+        expect(page).to have_content("Claim has been approved successfully")
+
+        expect(claim.email_address).to have_received_email(
+          ApplicationMailer::FURTHER_EDUCATION_PAYMENTS[:CLAIM_APPROVED_NOTIFY_TEMPLATE_ID]
+        )
+
+        visit admin_claim_decisions_path(claim)
+
+        expect(page).to have_content("Result Rejected").once
+
+        expect(page).to have_content("Result Approved").once
+      end
+    end
+  end
 end

--- a/spec/features/admin/approvals_spec.rb
+++ b/spec/features/admin/approvals_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Approvals" do
   before do
-    stub_const("Policies::EarlyYearsPayments::MIN_QA_THRESHOLD", 0)
+    stub_const("Policies::EarlyYearsPayments::APPROVED_MIN_QA_THRESHOLD", 0)
   end
 
   context "when the claim is auto-approved" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe Claim, type: :model do
 
       context "when above the min QA threshold" do
         before do
-          stub_const("Policies::#{claim.policy}::MIN_QA_THRESHOLD", 0)
+          stub_const("Policies::#{claim.policy}::APPROVED_MIN_QA_THRESHOLD", 0)
         end
 
         it { is_expected.to eq(false) }
@@ -434,7 +434,7 @@ RSpec.describe Claim, type: :model do
 
       context "when below the min QA threshold" do
         before do
-          stub_const("Policies::#{claim.policy}::MIN_QA_THRESHOLD", 100)
+          stub_const("Policies::#{claim.policy}::APPROVED_MIN_QA_THRESHOLD", 100)
         end
 
         it { is_expected.to eq(true) }
@@ -624,17 +624,17 @@ RSpec.describe Claim, type: :model do
 
     subject { build(:claim, policy: policy).below_min_qa_threshold? }
 
-    context "when the MIN_QA_THRESHOLD is set to zero" do
+    context "when the APPROVED_MIN_QA_THRESHOLD is set to zero" do
       before do
-        stub_const("Policies::#{policy}::MIN_QA_THRESHOLD", 0)
+        stub_const("Policies::#{policy}::APPROVED_MIN_QA_THRESHOLD", 0)
       end
 
       it { is_expected.to eq(false) }
     end
 
-    context "when the MIN_QA_THRESHOLD is set to 10" do
+    context "when the APPROVED_MIN_QA_THRESHOLD is set to 10" do
       before do
-        stub_const("Policies::#{policy}::MIN_QA_THRESHOLD", 10)
+        stub_const("Policies::#{policy}::APPROVED_MIN_QA_THRESHOLD", 10)
       end
 
       context "with no previously approved claims" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -418,7 +418,21 @@ RSpec.describe Claim, type: :model do
     context "when the claim has been rejected" do
       let(:claim) { create(:claim, :rejected) }
 
-      it { is_expected.to eq(false) }
+      context "when above the min QA threshold" do
+        before do
+          stub_const("Policies::#{claim.policy}::REJECTED_MIN_QA_THRESHOLD", 0)
+        end
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "when below the min QA threshold" do
+        before do
+          stub_const("Policies::#{claim.policy}::REJECTED_MIN_QA_THRESHOLD", 100)
+        end
+
+        it { is_expected.to eq(true) }
+      end
     end
 
     context "when the claim has been approved" do
@@ -618,11 +632,11 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "#below_min_qa_threshold?" do
+  describe "#below_min_qa_threshold_for_approval?" do
     let(:policy) { Policies::EarlyCareerPayments }
     let(:other_policy) { Policies::POLICIES.detect { |p| p != policy } }
 
-    subject { build(:claim, policy: policy).below_min_qa_threshold? }
+    subject { build(:claim, policy: policy).below_min_qa_threshold_for_approval? }
 
     context "when the APPROVED_MIN_QA_THRESHOLD is set to zero" do
       before do
@@ -824,6 +838,28 @@ RSpec.describe Claim, type: :model do
 
         it { is_expected.to eq(true) }
       end
+    end
+  end
+
+  describe "#below_min_qa_threshold_for_rejection?" do
+    it "returns true for 1 in 10 claims" do
+      policy = Policies::FurtherEducationPayments
+
+      stub_const("Policies::#{policy}::REJECTED_MIN_QA_THRESHOLD", 10)
+
+      claim = build(:claim, policy: policy)
+
+      random = double(Random)
+
+      allow(Random).to receive(:new).and_return(random)
+
+      allow(random).to receive(:rand).and_return(9)
+
+      expect(claim.below_min_qa_threshold_for_rejection?).to eq(true)
+
+      allow(random).to receive(:rand).and_return(99)
+
+      expect(claim.below_min_qa_threshold_for_rejection?).to eq(false)
     end
   end
 

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -325,7 +325,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
     claim_checking_steps(policy)
   end
 
-  scenario "service operator QAs a #{policy_name} claim", if: policy::MIN_QA_THRESHOLD.positive? do
+  scenario "service operator QAs a #{policy_name} claim", if: policy::APPROVED_MIN_QA_THRESHOLD.positive? do
     claim_checking_steps(policy)
     qa_approval_steps
   end

--- a/spec/support/have_received_email_matcher.rb
+++ b/spec/support/have_received_email_matcher.rb
@@ -1,4 +1,6 @@
 RSpec::Matchers.define :have_received_email do |template_id, expected_personalisation|
+  expected_personalisation ||= {}
+
   match do |email_address|
     emails = ActionMailer::Base.deliveries.select do |mail|
       mail.to.include? email_address

--- a/spec/support/stubbing_helpers.rb
+++ b/spec/support/stubbing_helpers.rb
@@ -1,7 +1,7 @@
 module StubbingHelpers
   def disable_claim_qa_flagging
     Policies::POLICIES.each do |policy|
-      stub_const("Policies::#{policy}::MIN_QA_THRESHOLD", 0)
+      stub_const("Policies::#{policy}::APPROVED_MIN_QA_THRESHOLD", 0)
     end
   end
 

--- a/spec/support/stubbing_helpers.rb
+++ b/spec/support/stubbing_helpers.rb
@@ -2,6 +2,7 @@ module StubbingHelpers
   def disable_claim_qa_flagging
     Policies::POLICIES.each do |policy|
       stub_const("Policies::#{policy}::APPROVED_MIN_QA_THRESHOLD", 0)
+      stub_const("Policies::#{policy}::REJECTED_MIN_QA_THRESHOLD", 0)
     end
   end
 


### PR DESCRIPTION
Flag 10% of rejected claims for QA

The requirement for this ticket was to flag a random 10% of all rejected
claims for QA, as such we can use a simpler implementation for picking
10% of claims than we use for approval by just using `rand`.
