### PR TITLE
[CAPT-2281] One login task status

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -158,7 +158,7 @@ module Admin
         status = "Passed"
         status_colour = "green"
       elsif task.passed == false
-        status = "Failed"
+        status = task.reason&.humanize || "Failed"
         status_colour = "red"
       elsif task.claim_verifier_match_all?
         status = "Full match"

--- a/app/models/automated_checks/claim_verifiers/one_login_identity.rb
+++ b/app/models/automated_checks/claim_verifiers/one_login_identity.rb
@@ -12,7 +12,7 @@ module AutomatedChecks
         return unless awaiting_task?(TASK_NAME)
 
         if !claim.identity_confirmed_with_onelogin?
-          create_task(passed: false)
+          create_task(passed: false, reason: "no_data")
         elsif claim.one_login_idv_mismatch?
           create_task(passed: false)
         else
@@ -28,13 +28,14 @@ module AutomatedChecks
         claim.tasks.none? { |task| task.name == task_name }
       end
 
-      def create_task(passed:)
+      def create_task(passed:, reason: nil)
         task = claim.tasks.build(
           {
             name: TASK_NAME,
             claim_verifier_match: nil,
             passed: passed,
-            manual: false
+            manual: false,
+            reason:
           }
         )
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -53,6 +53,10 @@ class Task < ApplicationRecord
     name
   end
 
+  def failed?
+    passed == false
+  end
+
   def identity_confirmation?
     name == "identity_confirmation"
   end

--- a/app/views/admin/tasks/_task_outcome.html.erb
+++ b/app/views/admin/tasks/_task_outcome.html.erb
@@ -1,19 +1,23 @@
-<%= render "admin/tasks/notes", notes: @notes, display_description: false %>
+<% if lookup_context.find_all("admin/tasks/_task_outcome_#{task.name}").any? %>
+  <%= render "admin/tasks/task_outcome_#{task.name}", task: %>
+<% else %>
+  <%= render "admin/tasks/notes", notes: @notes, display_description: false %>
 
-<div class="govuk-inset-text task-outcome">
-  <p class="govuk-body">
-    <%= task_status_tag(task.claim, task.name) %>
-  </p>
+  <div class="govuk-inset-text task-outcome">
+    <p class="govuk-body">
+      <%= task_status_tag(task.claim, task.name) %>
+    </p>
 
-  <p class="govuk-body">
-    <% if task.manual %>
-      This task was performed by <%= user_details(task.created_by, include_line_break: false) %> on <%= l(task.updated_at) %>
-    <% elsif task.created_by %>
-      This task was performed by an automated check uploaded by <%= user_details(task.created_by, include_line_break: false) %> on <%= l(task.created_at) %>
-    <% elsif task.identity_confirmation? && task.claim.identity_confirmed_with_onelogin? %>
-      This task was performed by GOV.UK One Login on <%= l(task.claim.onelogin_idv_at) %>
-    <% else  %>
-      This task was performed by an automated check on <%= l(task.created_at) %>
-    <% end %>
-  </p>
-</div>
+    <p class="govuk-body">
+      <% if task.manual %>
+        This task was performed by <%= user_details(task.created_by, include_line_break: false) %> on <%= l(task.updated_at) %>
+      <% elsif task.created_by %>
+        This task was performed by an automated check uploaded by <%= user_details(task.created_by, include_line_break: false) %> on <%= l(task.created_at) %>
+      <% elsif task.identity_confirmation? && task.claim.identity_confirmed_with_onelogin? %>
+        This task was performed by GOV.UK One Login on <%= l(task.claim.onelogin_idv_at) %>
+      <% else  %>
+        This task was performed by an automated check on <%= l(task.created_at) %>
+      <% end %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/admin/tasks/_task_outcome_one_login_identity.html.erb
+++ b/app/views/admin/tasks/_task_outcome_one_login_identity.html.erb
@@ -1,0 +1,21 @@
+<%= render "admin/tasks/notes", notes: @notes, display_description: false %>
+
+<div class="govuk-inset-text task-outcome">
+  <p class="govuk-body">
+    <%= task_status_tag(task.claim, task.name) %>
+  </p>
+
+  <p class="govuk-body">
+    <% if task.manual %>
+      This task was performed by <%= user_details(task.created_by, include_line_break: false) %> on <%= l(task.updated_at) %>
+    <% elsif task.created_by %>
+      This task was performed by an automated check uploaded by <%= user_details(task.created_by, include_line_break: false) %> on <%= l(task.created_at) %>
+    <% elsif task.identity_confirmation? && task.claim.identity_confirmed_with_onelogin? %>
+      This task was performed by GOV.UK One Login on <%= l(task.claim.onelogin_idv_at) %>
+    <% elsif task.failed? && task.reason == "no_data" %>
+      This claimant was unable to verify their identity with GOV.UK One Login on <%= l(task.claim.onelogin_idv_at) %>. THIS WILL LINK TO ALTERNATIVE IDV TASK
+    <% else  %>
+      This task was performed by an automated check on <%= l(task.created_at) %>
+    <% end %>
+  </p>
+</div>

--- a/app/views/admin/tasks/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/identity_confirmation.html.erb
@@ -21,8 +21,7 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% if !@task.passed.nil? %>
-      <%= render "task_outcome", task: @task do %>
-      <% end %>
+      <%= render "task_outcome", task: @task %>
     <% else %>
       <%= render "form", task_name: "identity_confirmation", claim: @claim %>
     <% end %>

--- a/app/views/admin/tasks/one_login_identity.html.erb
+++ b/app/views/admin/tasks/one_login_identity.html.erb
@@ -23,8 +23,7 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% if !@task.passed.nil? %>
-      <%= render "task_outcome", task: @task do %>
-      <% end %>
+      <%= render "task_outcome", task: @task %>
     <% else %>
       <%= render "form", task_name: "one_login_identity", claim: @claim %>
     <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -29,6 +29,7 @@ shared:
     - passed
     - manual
     - claim_verifier_match
+    - reason
   :amendments:
     - id
     - claim_id

--- a/db/migrate/20250317120537_add_reason_to_tasks.rb
+++ b/db/migrate/20250317120537_add_reason_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddReasonToTasks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tasks, :reason, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -646,6 +646,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_19_180055) do
     t.boolean "passed"
     t.boolean "manual"
     t.integer "claim_verifier_match"
+    t.text "reason"
     t.index ["claim_id"], name: "index_tasks_on_claim_id"
     t.index ["created_by_id"], name: "index_tasks_on_created_by_id"
     t.index ["name", "claim_id"], name: "index_tasks_on_name_and_claim_id", unique: true

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -443,6 +443,28 @@ describe Admin::ClaimsHelper do
       end
     end
 
+    context "when task failed with reason" do
+      subject(:task_status_tag) { helper.task_status_tag(claim, "one_login_identity") }
+
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "one_login_identity",
+            passed: false,
+            reason: "no_data"
+          )
+        ]
+      end
+
+      it "returns 'No data' in red" do
+        expect(task_status_tag).to match("No data")
+        expect(task_status_tag).to match("govuk-tag app-task-list__task-completed")
+        expect(task_status_tag).to match("govuk-tag--red")
+      end
+    end
+
     context "with task passed nil" do
       let(:claim_tasks) do
         [

--- a/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::OneLoginIdentity do
         )
       end
 
-      it "creates a failed task" do
+      it "creates a failed task with no_data reason" do
         expect {
           subject.perform
-        }.to change(Task.where(passed: false), :count).by(1)
+        }.to change(Task.where(passed: false, reason: "no_data"), :count).by(1)
       end
     end
 

--- a/spec/views/admin/tasks/one_login_identity.html.erb_spec.rb
+++ b/spec/views/admin/tasks/one_login_identity.html.erb_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "admin/tasks/one_login_identity.html.erb" do
+  let(:claim) do
+    create(
+      :claim,
+      :submitted,
+      policy: Policies::FurtherEducationPayments,
+      onelogin_idv_at: 1.second.ago
+    )
+  end
+
+  let(:task) do
+    create(
+      :task,
+      name: "one_login_identity",
+      claim:,
+      passed: false,
+      reason: "no_data",
+      manual: false,
+      created_by: nil
+    )
+  end
+
+  let(:claim_checking_tasks) do
+    ClaimCheckingTasks.new(claim)
+  end
+
+  before do
+    allow(view).to receive(:current_page?).and_return(true)
+  end
+
+  it "renders correct text" do
+    assign(:claim, claim)
+    assign(:claim_checking_tasks, claim_checking_tasks)
+    assign(:tasks_presenter, claim.policy::AdminTasksPresenter.new(claim))
+    assign(:task, task)
+    assign(:current_task_name, "one_login_identity")
+    assign(:notes, [])
+    assign(:task_pagination, Admin::TaskPagination.new(claim:, current_task_name: "one_login_identity"))
+
+    render
+
+    expect(rendered).to include("This claimant was unable to verify their identity with")
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2281
- Able to add reason to a task which can then surfaced back to the admin
- in order to for admin task view to consider the task being viewed. this will now delegate to relevant partial if it exists