### PR TITLE
CAPT 2310/cant approve claim with failed idv

### DIFF
--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -101,7 +101,7 @@ module Policies
     def approvable?(claim)
       ClaimCheckingTasks.new(claim).incomplete_task_names.exclude?(
         "alternative_identity_verification"
-      )
+      ) && !claim.tasks.find_by(name: "alternative_identity_verification")&.failed?
     end
 
     def rejectable?(claim)

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -807,7 +807,7 @@ RSpec.feature "Admin claim further education payments" do
         end
 
         context "when the alternative idv task is a fail" do
-          it "doesn't show a warning" do
+          it "only allows admins to reject the claim" do
             stub_const(
               "Policies::FurtherEducationPayments::REJECTED_MIN_QA_THRESHOLD",
               0
@@ -844,7 +844,7 @@ RSpec.feature "Admin claim further education payments" do
 
             approve_button = find("#decision_approved_true")
 
-            expect(approve_button).not_to be_disabled
+            expect(approve_button).to be_disabled
 
             reject_button = find("#decision_approved_false")
 
@@ -868,7 +868,7 @@ RSpec.feature "Admin claim further education payments" do
         end
 
         context "when the alternative idv task is a pass" do
-          it "doesn't show a warning" do
+          it "allows admins to approve or reject the claim" do
             claim = create(
               :claim,
               :submitted,


### PR DESCRIPTION
Don't allow approving if alt idv failed

If the alternative identity verification failed we don't want to allow
admins to approve a claim.