### PR TITLE
move current academic year

### DIFF
--- a/app/jobs/qualifications_no_match_check_job.rb
+++ b/app/jobs/qualifications_no_match_check_job.rb
@@ -48,6 +48,6 @@ class QualificationsNoMatchCheckJob < ApplicationJob
   end
 
   def current_academic_year
-    Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year
+    Policies::EarlyCareerPayments.current_academic_year
   end
 end

--- a/app/jobs/student_loan_amount_check_job.rb
+++ b/app/jobs/student_loan_amount_check_job.rb
@@ -34,6 +34,6 @@ class StudentLoanAmountCheckJob < ApplicationJob
   end
 
   def current_academic_year
-    Journeys.for_policy(Policies::StudentLoans).configuration.current_academic_year
+    Policies::StudentLoans.current_academic_year
   end
 end

--- a/app/models/automated_checks/claim_verifiers/employment.rb
+++ b/app/models/automated_checks/claim_verifiers/employment.rb
@@ -58,12 +58,12 @@ module AutomatedChecks
       end
 
       def start_of_previous_financial_year
-        previous_academic_year = Journeys.for_policy(Policies::StudentLoans).configuration.current_academic_year - 1
+        previous_academic_year = Policies::StudentLoans.current_academic_year - 1
         Date.new(previous_academic_year.start_year, 4, 6)
       end
 
       def end_of_previous_financial_year
-        Date.new(Journeys.for_policy(Policies::StudentLoans).configuration.current_academic_year.start_year, 4, 5)
+        Date.new(Policies::StudentLoans.current_academic_year.start_year, 4, 5)
       end
 
       def no_data

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -77,4 +77,8 @@ module BasePolicy
   def max_topup_amount(claim)
     10_000.00
   end
+
+  def current_academic_year
+    Journeys.for_policy(self).configuration.current_academic_year
+  end
 end

--- a/app/models/concerns/eligibility_checkable.rb
+++ b/app/models/concerns/eligibility_checkable.rb
@@ -95,7 +95,7 @@ module EligibilityCheckable
   end
 
   def claim_year
-    Journeys.for_policy(policy).configuration.current_academic_year
+    policy.current_academic_year
   end
 
   def insufficient_teaching?

--- a/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
+++ b/app/models/journeys/additional_payments_for_teaching/answers_presenter.rb
@@ -159,7 +159,7 @@ module Journeys
         policy = eligibility.policy
 
         subjects = policy.current_and_future_subject_symbols(
-          claim_year: Journeys.for_policy(policy).configuration.current_academic_year,
+          claim_year: policy.current_academic_year,
           itt_year: journey_session.answers.itt_academic_year
         )
 

--- a/app/models/policies/targeted_retention_incentive_payments/dqt_record.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/dqt_record.rb
@@ -71,7 +71,7 @@ module Policies
       end
 
       def current_academic_year
-        Journeys.for_policy(TargetedRetentionIncentivePayments).configuration.current_academic_year
+        TargetedRetentionIncentivePayments.current_academic_year
       end
 
       def eligible_code?(codes)

--- a/app/models/policies/targeted_retention_incentive_payments/eligibility.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/eligibility.rb
@@ -63,7 +63,7 @@ module Policies
       private
 
       def award_amount_must_be_in_range
-        claim_year = Journeys.for_policy(policy).configuration.current_academic_year
+        claim_year = policy.current_academic_year
         max = TargetedRetentionIncentivePayments::Award.by_academic_year(claim_year).maximum(:award_amount)
 
         unless award_amount&.between?(1, max)

--- a/app/models/policies/targeted_retention_incentive_payments/school_eligibility.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/school_eligibility.rb
@@ -21,7 +21,7 @@ module Policies
       private
 
       def current_academic_year
-        Journeys.for_policy(TargetedRetentionIncentivePayments).configuration.current_academic_year
+        TargetedRetentionIncentivePayments.current_academic_year
       end
     end
   end

--- a/app/models/teachers_pensions_service.rb
+++ b/app/models/teachers_pensions_service.rb
@@ -31,9 +31,9 @@ class TeachersPensionsService < ApplicationRecord
   end
 
   def self.tps_school_for_student_loan_in_previous_financial_year(teacher_reference_number:)
-    previous_academic_year = Journeys.for_policy(Policies::StudentLoans).configuration.current_academic_year - 1
+    previous_academic_year = Policies::StudentLoans.current_academic_year - 1
     start_of_previous_financial_year = Date.new(previous_academic_year.start_year, 4, 6)
-    end_of_previous_financial_year = Date.new(Journeys.for_policy(Policies::StudentLoans).configuration.current_academic_year.start_year, 4, 5)
+    end_of_previous_financial_year = Date.new(Policies::StudentLoans.current_academic_year.start_year, 4, 5)
 
     tps_records = where(teacher_reference_number: teacher_reference_number)
       .employed_between(start_of_previous_financial_year, end_of_previous_financial_year)

--- a/db/test_seeders/claims_importer.rb
+++ b/db/test_seeders/claims_importer.rb
@@ -46,7 +46,7 @@ module TestSeeders
 
     def insert_claims
       eligibility_type ||= eligibilities.first.class.name
-      claim_academic_year ||= Journeys.for_policy(eligibilities.first.policy).configuration.current_academic_year.to_s
+      claim_academic_year ||= eligibilities.first.policy.current_academic_year.to_s
 
       Claim.copy_from_client CLAIM_COLUMNS do |copy|
         records.each do |data|

--- a/docs/claims_with_lup_uplifts_report.md
+++ b/docs/claims_with_lup_uplifts_report.md
@@ -29,7 +29,7 @@ elig_ids = Policies::LevellingUpPremiumPayments::Eligibility.where(current_schoo
 csv_output = CSV.generate(headers: true) do |csv|
   csv << ["claim_reference", "full_name", "trn", "school_urn", "school_name", "submitted_date", "claim_status", "award_amount", "new_award_amount"]
 
-  current_academic_year = Journeys.for_policy(Policies::LevellingUpPremiumPayments).configuration.current_academic_year
+  current_academic_year = Policies::LevellingUpPremiumPayments.current_academic_year
 
   elig_ids.each do |elig_id|
     elig = Policies::LevellingUpPremiumPayments::Eligibility.find(elig_id)

--- a/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/spec/factories/journeys/additional_payments_for_teaching/session_answers.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
     end
 
     trait :with_no_eligible_subjects do
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 1 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 1 }
     end
 
     trait :with_teaching_subject_now do
@@ -91,7 +91,7 @@ FactoryBot.define do
     end
 
     trait :itt_year_good_for_life_of_targeted_retention_incentive_policy do
-      itt_academic_year { Journeys.for_policy(Policies::TargetedRetentionIncentivePayments).configuration.current_academic_year - 1 }
+      itt_academic_year { Policies::TargetedRetentionIncentivePayments.current_academic_year - 1 }
     end
 
     trait :targeted_retention_incentive_eligible do
@@ -118,7 +118,7 @@ FactoryBot.define do
       qualification { :postgraduate_itt }
       induction_completed { true }
       teaching_subject_now { true }
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 3 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 3 }
       eligible_itt_subject { :mathematics }
       employed_directly { true }
     end
@@ -140,7 +140,7 @@ FactoryBot.define do
     end
 
     trait :ecp_eligible_itt_subject_later do
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 4 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 4 }
       eligible_itt_subject { :mathematics }
     end
 

--- a/spec/factories/policies/early_career_payments/eligibilities.rb
+++ b/spec/factories/policies/early_career_payments/eligibilities.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     award_amount { 5000.0 }
 
     itt_academic_year do
-      Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 3
+      Policies::EarlyCareerPayments.current_academic_year - 3
     end
 
     trait :eligible do
@@ -25,12 +25,12 @@ FactoryBot.define do
 
     trait :ineligible_now_but_eligible_next_year do
       eligible_now_with_mathematics
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 4 } # this makes it ineligible
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 4 } # this makes it ineligible
     end
 
     trait :eligible_now_and_again_but_two_years_later do
       eligible_now_with_mathematics
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 3 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 3 }
     end
 
     trait :eligible_school_ecp_only do
@@ -50,12 +50,12 @@ FactoryBot.define do
     end
 
     trait :eligible_itt_subject_now do
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 3 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 3 }
       eligible_itt_subject { :mathematics }
     end
 
     trait :eligible_itt_subject_later do
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 4 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 4 }
       eligible_itt_subject { :mathematics }
     end
 
@@ -65,7 +65,7 @@ FactoryBot.define do
 
     trait :no_eligible_subjects do
       eligible_now
-      itt_academic_year { Journeys.for_policy(Policies::EarlyCareerPayments).configuration.current_academic_year - 1 }
+      itt_academic_year { Policies::EarlyCareerPayments.current_academic_year - 1 }
     end
 
     trait :ineligible do

--- a/spec/factories/targeted_retention_incentive_payments/awards.rb
+++ b/spec/factories/targeted_retention_incentive_payments/awards.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :targeted_retention_incentive_payments_award, class: "Policies::TargetedRetentionIncentivePayments::Award" do
     association :school
-    academic_year { Journeys.for_policy(Policies::TargetedRetentionIncentivePayments).configuration.current_academic_year }
+    academic_year { Policies::TargetedRetentionIncentivePayments.current_academic_year }
     award_amount { 2_000 }
 
     file_upload {

--- a/spec/factories/targeted_retention_incentive_payments/eligibilities.rb
+++ b/spec/factories/targeted_retention_incentive_payments/eligibilities.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
 
     trait :itt_year_good_for_life_of_targeted_retention_incentive_policy do
-      itt_academic_year { Journeys.for_policy(Policies::TargetedRetentionIncentivePayments).configuration.current_academic_year - 1 }
+      itt_academic_year { Policies::TargetedRetentionIncentivePayments.current_academic_year - 1 }
     end
 
     trait :targeted_retention_incentive_itt_subject do

--- a/spec/features/admin/admin_claim_tasks_update_with_dqt_api_spec.rb
+++ b/spec/features/admin/admin_claim_tasks_update_with_dqt_api_spec.rb
@@ -143,7 +143,7 @@ RSpec.feature "Admin claim tasks update with DQT API" do
 
     policy = claim.eligibility.policy
 
-    claim_year = Journeys.for_policy(policy).configuration.current_academic_year
+    claim_year = policy.current_academic_year
 
     itt_years = policy.selectable_itt_years_for_claim_year(claim_year)
 


### PR DESCRIPTION
Add current_academic_year to policy

In quite a few places in the app we're getting the current academic year
from the policy by going through the journey. This commit adds a method
to the base policy to return the current academic year to avoid the
chained method calls, and make it easier to overwrite this method if
needs be.
Ideally we'd be able to use `AcademicYear.current` however there are
some scenarios, such as in QA,  where being able to run a journey in a
different acadmic year is useful.

