### PR TITLE
Highlight sign out on focus

### DIFF
--- a/app/assets/stylesheets/components/button_to.scss
+++ b/app/assets/stylesheets/components/button_to.scss
@@ -13,6 +13,10 @@
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
+
+  &:focus {
+    @include govuk-focused-text;
+  }
 }
 
 .button-to-as-link:hover {


### PR DESCRIPTION
When the sign out button is focused we want to high light it to meet
WCAG guidance.
