### PR TITLE
Remove slugs method

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -114,10 +114,6 @@ module FormSubmittable
       current_slug.underscore
     end
 
-    def slugs
-      journey.slug_sequence::SLUGS
-    end
-
     def first_slug
       slugs.first.to_sym
     end


### PR DESCRIPTION
This method is overwritten in the claims controller by the delegation to
the PageSequence#slugs method, so it never used.
