### PR TITLE
Fix admin amend claim

### DIFF
--- a/app/forms/admin/amendment_form.rb
+++ b/app/forms/admin/amendment_form.rb
@@ -25,6 +25,7 @@ class Admin::AmendmentForm
   attribute :created_by
 
   before_validation :normalise_bank_sort_code
+  before_validation :nilify_student_loan_repayment_plan
 
   validates :teacher_reference_number,
     length: {
@@ -124,6 +125,12 @@ class Admin::AmendmentForm
   end
 
   private
+
+  def nilify_student_loan_repayment_plan
+    if student_loan_plan == ""
+      self.student_loan_plan = nil
+    end
+  end
 
   def normalise_bank_sort_code
     return if bank_sort_code.nil?

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -1,7 +1,7 @@
 module Policies
   module FurtherEducationPayments
     class Eligibility < ApplicationRecord
-      AMENDABLE_ATTRIBUTES = [].freeze
+      AMENDABLE_ATTRIBUTES = [:award_amount, :teacher_reference_number].freeze
 
       self.table_name = "further_education_payments_eligibilities"
 

--- a/spec/forms/admin/amendment_form_spec.rb
+++ b/spec/forms/admin/amendment_form_spec.rb
@@ -19,10 +19,35 @@ RSpec.describe Admin::AmendmentForm, type: :model do
 
   describe "validations" do
     let(:claim) { build(:claim, :submitted) }
+    let(:current_user) { create(:dfe_signin_user) }
+    let(:notes) { "made some changes" }
 
-    subject { described_class.new(claim:) }
+    subject { described_class.new(claim:, created_by: current_user, notes:) }
 
     it { is_expected.to validate_presence_of(:date_of_birth).with_message("Enter a date of birth") }
     it { is_expected.to validate_presence_of(:created_by) }
+  end
+
+  describe "#save" do
+    let(:claim) { create(:claim, :submitted) }
+    let(:current_user) { create(:dfe_signin_user) }
+    let(:notes) { "made some changes" }
+
+    context "when student_loan_plan is empty string" do
+      subject do
+        described_class.new(
+          claim:,
+          created_by: current_user,
+          notes:,
+          student_loan_plan: ""
+        )
+      end
+
+      it "saves it as nil" do
+        subject.valid?
+        subject.save
+        expect(claim.reload.student_loan_plan).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
# Context

- When admin amends a claim and does not choose a student loan plan
- Browser sends this as empty string
- On the backend this is stored as nil
- So on validation of form we convert empty string to nil
- This allows the form to be saved and not raise an error
- Also fixes regression and FE award amount + TRN is now amendable again
