### PR TITLE
[CAPT-2180] Amend banking name

### DIFF
--- a/app/controllers/admin/amendments_controller.rb
+++ b/app/controllers/admin/amendments_controller.rb
@@ -8,12 +8,12 @@ class Admin::AmendmentsController < Admin::BaseAdminController
 
   def new
     @amendment = @claim.amendments.build
-    @form = Admin::AmendmentForm.new(claim: @claim)
+    @form = Admin::AmendmentForm.new(claim: @claim, admin_user:)
     @form.load_data_from_claim
   end
 
   def create
-    @form = Admin::AmendmentForm.new(amendment_params.merge(claim: @claim, created_by: admin_user))
+    @form = Admin::AmendmentForm.new(amendment_params.merge(claim: @claim, admin_user:))
 
     if @form.valid? && @form.save
       redirect_to admin_claim_tasks_url(@claim), notice: "Claim has been amended successfully"
@@ -35,6 +35,8 @@ class Admin::AmendmentsController < Admin::BaseAdminController
   end
 
   def amendment_params
-    params.require(:amendment).permit(Claim::AMENDABLE_ATTRIBUTES + Policies::AMENDABLE_ELIGIBILITY_ATTRIBUTES + [:notes])
+    params
+      .require(:amendment)
+      .permit(Admin::AmendmentForm.amendable_attributes(claim: @claim, admin_user:))
   end
 end

--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -41,7 +41,7 @@ module Admin
     end
 
     def developer_session
-      DfeSignIn::AuthenticatedSession.new(nil, nil, ["teacher_payments_access"])
+      DfeSignIn::AuthenticatedSession.new(nil, nil, params[:roles])
     end
   end
 end

--- a/app/models/dfe_sign_in/user.rb
+++ b/app/models/dfe_sign_in/user.rb
@@ -3,6 +3,7 @@ module DfeSignIn
     include Deletable
 
     SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_access"
+    SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_admin"
     SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_support"
     PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_payroll"
 
@@ -40,6 +41,10 @@ module DfeSignIn
 
     def is_payroll_operator?
       role_codes.include?(PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    end
+
+    def is_service_admin?
+      role_codes.include?(SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE)
     end
 
     def has_admin_access?

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -70,6 +70,22 @@
     </div>
   </div>
 
+  <% if @form.show_banking_name? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-body">
+          <%= label_tag "amendment-banking-name-field", "Banking name" %>
+        </div>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <%= f.govuk_text_field :banking_name,
+          label: nil,
+          width: 10,
+          disabled: @form.banking_name_disabled? %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       <div class="govuk-body">

--- a/app/views/admin/auth/sign_in.html.erb
+++ b/app/views/admin/auth/sign_in.html.erb
@@ -5,9 +5,10 @@
     </h1>
 
     <% if DfESignIn.bypass? %>
-      <%= button_to 'Sign in (bypass DfE Sign-in)', admin_dfe_sign_in_bypass_callback_path, class: 'govuk-button' %>
+      <%= govuk_button_to 'Sign in (bypass DfE Sign-in)', admin_dfe_sign_in_bypass_callback_path, params: { roles: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE] } %>
+      <%= govuk_button_to 'Sign in as admin (bypass DfE Sign-in)', admin_dfe_sign_in_bypass_callback_path, params: { roles: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE] } %>
     <% else %>
-      <%= button_to "Sign in", "/admin/auth/dfe", class: "govuk-button" %>
+      <%= govuk_button_to "Sign in", "/admin/auth/dfe" %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,10 @@ Rails.application.routes.draw do
     # DfE Sign-in OpenID routes
     get "/auth/callback", to: "auth#callback"
     get "/auth/failure", to: "auth#failure"
-    post "/auth/developer/callback", to: "auth#bypass_callback", as: :dfe_sign_in_bypass_callback
+
+    if DfESignIn.bypass?
+      post "/auth/developer/callback", to: "auth#bypass_callback", as: :dfe_sign_in_bypass_callback
+    end
 
     resources :claims, only: [:index, :show] do
       resources :tasks, only: [:index, :show, :create, :update], param: :name, constraints: {name: %r{#{Task::NAMES.join("|")}}}

--- a/spec/features/admin/admin_amend_claim_spec.rb
+++ b/spec/features/admin/admin_amend_claim_spec.rb
@@ -212,3 +212,135 @@ RSpec.feature "Admin amends a claim" do
     end
   end
 end
+
+RSpec.feature "Admin amends a claim" do
+  before do
+    create(:journey_configuration, :student_loans)
+  end
+
+  context "when user has failed hmrc bank validation" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        hmrc_bank_validation_succeeded: false
+      )
+    end
+
+    context "when back office user is an admin" do
+      before do
+        sign_in_as_service_admin
+      end
+
+      scenario "admin can view and edit account name" do
+        visit admin_claim_url(claim)
+        click_link "Amend claim"
+
+        new_banking_name = "#{claim.banking_name}A"
+
+        expect(page).to have_field("Banking name", with: claim.banking_name)
+        fill_in "Banking name", with: new_banking_name
+        fill_in "Change notes", with: "update banking name"
+        click_button "Amend claim"
+
+        click_link "Amend claim"
+
+        expect(page).to have_field("Banking name", with: new_banking_name)
+      end
+    end
+
+    context "back office user does does not have admin role" do
+      before do
+        sign_in_as_service_operator
+      end
+
+      scenario "admin can view but not edit account name" do
+        visit admin_claim_url(claim)
+        click_link "Amend claim"
+
+        expect(page).to have_field("Banking name", with: claim.banking_name, disabled: true)
+      end
+    end
+  end
+
+  context "when user has passed hmrc bank validation" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        hmrc_bank_validation_succeeded: true
+      )
+    end
+
+    context "when back office user is an admin" do
+      before do
+        sign_in_as_service_admin
+      end
+
+      scenario "admin cannot view or edit account name" do
+        visit admin_claim_url(claim)
+        click_link "Amend claim"
+
+        expect(page).not_to have_field("Banking name", with: claim.banking_name)
+      end
+    end
+
+    context "back office user does does not have admin role" do
+      before do
+        sign_in_as_service_operator
+      end
+
+      scenario "admin can view but not edit account name" do
+        visit admin_claim_url(claim)
+        click_link "Amend claim"
+
+        expect(page).not_to have_field("Banking name", with: claim.banking_name)
+      end
+    end
+  end
+
+  context "when user has failed hmrc bank validation" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        hmrc_bank_validation_succeeded: false
+      )
+    end
+
+    context "when back office user is an admin" do
+      before do
+        sign_in_as_service_admin
+      end
+
+      scenario "admin can view and edit account name" do
+        visit admin_claim_url(claim)
+        click_link "Amend claim"
+
+        new_banking_name = "#{claim.banking_name}A"
+
+        expect(page).to have_field("Banking name", with: claim.banking_name)
+        fill_in "Banking name", with: new_banking_name
+        fill_in "Change notes", with: "update banking name"
+        click_button "Amend claim"
+
+        click_link "Amend claim"
+
+        expect(page).to have_field("Banking name", with: new_banking_name)
+      end
+    end
+
+    context "back office user does does not have admin role" do
+      before do
+        sign_in_as_service_operator
+      end
+
+      scenario "admin can view but not edit account name" do
+        visit admin_claim_url(claim)
+        click_link "Amend claim"
+
+        expect(page).to have_field("Banking name", with: claim.banking_name, disabled: true)
+      end
+    end
+  end
+end

--- a/spec/forms/admin/amendment_form_spec.rb
+++ b/spec/forms/admin/amendment_form_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Admin::AmendmentForm, type: :model do
+  let(:admin_user) { create(:dfe_signin_user) }
+
   describe "#date_of_birth" do
     context "when out of range ie invalid date" do
       subject do
@@ -19,25 +21,24 @@ RSpec.describe Admin::AmendmentForm, type: :model do
 
   describe "validations" do
     let(:claim) { build(:claim, :submitted) }
-    let(:current_user) { create(:dfe_signin_user) }
+    let(:admin_user) { create(:dfe_signin_user) }
     let(:notes) { "made some changes" }
 
-    subject { described_class.new(claim:, created_by: current_user, notes:) }
+    subject { described_class.new(claim:, admin_user:, notes:) }
 
     it { is_expected.to validate_presence_of(:date_of_birth).with_message("Enter a date of birth") }
-    it { is_expected.to validate_presence_of(:created_by) }
   end
 
   describe "#save" do
     let(:claim) { create(:claim, :submitted) }
-    let(:current_user) { create(:dfe_signin_user) }
+    let(:admin_user) { create(:dfe_signin_user) }
     let(:notes) { "made some changes" }
 
     context "when student_loan_plan is empty string" do
       subject do
         described_class.new(
           claim:,
-          created_by: current_user,
+          admin_user:,
           notes:,
           student_loan_plan: ""
         )

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -90,10 +90,16 @@ module FeatureHelpers
     click_on "Continue"
   end
 
-  # Signs in as a user with the service operator role. Returns the signed-in User record.
   def sign_in_as_service_operator
     user = create(:dfe_signin_user)
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+    user
+  end
+
+  def sign_in_as_service_admin
+    user = create(:dfe_signin_user)
+    roles = [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE]
+    sign_in_to_admin_with_role(roles, user.dfe_sign_in_id)
     user
   end
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2180
- All back office users can view banking name in the amend screen if the call to HMRC failed
- If HMRC check passed back office users do not see the banking name
- If back office user has admin role that can amend the banking name
- For other back office users they will have the field disabled
- Developer auth can now login as normal or admin back office user
