### PR TITLE
[CAPT-2270] FE alternative idv collects passport

### DIFF
--- a/app/forms/journeys/further_education_payments/passport_form.rb
+++ b/app/forms/journeys/further_education_payments/passport_form.rb
@@ -1,0 +1,33 @@
+module Journeys
+  module FurtherEducationPayments
+    class PassportForm < Form
+      attribute :valid_passport, :boolean
+      attribute :passport_number, :string
+
+      validates :valid_passport,
+        inclusion: {
+          in: [true, false],
+          message: i18n_error_message(:inclusion)
+        }
+
+      validates :passport_number,
+        length: {
+          minimum: 8,
+          maximum: 9,
+          message: i18n_error_message(:length)
+        },
+        if: proc { |form| form.valid_passport }
+
+      def save
+        return false if invalid?
+
+        journey_session.answers.assign_attributes(
+          valid_passport:,
+          passport_number:
+        )
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -33,6 +33,7 @@ module Journeys
         "check-your-answers" => CheckYourAnswersForm,
         "half-teaching-hours" => HalfTeachingHoursForm,
         "hours-teaching-eligible-subjects" => HoursTeachingEligibleSubjectsForm,
+        "passport" => PassportForm,
         "eligible" => EligibleForm,
         "ineligible" => IneligibleForm,
         "teacher-reference-number" => TeacherReferenceNumberForm

--- a/app/models/journeys/further_education_payments/answers_presenter.rb
+++ b/app/models/journeys/further_education_payments/answers_presenter.rb
@@ -4,6 +4,26 @@ module Journeys
       include ActionView::Helpers::TranslationHelper
       include CoursesHelper
 
+      def identity_answers
+        [].tap do |a|
+          a << [t("questions.name"), answers.full_name, "personal-details"] if show_name?
+          a << [t("forms.address.questions.your_address"), answers.address, "address"]
+
+          a << [t("further_education_payments.forms.passport.question"), (answers.valid_passport ? "Yes" : "No"), "passport"] if !answers.valid_passport.nil?
+          a << [t("further_education_payments.forms.passport.conditional_question"), answers.passport_number, "passport"] if answers.passport_number.present?
+
+          a << [t("questions.date_of_birth"), date_of_birth_string, "personal-details"] if show_dob?
+          a << payroll_gender
+          a << teacher_reference_number if show_trn?
+          a << [t("questions.national_insurance_number"), answers.national_insurance_number, "personal-details"] if show_nino?
+          a << [t("questions.email_address"), answers.email_address, "email-address"] unless show_email_select?
+          a << [text_for(:select_email), answers.email_address, "select-email"] if show_email_select?
+          a << [t("questions.provide_mobile_number"), answers.provide_mobile_number? ? "Yes" : "No", "provide-mobile-number"] unless show_mobile_select?
+          a << [t("questions.mobile_number"), answers.mobile_number, "mobile-number"] unless show_mobile_select? || !answers.provide_mobile_number?
+          a << [t("additional_payments.forms.select_mobile_form.questions.which_number"), answers.mobile_number.present? ? answers.mobile_number : t("additional_payments.forms.select_mobile_form.answers.decline"), "select-mobile"] if show_mobile_select?
+        end
+      end
+
       # Formats the eligibility as a list of questions and answers, each
       # accompanied by a slug for changing the answer. Suitable for playback to
       # the claimant for them to review on the check-your-answers page.

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -25,6 +25,8 @@ module Journeys
       attribute :subject_to_disciplinary_action, :boolean, pii: false
       attribute :half_teaching_hours, :boolean, pii: false
       attribute :award_amount, :decimal, pii: false
+      attribute :valid_passport, :boolean, pii: false
+      attribute :passport_number, :string, pii: true
 
       def policy
         Policies::FurtherEducationPayments

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -34,6 +34,7 @@ module Journeys
         postcode-search
         select-home-address
         address
+        passport
         email-address
         email-verification
         provide-mobile-number
@@ -144,6 +145,10 @@ module Journeys
 
           if answers.address_line_1.present? && answers.postcode.present?
             sequence.delete("address")
+          end
+
+          if !FeatureFlag.enabled?(:alternative_idv)
+            sequence.delete("passport")
           end
 
           if !eligibility_checker.ineligible?

--- a/app/views/further_education_payments/claims/passport.html.erb
+++ b/app/views/further_education_payments/claims/passport.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:page_title, page_title(@form.t(:question), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:valid_passport, legend: { tag: "h1", size: "l", text: @form.t(:question) }, hint: { text: "You can check if a passport is valid by looking at the expiration date on the passport photo page" }) do %>
+        <%= f.govuk_radio_button :valid_passport, "true", label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_text_field :passport_number, label: { text: "Passport number", size: "s" }, hint: { text: "This is the 9 digit number in the top right hand corner of the photo page in your passport" } %>
+        <% end %>
+        <%= f.govuk_radio_button :valid_passport, "false", label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -314,6 +314,7 @@ shared:
     - teacher_reference_number
     - provider_verification_email_count
     - claimant_identity_verified_at
+    - valid_passport
   :eligible_fe_providers:
     - id
     - ukprn

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -105,6 +105,7 @@
   - claimant_national_insurance_number
   - claimant_valid_passport
   - claimant_passport_number
+  - passport_number
   :journeys_sessions:
   - answers
   :early_years_payment_eligibilities:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1227,6 +1227,7 @@ en:
             Select yes if you spend at least half of your timetabled teaching hours teaching these eligible courses
       passport:
         question: Do you have a valid passport?
+        conditional_question: Passport number
         errors:
           inclusion: Select yes if you have a valid passport
           length: Passport number should be between 8 and 9 characters long

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1225,6 +1225,11 @@ en:
         errors:
           inclusion:
             Select yes if you spend at least half of your timetabled teaching hours teaching these eligible courses
+      passport:
+        question: Do you have a valid passport?
+        errors:
+          inclusion: Select yes if you have a valid passport
+          length: Passport number should be between 8 and 9 characters long
       teacher_reference_number:
         heading: Teacher reference number (TRN)
         questions:

--- a/db/migrate/20250310152749_add_passport_to_fe_eligibilities.rb
+++ b/db/migrate/20250310152749_add_passport_to_fe_eligibilities.rb
@@ -1,0 +1,6 @@
+class AddPassportToFeEligibilities < ActiveRecord::Migration[8.0]
+  def change
+    add_column :further_education_payments_eligibilities, :valid_passport, :boolean, null: true
+    add_column :further_education_payments_eligibilities, :passport_number, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -297,6 +297,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_10_160859) do
     t.boolean "claimant_valid_passport"
     t.string "claimant_passport_number"
     t.datetime "claimant_identity_verified_at"
+    t.boolean "valid_passport"
+    t.text "passport_number"
     t.index ["possible_school_id"], name: "index_fe_payments_eligibilities_on_possible_school_id"
     t.index ["school_id"], name: "index_fe_payments_eligibilities_on_school_id"
   end

--- a/spec/features/further_education_payments/happy_path_spec.rb
+++ b/spec/features/further_education_payments/happy_path_spec.rb
@@ -170,6 +170,8 @@ RSpec.feature "Further education payments" do
     click_on "Continue"
 
     expect(page).to have_content("Check your answers before sending your application")
+    expect(page).not_to have_content("Do you have a valid passport?")
+    expect(page).not_to have_content("Passport number")
 
     expect do
       click_on "Accept and send"

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -156,6 +156,11 @@ RSpec.feature "Further education payments" do
     fill_in "Postcode", with: "DE22 4BS"
     click_on "Continue"
 
+    expect(page).to have_content("Do you have a valid passport?")
+    choose "Yes"
+    fill_in "Passport number", with: "123456789"
+    click_on "Continue"
+
     expect(page).to have_content("Email address")
     fill_in "Email address", with: "john.doe@example.com"
     click_on "Continue"
@@ -206,6 +211,8 @@ RSpec.feature "Further education payments" do
     eligibility = Policies::FurtherEducationPayments::Eligibility.last
 
     expect(eligibility.teacher_reference_number).to eql("1234567")
+    expect(eligibility.valid_passport).to be_truthy
+    expect(eligibility.passport_number).to eql("123456789")
 
     expect(page).to have_content("You applied for a further education targeted retention incentive payment")
 

--- a/spec/features/further_education_payments/one_login_without_idv_spec.rb
+++ b/spec/features/further_education_payments/one_login_without_idv_spec.rb
@@ -190,6 +190,8 @@ RSpec.feature "Further education payments" do
     click_on "Continue"
 
     expect(page).to have_content("Check your answers before sending your application")
+    expect(page).to have_content("Do you have a valid passport?")
+    expect(page).to have_content("Passport number")
 
     expect do
       click_on "Accept and send"

--- a/spec/forms/journeys/further_education_payments/passport_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/passport_form_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Journeys::FurtherEducationPayments::PassportForm, type: :model do
+  let(:journey) { Journeys::FurtherEducationPayments }
+  let(:journey_session) { create(:further_education_payments_session, answers:) }
+  let(:answers) { build(:further_education_payments_answers, answers_hash) }
+  let(:school) { create(:school) }
+  let(:answers_hash) do
+    {school_id: school.id}
+  end
+  let(:valid_passport) { nil }
+  let(:passport_number) { nil }
+
+  let(:params) do
+    ActionController::Parameters.new(
+      claim: {
+        valid_passport:,
+        passport_number:
+      }
+    )
+  end
+
+  subject do
+    described_class.new(
+      journey_session:,
+      journey:,
+      params:
+    )
+  end
+
+  describe "validations" do
+    it do
+      is_expected.not_to(
+        allow_value(nil)
+        .for(:valid_passport)
+        .with_message("Select yes if you have a valid passport")
+      )
+    end
+
+    context "when no selected" do
+      let(:valid_passport) { "false" }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when yes selected without passport number" do
+      let(:valid_passport) { "true" }
+
+      it "is not valid" do
+        expect(subject).to be_invalid
+      end
+    end
+
+    context "when yes selected with invalid passport number" do
+      let(:valid_passport) { "true" }
+      let(:passport_number) { "123" }
+
+      it "is not valid" do
+        expect(subject).to be_invalid
+      end
+    end
+
+    context "when yes selected with valid passport number" do
+      let(:valid_passport) { "true" }
+      let(:passport_number) { "123456789" }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:valid_passport) { "true" }
+    let(:passport_number) { "123456789" }
+
+    it "updates the journey session" do
+      expect { expect(subject.save).to be(true) }.to(
+        change { journey_session.reload.answers.valid_passport }.to(true)
+        .and(change { journey_session.answers.passport_number }.to("123456789"))
+      )
+    end
+  end
+end

--- a/spec/models/policies/targeted_retention_incentive_payments/award_csv_importer_spec.rb
+++ b/spec/models/policies/targeted_retention_incentive_payments/award_csv_importer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Policies::TargetedRetentionIncentivePayments::AwardCsvImporter do
 
       it "retains old data" do
         importer.process
-        expect { old_award_same_academic_year.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+        expect { old_award_same_academic_year.reload }.not_to raise_error
       end
 
       it "does not delete data from other academic years" do


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2270
- Collects passport number for FE as part of alternative idv journey
- Also fixed an rspec warning
