### PR TITLE
Fix missing nursery name in report

### DIFF
--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -19,7 +19,10 @@ module Policies
       end
 
       def eligible_ey_provider
-        EligibleEyProvider.find_by_urn(nursery_urn)
+        EligibleEyProvider
+          .unscoped
+          .order(created_at: :desc)
+          .find_by(urn: nursery_urn)
       end
 
       def provider_claim_submitted?


### PR DESCRIPTION
We can't find the provider for EY claims in the following scenario:

* EY claim submitted for provider A
* EY provider CSV is updated to no longer include provider A

In the admin area and in reports we need to show who the provider was even
if the eligible providers list has been updated.

To resolve this we're unscoping the default scope when looking for the
provider and picking the latest one with a matching urn.

We probably want to revisit our use of default scope.
Additionally we should move `eligible_ey_provider` to a scope on the
eligibility, this will make queries easier to run, and we should look
into why we're using `find_by`, there should always be an ey provider
for a submitted claim, so we should use `find_by!` or equivalent.
