### PR TITLE
Revert bugfix

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -22,11 +22,7 @@ module Admin
 
     def admin_policy_options_provided(claim)
       claim.policy_options_provided.map do |option|
-        policy = if option["policy"] == "LevellingUpPremiumPayments"
-          Policies::TargetedRetentionIncentivePayments
-        else
-          Policies.constantize(option["policy"])
-        end
+        policy = Policies.constantize(option["policy"])
         label = t(:payment_name, scope: policy.locale_key)
         answer = number_to_currency(option["award_amount"], precision: 0)
 


### PR DESCRIPTION
Now the data migration has been run we don't need this special case
handling.

Don't merge until data-migration-policy-options has been run on production
