### PR TITLE
[CAPT-2249] OL without idv

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -176,7 +176,11 @@ class OmniauthCallbacksController < ApplicationController
     if request.path == "/auth/onelogin"
       OmniAuth::AuthHash.new(uid: "12345", info: {email: "test@example.com"}, extra: {raw_info: {}})
     elsif request.path == "/auth/onelogin_identity"
-      OmniAuth::AuthHash.new(uid: "12345", info: {email: ""}, extra: {raw_info: {ONELOGIN_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]}})
+      if FeatureFlag.enabled?(:alternative_idv)
+        OmniAuth::AuthHash.new(uid: "12345", info: {email: ""}, extra: {raw_info: {ONELOGIN_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]}})
+      else
+        OmniAuth::AuthHash.new(uid: "12345", info: {email: ""}, extra: {raw_info: {ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY => "test"}})
+      end
     end
   end
 

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -131,7 +131,8 @@ class OmniauthCallbacksController < ApplicationController
   def process_one_login_return_codes_callback
     journey_session.answers.assign_attributes(
       identity_confirmed_with_onelogin: false,
-      onelogin_idv_at: Time.now
+      onelogin_idv_at: Time.now,
+      onelogin_idv_return_codes: one_login_return_codes
     )
     journey_session.save!
 
@@ -181,7 +182,7 @@ class OmniauthCallbacksController < ApplicationController
 
   def omniauth_hash
     @omniauth_hash ||= if OneLoginSignIn.bypass?
-      test_user_auth_hash
+      OmniAuth.config.mock_auth[:onelogin] || test_user_auth_hash
     else
       request.env["omniauth.auth"]
     end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class OmniauthCallbacksController < ApplicationController
   include JourneyConcern
 
   ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY = "https://vocab.account.gov.uk/v1/coreIdentityJWT".freeze
-  ONELOGIN_JWT_RETURN_CODE_HASH_KEY = "https://vocab.account.gov.uk/v1/returnCode".freeze
+  ONELOGIN_RETURN_CODE_HASH_KEY = "https://vocab.account.gov.uk/v1/returnCode".freeze
 
   def callback
     auth = request.env["omniauth.auth"]
@@ -62,7 +62,7 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   def one_login_return_codes
-    omniauth_hash.extra.raw_info.fetch(ONELOGIN_JWT_RETURN_CODE_HASH_KEY, []).map { |hash| hash["code"] }
+    omniauth_hash.extra.raw_info.fetch(ONELOGIN_RETURN_CODE_HASH_KEY, []).map { |hash| hash["code"] }
   end
 
   def current_journey_routing_name

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -176,7 +176,7 @@ class OmniauthCallbacksController < ApplicationController
     if request.path == "/auth/onelogin"
       OmniAuth::AuthHash.new(uid: "12345", info: {email: "test@example.com"}, extra: {raw_info: {}})
     elsif request.path == "/auth/onelogin_identity"
-      OmniAuth::AuthHash.new(uid: "12345", info: {email: ""}, extra: {raw_info: {ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY => "test"}})
+      OmniAuth::AuthHash.new(uid: "12345", info: {email: ""}, extra: {raw_info: {ONELOGIN_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]}})
     end
   end
 

--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -6,6 +6,9 @@ module Journeys
 
         if Policies::FurtherEducationPayments.duplicate_claim?(claim)
           claim.eligibility.update!(flagged_as_duplicate: true)
+        elsif !claim.identity_confirmed_with_onelogin?
+          Policies::FurtherEducationPayments::ProviderVerificationEmails.new(claim)
+            .send_further_education_payment_provider_verification_email
         elsif claim.one_login_idv_mismatch?
           # noop
           # do not send provider verification email

--- a/app/forms/journeys/further_education_payments/claim_submission_form.rb
+++ b/app/forms/journeys/further_education_payments/claim_submission_form.rb
@@ -6,7 +6,7 @@ module Journeys
 
         if Policies::FurtherEducationPayments.duplicate_claim?(claim)
           claim.eligibility.update!(flagged_as_duplicate: true)
-        elsif !claim.identity_confirmed_with_onelogin?
+        elsif FeatureFlag.enabled?(:alternative_idv) && !claim.identity_confirmed_with_onelogin?
           Policies::FurtherEducationPayments::ProviderVerificationEmails.new(claim)
             .send_further_education_payment_provider_verification_email
         elsif claim.one_login_idv_mismatch?

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -19,6 +19,9 @@ module AutomatedChecks
 
         if claim.identity_confirmed_with_onelogin?
           one_login
+        elsif claim.onelogin_idv_at.present? && !claim.identity_confirmed_with_onelogin?
+          # noop
+          # TODO: tbd what happens when OL user that fails OL idv comes thru
         else
           # Order of matching matters so that subsequent conditions in methods fall through to execute the right thing
           no_match || partial_match || complete_match

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -19,7 +19,7 @@ module AutomatedChecks
 
         if claim.identity_confirmed_with_onelogin?
           one_login
-        elsif claim.onelogin_idv_at.present? && !claim.identity_confirmed_with_onelogin?
+        elsif FeatureFlag.enabled?(:alternative_idv) && claim.onelogin_idv_at.present? && !claim.identity_confirmed_with_onelogin?
           # noop
           # TODO: tbd what happens when OL user that fails OL idv comes thru
         else

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -54,6 +54,7 @@ module Journeys
     attribute :onelogin_idv_last_name, :string, pii: true
     attribute :onelogin_idv_full_name, :string, pii: true
     attribute :onelogin_idv_date_of_birth, :date, pii: false
+    attribute :onelogin_idv_return_codes, default: [], pii: true
 
     attribute :onelogin_auth_at, :datetime, pii: false
     attribute :onelogin_idv_at, :datetime, pii: false

--- a/app/views/claims/_sign_in.html.erb
+++ b/app/views/claims/_sign_in.html.erb
@@ -1,5 +1,7 @@
 <% if @journey_session.answers.identity_confirmed_with_onelogin? %>
   <%= render "sign_in_3_identified" %>
+<% elsif @journey_session.answers.logged_in_with_onelogin? && @journey_session.answers.onelogin_idv_return_codes.present? %>
+  <%= render "sign_in_3_not_identified" %>
 <% elsif @journey_session.answers.logged_in_with_onelogin? %>
   <%= render "sign_in_2_authed" %>
 <% else %>

--- a/app/views/claims/_sign_in.html.erb
+++ b/app/views/claims/_sign_in.html.erb
@@ -1,6 +1,6 @@
 <% if @journey_session.answers.identity_confirmed_with_onelogin? %>
   <%= render "sign_in_3_identified" %>
-<% elsif @journey_session.answers.logged_in_with_onelogin? && @journey_session.answers.onelogin_idv_return_codes.present? %>
+<% elsif FeatureFlag.enabled?(:alternative_idv) && @journey_session.answers.logged_in_with_onelogin? && @journey_session.answers.onelogin_idv_return_codes.present? %>
   <%= render "sign_in_3_not_identified" %>
 <% elsif @journey_session.answers.logged_in_with_onelogin? %>
   <%= render "sign_in_2_authed" %>

--- a/app/views/claims/_sign_in_3_not_identified.html.erb
+++ b/app/views/claims/_sign_in_3_not_identified.html.erb
@@ -1,9 +1,13 @@
 <h1 class="govuk-heading-l">
-  You have not proved your identity with GOV.UK One Login
+  We cannot verify your identity via GOV.UK One Login
 </h1>
 
 <p class="govuk-body">
-  You can now continue with your application.
+  We will verify your identity using an alternative method. You can continue with your application.
+</p>
+
+<p class="govuk-body">
+  If you have any questions about the application process, email <%= govuk_mail_to I18n.t("further_education_payments.support_email_address") %>.
 </p>
 
 <%= form_with model: @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>

--- a/app/views/claims/_sign_in_3_not_identified.html.erb
+++ b/app/views/claims/_sign_in_3_not_identified.html.erb
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-l">
+  You have not proved your identity with GOV.UK One Login
+</h1>
+
+<p class="govuk-body">
+  You can now continue with your application.
+</p>
+
+<%= form_with model: @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -83,6 +83,7 @@ shared:
     - onelogin_uid
     - started_at
     - verified_at
+    - onelogin_idv_return_codes
   :decisions:
     - id
     - claim_id

--- a/db/migrate/20250227151439_add_ol_claim_return_codes.rb
+++ b/db/migrate/20250227151439_add_ol_claim_return_codes.rb
@@ -1,0 +1,5 @@
+class AddOlClaimReturnCodes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :claims, :onelogin_idv_return_codes, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -114,6 +114,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_07_152200) do
     t.datetime "started_at", precision: nil, null: false
     t.datetime "verified_at"
     t.text "onelogin_idv_full_name"
+    t.text "onelogin_idv_return_codes", array: true
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"

--- a/spec/features/early_years_payment/practitioner/happy_path_spec.rb
+++ b/spec/features/early_years_payment/practitioner/happy_path_spec.rb
@@ -18,8 +18,12 @@ RSpec.feature "Early years payment practitioner" do
     fill_in "Claim reference number", with: claim.reference
     click_button "Submit"
 
+    mock_one_login_auth
+
     expect(page).to have_content "Sign in with GOV.UK One Login"
     click_on "Continue"
+
+    mock_one_login_idv
 
     expect(page).to have_content "You have successfully signed in to GOV.UK One Login"
     click_on "Continue"

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -1,0 +1,243 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments" do
+  include ActionView::Helpers::NumberHelper
+
+  let(:college) { create(:school, :further_education, :fe_eligible) }
+  let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
+
+  scenario "claim with failed OL idv" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Permanent contract")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
+    check("Chemistry")
+    check("Computing, including digital and ICT")
+    check("Early years")
+    check("Engineering and manufacturing, including transport engineering and electronics")
+    check("Maths")
+    check("Physics")
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Which chemistry courses do you teach?")
+    check "GCSE chemistry"
+    click_button "Continue"
+
+    expect(page).to have_content("Which computing courses do you teach?")
+    check "T Level in digital support services"
+    click_button "Continue"
+
+    expect(page).to have_content("Which early years courses do you teach?")
+    check "T Level in education and early years (early years educator)"
+    click_button "Continue"
+
+    expect(page).to have_content("Which engineering and manufacturing courses do you teach?")
+    check "T Level in design and development for engineering and manufacturing"
+    click_button "Continue"
+
+    expect(page).to have_content("Which maths courses do you teach?")
+
+    check("claim-maths-courses-approved-level-321-maths-field")
+    click_button "Continue"
+
+    expect(page).to have_content("Which physics courses do you teach?")
+    check "A or AS level physics"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    expect(page).to have_content("T Level in building services engineering for construction")
+    expect(page).to have_content("GCSE chemistry")
+    expect(page).to have_content("T Level in digital support services")
+    expect(page).to have_content("T Level in education and early years (early years educator)")
+    expect(page).to have_content("T Level in design and development for engineering and manufacturing")
+    expect(page).to have_content("Qualifications approved for funding at level 3 and below in the")
+    expect(page).to have_content("A or AS level physics")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you subject to any formal performance measures as a result of continuous poor teaching standards")
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    expect(page).to have_content("Are you currently subject to disciplinary action?")
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a targeted retention incentive payment")
+    expect(page).to have_content(number_to_currency(expected_award_amount, precision: 0))
+    expect(page).to have_content("Apply now")
+    click_button "Apply now"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    click_button "Continue"
+
+    hash = OmniAuth::AuthHash.new(
+      uid: "12345",
+      info: {
+        email: ""
+      },
+      extra: {
+        raw_info: {
+          OmniauthCallbacksController::ONELOGIN_JWT_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]
+        }
+      }
+    )
+
+    OmniAuth.config.mock_auth[:onelogin] = hash
+    Rails.application.env_config["omniauth.auth"] = hash
+
+    session = Journeys::FurtherEducationPayments::Session.last
+
+    expect(page).to have_content("You have successfully signed in to GOV.UK One Login")
+    expect {
+      click_button "Continue"
+    }.to change { session.reload.answers.onelogin_idv_return_codes }.from([]).to(["ABC"])
+
+    expect(page).to have_content("You have not proved your identity with GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
+    click_button "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    expect(page).to have_content("What is your home address?")
+    click_button("Enter your address manually")
+
+    expect(page).to have_content("What is your address?")
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    expect(page).to have_content("Email address")
+    fill_in "Email address", with: "john.doe@example.com"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter the 6-digit passcode")
+    mail = ActionMailer::Base.deliveries.last
+    otp_in_mail_sent = mail[:personalisation].decoded.scan(/\b[0-9]{6}\b/).first
+    fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+    click_on "Confirm"
+
+    expect(page).to have_content("Would you like to provide your mobile number?")
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter your personal bank account details")
+    fill_in "Name on your account", with: "Jo Bloggs"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    expect(page).to have_content("How is your gender recorded on your employer’s payroll system?")
+    choose "Female"
+    click_on "Continue"
+
+    expect(page).to have_content("Teacher reference number (TRN)")
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
+    click_on "Continue"
+
+    expect(page).to have_content("Check your answers before sending your application")
+
+    expect do
+      click_on "Accept and send"
+    end.to change { Claim.count }.by(1)
+      .and change { Policies::FurtherEducationPayments::Eligibility.count }.by(1)
+      .and have_enqueued_mail(ClaimMailer, :submitted).with(Claim.last)
+
+    claim = Claim.last
+
+    expect(claim.first_name).to eql("John")
+    expect(claim.surname).to eql("Doe")
+    expect(claim.student_loan_plan).to eq "plan_1"
+
+    expect(claim.onelogin_idv_full_name).to be_nil
+    expect(claim.onelogin_idv_return_codes).to eql(["ABC"])
+    expect(claim.onelogin_idv_at).to be_within(1.minute).of(Time.now)
+    expect(claim.identity_confirmed_with_onelogin).to eql(false)
+
+    eligibility = Policies::FurtherEducationPayments::Eligibility.last
+
+    expect(eligibility.teacher_reference_number).to eql("1234567")
+
+    expect(page).to have_content("You applied for a further education targeted retention incentive payment")
+
+    expect do
+      click_link "Set reminder"
+    end.to change { Reminder.count }.by(1)
+      .and change { ActionMailer::Base.deliveries.count }.by(1)
+
+    reminder = Reminder.last
+
+    expect(reminder.full_name).to eql("John Doe")
+    expect(reminder.email_address).to eql("john.doe@example.com")
+    expect(reminder.email_verified).to be_truthy
+    expect(reminder.itt_academic_year).to eql(AcademicYear.next.to_s)
+    expect(reminder.itt_subject).to be_nil
+    expect(reminder.journey_class).to eql("Journeys::FurtherEducationPayments")
+
+    expect(page).to have_content("We have set your reminder")
+  end
+
+  def and_college_exists
+    college
+  end
+end

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Further education payments" do
       click_button "Continue"
     }.to change { session.reload.answers.onelogin_idv_return_codes }.from([]).to(["ABC"])
 
-    expect(page).to have_content("You have not proved your identity with GOV.UK One Login")
+    expect(page).to have_content("We cannot verify your identity via GOV.UK One Login")
     click_button "Continue"
 
     expect(page).to have_content("How we will use the information you provide")

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -115,23 +115,12 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Apply now")
     click_button "Apply now"
 
+    mock_one_login_auth
+
     expect(page).to have_content("Sign in with GOV.UK One Login")
     click_button "Continue"
 
-    hash = OmniAuth::AuthHash.new(
-      uid: "12345",
-      info: {
-        email: ""
-      },
-      extra: {
-        raw_info: {
-          OmniauthCallbacksController::ONELOGIN_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]
-        }
-      }
-    )
-
-    OmniAuth.config.mock_auth[:onelogin] = hash
-    Rails.application.env_config["omniauth.auth"] = hash
+    mock_one_login_idv_with_return_codes
 
     session = Journeys::FurtherEducationPayments::Session.last
 

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature "Further education payments" do
       },
       extra: {
         raw_info: {
-          OmniauthCallbacksController::ONELOGIN_JWT_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]
+          OmniauthCallbacksController::ONELOGIN_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]
         }
       }
     )

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Further education payments" do
   let(:college) { create(:school, :further_education, :fe_eligible) }
   let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
 
-  scenario "claim with failed OL idv" do
+  scenario "claim with failed OL idv", feature_flag: :alternative_idv do
     when_student_loan_data_exists
     when_further_education_payments_journey_configuration_exists
     and_college_exists

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.include OneLoginHelper, type: :feature
   config.include FeatureHelpers, type: :feature
   config.include RequestHelpers, type: :request
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.before :each do
+    data = RSpec.current_example.metadata[:feature_flag]
+
+    if data.present?
+      Array(data).each do |name|
+        FeatureFlag.create!(name:, enabled: true)
+      end
+    end
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -157,8 +157,12 @@ module FeatureHelpers
   end
 
   def sign_in_with_one_login
+    mock_one_login_auth
+
     expect(page).to have_content("Sign in with GOV.UK One Login")
     click_button "Continue"
+
+    mock_one_login_idv
 
     expect(page).to have_content("You have successfully signed in to GOV.UK One Login")
     click_button "Continue"

--- a/spec/support/one_login_helper.rb
+++ b/spec/support/one_login_helper.rb
@@ -1,0 +1,50 @@
+module OneLoginHelper
+  def mock_one_login_auth
+    hash = OmniAuth::AuthHash.new(
+      uid: "12345",
+      info: {
+        email: "test@example.com"
+      },
+      extra: {
+        raw_info: {}
+      }
+    )
+
+    OmniAuth.config.mock_auth[:onelogin] = hash
+    Rails.application.env_config["omniauth.auth"] = hash
+  end
+
+  def mock_one_login_idv
+    hash = OmniAuth::AuthHash.new(
+      uid: "12345",
+      info: {
+        email: ""
+      },
+      extra: {
+        raw_info: {
+          OmniauthCallbacksController::ONELOGIN_JWT_CORE_IDENTITY_HASH_KEY => "test"
+        }
+      }
+    )
+
+    OmniAuth.config.mock_auth[:onelogin] = hash
+    Rails.application.env_config["omniauth.auth"] = hash
+  end
+
+  def mock_one_login_idv_with_return_codes
+    hash = OmniAuth::AuthHash.new(
+      uid: "12345",
+      info: {
+        email: ""
+      },
+      extra: {
+        raw_info: {
+          OmniauthCallbacksController::ONELOGIN_RETURN_CODE_HASH_KEY => [{"code" => "ABC"}]
+        }
+      }
+    )
+
+    OmniAuth.config.mock_auth[:onelogin] = hash
+    Rails.application.env_config["omniauth.auth"] = hash
+  end
+end

--- a/spec/support/steps/early_years_practitioner_journey.rb
+++ b/spec/support/steps/early_years_practitioner_journey.rb
@@ -3,9 +3,20 @@ def when_personal_details_entered_up_to_address
   fill_in "Claim reference number", with: claim.reference
   click_button "Submit"
 
+  mock_one_login_auth
+
+  expect(page).to have_content "Sign in with GOV.UK One Login"
   click_on "Continue"
+
+  mock_one_login_idv
+
+  expect(page).to have_content "You have successfully signed in to GOV.UK One Login"
   click_on "Continue"
+
+  expect(page).to have_content "You have successfully proved your identity with GOV.UK One Login"
   click_on "Continue"
+
+  expect(page).to have_content "How we’ll process your claim"
   click_on "Continue"
 
   fill_in "First name", with: "John"


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2249
- Allow users who cannot pass OL idv to continue their journey

# Changes

- For review app testing this always makes the user fail OL idv
- In order to achieve this more explicit mocking of OL has had to be added to tests
- We store their OL return codes onto their session and subsequently their claim when created