### PR TITLE
pass session into answers

### DIFF
--- a/app/forms/journeys/additional_payments_for_teaching/correct_school_form.rb
+++ b/app/forms/journeys/additional_payments_for_teaching/correct_school_form.rb
@@ -19,7 +19,7 @@ module Journeys
       private
 
       def current_school
-        @current_school ||= journey_session.recent_tps_school || answers.current_school
+        @current_school ||= answers.recent_tps_school || answers.current_school
       end
 
       def change_school?

--- a/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/select_claim_school_form.rb
@@ -42,7 +42,7 @@ module Journeys
       private
 
       def claim_school
-        @claim_school ||= journey_session.tps_school_for_student_loan_in_previous_financial_year || answers.claim_school
+        @claim_school ||= answers.tps_school_for_student_loan_in_previous_financial_year || answers.claim_school
       end
 
       def change_school?

--- a/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/still_teaching_form.rb
@@ -18,8 +18,8 @@ module Journeys
       end
 
       def school
-        if journey_session.logged_in_with_tid_and_has_recent_tps_school?
-          journey_session.recent_tps_school
+        if answers.logged_in_with_tid_and_has_recent_tps_school?
+          answers.recent_tps_school
         else
           answers.claim_school
         end
@@ -35,7 +35,7 @@ module Journeys
 
       # Helper used in the view to choose partials and locale keys
       def tps_or_claim_school
-        if journey_session.logged_in_with_tid_and_has_recent_tps_school?
+        if answers.logged_in_with_tid_and_has_recent_tps_school?
           "tps_school"
         else
           "claim_school"

--- a/app/models/journeys/additional_payments_for_teaching/session.rb
+++ b/app/models/journeys/additional_payments_for_teaching/session.rb
@@ -1,11 +1,5 @@
 module Journeys
   module AdditionalPaymentsForTeaching
-    class Session < Journeys::Session
-      attribute :answers, SessionAnswersType.new
-
-      def answers
-        super.tap { it.session = self }
-      end
-    end
+    class Session < Journeys::Session; end
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching/session.rb
+++ b/app/models/journeys/additional_payments_for_teaching/session.rb
@@ -2,6 +2,10 @@ module Journeys
   module AdditionalPaymentsForTeaching
     class Session < Journeys::Session
       attribute :answers, SessionAnswersType.new
+
+      def answers
+        super.tap { it.session = self }
+      end
     end
   end
 end

--- a/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
+++ b/app/models/journeys/additional_payments_for_teaching/slug_sequence.rb
@@ -139,7 +139,7 @@ module Journeys
 
           sequence.delete("teacher-reference-number") if answers.logged_in_with_tid? && answers.teacher_reference_number.present?
 
-          sequence.delete("correct-school") unless journey_session.logged_in_with_tid_and_has_recent_tps_school?
+          sequence.delete("correct-school") unless answers.logged_in_with_tid_and_has_recent_tps_school?
           sequence.delete("current-school") if journey_session.answers.school_somewhere_else == false
 
           if answers.provide_mobile_number == false

--- a/app/models/journeys/early_years_payment/practitioner/session.rb
+++ b/app/models/journeys/early_years_payment/practitioner/session.rb
@@ -1,13 +1,7 @@
 module Journeys
   module EarlyYearsPayment
     module Practitioner
-      class Session < Journeys::Session
-        attribute :answers, SessionAnswersType.new
-
-        def answers
-          super.tap { it.session = self }
-        end
-      end
+      class Session < Journeys::Session; end
     end
   end
 end

--- a/app/models/journeys/early_years_payment/practitioner/session.rb
+++ b/app/models/journeys/early_years_payment/practitioner/session.rb
@@ -3,6 +3,10 @@ module Journeys
     module Practitioner
       class Session < Journeys::Session
         attribute :answers, SessionAnswersType.new
+
+        def answers
+          super.tap { it.session = self }
+        end
       end
     end
   end

--- a/app/models/journeys/early_years_payment/provider/authenticated/session.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session.rb
@@ -2,13 +2,7 @@ module Journeys
   module EarlyYearsPayment
     module Provider
       module Authenticated
-        class Session < Journeys::Session
-          attribute :answers, SessionAnswersType.new
-
-          def answers
-            super.tap { it.session = self }
-          end
-        end
+        class Session < Journeys::Session; end
       end
     end
   end

--- a/app/models/journeys/early_years_payment/provider/authenticated/session.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated/session.rb
@@ -4,6 +4,10 @@ module Journeys
       module Authenticated
         class Session < Journeys::Session
           attribute :answers, SessionAnswersType.new
+
+          def answers
+            super.tap { it.session = self }
+          end
         end
       end
     end

--- a/app/models/journeys/early_years_payment/provider/start/session.rb
+++ b/app/models/journeys/early_years_payment/provider/start/session.rb
@@ -2,13 +2,7 @@ module Journeys
   module EarlyYearsPayment
     module Provider
       module Start
-        class Session < Journeys::Session
-          attribute :answers, SessionAnswersType.new
-
-          def answers
-            super.tap { it.session = self }
-          end
-        end
+        class Session < Journeys::Session; end
       end
     end
   end

--- a/app/models/journeys/early_years_payment/provider/start/session.rb
+++ b/app/models/journeys/early_years_payment/provider/start/session.rb
@@ -4,6 +4,10 @@ module Journeys
       module Start
         class Session < Journeys::Session
           attribute :answers, SessionAnswersType.new
+
+          def answers
+            super.tap { it.session = self }
+          end
         end
       end
     end

--- a/app/models/journeys/further_education_payments/provider/session.rb
+++ b/app/models/journeys/further_education_payments/provider/session.rb
@@ -3,6 +3,10 @@ module Journeys
     module Provider
       class Session < Journeys::Session
         attribute :answers, SessionAnswersType.new
+
+        def answers
+          super.tap { it.session = self }
+        end
       end
     end
   end

--- a/app/models/journeys/further_education_payments/provider/session.rb
+++ b/app/models/journeys/further_education_payments/provider/session.rb
@@ -1,13 +1,7 @@
 module Journeys
   module FurtherEducationPayments
     module Provider
-      class Session < Journeys::Session
-        attribute :answers, SessionAnswersType.new
-
-        def answers
-          super.tap { it.session = self }
-        end
-      end
+      class Session < Journeys::Session; end
     end
   end
 end

--- a/app/models/journeys/further_education_payments/session.rb
+++ b/app/models/journeys/further_education_payments/session.rb
@@ -1,11 +1,5 @@
 module Journeys
   module FurtherEducationPayments
-    class Session < Journeys::Session
-      attribute :answers, SessionAnswersType.new
-
-      def answers
-        super.tap { it.session = self }
-      end
-    end
+    class Session < Journeys::Session; end
   end
 end

--- a/app/models/journeys/further_education_payments/session.rb
+++ b/app/models/journeys/further_education_payments/session.rb
@@ -2,6 +2,10 @@ module Journeys
   module FurtherEducationPayments
     class Session < Journeys::Session
       attribute :answers, SessionAnswersType.new
+
+      def answers
+        super.tap { it.session = self }
+      end
     end
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session.rb
@@ -2,6 +2,10 @@ module Journeys
   module GetATeacherRelocationPayment
     class Session < Journeys::Session
       attribute :answers, SessionAnswersType.new
+
+      def answers
+        super.tap { it.session = self }
+      end
     end
   end
 end

--- a/app/models/journeys/get_a_teacher_relocation_payment/session.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session.rb
@@ -1,11 +1,5 @@
 module Journeys
   module GetATeacherRelocationPayment
-    class Session < Journeys::Session
-      attribute :answers, SessionAnswersType.new
-
-      def answers
-        super.tap { it.session = self }
-      end
-    end
+    class Session < Journeys::Session; end
   end
 end

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -4,6 +4,16 @@ module Journeys
 
     self.table_name = "journeys_sessions"
 
+    def self.inherited(subclass)
+      super
+
+      subclass.attribute :answers, subclass.module_parent::SessionAnswersType.new
+
+      subclass.define_method(:answers) do
+        super().tap { it.session = self }
+      end
+    end
+
     has_one :claim,
       dependent: :nullify,
       inverse_of: :journey_session,

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -28,30 +28,5 @@ module Journeys
     def submitted?
       claim.present?
     end
-
-    def logged_in_with_tid_and_has_recent_tps_school?
-      answers.trn_from_tid? && recent_tps_school.present?
-    end
-
-    # NOTE getting the trn from answers.teacher_id_user_info was the previous
-    # implementation, TODO switch to `answers.teacher_reference_number` as it's
-    # set in the sign in or continue form at the same time.
-    def recent_tps_school
-      @recent_tps_school ||= TeachersPensionsService.recent_tps_school(
-        claim_date: created_at,
-        teacher_reference_number: answers.teacher_id_user_info["trn"]
-      )
-    end
-
-    def has_tps_school_for_student_loan_in_previous_financial_year?
-      tps_school_for_student_loan_in_previous_financial_year.present?
-    end
-
-    def tps_school_for_student_loan_in_previous_financial_year
-      @tps_school_for_student_loan_in_previous_financial_year ||=
-        TeachersPensionsService.tps_school_for_student_loan_in_previous_financial_year(
-          teacher_reference_number: answers.teacher_id_user_info["trn"]
-        )
-    end
   end
 end

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -7,6 +7,8 @@ module Journeys
     include Sessions::PiiAttributes
     include BooleanAttributes
 
+    attr_accessor :session
+
     attribute :service_access_code, :string, pii: false
 
     attribute :current_school_id, :string, pii: false # UUID

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -102,5 +102,19 @@ module Journeys
         postcode
       ].reject(&:blank?).join(separator)
     end
+
+    def logged_in_with_tid_and_has_recent_tps_school?
+      trn_from_tid? && recent_tps_school.present?
+    end
+
+    # NOTE getting the trn from answers.teacher_id_user_info was the previous
+    # implementation, TODO switch to `answers.teacher_reference_number` as it's
+    # set in the sign in or continue form at the same time.
+    def recent_tps_school
+      @recent_tps_school ||= TeachersPensionsService.recent_tps_school(
+        claim_date: session.created_at,
+        teacher_reference_number: teacher_id_user_info["trn"]
+      )
+    end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session.rb
@@ -1,11 +1,5 @@
 module Journeys
   module TeacherStudentLoanReimbursement
-    class Session < Journeys::Session
-      attribute :answers, SessionAnswersType.new
-
-      def answers
-        super.tap { it.session = self }
-      end
-    end
+    class Session < Journeys::Session; end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session.rb
@@ -2,6 +2,10 @@ module Journeys
   module TeacherStudentLoanReimbursement
     class Session < Journeys::Session
       attribute :answers, SessionAnswersType.new
+
+      def answers
+        super.tap { it.session = self }
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -71,6 +71,17 @@ module Journeys
       def employed_at_recent_tps_school?
         employment_status.to_s == "recent_tps_school"
       end
+
+      def has_tps_school_for_student_loan_in_previous_financial_year?
+        tps_school_for_student_loan_in_previous_financial_year.present?
+      end
+
+      def tps_school_for_student_loan_in_previous_financial_year
+        @tps_school_for_student_loan_in_previous_financial_year ||=
+          TeachersPensionsService.tps_school_for_student_loan_in_previous_financial_year(
+            teacher_reference_number: teacher_id_user_info["trn"]
+          )
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -114,7 +114,7 @@ module Journeys
             sequence.delete("mobile-number")
             sequence.delete("mobile-verification")
           end
-          unless answers.trn_from_tid? && journey_session.has_tps_school_for_student_loan_in_previous_financial_year?
+          unless answers.trn_from_tid? && answers.has_tps_school_for_student_loan_in_previous_financial_year?
             sequence.delete("select-claim-school")
           end
           sequence.delete("claim-school") if answers.claim_school_somewhere_else == false


### PR DESCRIPTION
Pass reference to a session to answers

Sometimes we need a reference to the session in the answers for things
like timestamps.
Passing a reference to the session to the answers allows us to move some
attributes that are derived from the session answers off the journey session
model and onto the answers model.
Having access to the session on the answers will also allow us to implement
things like `answers.update!` and clean up the code where we have to do
`journey_session.assign_attributes(xxx); journey_session.save!`.

As we want to support subclasses of session answers for each journey we
unfortunately have to use a bit of Ruby magic to get this to work.

This code is extracted from the LUP only journey branch. If this approach is a
bit too esoteric we can leave some methods on the journey session and I'll
update the LUP only branch.
