### PR TITLE
[CAPT-2194] add titles to iframes

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -38,6 +38,7 @@
         <noscript>
           <iframe
             src="https://www.googletagmanager.com/ns.html?<%= ENV["GTM_ANALYTICS"] %>"
+            title="Google tag manager tracking code"
             height="0"
             width="0"
             style="display:none;visibility:hidden">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,7 @@
         <noscript>
           <iframe
             src="https://www.googletagmanager.com/ns.html?<%= ENV["GTM_ANALYTICS"] %>"
+            title="Google tag manager tracking code"
             height="0"
             width="0"
             style="display:none;visibility:hidden">


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2194
- Added titles to iframes, although, not really needed though as the iframes are hidden. don't see any harm in doing so

