### PR TITLE
Don't allow verifying rejected claims

### DIFF
--- a/app/models/journeys/further_education_payments/provider/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/provider/slug_sequence.rb
@@ -6,7 +6,8 @@ module Journeys
           "sign-in",
           "verify-claim",
           "complete",
-          "unauthorised"
+          "unauthorised",
+          "expired-link"
         ]
 
         RESTRICTED_SLUGS = [
@@ -36,6 +37,15 @@ module Journeys
         end
 
         def slugs
+          if @journey_session.answers.claim.rejected?
+            return [
+              "expired-link",
+              # FormSubmittable requires a "next_slug", if the claim is
+              # rejected there isn't a next slug
+              "expired-link"
+            ]
+          end
+
           SLUGS
         end
 

--- a/app/views/further_education_payments/provider/claims/expired_link.html.erb
+++ b/app/views/further_education_payments/provider/claims/expired_link.html.erb
@@ -1,0 +1,26 @@
+<% content_for(
+  :page_title,
+  page_title(
+    "Verify a targeted retention incentive payment for further education teachers",
+    journey: current_journey_routing_name
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Verify a targeted retention incentive payment for further education
+      teachers
+    </h1>
+
+    <p class="govuk-body govuk-!-margin-top-6">
+      This verification request is no longer active.
+    </p>
+
+    <p class="govuk-body">
+      If you have any questions regarding this claim, please email
+      <%= govuk_mail_to "FE-Targeted.Retention-Incentive@education.gov.uk" %>
+      quoting claim reference <%= journey_session.answers.claim.reference %>.
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
If the claim has been rejected we don't want the provider to be able to
verify the cliam.
The FormSubmittable module assumes there is a next slug or we want to
define a callback if there isn't one. In our use case we don't want to
define a callback and there is no next slug, so the simplest work around
is to just have two "expired-link" slugs.

[CAPT-2241](https://dfedigital.atlassian.net/browse/CAPT-2241)

[CAPT-2241]: https://dfedigital.atlassian.net/browse/CAPT-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ