### PR TITLE
CAPT 2377/ey ol partial matches

### DIFF
--- a/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/early_years_payments/identity.rb
@@ -6,9 +6,9 @@ module AutomatedChecks
           return unless claim.eligibility.practitioner_journey_completed?
           return unless awaiting_task?(TASK_NAME)
 
-          if one_login_idv_match?
+          if one_login_idv_match_details_from_provider?
             create_task(match: nil, passed: true)
-          elsif one_login_idv_partial_match?
+          elsif one_login_idv_partially_match_details_from_provider?
             create_task(match: :any, passed: nil)
 
             create_note(body: note_body("Names partially match"))
@@ -25,13 +25,13 @@ module AutomatedChecks
 
         private
 
-        def one_login_idv_match?
+        def one_login_idv_match_details_from_provider?
           return false unless claim.one_login_idv_match?
 
           claim.eligibility.practitioner_and_provider_entered_names_match?
         end
 
-        def one_login_idv_partial_match?
+        def one_login_idv_partially_match_details_from_provider?
           return false unless claim.one_login_idv_match?
 
           claim.eligibility.practitioner_and_provider_entered_names_partial_match?

--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -43,17 +43,27 @@ module Policies
       end
 
       def practitioner_and_provider_entered_names_match?
-        practitioner_first_name.downcase == claim.onelogin_idv_first_name.downcase &&
-          practitioner_surname.downcase == claim.onelogin_idv_last_name.downcase
+        first_names_match? && surnames_match?
       end
 
       def practitioner_and_provider_entered_names_partial_match?
-        practitioner_first_name.downcase == claim.onelogin_idv_first_name.downcase ||
-          practitioner_surname.downcase == claim.onelogin_idv_last_name.downcase
+        first_names_match? || surnames_match?
       end
 
       def practitioner_journey_completed?
         claim.submitted_at.present?
+      end
+
+      private
+
+      def first_names_match?
+        practitioner_first_name.downcase.strip ==
+          claim.onelogin_idv_first_name.downcase.strip
+      end
+
+      def surnames_match?
+        practitioner_surname.downcase.strip ==
+          claim.onelogin_idv_last_name.downcase.strip
       end
     end
   end

--- a/spec/models/policies/early_years_payments/eligibility_spec.rb
+++ b/spec/models/policies/early_years_payments/eligibility_spec.rb
@@ -38,4 +38,133 @@ RSpec.describe Policies::EarlyYearsPayments::Eligibility do
       end
     end
   end
+
+  describe "#practitioner_and_provider_entered_names_match?" do
+    subject { eligibility.practitioner_and_provider_entered_names_match? }
+
+    before do
+      eligibility.claim = build(
+        :claim, :with_onelogin_idv_data,
+        onelogin_idv_first_name: claim_first_name,
+        onelogin_idv_last_name: claim_last_name
+      )
+
+      eligibility.practitioner_first_name = provider_entered_first_name
+      eligibility.practitioner_surname = provider_entered_surname
+    end
+
+    context "when both first name and surname match exactly" do
+      let(:claim_first_name) { "John" }
+      let(:claim_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "John" }
+      let(:provider_entered_surname) { "Smith" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when both first name and surname match with different casing" do
+      let(:claim_first_name) { "John" }
+      let(:claim_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "JOHN" }
+      let(:provider_entered_surname) { "SMITH" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when both first name and surname match with extra whitespace" do
+      let(:claim_first_name) { "John" }
+      let(:claim_last_name) { "Smith" }
+      let(:provider_entered_first_name) { " John " }
+      let(:provider_entered_surname) { " Smith " }
+
+      it { is_expected.to be true }
+    end
+
+    context "when first name matches but surname does not" do
+      let(:claim_first_name) { "John" }
+      let(:claim_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "John" }
+      let(:provider_entered_surname) { "Jones" }
+
+      it { is_expected.to be false }
+    end
+
+    context "when surname matches but first name does not" do
+      let(:claim_first_name) { "John" }
+      let(:claim_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "James" }
+      let(:provider_entered_surname) { "Smith" }
+
+      it { is_expected.to be false }
+    end
+
+    context "when neither first name nor surname match" do
+      let(:claim_first_name) { "John" }
+      let(:claim_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "James" }
+      let(:provider_entered_surname) { "Jones" }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#practitioner_and_provider_entered_names_partial_match?" do
+    subject { eligibility.practitioner_and_provider_entered_names_partial_match? }
+
+    before do
+      eligibility.claim = build(
+        :claim, :with_onelogin_idv_data,
+        onelogin_idv_first_name: onelogin_idv_first_name,
+        onelogin_idv_last_name: onelogin_idv_last_name
+      )
+
+      eligibility.practitioner_first_name = provider_entered_first_name
+      eligibility.practitioner_surname = provider_entered_surname
+    end
+
+    context "when both first name and surname match exactly" do
+      let(:onelogin_idv_first_name) { "John" }
+      let(:onelogin_idv_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "John" }
+      let(:provider_entered_surname) { "Smith" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when both first name and surname match with different casing" do
+      let(:onelogin_idv_first_name) { "John" }
+      let(:onelogin_idv_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "JOHN" }
+      let(:provider_entered_surname) { "SMITH" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when first name matches but surname does not" do
+      let(:onelogin_idv_first_name) { "John" }
+      let(:onelogin_idv_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "John" }
+      let(:provider_entered_surname) { "Jones" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when surname matches but first name does not" do
+      let(:onelogin_idv_first_name) { "John" }
+      let(:onelogin_idv_last_name) { "Smith" }
+      let(:provider_entered_first_name) { " James " }
+      let(:provider_entered_surname) { "Smith" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when neither first name nor surname match" do
+      let(:onelogin_idv_first_name) { "John" }
+      let(:onelogin_idv_last_name) { "Smith" }
+      let(:provider_entered_first_name) { "James" }
+      let(:provider_entered_surname) { "Jones" }
+
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
Strip whitespace

When comparing names we don't want to fail just because the provider
added whitespace before or after the name

