### PR TITLE
CAPT 2283/new rejection reason

### DIFF
--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -100,7 +100,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
   end
 
   def rejected_reasons_params
-    Decision.rejected_reasons_for(@claim.policy).map { |r| :"rejected_reasons_#{r}" }
+    Decision.rejected_reasons_for(@claim).map { |r| :"rejected_reasons_#{r}" }
   end
 
   def qa_decision_task?

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -77,6 +77,10 @@ module BasePolicy
     true
   end
 
+  def rejected_reasons(claim)
+    self::ADMIN_DECISION_REJECTED_REASONS
+  end
+
   # Overwrite this in the policies if they set a maximum topup amount
   def max_topup_amount(claim)
     10_000.00

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -41,8 +41,8 @@ class Decision < ApplicationRecord
     approved ? "approved" : "rejected"
   end
 
-  def self.rejected_reasons_for(policy)
-    policy::ADMIN_DECISION_REJECTED_REASONS
+  def self.rejected_reasons_for(claim)
+    claim.policy.rejected_reasons(claim)
   end
 
   def readonly?
@@ -88,7 +88,7 @@ class Decision < ApplicationRecord
   end
 
   def rejected_reasons_selectable
-    available_rejected_reasons = self.class.rejected_reasons_for(claim.policy)
+    available_rejected_reasons = self.class.rejected_reasons_for(claim)
     return if (selected_rejected_reasons - available_rejected_reasons).empty?
 
     errors.add(:rejected_reasons, "One or more reasons are not selectable for this claim")

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -30,6 +30,7 @@ module Policies
       :subject_to_performance_measures,
       :subject_to_disciplinary_action,
       :identity_check_failed,
+      :alternative_identity_verification_check_failed,
       :duplicate_claim,
       :no_response,
       :no_response_from_employer,
@@ -107,6 +108,17 @@ module Policies
       ClaimCheckingTasks.new(claim).incomplete_task_names.exclude?(
         "alternative_identity_verification"
       )
+    end
+
+    def rejected_reasons(claim)
+      ADMIN_DECISION_REJECTED_REASONS.select do |reason|
+        case reason
+        when :alternative_identity_verification_check_failed
+          alternative_identity_verification_required?(claim)
+        else
+          true
+        end
+      end
     end
   end
 end

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -104,7 +104,7 @@
             <%= errors_tag decision, :rejected_reasons %>
 
             <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
-              <% Decision.rejected_reasons_for(claim.policy).each do |reason| %>
+              <% Decision.rejected_reasons_for(claim).each do |reason| %>
                 <% reason_prefixed = "rejected_reasons_#{reason}" %>
                 <div class="govuk-checkboxes__item">
                   <%= f.hidden_field reason_prefixed, value: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -924,7 +924,7 @@ en:
           insufficient_time_spent_teaching_eligibble_students: "Insufficient time spent teaching eligible students"
           subject_to_performance_measures: "Subject to performance measures"
           subject_to_disciplinary_action: "Subject to disciplinary action"
-          identity_check_failed: "Identity check failed"
+          identity_check_failed: "GOV One Login identity check failed"
           alternative_identity_verification_check_failed: "Provider-led identity check failed"
           duplicate_claim: "Duplicate claim"
           no_response: "No response"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -925,6 +925,7 @@ en:
           subject_to_performance_measures: "Subject to performance measures"
           subject_to_disciplinary_action: "Subject to disciplinary action"
           identity_check_failed: "Identity check failed"
+          alternative_identity_verification_check_failed: "Provider-led identity check failed"
           duplicate_claim: "Duplicate claim"
           no_response: "No response"
           no_response_from_employer: "No response from employer"

--- a/spec/features/admin/admin_reject_claim_spec.rb
+++ b/spec/features/admin/admin_reject_claim_spec.rb
@@ -197,7 +197,7 @@ RSpec.feature "Admin rejects a claim" do
 
         choose "Reject"
 
-        check "Identity check failed"
+        check "GOV One Login identity check failed"
 
         fill_in "Decision notes", with: "QA failed"
 

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -98,7 +98,9 @@ RSpec.describe Decision, type: :model do
   end
 
   describe ".rejected_reasons_for" do
-    subject { described_class.rejected_reasons_for(policy) }
+    subject { described_class.rejected_reasons_for(claim) }
+
+    let(:claim) { create(:claim, policy: policy) }
 
     let(:expected_reasons_ecp) do
       [

--- a/spec/models/policies/further_education_payments_spec.rb
+++ b/spec/models/policies/further_education_payments_spec.rb
@@ -6,4 +6,53 @@ RSpec.describe Policies::FurtherEducationPayments do
       expect(subject.payroll_file_name).to eql("FELUPEXPANSION")
     end
   end
+
+  describe ".rejected_reasons" do
+    before do
+      FeatureFlag.create!(
+        name: "fe_provider_identity_verification",
+        enabled: true
+      )
+    end
+
+    subject { described_class.rejected_reasons(claim) }
+
+    describe "alternative_identity_verification_check_failed" do
+      context "when the claim requires alternative identity verification" do
+        let(:claim) do
+          create(
+            :claim,
+            :submitted,
+            policy: described_class,
+            onelogin_idv_at: 1.day.ago,
+            identity_confirmed_with_onelogin: false
+          )
+        end
+
+        it do
+          is_expected.to include(
+            :alternative_identity_verification_check_failed
+          )
+        end
+      end
+
+      context "when the claim does not require alternative identity verification" do
+        let(:claim) do
+          create(
+            :claim,
+            :submitted,
+            policy: described_class,
+            onelogin_idv_at: 1.day.ago,
+            identity_confirmed_with_onelogin: true
+          )
+        end
+
+        it do
+          is_expected.not_to include(
+            :alternative_identity_verification_check_failed
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add alt idv rejection reason

We want a new rejection reason for claims that have failed alternative
identity verification. We only want this rejection reason to be
avalabile after 31st March.
The tricky bit is any rejection reasons we add to the notify template
need to be sent for all rejection emails. To handle this we only include
the rejection reason in the list of reasons admins see if the claim
requires alternative identity verification (which is feature flagged)
however the `Decision#rejected_reasons_hash` which is what is sent to
notify unconditionally includes this reason.

The `FurtherEducationPayments` policy class now has quite a few methods
that take a `Claim` as their only argument, while this works fine and is
pretty maintainable, it hints that we're missing some object.

