### PR TITLE
CAPT 2280/alternative idv task

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -153,32 +153,9 @@ module Admin
     end
 
     def task_status_tag(claim, task_name)
-      task = claim.tasks.detect { |t| t.name == task_name }
+      status, colour = Tasks.status(claim: claim, task_name: task_name)
 
-      if task.nil?
-        status = "Incomplete"
-        status_colour = "grey"
-      elsif task.passed?
-        status = "Passed"
-        status_colour = "green"
-      elsif task.passed == false
-        status = task.reason&.humanize || "Failed"
-        status_colour = "red"
-      elsif task.claim_verifier_match_all?
-        status = "Full match"
-        status_colour = "green"
-      elsif task.claim_verifier_match_any?
-        status = "Partial match"
-        status_colour = "yellow"
-      elsif task.claim_verifier_match_none?
-        status = "No match"
-        status_colour = "red"
-      elsif task.claim_verifier_match.nil? && %w[census_subjects_taught employment induction_confirmation student_loan_amount student_loan_plan].include?(task_name)
-        status = "No data"
-        status_colour = "red"
-      end
-
-      task_status_content_tag(status_colour:, status:)
+      task_status_content_tag(status_colour: colour, status: status)
     end
 
     def task_status_content_tag(status_colour:, status:)

--- a/app/models/automated_checks/claim_verifiers/alternative_identity_verification.rb
+++ b/app/models/automated_checks/claim_verifiers/alternative_identity_verification.rb
@@ -1,0 +1,116 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    class AlternativeIdentityVerification
+      TASK_NAME = "alternative_identity_verification".freeze
+
+      def initialize(claim:)
+        @claim = claim
+      end
+
+      def perform
+        return unless eligibility.claimant_identity_verified_at?
+        return if task_exists?
+
+        create_task!
+      end
+
+      private
+
+      attr_reader :claim
+
+      delegate :eligibility, to: :claim
+
+      def create_task!
+        task = claim.tasks.build(
+          name: TASK_NAME,
+          manual: manual,
+          passed: passed,
+          claim_verifier_match: claim_verifier_match,
+          created_by: created_by
+        )
+
+        task.save!(context: :claim_verifier)
+
+        task
+      end
+
+      def passed
+        if all_details_match?
+          true
+        end
+      end
+
+      def manual
+        if all_details_match?
+          false
+        end
+      end
+
+      def claim_verifier_match
+        if all_details_match?
+          "all"
+        else
+          # Some of the answers may match but the designs call for displaying
+          # "no match" unless all details match.
+          "none"
+        end
+      end
+
+      def task_exists?
+        claim.tasks.where(name: TASK_NAME).exists?
+      end
+
+      def all_details_match?
+        postcodes_match? &&
+          national_insurance_numbers_match? &&
+          dates_of_birth_match? &&
+          passports_match?
+      end
+
+      def postcodes_match?
+        normalise(claim.postcode) == normalise(eligibility.claimant_postcode)
+      end
+
+      def national_insurance_numbers_match?
+        normalise(claim.national_insurance_number) ==
+          normalise(eligibility.claimant_national_insurance_number)
+      end
+
+      def dates_of_birth_match?
+        claim.date_of_birth == eligibility.claimant_date_of_birth
+      end
+
+      def passports_match?
+        # If both parties say they don't have a passport, don't compare passport
+        # numbers.
+        if !eligibility.valid_passport? && !eligibility.claimant_valid_passport?
+          return true
+        end
+
+        eligibility.valid_passport? == eligibility.claimant_valid_passport? &&
+          normalise(eligibility.passport_number) ==
+            normalise(eligibility.claimant_passport_number)
+      end
+
+      def normalise(string)
+        string.to_s.remove(/\s/).downcase
+      end
+
+      def verifier
+        claim.eligibility.verification.fetch("verifier")
+      end
+
+      def created_by
+        return unless all_details_match?
+
+        DfeSignIn::User.find_or_create_by!(dfe_sign_in_id: verifier.fetch("dfe_sign_in_uid")) do |user|
+          user.given_name = verifier.fetch("first_name")
+          user.family_name = verifier.fetch("last_name")
+          user.email = verifier.fetch("email")
+          user.organisation_name = verifier.fetch("dfe_sign_in_organisation_name")
+          user.role_codes = verifier.fetch("dfe_sign_in_role_codes")
+        end
+      end
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -432,6 +432,10 @@ class Claim < ApplicationRecord
     @attributes_flagged_by_risk_indicator ||= RiskIndicator.flagged_attributes(self)
   end
 
+  def failed_one_login_idv?
+    onelogin_idv_at.present? && !identity_confirmed_with_onelogin?
+  end
+
   private
 
   def one_login_idv_name_match?

--- a/app/models/journeys/further_education_payments/provider/session_answers.rb
+++ b/app/models/journeys/further_education_payments/provider/session_answers.rb
@@ -63,12 +63,8 @@ module Journeys
         end
 
         def identity_verification_required?
-          unless FeatureFlag.enabled?(:fe_provider_identity_verification)
-            return false
-          end
-
-          claim.onelogin_idv_at.present? &&
-            !claim.identity_confirmed_with_onelogin?
+          Policies::FurtherEducationPayments
+            .alternative_identity_verification_required?(claim)
         end
       end
     end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -94,7 +94,7 @@ module Policies
     def alternative_identity_verification_required?(claim)
       return false unless FeatureFlag.enabled?(:fe_provider_identity_verification)
 
-      claim.onelogin_idv_at.present? && !claim.identity_confirmed_with_onelogin?
+      claim.failed_one_login_idv?
     end
   end
 end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -89,5 +89,11 @@ module Policies
     def payroll_file_name
       "FELUPEXPANSION"
     end
+
+    def alternative_identity_verification_required?(claim)
+      return false unless FeatureFlag.enabled?(:fe_provider_identity_verification)
+
+      claim.onelogin_idv_at.present? && !claim.identity_confirmed_with_onelogin?
+    end
   end
 end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -13,6 +13,7 @@ module Policies
     VERIFIERS = [
       AutomatedChecks::ClaimVerifiers::OneLoginIdentity,
       AutomatedChecks::ClaimVerifiers::ProviderVerification,
+      AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification,
       AutomatedChecks::ClaimVerifiers::Employment,
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan,
       AutomatedChecks::ClaimVerifiers::FraudRisk

--- a/app/models/policies/further_education_payments/admin_alternative_identity_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_alternative_identity_verification_task_presenter.rb
@@ -8,14 +8,12 @@ module Policies
       end
 
       def submitted?
-        claim.eligibility.claimant_identity_verified_at.present? && task.present?
+        claim.eligibility.claimant_identity_verified_at.present?
       end
 
       # Does an admin need to review the alternative identity details?
       def admin_check_required?
-        # The claim verifier leaves the task passed state as nil if there isn't
-        # a match on all provided details.
-        task.passed.nil?
+        task.nil?
       end
 
       def task

--- a/app/models/policies/further_education_payments/admin_alternative_identity_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_alternative_identity_verification_task_presenter.rb
@@ -1,0 +1,26 @@
+module Policies
+  module FurtherEducationPayments
+    class AdminAlternativeIdentityVerificationTaskPresenter
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      def submitted?
+        claim.eligibility.claimant_identity_verified_at.present? && task.present?
+      end
+
+      # Does an admin need to review the alternative identity details?
+      def admin_check_required?
+        # The claim verifier leaves the task passed state as nil if there isn't
+        # a match on all provided details.
+        task.passed.nil?
+      end
+
+      def task
+        @task ||= @claim.tasks.find_by(name: "alternative_identity_verification")
+      end
+    end
+  end
+end

--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -13,6 +13,10 @@ module Policies
         AdminProviderVerificationTaskPresenter.new(claim)
       end
 
+      def alternative_identity_verification
+        AdminAlternativeIdentityVerificationTaskPresenter.new(claim)
+      end
+
       def provider_name
         [verifier.fetch("first_name"), verifier.fetch("last_name")].join(" ").presence || verifier.fetch("email")
       end

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -17,6 +17,7 @@ module Policies
         tasks << "one_login_identity"
         tasks << "provider_verification"
         tasks << "provider_details" if claim.eligibility.provider_and_claimant_details_match?
+        tasks << "alternative_identity_verification" if FurtherEducationPayments.alternative_identity_verification_required?(claim)
         tasks << "employment" if claim.eligibility.teacher_reference_number.present?
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,6 +11,7 @@ class Task < ApplicationRecord
     one_login_identity
     previous_payment
     identity_confirmation
+    alternative_identity_verification
     provider_verification
     provider_details
     visa

--- a/app/models/tasks.rb
+++ b/app/models/tasks.rb
@@ -2,7 +2,12 @@ module Tasks
   def self.status(claim:, task_name:)
     task = claim.tasks.detect { |t| t.name == task_name }
 
-    _generic(task)
+    case task_name
+    when "alternative_identity_verification"
+      _alternative_identity_verification(task: task, claim: claim)
+    else
+      _generic(task)
+    end
   end
 
   def self._generic(task)
@@ -27,6 +32,26 @@ module Tasks
     elsif task.claim_verifier_match.nil? && %w[census_subjects_taught employment induction_confirmation student_loan_amount student_loan_plan].include?(task.name)
       status = "No data"
       status_colour = "red"
+    end
+
+    [status, status_colour]
+  end
+
+  def self._alternative_identity_verification(task:, claim:)
+    if task.nil? && claim.eligibility.claimant_identity_verified_at?
+      status = "No match"
+      status_colour = "red"
+    elsif task.nil?
+      status = "Incomplete"
+      status_colour = "grey"
+    elsif task.passed?
+      status = "Passed"
+      status_colour = "green"
+    elsif task.passed == false
+      status = "Failed"
+      status_colour = "red"
+    else
+      fail "Unknown status for task #{task.inspect}"
     end
 
     [status, status_colour]

--- a/app/models/tasks.rb
+++ b/app/models/tasks.rb
@@ -1,0 +1,34 @@
+module Tasks
+  def self.status(claim:, task_name:)
+    task = claim.tasks.detect { |t| t.name == task_name }
+
+    _generic(task)
+  end
+
+  def self._generic(task)
+    if task.nil?
+      status = "Incomplete"
+      status_colour = "grey"
+    elsif task.passed?
+      status = "Passed"
+      status_colour = "green"
+    elsif task.passed == false
+      status = task.reason&.humanize || "Failed"
+      status_colour = "red"
+    elsif task.claim_verifier_match_all?
+      status = "Full match"
+      status_colour = "green"
+    elsif task.claim_verifier_match_any?
+      status = "Partial match"
+      status_colour = "yellow"
+    elsif task.claim_verifier_match_none?
+      status = "No match"
+      status_colour = "red"
+    elsif task.claim_verifier_match.nil? && %w[census_subjects_taught employment induction_confirmation student_loan_amount student_loan_plan].include?(task.name)
+      status = "No data"
+      status_colour = "red"
+    end
+
+    [status, status_colour]
+  end
+end

--- a/app/views/admin/tasks/_alternative_identity_verification_submitted.html.erb
+++ b/app/views/admin/tasks/_alternative_identity_verification_submitted.html.erb
@@ -1,0 +1,44 @@
+<%= govuk_table do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(text: "Identity check") %>
+      <% row.with_cell(text: "Claimant submitted") %>
+      <% row.with_cell(text: "Provider response") %>
+    <% end %>
+  <% end %>
+
+  <% table.with_body do |body| %>
+    <% body.with_row do |row| %>
+      <% row.with_cell(header: true, text: "National Insurance number") %>
+      <% row.with_cell(text: claim.national_insurance_number) %>
+      <% row.with_cell(text: claim.eligibility.claimant_national_insurance_number) %>
+    <% end %>
+
+    <% body.with_row do |row| %>
+      <% row.with_cell(header: true, text: "Post code") %>
+      <% row.with_cell(text: claim.postcode) %>
+      <% row.with_cell(text: claim.eligibility.claimant_postcode) %>
+    <% end %>
+
+    <% body.with_row do |row| %>
+      <% row.with_cell(header: true, text: "Date of Birth") %>
+      <% row.with_cell(text: l(claim.date_of_birth)) %>
+      <% row.with_cell(text: l(claim.eligibility.claimant_date_of_birth)) %>
+    <% end %>
+
+    <% body.with_row do |row| %>
+      <% row.with_cell(header: true, text: "Passport number") %>
+      <% if claim.eligibility.valid_passport %>
+        <% row.with_cell(text: claim.eligibility.passport_number) %>
+      <% else %>
+        <% row.with_cell(text: "No passport") %>
+      <% end %>
+
+      <% if claim.eligibility.claimant_valid_passport %>
+        <% row.with_cell(text: claim.eligibility.claimant_passport_number) %>
+      <% else %>
+        <% row.with_cell(text: "No passport") %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/tasks/alternative_identity_verification.html.erb
+++ b/app/views/admin/tasks/alternative_identity_verification.html.erb
@@ -1,0 +1,62 @@
+<% content_for(:page_title) do %>
+  <% page_title("Claim #{@claim.reference} alternative identity verification") %>
+<% end %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <%= render(
+    "claim_summary_further_education_payments",
+    claim: @claim,
+    heading: "Alternative identity verification"
+  ) %>
+
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-xl"><%= @current_task_name.humanize %></h2>
+
+    <% if @tasks_presenter.alternative_identity_verification.submitted? %>
+      <%= render(
+        partial: "alternative_identity_verification_submitted",
+        locals: { claim: @claim }
+      ) %>
+
+      <% if @tasks_presenter.alternative_identity_verification.admin_check_required? %>
+        <%= render(
+          "form",
+          task_name: "alternative_identity_verification",
+          claim: @claim
+        ) %>
+      <% else %>
+        <div class="govuk-inset-text task-outcome">
+          <p class="govuk-body">
+            <%= task_status_tag(@task.claim, @task.name) %>
+          </p>
+          <p class="govuk-body">
+            <%# the alternative_identity_verification claim verifier sets the
+            claim_verifier_match field to "all" if the provider has passed the
+            task %>
+            <% if @task.claim_verifier_match_all? %>
+              This task was performed by the provider
+              (<%= user_details(@task.created_by, include_line_break: false) %>)
+              on <%= l(@task.updated_at) %>
+            <% else %>
+              This task was performed by
+              <%= user_details(@task.created_by, include_line_break: false) %>
+              on <%= l(@task.updated_at) %>
+            <% end %>
+          </p>
+        </div>
+      <% end %>
+
+    <% else %>
+      <%= render "provider_verification_unsubmitted" %>
+    <% end %>
+
+    <%= render(
+      partial: "admin/task_pagination",
+      locals: { task_pagination: @task_pagination }
+    ) %>
+  </div>
+</div>

--- a/app/views/admin/tasks/provider_verification.html.erb
+++ b/app/views/admin/tasks/provider_verification.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { page_title("Claim #{@claim.reference} provider verification check for# {@claim.policy.short_name}") } %>
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} provider verification check for #{@claim.policy.short_name}") } %>
 
 <% content_for :back_link do %>
   <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,9 @@ en:
       one_login_identity:
         name: One Login identity check
         title: Confirm the claimant made the claim
+      alternative_identity_verification:
+        name: "Alternative identity verification"
+        title: "Confirm the provider has verified the claimant's identity"
       previous_payment:
         name: Previous payment
         title: Check for previous payment
@@ -931,6 +934,8 @@ en:
           title: Do the One Login details match the personal details entered by the claimant?
         identity_confirmation:
           title: Do the One Login details match the personal details entered by the claimant?
+        alternative_identity_verification:
+          title: "Do the details entered by the claimant match the personal details entered by the provider?"
         matching_details:
           title: Is this claim still valid despite having matching details with other claims?
         payroll_details:

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -138,5 +138,14 @@ FactoryBot.define do
       eligible
       teacher_reference_number { generate(:teacher_reference_number) }
     end
+
+    trait :identity_verified_by_provider do
+      claimant_date_of_birth { Date.new(1990, 1, 1) }
+      claimant_postcode { "SW1A 1AA" }
+      claimant_national_insurance_number { "QQ123456C" }
+      claimant_valid_passport { true }
+      claimant_passport_number { "123456789" }
+      claimant_identity_verified_at { Time.zone.now }
+    end
   end
 end

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Admin claim further education payments" do
   end
 
   before do
+    FeatureFlag.create!(name: :fe_provider_identity_verification, enabled: true)
     create(:journey_configuration, :further_education_payments_provider)
     sign_in_as_service_operator
   end
@@ -484,6 +485,286 @@ RSpec.feature "Admin claim further education payments" do
             visit admin_claim_tasks_path(claim)
 
             expect(task_status("Provider verification")).to eq "Failed"
+          end
+        end
+      end
+    end
+
+    describe "provider identity verification task" do
+      context "when the claimant has failed IDV" do
+        context "when the provider hasn't verified the claim" do
+          it "shows the alternative idv task" do
+            claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::FurtherEducationPayments,
+              onelogin_idv_at: 1.day.ago,
+              identity_confirmed_with_onelogin: false
+            )
+
+            create(
+              :further_education_payments_eligibility,
+              claim: claim,
+              provider_verification_email_last_sent_at: DateTime.new(2025, 3, 1, 9, 0, 0),
+              provider_verification_email_count: 1
+            )
+
+            visit admin_claim_tasks_path(claim)
+
+            expect(page).to have_content("Alternative identity verification")
+
+            click_on "Confirm the provider has verified the claimant's identity"
+
+            expect(page).to have_content(
+              "Resend provider verification request"
+            )
+          end
+
+          it "shows the option to send the verificaiton email for duplicates" do
+            claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::FurtherEducationPayments,
+              onelogin_idv_at: 1.day.ago,
+              identity_confirmed_with_onelogin: false
+            )
+
+            fe_provider = create(
+              :school,
+              :further_education,
+              :fe_eligible,
+              name: "Springfield A and M"
+            )
+
+            create(
+              :further_education_payments_eligibility,
+              claim: claim,
+              school: fe_provider,
+              flagged_as_duplicate: true
+            )
+
+            visit admin_claim_tasks_path(claim)
+
+            expect(page).to have_content("Alternative identity verification")
+
+            click_on "Confirm the provider has verified the claimant's identity"
+
+            expect(page).to have_content(
+              "This task has not been sent to the provider yet."
+            )
+
+            expect(page).not_to have_content(
+              "The verification request was sent to the provider"
+            )
+
+            perform_enqueued_jobs do
+              click_on "Send provider verification request"
+            end
+
+            expect(page).to have_content(
+              "The verification request was sent to the provider by " \
+              "Aaron Admin on 9 September #{AcademicYear.current.start_year} " \
+              "11:00am"
+            )
+
+            provider_email_address = fe_provider.eligible_fe_provider.primary_key_contact_email_address
+
+            expect(provider_email_address).to(
+              have_received_email("9a25fe46-2ee4-4a5c-8d47-0f04f058a87d")
+            )
+          end
+        end
+
+        context "when the provider has verified the claim" do
+          it "shows the provider and claimant entered details" do
+            claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::FurtherEducationPayments,
+              onelogin_idv_at: 1.day.ago,
+              identity_confirmed_with_onelogin: false,
+              national_insurance_number: "QQ123456B",
+              postcode: "TE57 2NG",
+              date_of_birth: Date.new(1990, 2, 1)
+            )
+
+            create(
+              :further_education_payments_eligibility,
+              claim: claim,
+              flagged_as_duplicate: true,
+              claimant_date_of_birth: Date.new(1990, 1, 1),
+              claimant_postcode: "TE57 1NG",
+              claimant_national_insurance_number: "QQ123456C",
+              claimant_valid_passport: true,
+              claimant_passport_number: "123456789",
+              claimant_identity_verified_at: DateTime.now,
+              valid_passport: true,
+              passport_number: "123456780"
+            )
+
+            AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification
+              .new(claim: claim).perform
+
+            visit admin_claim_tasks_path(claim)
+
+            click_on "Confirm the provider has verified the claimant's identity"
+
+            within_table_row("National Insurance number") do |claimant, provider|
+              expect(claimant).to have_text("QQ123456B")
+              expect(provider).to have_text("QQ123456C")
+            end
+
+            within_table_row("Post code") do |claimant, provider|
+              expect(claimant).to have_text("TE57 2NG")
+              expect(provider).to have_text("TE57 1NG")
+            end
+
+            within_table_row("Date of Birth") do |claimant, provider|
+              expect(claimant).to have_text("1 February 1990")
+              expect(provider).to have_text("1 January 1990")
+            end
+
+            within_table_row("Passport number") do |claimant, provider|
+              expect(claimant).to have_text("123456780")
+              expect(provider).to have_text("123456789")
+            end
+          end
+
+          context "when the provider and claimant details match" do
+            it "shows the task as passed" do
+              claim = create(
+                :claim,
+                :submitted,
+                policy: Policies::FurtherEducationPayments,
+                onelogin_idv_at: 1.day.ago,
+                identity_confirmed_with_onelogin: false,
+                national_insurance_number: "QQ123456C",
+                postcode: "TE57 1NG",
+                date_of_birth: Date.new(1990, 1, 1)
+              )
+
+              create(
+                :further_education_payments_eligibility,
+                claim: claim,
+                flagged_as_duplicate: true,
+                claimant_date_of_birth: Date.new(1990, 1, 1),
+                claimant_postcode: "TE57 1NG",
+                claimant_national_insurance_number: "QQ123456C",
+                claimant_valid_passport: true,
+                claimant_passport_number: "123456789",
+                claimant_identity_verified_at: DateTime.now,
+                valid_passport: true,
+                passport_number: "123456789",
+                verification: {
+                  verifier: {
+                    dfe_sign_in_uid: "123",
+                    first_name: "Seymour",
+                    last_name: "Skinner",
+                    email: "seymore.skinner@springfield-elementary.edu",
+                    dfe_sign_in_organisation_name: "Springfield Elementary",
+                    dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
+                  }
+                }
+              )
+
+              AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification
+                .new(claim: claim).perform
+
+              visit admin_claim_tasks_path(claim)
+
+              expect(
+                task_status("Alternative identity verification")
+              ).to eq("Passed")
+
+              click_on(
+                "Confirm the provider has verified the claimant's identity"
+              )
+
+              expect(page).not_to have_content(
+                "Do the details entered by the claimant match the personal " \
+                "details entered by the provider?"
+              )
+
+              expect(find(".govuk-tag")).to have_text("Passed")
+
+              expect(page).to have_content(
+                "This task was performed by the provider (Seymour Skinner) on " \
+                "9 September #{AcademicYear.current.start_year} 11:00am"
+              )
+            end
+          end
+
+          context "when the provider and claimant details don't match" do
+            it "shows the task as no match and shows the manual approval form" do
+              claim = create(
+                :claim,
+                :submitted,
+                policy: Policies::FurtherEducationPayments,
+                onelogin_idv_at: 1.day.ago,
+                identity_confirmed_with_onelogin: false,
+                national_insurance_number: "QQ123456B",
+                postcode: "TE57 2NG",
+                date_of_birth: Date.new(1990, 2, 1)
+              )
+
+              create(
+                :further_education_payments_eligibility,
+                claim: claim,
+                flagged_as_duplicate: true,
+                claimant_date_of_birth: Date.new(1990, 1, 1),
+                claimant_postcode: "TE57 1NG",
+                claimant_national_insurance_number: "QQ123456C",
+                claimant_valid_passport: true,
+                claimant_passport_number: "123456789",
+                claimant_identity_verified_at: DateTime.now,
+                valid_passport: false,
+                passport_number: nil
+              )
+
+              AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification
+                .new(claim: claim).perform
+
+              visit admin_claim_tasks_path(claim)
+
+              expect(
+                task_status("Alternative identity verification")
+              ).to eq("No match")
+
+              click_on(
+                "Confirm the provider has verified the claimant's identity"
+              )
+
+              expect(page).to have_content(
+                "Do the details entered by the claimant match the personal " \
+                "details entered by the provider?"
+              )
+
+              choose "No"
+
+              click_on "Save and continue"
+
+              visit admin_claim_tasks_path(claim)
+
+              expect(
+                task_status("Alternative identity verification")
+              ).to eq("Failed")
+
+              click_on(
+                "Confirm the provider has verified the claimant's identity"
+              )
+
+              expect(page).not_to have_content(
+                "Do the details entered by the claimant match the personal " \
+                "details entered by the provider?"
+              )
+
+              expect(find(".govuk-tag")).to have_text("Failed")
+
+              expect(page).to have_content(
+                "This task was performed by Aaron Admin on 9 September " \
+                "#{AcademicYear.current.start_year} 11:00am"
+              )
+            end
           end
         end
       end

--- a/spec/models/automated_checks/claim_verifiers/alternative_identity_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/alternative_identity_verification_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification do
+  describe "#perform" do
+    context "when the claimant's identity has not been verified" do
+      it "doesn't create a task" do
+        claim = create(
+          :further_education_payments_eligibility,
+          claimant_identity_verified_at: nil
+        ).claim
+
+        expect { described_class.new(claim: claim).perform }.not_to(
+          change { claim.tasks.count }
+        )
+      end
+    end
+
+    context "when the claimant's identity has been verified" do
+      context "when the task has already been performed" do
+        it "doesn't create a new task" do
+          claim = create(
+            :further_education_payments_eligibility,
+            claimant_identity_verified_at: DateTime.now
+          ).claim
+
+          create(
+            :task,
+            name: "alternative_identity_verification",
+            claim: claim
+          )
+
+          expect { described_class.new(claim: claim).perform }.not_to(
+            change { claim.tasks.count }
+          )
+        end
+      end
+
+      context "when the task has not been performed" do
+        context "when the provider and claimant details match" do
+          it "passes the task" do
+            eligibility = create(
+              :further_education_payments_eligibility,
+              claimant_identity_verified_at: DateTime.now,
+              claimant_date_of_birth: Date.new(1990, 1, 1),
+              claimant_postcode: "TE57 1NG",
+              claimant_national_insurance_number: "QQ123456C",
+              claimant_valid_passport: false,
+              claimant_passport_number: nil,
+              valid_passport: false,
+              passport_number: nil,
+              verification: {
+                verifier: {
+                  dfe_sign_in_uid: "123",
+                  first_name: "Seymour",
+                  last_name: "Skinner",
+                  email: "seymore.skinner@springfield-elementary.edu",
+                  dfe_sign_in_organisation_name: "Springfield Elementary",
+                  dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
+                }
+              }
+            )
+
+            claim = create(
+              :claim,
+              eligibility: eligibility,
+              policy: eligibility.policy,
+              postcode: "te571ng",
+              national_insurance_number: "qq123456c",
+              date_of_birth: Date.new(1990, 1, 1)
+            )
+
+            expect { described_class.new(claim: claim).perform }.to(
+              change(
+                claim.tasks.where(name: "alternative_identity_verification"),
+                :count
+              ).from(0).to(1)
+            )
+
+            task = claim.tasks.find_by!(
+              name: "alternative_identity_verification"
+            )
+
+            expect(task.passed).to eq(true)
+            expect(task.manual).to eq(false)
+            expect(task.created_by.email).to eq(
+              "seymore.skinner@springfield-elementary.edu"
+            )
+          end
+        end
+
+        context "when the provider and claimant details do not match" do
+          it "sets the task to no match" do
+            eligibility = create(
+              :further_education_payments_eligibility,
+              claimant_identity_verified_at: DateTime.now,
+              claimant_date_of_birth: Date.new(1990, 1, 1),
+              claimant_postcode: "TE57 1NG",
+              claimant_national_insurance_number: "QQ123456C",
+              claimant_valid_passport: true,
+              claimant_passport_number: "123456789",
+              valid_passport: false,
+              passport_number: nil,
+              verification: {
+                verifier: {
+                  dfe_sign_in_uid: "123",
+                  first_name: "Seymour",
+                  last_name: "Skinner",
+                  email: "seymore.skinner@springfield-elementary.edu",
+                  dfe_sign_in_organisation_name: "Springfield Elementary",
+                  dfe_sign_in_role_codes: ["teacher_payments_claim_verifier"]
+                }
+              }
+            )
+
+            claim = create(
+              :claim,
+              eligibility: eligibility,
+              policy: eligibility.policy,
+              postcode: "TE57 1NG",
+              national_insurance_number: "QQ123456C",
+              date_of_birth: Date.new(1990, 1, 1)
+            )
+
+            expect { described_class.new(claim: claim).perform }.to(
+              change(
+                claim.tasks.where(name: "alternative_identity_verification"),
+                :count
+              ).from(0).to(1)
+            )
+
+            task = claim.tasks.find_by!(
+              name: "alternative_identity_verification"
+            )
+
+            expect(task.passed).to eq(nil)
+            expect(task.manual).to eq(nil)
+            expect(task.created_by).to eq(nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/automated_checks/claim_verifiers/alternative_identity_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/alternative_identity_verification_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification 
         end
 
         context "when the provider and claimant details do not match" do
-          it "sets the task to no match" do
+          it "doesn't create the task" do
             eligibility = create(
               :further_education_payments_eligibility,
               claimant_identity_verified_at: DateTime.now,
@@ -121,20 +121,12 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification 
               date_of_birth: Date.new(1990, 1, 1)
             )
 
-            expect { described_class.new(claim: claim).perform }.to(
+            expect { described_class.new(claim: claim).perform }.not_to(
               change(
                 claim.tasks.where(name: "alternative_identity_verification"),
                 :count
-              ).from(0).to(1)
+              )
             )
-
-            task = claim.tasks.find_by!(
-              name: "alternative_identity_verification"
-            )
-
-            expect(task.passed).to eq(nil)
-            expect(task.manual).to eq(nil)
-            expect(task.created_by).to eq(nil)
           end
         end
       end

--- a/spec/models/further_education_payments_spec.rb
+++ b/spec/models/further_education_payments_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Policies::FurtherEducationPayments, type: :model do
     expect(subject::VERIFIERS).to eq([
       AutomatedChecks::ClaimVerifiers::OneLoginIdentity,
       AutomatedChecks::ClaimVerifiers::ProviderVerification,
+      AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification,
       AutomatedChecks::ClaimVerifiers::Employment,
       AutomatedChecks::ClaimVerifiers::StudentLoanPlan,
       AutomatedChecks::ClaimVerifiers::FraudRisk

--- a/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks do
+  before do
+    FeatureFlag.create!(name: :fe_provider_identity_verification, enabled: true)
+  end
+
   describe "#applicable_task_names" do
     subject { described_class.new(claim).applicable_task_names }
 
@@ -11,6 +15,8 @@ RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks do
     let(:claimant_first_name) { "Edna" }
     let(:claimant_surname) { "Krabappel" }
     let(:claimant_email_address) { "e.krabappel@springfield-elementary.edu" }
+    let(:onelogin_idv_at) { 1.day.ago }
+    let(:identity_confirmed_with_onelogin) { true }
 
     let(:eligibility) do
       build(
@@ -35,7 +41,9 @@ RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks do
         eligibility: eligibility,
         first_name: claimant_first_name,
         surname: claimant_surname,
-        email_address: claimant_email_address
+        email_address: claimant_email_address,
+        onelogin_idv_at: onelogin_idv_at,
+        identity_confirmed_with_onelogin: identity_confirmed_with_onelogin
       )
     end
 
@@ -113,6 +121,11 @@ RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks do
     context "when the claim and provider details are different" do
       it { is_expected.not_to include("provider_details") }
       it { is_expected.to include(*invariant_tasks) }
+    end
+
+    context "when the claimant fails IDV" do
+      let(:identity_confirmed_with_onelogin) { false }
+      it { is_expected.to include("alternative_identity_verification") }
     end
   end
 end

--- a/spec/models/tasks_spec.rb
+++ b/spec/models/tasks_spec.rb
@@ -117,5 +117,47 @@ RSpec.describe Tasks do
         it { is_expected.to eq([nil, nil]) }
       end
     end
+
+    context "with an alternative_identity_verification task" do
+      let(:task_name) { "alternative_identity_verification" }
+
+      let(:claim) do
+        create(:claim, :submitted, policy: Policies::FurtherEducationPayments)
+      end
+
+      context "when the task hasn't been created" do
+        context "when the provider has submitted the verification" do
+          before do
+            create(
+              :further_education_payments_eligibility,
+              :identity_verified_by_provider,
+              claim: claim
+            )
+          end
+
+          it { is_expected.to eq(["No match", "red"]) }
+        end
+
+        context "when the provider has not submitted the verification" do
+          it { is_expected.to eq(["Incomplete", "grey"]) }
+        end
+      end
+
+      context "when the task has passed" do
+        before do
+          create(:task, :passed, claim: claim, name: task_name)
+        end
+
+        it { is_expected.to eq(["Passed", "green"]) }
+      end
+
+      context "when the task has failed" do
+        before do
+          create(:task, :failed, claim: claim, name: task_name)
+        end
+
+        it { is_expected.to eq(["Failed", "red"]) }
+      end
+    end
   end
 end

--- a/spec/models/tasks_spec.rb
+++ b/spec/models/tasks_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+RSpec.describe Tasks do
+  describe ".status" do
+    subject { Tasks.status(claim: claim, task_name: task_name) }
+
+    context "with a generic task" do
+      let(:claim) { create(:claim, :submitted) }
+      let(:task_name) { "identity_confirmation" }
+
+      context "when the task does not exist" do
+        it "returns incomplete status with grey color" do
+          status, color = Tasks.status(claim: claim, task_name: task_name)
+          expect(status).to eq("Incomplete")
+          expect(color).to eq("grey")
+        end
+      end
+
+      context "when the task has passed" do
+        before do
+          create(:task, :passed, claim: claim, name: task_name)
+        end
+
+        it { is_expected.to eq(["Passed", "green"]) }
+      end
+
+      context "when the task has failed" do
+        before do
+          create(:task, :failed, claim: claim, name: task_name)
+        end
+
+        it { is_expected.to eq(["Failed", "red"]) }
+      end
+
+      context "when the task has full match from claim verifier" do
+        before do
+          create(
+            :task,
+            :claim_verifier_context,
+            claim: claim,
+            name: task_name,
+            passed: nil,
+            claim_verifier_match: "all"
+          )
+        end
+
+        it { is_expected.to eq(["Full match", "green"]) }
+      end
+
+      context "when the task has partial match from claim verifier" do
+        before do
+          create(
+            :task,
+            :claim_verifier_context,
+            claim: claim,
+            name: task_name,
+            passed: nil,
+            claim_verifier_match: "any"
+          )
+        end
+
+        it { is_expected.to eq(["Partial match", "yellow"]) }
+      end
+
+      context "when the task has no match from claim verifier" do
+        before do
+          create(
+            :task,
+            :claim_verifier_context,
+            claim: claim,
+            name: task_name,
+            passed: nil,
+            claim_verifier_match: "none"
+          )
+        end
+
+        it { is_expected.to eq(["No match", "red"]) }
+      end
+
+      context "when specific tasks have no data" do
+        ["census_subjects_taught", "employment", "induction_confirmation", "student_loan_amount", "student_loan_plan"].each do |special_task_name|
+          context "with #{special_task_name} task" do
+            let(:task_name) { special_task_name }
+
+            before do
+              create(
+                :task,
+                :claim_verifier_context,
+                claim: claim,
+                name: task_name,
+                passed: nil,
+                claim_verifier_match: nil
+              )
+            end
+
+            it { is_expected.to eq(["No data", "red"]) }
+          end
+        end
+      end
+
+      # FIXME determine what we should do in this scenario, this was the
+      # existing behaviour
+      context "when a non-specific task has no claim verifier match" do
+        let(:task_name) { "payroll_details" }
+
+        before do
+          create(
+            :task,
+            :claim_verifier_context,
+            claim: claim,
+            name: task_name,
+            passed: nil,
+            claim_verifier_match: nil
+          )
+        end
+
+        it { is_expected.to eq([nil, nil]) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a claimant fails one login IDV we need to ask the provider to verify
the claimants identity. This commit adds the new task to the admin area
to track this alternative identity verification.

When a claim is considered to be a duplicate we don't automatically send
the verification email to the provider, it needs to be manually
triggered by an ops team member. The designs call for showing the resend
verification email on both the `alternative_identity_verification` and
`provider_verification` task views, both designs for this are the same,
so we've reused the parital from the `provider_verification` that
already handles this.