### PR TITLE
define predicate methods

### DIFF
--- a/app/models/concerns/boolean_attributes.rb
+++ b/app/models/concerns/boolean_attributes.rb
@@ -1,0 +1,11 @@
+module BooleanAttributes
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def attribute(name, type = nil, **options)
+      super
+
+      define_method(:"#{name}?") { !!public_send(name) } if type == :boolean
+    end
+  end
+end

--- a/app/models/journeys/additional_payments_for_teaching/session_answers.rb
+++ b/app/models/journeys/additional_payments_for_teaching/session_answers.rb
@@ -68,40 +68,12 @@ module Journeys
         current_academic_year
       end
 
-      def nqt_in_academic_year_after_itt?
-        !!nqt_in_academic_year_after_itt
-      end
-
-      def teaching_subject_now?
-        !!teaching_subject_now
-      end
-
-      def induction_completed?
-        !!induction_completed
-      end
-
       def induction_not_completed?
         !induction_completed.nil? && !induction_completed?
       end
 
       def itt_subject_none_of_the_above?
         eligible_itt_subject == "none_of_the_above"
-      end
-
-      def employed_as_supply_teacher?
-        !!employed_as_supply_teacher
-      end
-
-      def subject_to_formal_performance_action?
-        !!subject_to_formal_performance_action
-      end
-
-      def subject_to_disciplinary_action?
-        !!subject_to_disciplinary_action
-      end
-
-      def eligible_degree_subject?
-        !!eligible_degree_subject
       end
 
       def current_school
@@ -132,18 +104,6 @@ module Journeys
 
       def trainee_teacher?
         nqt_in_academic_year_after_itt == false
-      end
-
-      def school_somewhere_else?
-        !!school_somewhere_else
-      end
-
-      def has_entire_term_contract?
-        !!has_entire_term_contract
-      end
-
-      def employed_directly?
-        !!employed_directly
       end
 
       private

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -42,22 +42,6 @@ module Journeys
         @possible_school ||= School.find(possible_school_id)
       end
 
-      def teaching_responsibilities?
-        !!teaching_responsibilities
-      end
-
-      def half_teaching_hours?
-        !!half_teaching_hours
-      end
-
-      def subject_to_formal_performance_action?
-        !!subject_to_formal_performance_action
-      end
-
-      def subject_to_disciplinary_action?
-        !!subject_to_disciplinary_action
-      end
-
       def recent_further_education_teacher?
         !further_education_teaching_start_year&.start_with?("pre-")
       end
@@ -80,10 +64,6 @@ module Journeys
 
       def less_than_half_hours_teaching_fe?
         half_teaching_hours == false
-      end
-
-      def hours_teaching_eligible_subjects?
-        !!hours_teaching_eligible_subjects
       end
 
       def eligible_fe_provider?

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -5,6 +5,7 @@ module Journeys
     include ActiveModel::Dirty
     include Sessions::TeacherId
     include Sessions::PiiAttributes
+    include BooleanAttributes
 
     attribute :current_school_id, :string, pii: false # UUID
     attribute :address_line_1, :string, pii: true
@@ -83,22 +84,6 @@ module Journeys
       @current_school ||= School.find_by(id: current_school_id)
     end
 
-    def details_check?
-      !!details_check
-    end
-
-    def email_address_check?
-      !!email_address_check
-    end
-
-    def provide_mobile_number?
-      !!provide_mobile_number
-    end
-
-    def hmrc_bank_validation_succeeded?
-      !!hmrc_bank_validation_succeeded
-    end
-
     def full_name
       [first_name, middle_name, surname].reject(&:blank?).join(" ")
     end
@@ -111,26 +96,6 @@ module Journeys
         address_line_4,
         postcode
       ].reject(&:blank?).join(separator)
-    end
-
-    def qualifications_details_check?
-      !!qualifications_details_check
-    end
-
-    def has_student_loan?
-      !!has_student_loan
-    end
-
-    def email_verified?
-      !!email_verified
-    end
-
-    def logged_in_with_onelogin?
-      logged_in_with_onelogin
-    end
-
-    def identity_confirmed_with_onelogin?
-      identity_confirmed_with_onelogin
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -43,10 +43,6 @@ module Journeys
         claim_school&.name
       end
 
-      def claim_school_somewhere_else?
-        !!claim_school_somewhere_else
-      end
-
       def subjects_taught
         [
           :biology_taught,
@@ -71,14 +67,6 @@ module Journeys
 
       def employed_at_recent_tps_school?
         employment_status.to_s == "recent_tps_school"
-      end
-
-      def had_leadership_position?
-        !!had_leadership_position
-      end
-
-      def mostly_performed_leadership_duties?
-        !!mostly_performed_leadership_duties
       end
     end
   end


### PR DESCRIPTION
Automatically define predicate methods for bools

Working on adding a new journey and remembering to add the predicate
methods for boolean attributes is a bit annoying. ActiveRecord gives us
these methods for boolean columns but ActiveModel doesn't do the same
for boolean attributes. This commit adds some functionality to define
predicate methods for boolean attributes and removes our previous manual
implementations.

