### PR TITLE
Fix pending database migrations preventing dfe-analytics initialisation

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -51,6 +51,15 @@ runs:
         project_id: claim-additional-payments
         workload_identity_provider: projects/638192024625/locations/global/workloadIdentityPools/claim-additional-payments-for-te/providers/claim-additional-payments-for-te
 
+    - name: Prepare database
+      if: ${{ inputs.prepare-database }}
+      shell: bash
+      run: |
+        make ci ${{ inputs.environment }} get-cluster-credentials
+        kubectl exec -n ${{ inputs.aks-namespace }} deployment/${{ inputs.aks-deployment }}-worker -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/prepare-database"
+      env:
+        PR_NUMBER: ${{ inputs.pull-request-number }}
+
     - name: Terraform Apply
       shell: bash
       run: |
@@ -74,12 +83,3 @@ runs:
 
     - name: Set kubectl
       uses: DFE-Digital/github-actions/set-kubectl@master
-
-    - name: Prepare database
-      if: ${{ inputs.prepare-database }}
-      shell: bash
-      run: |
-        make ci ${{ inputs.environment }} get-cluster-credentials
-        kubectl exec -n ${{ inputs.aks-namespace }} deployment/${{ inputs.aks-deployment }}-worker -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/prepare-database"
-      env:
-        PR_NUMBER: ${{ inputs.pull-request-number }}


### PR DESCRIPTION
We have noticed that when deploying changes including database migrations, dfe-analytics stops sending ActiveRecord-related events. Web request events still work. This is because dfe-analytics is [rescuing the exception and failing to initialise](https://github.com/DFE-Digital/dfe-analytics/blob/ad9e5a24296aa4bf755d04ceb96ad21f7f8c76d8/lib/dfe/analytics.rb#L134).

We are advised that moving the `prepare-database` step to before `terraform-apply` should resolve this.