### PR TITLE
Add `try_t`

### DIFF
--- a/app/forms/form_helpers.rb
+++ b/app/forms/form_helpers.rb
@@ -22,6 +22,12 @@ module FormHelpers
     I18n.t("#{i18n_namespace}.#{base_key}", default: base_key, **args)
   end
 
+  def try_t(key, args = {})
+    t(key, args)
+  rescue I18n::MissingTranslationData
+    nil
+  end
+
   private
 
   def i18n_form_namespace


### PR DESCRIPTION
This method doesn't raise when a translation is missing, which is handy
for optional text like hints, letting us avoid a conditional.
````
hint: { text: @form.try_t([:hint, @form.answers.qualification]) }
````
