### PR TITLE
[CAPT-2279] Split out FE OL task

### DIFF
--- a/app/models/automated_checks/claim_verifiers/one_login_identity.rb
+++ b/app/models/automated_checks/claim_verifiers/one_login_identity.rb
@@ -11,9 +11,10 @@ module AutomatedChecks
 
       def perform
         return unless awaiting_task?(TASK_NAME)
-        return unless claim.identity_confirmed_with_onelogin?
 
-        if claim.one_login_idv_mismatch?
+        if !claim.identity_confirmed_with_onelogin?
+          create_task(passed: false)
+        elsif claim.one_login_idv_mismatch?
           create_task(passed: false)
         else
           create_task(passed: true)

--- a/app/models/automated_checks/claim_verifiers/one_login_identity.rb
+++ b/app/models/automated_checks/claim_verifiers/one_login_identity.rb
@@ -1,0 +1,48 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    class OneLoginIdentity
+      TASK_NAME = "one_login_identity".freeze
+      private_constant :TASK_NAME
+
+      def initialize(claim:, admin_user: nil)
+        self.admin_user = admin_user
+        self.claim = claim
+      end
+
+      def perform
+        return unless awaiting_task?(TASK_NAME)
+        return unless claim.identity_confirmed_with_onelogin?
+
+        if claim.one_login_idv_mismatch?
+          create_task(passed: false)
+        else
+          create_task(passed: true)
+        end
+      end
+
+      private
+
+      attr_accessor :admin_user, :claim
+
+      def awaiting_task?(task_name)
+        claim.tasks.none? { |task| task.name == task_name }
+      end
+
+      def create_task(passed:)
+        task = claim.tasks.build(
+          {
+            name: TASK_NAME,
+            claim_verifier_match: nil,
+            passed: passed,
+            manual: false,
+            created_by: admin_user
+          }
+        )
+
+        task.save!(context: :claim_verifier)
+
+        task
+      end
+    end
+  end
+end

--- a/app/models/automated_checks/claim_verifiers/one_login_identity.rb
+++ b/app/models/automated_checks/claim_verifiers/one_login_identity.rb
@@ -4,8 +4,7 @@ module AutomatedChecks
       TASK_NAME = "one_login_identity".freeze
       private_constant :TASK_NAME
 
-      def initialize(claim:, admin_user: nil)
-        self.admin_user = admin_user
+      def initialize(claim:)
         self.claim = claim
       end
 
@@ -23,7 +22,7 @@ module AutomatedChecks
 
       private
 
-      attr_accessor :admin_user, :claim
+      attr_accessor :claim
 
       def awaiting_task?(task_name)
         claim.tasks.none? { |task| task.name == task_name }
@@ -35,8 +34,7 @@ module AutomatedChecks
             name: TASK_NAME,
             claim_verifier_match: nil,
             passed: passed,
-            manual: false,
-            created_by: admin_user
+            manual: false
           }
         )
 

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -10,7 +10,7 @@ class ClaimCheckingTasks
     when "qa_decision"
       "QA decision"
     else
-      task_name.humanize
+      I18n.t(:name, scope: [:admin, :tasks, task_name], default: task_name.humanize)
     end
   end
 
@@ -36,6 +36,7 @@ class ClaimCheckingTasks
         .applicable_task_names
     else
       Task::NAMES.dup.tap do |task_names|
+        task_names.delete("one_login_identity")
         task_names.delete("previous_payment")
         task_names.delete("previous_residency")
         task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -21,40 +21,9 @@ class ClaimCheckingTasks
   delegate :policy, to: :claim
 
   def applicable_task_names
-    case policy
-    when Policies::FurtherEducationPayments
-      Policies::FurtherEducationPayments::ClaimCheckingTasks
-        .new(claim)
-        .applicable_task_names
-    when Policies::InternationalRelocationPayments
-      Policies::InternationalRelocationPayments::ClaimCheckingTasks
-        .new(claim)
-        .applicable_task_names
-    when Policies::EarlyYearsPayments
-      Policies::EarlyYearsPayments::ClaimCheckingTasks
-        .new(claim)
-        .applicable_task_names
-    else
-      Task::NAMES.dup.tap do |task_names|
-        task_names.delete("one_login_identity")
-        task_names.delete("previous_payment")
-        task_names.delete("previous_residency")
-        task_names.delete("induction_confirmation") unless claim.policy == Policies::EarlyCareerPayments
-        task_names.delete("student_loan_amount") unless claim.policy == Policies::StudentLoans
-        task_names.delete("student_loan_plan") unless claim.has_ecp_or_targeted_retention_incentive_policy? && claim.submitted_without_slc_data?
-        task_names.delete("payroll_details") unless claim.must_manually_validate_bank_details?
-        task_names.delete("matching_details") unless matching_claims.exists?
-        task_names.delete("payroll_gender") unless claim.payroll_gender_missing? || task_names_for_claim.include?("payroll_gender")
-        task_names.delete("visa")
-        task_names.delete("arrival_date")
-        task_names.delete("employment_contract")
-        task_names.delete("employment_start")
-        task_names.delete("subject")
-        task_names.delete("teaching_hours")
-        task_names.delete("provider_verification")
-        task_names.delete("provider_details")
-      end
-    end
+    policy::ClaimCheckingTasks
+      .new(claim)
+      .applicable_task_names
   end
 
   def pageable_tasks
@@ -82,9 +51,5 @@ class ClaimCheckingTasks
 
   def task_names_for_claim
     claim.tasks.pluck(:name)
-  end
-
-  def matching_claims
-    @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims
   end
 end

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -26,6 +26,24 @@ class ClaimCheckingTasks
       .applicable_task_names
   end
 
+  def locale_key_for_task_name(name)
+    r = applicable_task_objects.find do |object|
+      object.name == name
+    end
+
+    if r.nil?
+      name
+    else
+      r.locale_key
+    end
+  end
+
+  def applicable_task_objects
+    policy::ClaimCheckingTasks
+      .new(claim)
+      .applicable_task_objects
+  end
+
   def pageable_tasks
     array = applicable_task_names
     array << "decision"

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -2,4 +2,8 @@ class FeatureFlag < ApplicationRecord
   def self.enabled?(name)
     where(name: name, enabled: true).exists?
   end
+
+  def self.disabled?(name)
+    !enabled?(name)
+  end
 end

--- a/app/models/policies/early_career_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_career_payments/claim_checking_tasks.rb
@@ -27,6 +27,12 @@ module Policies
         tasks
       end
 
+      def applicable_task_objects
+        applicable_task_names.map do |name|
+          OpenStruct.new(name:, locale_key: name)
+        end
+      end
+
       private
 
       def matching_claims

--- a/app/models/policies/early_career_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_career_payments/claim_checking_tasks.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Policies
+  module EarlyCareerPayments
+    class ClaimCheckingTasks
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      delegate :policy, to: :claim
+
+      def applicable_task_names
+        tasks = []
+
+        tasks << "identity_confirmation"
+        tasks << "qualifications"
+        tasks << "induction_confirmation"
+        tasks << "census_subjects_taught"
+        tasks << "employment"
+        tasks << "student_loan_plan" if claim.submitted_without_slc_data?
+        tasks << "payroll_details" if claim.must_manually_validate_bank_details?
+        tasks << "matching_details" if matching_claims.exists?
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || claim.tasks.exists?(name: "payroll_gender")
+
+        tasks
+      end
+
+      private
+
+      def matching_claims
+        @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims
+      end
+    end
+  end
+end

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -24,6 +24,12 @@ module Policies
         tasks
       end
 
+      def applicable_task_objects
+        applicable_task_names.map do |name|
+          OpenStruct.new(name:, locale_key: name)
+        end
+      end
+
       private
 
       def matching_claims

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -11,7 +11,7 @@ module Policies
     REJECTED_MIN_QA_THRESHOLD = 10
 
     VERIFIERS = [
-      AutomatedChecks::ClaimVerifiers::Identity,
+      AutomatedChecks::ClaimVerifiers::OneLoginIdentity,
       AutomatedChecks::ClaimVerifiers::ProviderVerification,
       AutomatedChecks::ClaimVerifiers::Employment,
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan,

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -26,6 +26,18 @@ module Policies
         tasks
       end
 
+      def applicable_task_objects
+        applicable_task_names.map do |name|
+          if FeatureFlag.disabled?(:alternative_idv) && name == "one_login_identity"
+            OpenStruct.new(name:, locale_key: "identity_confirmation")
+          elsif FeatureFlag.enabled?(:alternative_idv) && name == "provider_verification"
+            OpenStruct.new(name:, locale_key: "eligibility_check")
+          else
+            OpenStruct.new(name:, locale_key: name)
+          end
+        end
+      end
+
       private
 
       def matching_claims

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -14,7 +14,7 @@ module Policies
       def applicable_task_names
         tasks = []
 
-        tasks << "identity_confirmation"
+        tasks << "one_login_identity"
         tasks << "provider_verification"
         tasks << "provider_details" if claim.eligibility.provider_and_claimant_details_match?
         tasks << "employment" if claim.eligibility.teacher_reference_number.present?

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -31,6 +31,12 @@ module Policies
         tasks
       end
 
+      def applicable_task_objects
+        applicable_task_names.map do |name|
+          OpenStruct.new(name:, locale_key: name)
+        end
+      end
+
       private
 
       def matching_claims

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -26,6 +26,12 @@ module Policies
         tasks
       end
 
+      def applicable_task_objects
+        applicable_task_names.map do |name|
+          OpenStruct.new(name:, locale_key: name)
+        end
+      end
+
       private
 
       def matching_claims

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Policies
+  module StudentLoans
+    class ClaimCheckingTasks
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      delegate :policy, to: :claim
+
+      def applicable_task_names
+        tasks = []
+
+        tasks << "identity_confirmation"
+        tasks << "qualifications"
+        tasks << "census_subjects_taught"
+        tasks << "employment"
+        tasks << "student_loan_amount"
+        tasks << "payroll_details" if claim.must_manually_validate_bank_details?
+        tasks << "matching_details" if matching_claims.exists?
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || claim.tasks.exists?(name: "payroll_gender")
+
+        tasks
+      end
+
+      private
+
+      def matching_claims
+        @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims
+      end
+    end
+  end
+end

--- a/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Policies
+  module TargetedRetentionIncentivePayments
+    class ClaimCheckingTasks
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      delegate :policy, to: :claim
+
+      def applicable_task_names
+        tasks = []
+
+        tasks << "identity_confirmation"
+        tasks << "qualifications"
+        tasks << "census_subjects_taught"
+        tasks << "employment"
+        tasks << "student_loan_plan" if claim.submitted_without_slc_data?
+        tasks << "payroll_details" if claim.must_manually_validate_bank_details?
+        tasks << "matching_details" if matching_claims.exists?
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || claim.tasks.exists?(name: "payroll_gender")
+
+        tasks
+      end
+
+      private
+
+      def matching_claims
+        @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims
+      end
+    end
+  end
+end

--- a/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
@@ -26,6 +26,12 @@ module Policies
         tasks
       end
 
+      def applicable_task_objects
+        applicable_task_names.map do |name|
+          OpenStruct.new(name:, locale_key: name)
+        end
+      end
+
       private
 
       def matching_claims

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,6 +8,7 @@
 # out.
 class Task < ApplicationRecord
   NAMES = %w[
+    one_login_identity
     previous_payment
     identity_confirmation
     provider_verification

--- a/app/views/admin/_task_pagination.html.erb
+++ b/app/views/admin/_task_pagination.html.erb
@@ -1,9 +1,11 @@
+<% object = ClaimCheckingTasks.new(@claim)  %>
+
 <%= govuk_pagination(block_mode: true) do |p| %>
   <% if task_pagination.previous_task_name.present? %>
-    <% p.with_previous_page(text: "Previous", label_text: ClaimCheckingTasks.formatted_task_name(task_pagination.previous_task_name), href: task_pagination.previous_task_path) %>
+    <% p.with_previous_page(text: "Previous", label_text: ClaimCheckingTasks.formatted_task_name(object.locale_key_for_task_name(task_pagination.previous_task_name)), href: task_pagination.previous_task_path) %>
   <% end %>
 
   <% if task_pagination.next_task_name.present? %>
-    <% p.with_next_page(text: "Next", label_text: ClaimCheckingTasks.formatted_task_name(task_pagination.next_task_name), href: task_pagination.next_task_path) %>
+    <% p.with_next_page(text: "Next", label_text: ClaimCheckingTasks.formatted_task_name(object.locale_key_for_task_name(task_pagination.next_task_name)), href: task_pagination.next_task_path) %>
   <% end %>
 <% end %>

--- a/app/views/admin/tasks/_one_login_idv.html.erb
+++ b/app/views/admin/tasks/_one_login_idv.html.erb
@@ -1,31 +1,29 @@
-<% if @claim.onelogin_idv_at.present? %>
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">
-      This task was performed by GOV.UK One Login on <%= l(@claim.onelogin_idv_at) %>
-    </p>
+<div class="govuk-grid-column-two-thirds">
+  <p class="govuk-body">
+    This task was performed by GOV.UK One Login on <%= l(@claim.onelogin_idv_at) %>
+  </p>
 
-    <%= govuk_table do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: "Claimant identity check") %>
-          <% row.with_cell(text: "Full name") %>
-          <% row.with_cell(text: "Date of birth") %>
-        <% end %>
-      <% end %>
-
-      <% table.with_body do |body| %>
-        <% body.with_row do |row| %>
-          <% row.with_cell(header: true, text: "One Login identity verification (IDV)") %>
-          <% row.with_cell(text: @claim.onelogin_idv_full_name) %>
-          <% row.with_cell(text: l(@claim.onelogin_idv_date_of_birth)) %>
-        <% end %>
-
-        <% body.with_row do |row| %>
-          <% row.with_cell(header: true, text: "Details provided by claimant") %>
-          <% row.with_cell(text: @claim.full_name) %>
-          <% row.with_cell(text: l(@claim.date_of_birth)) %>
-        <% end %>
+  <%= govuk_table do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Claimant identity check") %>
+        <% row.with_cell(text: "Full name") %>
+        <% row.with_cell(text: "Date of birth") %>
       <% end %>
     <% end %>
-  </div>
-<% end %>
+
+    <% table.with_body do |body| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(header: true, text: "One Login identity verification (IDV)") %>
+        <% row.with_cell(text: (@claim.onelogin_idv_full_name.presence || "Not available")) %>
+        <% row.with_cell(text: l(@claim.onelogin_idv_date_of_birth, default: "Not available")) %>
+      <% end %>
+
+      <% body.with_row do |row| %>
+        <% row.with_cell(header: true, text: "Details provided by claimant") %>
+        <% row.with_cell(text: @claim.full_name) %>
+        <% row.with_cell(text: l(@claim.date_of_birth)) %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -31,18 +31,17 @@
 
     <div class="govuk-tabs__panel">
       <ol class="app-task-list">
-
-        <% @claim_checking_tasks.applicable_task_names.each_with_index do |task_name, index| %>
+        <% @claim_checking_tasks.applicable_task_objects.each_with_index do |object, index| %>
           <li>
             <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= I18n.t(:name, scope: [:admin, :tasks, task_name]) %>
+              <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= I18n.t(:name, scope: [:admin, :tasks, object.locale_key]) %>
             </h2>
             <ul class="app-task-list__items">
-              <li class="app-task-list__item <%= task_name %>">
+              <li class="app-task-list__item <%= object.name %>">
                 <span class="app-task-list__task-name">
-                  <%= govuk_link_to I18n.t("#{@claim.policy.locale_key}.admin.tasks.#{task_name}.title", default: :"admin.tasks.#{task_name}.title"), admin_claim_task_path(claim_id: @claim.id, name: task_name) %>
+                  <%= govuk_link_to I18n.t("#{@claim.policy.locale_key}.admin.tasks.#{object.locale_key}.title", default: :"admin.tasks.#{object.locale_key}.title"), admin_claim_task_path(claim_id: @claim.id, name: object.name) %>
                 </span>
-                <%= task_status_tag(@claim, task_name) %>
+                <%= task_status_tag(@claim, object.name) %>
               </li>
             </ul>
           </li>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -35,7 +35,7 @@
         <% @claim_checking_tasks.applicable_task_names.each_with_index do |task_name, index| %>
           <li>
             <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= task_name.humanize %>
+              <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= I18n.t(:name, scope: [:admin, :tasks, task_name]) %>
             </h2>
             <ul class="app-task-list__items">
               <li class="app-task-list__item <%= task_name %>">

--- a/app/views/admin/tasks/one_login_identity.html.erb
+++ b/app/views/admin/tasks/one_login_identity.html.erb
@@ -13,6 +13,8 @@
     <h2 class="govuk-heading-l"><%= @current_task_name.humanize %></h2>
   </div>
 
+  <%= render "one_login_idv" %>
+
   <% unless @claim.identity_verified? || @tasks_presenter.identity_confirmation.empty? %>
     <div class="govuk-grid-column-two-thirds">
       <%= render "admin/claims/answers", answers: @tasks_presenter.identity_confirmation %>
@@ -24,7 +26,7 @@
       <%= render "task_outcome", task: @task do %>
       <% end %>
     <% else %>
-      <%= render "form", task_name: "identity_confirmation", claim: @claim %>
+      <%= render "form", task_name: "one_login_identity", claim: @claim %>
     <% end %>
 
     <%= render partial: "admin/task_pagination", locals: { task_pagination: @task_pagination } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,7 @@ en:
       This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
     tasks:
       one_login_identity:
-        name: Identity confirmation
+        name: One Login identity check
         title: Confirm the claimant made the claim
       previous_payment:
         name: Previous payment
@@ -156,7 +156,10 @@ en:
         title: "Confirm the claimant made the claim"
       provider_verification:
         name: Provider verification
-        title: "Confirm the provider has responded and verified the claimant's information"
+        title: "Confirm the provider has responded and verified the claimant’s information"
+      eligibility_check:
+        name: Eligibility check
+        title: "Confirm the provider has responded and verified the claimant’s information"
       provider_details:
         name: Provider details
         title: "Check the provider details"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,47 +130,70 @@ en:
     unknown_payroll_gender_preventing_approval_message:
       This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
     tasks:
+      one_login_identity:
+        name: Identity confirmation
+        title: Confirm the claimant made the claim
       previous_payment:
+        name: Previous payment
         title: Check for previous payment
       previous_residency:
+        name: Previous residency
         title: Check previous residency
       qualifications:
+        name: Qualifications
         title: "Check qualification information"
       induction_confirmation:
+        name: Induction confirmation
         title: "Check induction information"
       employment:
+        name: Employment
         title: "Check employment information"
       matching_details:
+        name: Matching details
         title: "Review matching details from other claims"
       identity_confirmation:
+        name: Identity confirmation
         title: "Confirm the claimant made the claim"
       provider_verification:
+        name: Provider verification
         title: "Confirm the provider has responded and verified the claimant's information"
       provider_details:
+        name: Provider details
         title: "Check the provider details"
       payroll_gender:
+        name: Payroll gender
         title: "How is the claimant’s gender recorded for payroll purposes?"
         hint: "The claimant answered ‘don’t know’ to the question ‘how is your gender recorded on your employer’s payroll system?’"
       student_loan_amount:
+        name: Student loan amount
         title: "Check student loan amount"
       student_loan_plan:
+        name: Student loan plan
         title: "Check student loan plan"
       payroll_details:
+        name: Payroll details
         title: "Check bank account details"
         question: "The claimant’s personal bank account details have not been automatically validated. Has the claimant confirmed their personal bank account details?"
       census_subjects_taught:
+        name: Census subjects taught
         title: "Check eligible subjects are taught"
       visa:
+        name: Visa
         title: "Check visa"
       arrival_date:
+        name: Arrival date
         title: "Check arrival date"
       employment_contract:
+        name: Employment contract
         title: "Check employment contract"
       employment_start:
+        name: Employment start
         title: "Check employment start date"
       subject:
+        name: Subject
         title: "Check subject"
       teaching_hours:
+        name: Teaching hours
         title: "Check teaching hours"
     undo_decision:
       approved: "Undo approval"
@@ -901,6 +924,8 @@ en:
           no_response_from_employer: "No response from employer"
           other: "Other"
       task_questions:
+        one_login_identity:
+          title: Do the One Login details match the personal details entered by the claimant?
         identity_confirmation:
           title: Do the One Login details match the personal details entered by the claimant?
         matching_details:

--- a/db/migrate/20250313111812_split_ol_identity_tasks.rb
+++ b/db/migrate/20250313111812_split_ol_identity_tasks.rb
@@ -1,0 +1,9 @@
+class SplitOlIdentityTasks < ActiveRecord::Migration[8.0]
+  def change
+    Task
+      .joins(:claim)
+      .where(name: "identity_confirmation")
+      .merge(Claim.by_policies([Policies::FurtherEducationPayments]))
+      .update_all(name: "one_login_identity")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_10_160859) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_13_111812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Admin claim further education payments" do
             click_on "View tasks"
 
             click_on(
-              "Confirm the provider has responded and verified the claimant's " \
+              "Confirm the provider has responded and verified the claimant’s " \
               "information"
             )
 
@@ -132,7 +132,7 @@ RSpec.feature "Admin claim further education payments" do
               click_on "View tasks"
 
               click_on(
-                "Confirm the provider has responded and verified the claimant's " \
+                "Confirm the provider has responded and verified the claimant’s " \
                 "information"
               )
 
@@ -201,7 +201,7 @@ RSpec.feature "Admin claim further education payments" do
               click_on "View tasks"
 
               click_on(
-                "Confirm the provider has responded and verified the claimant's " \
+                "Confirm the provider has responded and verified the claimant’s " \
                 "information"
               )
 
@@ -278,7 +278,7 @@ RSpec.feature "Admin claim further education payments" do
               click_on "View tasks"
 
               click_on(
-                "Confirm the provider has responded and verified the claimant's " \
+                "Confirm the provider has responded and verified the claimant’s " \
                 "information"
               )
 
@@ -321,7 +321,7 @@ RSpec.feature "Admin claim further education payments" do
             click_on "View tasks"
 
             click_on(
-              "Confirm the provider has responded and verified the claimant's " \
+              "Confirm the provider has responded and verified the claimant’s " \
               "information"
             )
 
@@ -413,7 +413,7 @@ RSpec.feature "Admin claim further education payments" do
             click_on "View tasks"
 
             click_on(
-              "Confirm the provider has responded and verified the claimant's " \
+              "Confirm the provider has responded and verified the claimant’s " \
               "information"
             )
 

--- a/spec/features/admin/tasks/identity_confirmation_spec.rb
+++ b/spec/features/admin/tasks/identity_confirmation_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Admin performs identity confirmation task" do
-  let(:claim) { create(:claim, :submitted, :with_onelogin_idv_data) }
+  let(:claim) { create(:claim, :submitted, :with_onelogin_idv_data, policy: Policies::FurtherEducationPayments) }
 
   before do
     disable_claim_qa_flagging

--- a/spec/models/automated_checks/claim_verifiers/identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/identity_spec.rb
@@ -69,59 +69,6 @@ module AutomatedChecks
       end
 
       describe "#perform" do
-        context "when IDV-ed with one login and data matches" do
-          let(:claim_arg) do
-            create(:claim, :submitted, :with_onelogin_idv_data)
-          end
-
-          it "creates a passed task" do
-            expect {
-              subject.perform
-            }.to change(Task.passed_automatically, :count).by(1)
-          end
-        end
-
-        context "when IDV-ed with one login and name does not match" do
-          let(:claim_arg) do
-            create(
-              :claim,
-              :submitted,
-              :with_onelogin_idv_data,
-              first_name: "John",
-              surname: "Doe",
-              onelogin_idv_first_name: "Tom",
-              onelogin_idv_last_name: "Jones",
-              onelogin_idv_full_name: "Tom Jones"
-            )
-          end
-
-          it "creates a failed task" do
-            expect {
-              subject.perform
-            }.to change(Task.where(passed: false), :count).by(1)
-          end
-        end
-
-        context "when IDV-ed with one login and date of birth does not match" do
-          let(:claim_arg) do
-            create(
-              :claim,
-              :submitted,
-              :with_onelogin_idv_data,
-              date_of_birth: Date.new(1980, 12, 13),
-              onelogin_idv_date_of_birth: Date.new(1970, 1, 1)
-            )
-          end
-
-          it "creates a failed task" do
-            expect {
-              subject.perform
-            }.to change(Task.where(passed: false), :count).by(1)
-          end
-        end
-      end
-
-      describe "#perform" do
         subject(:perform) { identity.perform }
 
         [

--- a/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::OneLoginIdentity do
         )
       end
 
-      it "does not create a task" do
+      it "creates a failed task" do
         expect {
           subject.perform
-        }.not_to change(Task, :count)
+        }.to change(Task.where(passed: false), :count).by(1)
       end
     end
 

--- a/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::ClaimVerifiers::OneLoginIdentity do
+  describe "#perform" do
+    subject do
+      described_class.new(claim:, admin_user: nil)
+    end
+
+    context "when identity_confirmed_with_onelogin? is false" do
+      let(:claim) do
+        create(
+          :claim,
+          identity_confirmed_with_onelogin: false
+        )
+      end
+
+      it "does not create a task" do
+        expect {
+          subject.perform
+        }.not_to change(Task, :count)
+      end
+    end
+
+    context "when identity_confirmed_with_onelogin is true" do
+      context "when there data matches" do
+        let(:claim) do
+          create(:claim, :submitted, :with_onelogin_idv_data)
+        end
+
+        it "creates a passed task" do
+          expect {
+            subject.perform
+          }.to change(Task.passed_automatically, :count).by(1)
+        end
+      end
+
+      context "when there is a data mis-match" do
+        let(:claim) do
+          create(
+            :claim,
+            :submitted,
+            :with_onelogin_idv_data,
+            first_name: "John",
+            surname: "Doe",
+            onelogin_idv_first_name: "Tom",
+            onelogin_idv_last_name: "Jones",
+            onelogin_idv_full_name: "Tom Jones"
+          )
+        end
+
+        it "creates a failed task" do
+          expect {
+            subject.perform
+          }.to change(Task.where(passed: false), :count).by(1)
+        end
+      end
+
+      context "when there is a DOB mis-match" do
+        let(:claim) do
+          create(
+            :claim,
+            :submitted,
+            :with_onelogin_idv_data,
+            date_of_birth: Date.new(1980, 12, 13),
+            onelogin_idv_date_of_birth: Date.new(1970, 1, 1)
+          )
+        end
+
+        it "creates a failed task" do
+          expect {
+            subject.perform
+          }.to change(Task.where(passed: false), :count).by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe AutomatedChecks::ClaimVerifiers::OneLoginIdentity do
   describe "#perform" do
     subject do
-      described_class.new(claim:, admin_user: nil)
+      described_class.new(claim:)
     end
 
     context "when identity_confirmed_with_onelogin? is false" do

--- a/spec/models/further_education_payments_spec.rb
+++ b/spec/models/further_education_payments_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Policies::FurtherEducationPayments, type: :model do
 
   it do
     expect(subject::VERIFIERS).to eq([
-      AutomatedChecks::ClaimVerifiers::Identity,
+      AutomatedChecks::ClaimVerifiers::OneLoginIdentity,
       AutomatedChecks::ClaimVerifiers::ProviderVerification,
       AutomatedChecks::ClaimVerifiers::Employment,
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan,

--- a/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks do
 
     let(:invariant_tasks) do
       [
-        "identity_confirmation",
+        "one_login_identity",
         "provider_verification",
         "student_loan_plan"
       ]

--- a/spec/views/admin/tasks/index.html.erb_spec.rb
+++ b/spec/views/admin/tasks/index.html.erb_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "admin/tasks/index.html.erb" do
+  context "FE claim" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::FurtherEducationPayments
+      )
+    end
+
+    let(:claim_checking_tasks) do
+      ClaimCheckingTasks.new(claim)
+    end
+
+    before do
+      allow(view).to receive(:current_page?).and_return(true)
+    end
+
+    context "when alternative_idv feature flag enabled", feature_flag: :alternative_idv do
+      it "ues new task names" do
+        assign(:claim, claim)
+        assign(:claim_checking_tasks, claim_checking_tasks)
+        assign(:banner_messages, [])
+
+        render
+
+        expect(rendered).to include("One Login identity check")
+        expect(rendered).to include("Eligibility check")
+
+        expect(rendered).not_to include("Identity confirmation")
+        expect(rendered).not_to include("Provider verification")
+      end
+    end
+
+    context "when alternative_idv feature flag disabled" do
+      it "ues old task names" do
+        assign(:claim, claim)
+        assign(:claim_checking_tasks, claim_checking_tasks)
+        assign(:banner_messages, [])
+
+        render
+
+        expect(rendered).to include("Identity confirmation")
+        expect(rendered).to include("Provider verification")
+
+        expect(rendered).not_to include("One Login identity check")
+        expect(rendered).not_to include("Eligibility check")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2279
- FE OL task is now a separate task from identity confirmation
- This includes a data migration to acheive this
- EY should not be affected by these changes and remain the same
- We now have finer grain control of tasks name in admin area by using locales lookups rather than simply `humanize` the task name
- Finish refactoring of checking claim tasks by extracting to classes
- Rename task names on front end based on if feature flag is toggled
- The whole task thing and names is rather messy. i think this whole area needs some thinking on how we best make tasks a lot more flexible