### PR TITLE
Send emails to both contacts

### DIFF
--- a/app/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form.rb
@@ -8,6 +8,8 @@ module Journeys
 
             ClaimMailer.early_years_payment_practitioner_email(claim).deliver_later
 
+            send_provider_completed_emails
+
             true
           end
 
@@ -27,6 +29,15 @@ module Journeys
 
           def claim_expected_to_have_email_address
             false
+          end
+
+          def send_provider_completed_emails
+            claim.eligibility.eligible_ey_provider.email_addresses.each do |email_address|
+              EarlyYearsPaymentsMailer.submitted_by_provider_and_send_to_provider(
+                claim: claim,
+                provider_email_address: email_address
+              ).deliver_later
+            end
           end
         end
       end

--- a/app/mailers/early_years_payments_mailer.rb
+++ b/app/mailers/early_years_payments_mailer.rb
@@ -2,8 +2,6 @@ class EarlyYearsPaymentsMailer < ApplicationMailer
   def submitted(claim)
     if claim.submitted_at.present?
       submitted_by_practitioner_and_send_to_practitioner(claim)
-    else
-      submitted_by_provider_and_send_to_provider(claim)
     end
   end
 
@@ -62,9 +60,7 @@ class EarlyYearsPaymentsMailer < ApplicationMailer
     )
   end
 
-  private
-
-  def submitted_by_provider_and_send_to_provider(claim)
+  def submitted_by_provider_and_send_to_provider(claim:, provider_email_address:)
     personalisation = {
       nursery_name: claim.eligibility.eligible_ey_provider.nursery_name,
       practitioner_first_name: claim.eligibility.practitioner_first_name,
@@ -74,12 +70,14 @@ class EarlyYearsPaymentsMailer < ApplicationMailer
 
     template_mail(
       "149c5999-12fb-4b99-aff5-23a7c3302783",
-      to: claim.eligibility.eligible_ey_provider.primary_key_contact_email_address,
+      to: provider_email_address,
       subject: nil,
       reply_to_id: claim.policy.notify_reply_to_id,
       personalisation:
     )
   end
+
+  private
 
   def submitted_by_practitioner_and_send_to_practitioner(claim)
     personalisation = {

--- a/app/models/eligible_ey_provider.rb
+++ b/app/models/eligible_ey_provider.rb
@@ -38,4 +38,11 @@ class EligibleEyProvider < ApplicationRecord
       where(secondary_contact_email_address: email_address)
     )
   end
+
+  def email_addresses
+    [
+      primary_key_contact_email_address,
+      secondary_contact_email_address
+    ].compact_blank
+  end
 end


### PR DESCRIPTION
If there are two key contacts for an eligibilitie ey provider, when one
of them submits their part of the claim email both contacts.
