### PR TITLE
CAPT 2313/ol review app functionality

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -3,7 +3,15 @@ class FeatureFlag < ApplicationRecord
     where(name: name, enabled: true).exists?
   end
 
+  def self.enable!(name)
+    find_or_create_by!(name: name).update!(enabled: true)
+  end
+
   def self.disabled?(name)
     !enabled?(name)
+  end
+
+  def self.disable!(name)
+    find_by(name: name)&.update!(enabled: false)
   end
 end

--- a/app/views/claims/_sign_in_2_authed.html.erb
+++ b/app/views/claims/_sign_in_2_authed.html.erb
@@ -10,4 +10,8 @@
   Once you have proven your identity through GOV.UK One Login, you will return to this service to complete your application.
 </p>
 
-<%= govuk_button_to "Continue", "/auth/onelogin_identity" %>
+<% if OneLoginSignIn.bypass? %>
+  <%= render "sign_in_2_bypass" %>
+<% else %>
+  <%= govuk_button_to "Continue", "/auth/onelogin_identity" %>
+<% end %>

--- a/app/views/claims/_sign_in_2_bypass.html.erb
+++ b/app/views/claims/_sign_in_2_bypass.html.erb
@@ -1,0 +1,58 @@
+<h2 class="govuk-heading-m">
+  Set GOVUK One Login payload details
+</h2>
+
+<p class="govuk-body">
+  In environments where GOVUK One Login is not enabled you can use this form
+  to set payload parameters to test different identity verification scenarios.
+</p>
+
+<p class="govuk-body">
+  If a return code is entered the user will fail IDV.
+</p>
+
+<%# `govuk_date_field` expects to have an object to work with when setting field
+  names and assigning default values, hence why we're using the
+  `PersonalDetailsForm` here %>
+<%= form_with(
+  url: "/auth/onelogin_identity",
+  method: :post,
+  model: PersonalDetailsForm.new(
+    journey_session: journey_session,
+    journey: nil,
+    params: ActionController::Parameters.new(
+      claim: {
+        first_name: "TEST",
+        surname: "USER",
+        :"date_of_birth(3i)" => 1,
+        :"date_of_birth(2i)" => 1,
+        :"date_of_birth(1i)" => 1970
+      }
+    )
+  ),
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
+  <%= f.govuk_text_field(
+    :first_name,
+    label: { text: "First name" }
+  ) %>
+
+  <%= f.govuk_text_field(
+    :surname,
+    label: { text: "Last name" }
+  ) %>
+
+  <%= f.govuk_date_field(
+    :date_of_birth,
+    date_of_birth: true,
+    legend: { text: "Date of birth" }
+  ) %>
+
+  <%= f.govuk_text_field(
+    :one_login_return_codes,
+    label: { text: "One Login return codes" },
+    hint: { text: 'Separate multiple codes with a comma eg "A,B,C"' }
+  ) %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/spec/features/admin/admin_ey_tasks_spec.rb
+++ b/spec/features/admin/admin_ey_tasks_spec.rb
@@ -649,13 +649,14 @@ RSpec.describe "Admin EY tasks" do
     one_login_date_of_birth:,
     payroll_gender: "Male"
   )
-    stub_const(
-      "OmniauthCallbacksController::ONE_LOGIN_TEST_USER",
-      {
-        first_name: one_login_first_name,
-        last_name: one_login_last_name,
-        date_of_birth: one_login_date_of_birth
-      }
+    allow(OmniauthCallbacksController::OneLoginTestUser).to(
+      receive(:new).and_return(
+        OpenStruct.new(
+          first_name: one_login_first_name,
+          surname: one_login_last_name,
+          date_of_birth: one_login_date_of_birth
+        )
+      )
     )
 
     create(:journey_configuration, :early_years_payment_practitioner)


### PR DESCRIPTION
Add form for test users to set return codes

In environments where we're bypassing one login we now present a form to
testers where they can enter details that would be returned from one
login, along with setting the desired one login return codes.
Now, rather than failing IDV in test based on the `alternative_idv`
feature flag we fail/pass IDV based on the presence of return codes
entered in the form.

Due to some quirks of how the form builder works, we've had to reuse the
`PersonalDetailsForm` to support this functionality. We subclass the
`PersonalDetailsForm` in the controller as `OneLoginTestUser` to make
bypassing it in tests more straightforward.

I think a slightly nicer approach would be to update the
`test_user_auth_hash` method to return a JWT with the content we want,
so we only have to branch on `OneLoginSignIn.bypass?` in one place. This
however would require moving quite a bit more code (injecting
`OneLogin::DidCache` as an are to the `CoreIdentityValidator`
constructor). Something to consider if we decide to refactor this
controller when we're a bit less pressed for time.

