### PR TITLE
Add Form::Option

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -1,4 +1,22 @@
 class Form
+  class Option
+    attr_reader :id, :name, :description, :hint
+
+    def initialize(id:, name:, description: nil, hint: nil)
+      @id = id
+      @name = name
+      @description = description
+      @hint = hint
+    end
+
+    def ==(other)
+      id == other.id &&
+        name == other.name &&
+        description == other.description &&
+        hint == other.hint
+    end
+  end
+
   include ActiveModel::Model
   include ActiveModel::Attributes
   include ActiveModel::Serialization

--- a/app/forms/journeys/additional_payments_for_teaching/eligibility_confirmed_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/eligibility_confirmed_form.rb
@@ -22,7 +22,7 @@ module Journeys
 
       def radio_options
         policies_eligible_now_and_sorted.map do |policy|
-          OpenStruct.new(
+          Option.new(
             id: policy.to_s,
             name: "#{award_amount_with_currency(policy)} #{policy.short_name.downcase.singularize}",
             description: I18n.t("#{policy.locale_key}.purpose")

--- a/app/forms/journeys/early_years_payment/provider/authenticated/returner_contract_type_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/returner_contract_type_form.rb
@@ -10,19 +10,19 @@ module Journeys
 
           def radio_options
             [
-              OpenStruct.new(
+              Option.new(
                 id: "permanent",
                 name: t("options.permanent")
               ),
-              OpenStruct.new(
+              Option.new(
                 id: "casual or temporary",
                 name: t("options.casual_or_temporary")
               ),
-              OpenStruct.new(
+              Option.new(
                 id: "voluntary or unpaid",
                 name: t("options.voluntary_or_unpaid")
               ),
-              OpenStruct.new(
+              Option.new(
                 id: "agency work and apprenticeship roles",
                 name: t("options.agency_work_and_apprenticeships")
               )

--- a/app/forms/journeys/further_education_payments/building_construction_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/building_construction_courses_form.rb
@@ -17,27 +17,27 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "level3_buildingconstruction_approved",
             name: course_option_description("level3_buildingconstruction_approved")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_building",
             name: course_option_description("tlevel_building")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_onsiteconstruction",
             name: course_option_description("tlevel_onsiteconstruction")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_design_surveying",
             name: course_option_description("tlevel_design_surveying")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "level2_3_apprenticeship",
             name: course_option_description("level2_3_apprenticeship")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/chemistry_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/chemistry_courses_form.rb
@@ -17,23 +17,23 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "alevel_chemistry",
             name: course_option_description("alevel_chemistry")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "gcse_chemistry",
             name: course_option_description("gcse_chemistry")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "ibo_level_3_chemistry",
             name: course_option_description("ibo_level_3_chemistry")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "ibo_level_1_2_myp_chemistry",
             name: course_option_description("ibo_level_1_2_myp_chemistry")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/computing_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/computing_courses_form.rb
@@ -17,39 +17,39 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "level3_and_below_ict_for_practitioners",
             name: course_option_description("level3_and_below_ict_for_practitioners")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "level3_and_below_ict_for_users",
             name: course_option_description("level3_and_below_ict_for_users")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "digitalskills_quals",
             name: course_option_description("digitalskills_quals")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_digitalsupport",
             name: course_option_description("tlevel_digitalsupport")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_digitalbusiness",
             name: course_option_description("tlevel_digitalbusiness")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_digitalproduction",
             name: course_option_description("tlevel_digitalproduction")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "ibo_level3_compsci",
             name: course_option_description("ibo_level3_compsci")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "level2_3_apprenticeship",
             name: course_option_description("level2_3_apprenticeship")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/contract_type_form.rb
+++ b/app/forms/journeys/further_education_payments/contract_type_form.rb
@@ -11,16 +11,16 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "permanent",
             name: t("options.permanent"),
             hint: "This includes full-time and part-time contracts"
           ),
-          OpenStruct.new(
+          Option.new(
             id: "fixed_term",
             name: t("options.fixed_term")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "variable_hours",
             name: t("options.variable_hours"),
             hint: "This includes zero hours contracts"

--- a/app/forms/journeys/further_education_payments/early_years_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/early_years_courses_form.rb
@@ -17,23 +17,23 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "eylevel2",
             name: course_option_description("eylevel2")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "eylevel3",
             name: course_option_description("eylevel3")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "eytlevel",
             name: course_option_description("eytlevel")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "coursetoeyq",
             name: course_option_description("coursetoeyq")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/engineering_manufacturing_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/engineering_manufacturing_courses_form.rb
@@ -17,35 +17,35 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "approved_level_321_engineering",
             name: course_option_description("approved_level_321_engineering")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "approved_level_321_manufacturing",
             name: course_option_description("approved_level_321_manufacturing")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "approved_level_321_transportation",
             name: course_option_description("approved_level_321_transportation")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_design",
             name: course_option_description("tlevel_design")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_maintenance",
             name: course_option_description("tlevel_maintenance")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "tlevel_engineering",
             name: course_option_description("tlevel_engineering")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "level2_3_apprenticeship",
             name: course_option_description("level2_3_apprenticeship")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/fixed_term_contract_form.rb
+++ b/app/forms/journeys/further_education_payments/fixed_term_contract_form.rb
@@ -11,11 +11,11 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(
+          Option.new(
             id: true,
             name: t("options.true", current_academic_year: current_academic_year)
           ),
-          OpenStruct.new(
+          Option.new(
             id: false,
             name: t("options.false", current_academic_year: current_academic_year)
           )

--- a/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_teaching_start_year_form.rb
@@ -13,13 +13,13 @@ module Journeys
       def radio_options
         array = (YEARS_BEFORE..0).map do |delta|
           academic_year = AcademicYear.current + delta
-          OpenStruct.new(
+          Option.new(
             id: academic_year.start_year.to_s,
             name: t("options.between_dates", start_year: academic_year.start_year, end_year: academic_year.end_year)
           )
         end
 
-        array << OpenStruct.new(
+        array << Option.new(
           id: "pre-#{before_year}",
           name: t("options.before_date", year: before_year)
         )

--- a/app/forms/journeys/further_education_payments/half_teaching_hours_form.rb
+++ b/app/forms/journeys/further_education_payments/half_teaching_hours_form.rb
@@ -11,8 +11,8 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(id: true, name: "Yes"),
-          OpenStruct.new(id: false, name: "No")
+          Option.new(id: true, name: "Yes"),
+          Option.new(id: false, name: "No")
         ]
       end
 

--- a/app/forms/journeys/further_education_payments/hours_teaching_eligible_subjects_form.rb
+++ b/app/forms/journeys/further_education_payments/hours_teaching_eligible_subjects_form.rb
@@ -13,8 +13,8 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(id: true, name: "Yes"),
-          OpenStruct.new(id: false, name: "No")
+          Option.new(id: true, name: "Yes"),
+          Option.new(id: false, name: "No")
         ]
       end
 

--- a/app/forms/journeys/further_education_payments/maths_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/maths_courses_form.rb
@@ -17,15 +17,15 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "approved_level_321_maths",
             name: course_option_description("approved_level_321_maths")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "gcse_maths",
             name: course_option_description("gcse_maths")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/physics_courses_form.rb
+++ b/app/forms/journeys/further_education_payments/physics_courses_form.rb
@@ -17,23 +17,23 @@ module Journeys
 
       def checkbox_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "alevel_physics",
             name: course_option_description("alevel_physics")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "gcse_physics",
             name: course_option_description("gcse_physics")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "ibo_level_1_2_myp_physics",
             name: course_option_description("ibo_level_1_2_myp_physics")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "ibo_level_3_physics",
             name: course_option_description("ibo_level_3_physics")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "none",
             name: course_option_description("none")
           )

--- a/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
+++ b/app/forms/journeys/further_education_payments/provider/verify_claim_form.rb
@@ -222,12 +222,10 @@ module Journeys
 
           def radio_options
             [
-              RadioOption.new(id: true, name: "Yes"),
-              RadioOption.new(id: false, name: "No")
+              Form::Option.new(id: true, name: "Yes"),
+              Form::Option.new(id: false, name: "No")
             ]
           end
-
-          class RadioOption < Struct.new(:id, :name, keyword_init: true); end
 
           def claimant
             parent_form.claim.first_name

--- a/app/forms/journeys/further_education_payments/subjects_taught_form.rb
+++ b/app/forms/journeys/further_education_payments/subjects_taught_form.rb
@@ -13,7 +13,7 @@ module Journeys
         inclusion: {in: ->(form) { form.checkbox_options.map(&:id) }, message: i18n_error_message(:inclusion)}
 
       def checkbox_options
-        (ALL_SUBJECTS + ["none"]).map { |subject| OpenStruct.new(id: subject, name: t("options.#{subject}")) }
+        (ALL_SUBJECTS + ["none"]).map { |subject| Option.new(id: subject, name: t("options.#{subject}")) }
       end
 
       def save

--- a/app/forms/journeys/further_education_payments/taught_at_least_one_term_form.rb
+++ b/app/forms/journeys/further_education_payments/taught_at_least_one_term_form.rb
@@ -11,11 +11,11 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(
+          Option.new(
             id: true,
             name: t("options.true", school_name: school.name)
           ),
-          OpenStruct.new(
+          Option.new(
             id: false,
             name: t("options.false", school_name: school.name)
           )

--- a/app/forms/journeys/further_education_payments/teaching_hours_per_week_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_hours_per_week_form.rb
@@ -11,15 +11,15 @@ module Journeys
 
       def radio_options
         @radio_options ||= [
-          OpenStruct.new(
+          Option.new(
             id: "more_than_12",
             name: t("options.more_than_12")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "between_2_5_and_12",
             name: t("options.between_2_5_and_12")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "less_than_2_5",
             name: t("options.less_than_2_5")
           )

--- a/app/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form.rb
@@ -11,11 +11,11 @@ module Journeys
 
       def radio_options
         @radio_options ||= [
-          OpenStruct.new(
+          Option.new(
             id: "at_least_2_5",
             name: t("options.at_least_2_5", school_name: school.name)
           ),
-          OpenStruct.new(
+          Option.new(
             id: "less_than_2_5",
             name: t("options.less_than_2_5", school_name: school.name)
           )

--- a/app/forms/journeys/further_education_payments/teaching_qualification_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_qualification_form.rb
@@ -9,19 +9,19 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(
+          Option.new(
             id: "yes",
             name: t("options.yes")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "not_yet",
             name: t("options.not_yet")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "no_but_planned",
             name: t("options.no_but_planned")
           ),
-          OpenStruct.new(
+          Option.new(
             id: "no_not_planned",
             name: t("options.no_not_planned")
           )

--- a/app/forms/journeys/further_education_payments/teaching_responsibilities_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_responsibilities_form.rb
@@ -11,8 +11,8 @@ module Journeys
 
       def radio_options
         [
-          OpenStruct.new(id: true, name: "Yes"),
-          OpenStruct.new(id: false, name: "No")
+          Option.new(id: true, name: "Yes"),
+          Option.new(id: false, name: "No")
         ]
       end
 

--- a/app/forms/poor_performance_form.rb
+++ b/app/forms/poor_performance_form.rb
@@ -16,14 +16,8 @@ class PoorPerformanceForm < Form
 
   def radio_options
     [
-      OpenStruct.new(
-        id: true,
-        name: "Yes"
-      ),
-      OpenStruct.new(
-        id: false,
-        name: "No"
-      )
+      Option.new(id: true, name: "Yes"),
+      Option.new(id: false, name: "No")
     ]
   end
 

--- a/app/forms/provide_mobile_number_form.rb
+++ b/app/forms/provide_mobile_number_form.rb
@@ -25,8 +25,8 @@ class ProvideMobileNumberForm < Form
 
   def radio_options
     [
-      OpenStruct.new(id: true, name: "Yes"),
-      OpenStruct.new(id: false, name: "No")
+      Option.new(id: true, name: "Yes"),
+      Option.new(id: false, name: "No")
     ]
   end
 

--- a/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/further_education_teaching_start_year_form_spec.rb
@@ -31,15 +31,15 @@ RSpec.describe Journeys::FurtherEducationPayments::FurtherEducationTeachingStart
     it "returns expected data" do
       travel_to Time.zone.local(2024, 12, 1) do
         expected = [
-          OpenStruct.new(id: "2020", name: "September 2020 to August 2021"),
-          OpenStruct.new(id: "2021", name: "September 2021 to August 2022"),
-          OpenStruct.new(id: "2022", name: "September 2022 to August 2023"),
-          OpenStruct.new(id: "2023", name: "September 2023 to August 2024"),
-          OpenStruct.new(id: "2024", name: "September 2024 to August 2025"),
-          OpenStruct.new(id: "pre-2020", name: "I started before September 2020")
+          Form::Option.new(id: "2020", name: "September 2020 to August 2021"),
+          Form::Option.new(id: "2021", name: "September 2021 to August 2022"),
+          Form::Option.new(id: "2022", name: "September 2022 to August 2023"),
+          Form::Option.new(id: "2023", name: "September 2023 to August 2024"),
+          Form::Option.new(id: "2024", name: "September 2024 to August 2025"),
+          Form::Option.new(id: "pre-2020", name: "I started before September 2020")
         ]
 
-        expect(subject.radio_options).to eql(expected)
+        expect(subject.radio_options).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
As part of the LUP separate journey work I've found myself introducing a
Struct to represent form options in a couple of forms. This commit adds
an Option class to the base form and replaces usage of OpenStruct with
it. We use a class rather than a Struct as we have some optional key
words.
`value` and `label` would probably make more sense as attribute names
but the existing code, and the form builder docs, use `id` and `name` so
we've stuck with them.
