### PR TITLE
Move no_selectable_subjects?

### DIFF
--- a/app/models/concerns/eligibility_checkable.rb
+++ b/app/models/concerns/eligibility_checkable.rb
@@ -54,7 +54,6 @@ module EligibilityCheckable
       indicated_ineligible_school?,
       supply_teacher_lacking_either_long_contract_or_direct_employment?,
       poor_performance?,
-      no_selectable_subjects?,
       ineligible_cohort?,
       insufficient_teaching?
     ].any?
@@ -74,17 +73,6 @@ module EligibilityCheckable
 
   def poor_performance?
     subject_to_formal_performance_action? || subject_to_disciplinary_action?
-  end
-
-  def no_selectable_subjects?
-    if claim_year.blank? || itt_academic_year.blank?
-      false
-    else
-      policy.current_and_future_subject_symbols(
-        claim_year: claim_year,
-        itt_year: itt_academic_year
-      ).empty?
-    end
   end
 
   def ineligible_cohort?

--- a/app/models/policies/early_career_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/early_career_payments/policy_eligibility_checker.rb
@@ -54,7 +54,7 @@ module Policies
       end
 
       def specific_ineligible_attributes?
-        trainee_teacher? || (induction_not_completed? && !any_future_policy_years?) || itt_subject_ineligible_now_and_in_the_future?
+        trainee_teacher? || (induction_not_completed? && !any_future_policy_years?) || itt_subject_ineligible_now_and_in_the_future? || no_selectable_subjects?
       end
 
       def itt_subject_ineligible_now_and_in_the_future?
@@ -104,6 +104,17 @@ module Policies
             claim_year: claim_year,
             itt_year: itt_academic_year
           ).exclude?(itt_subject_symbol)
+        end
+      end
+
+      def no_selectable_subjects?
+        if claim_year.blank? || itt_academic_year.blank?
+          false
+        else
+          EarlyCareerPayments.current_and_future_subject_symbols(
+            claim_year: claim_year,
+            itt_year: itt_academic_year
+          ).empty?
         end
       end
     end


### PR DESCRIPTION
This method doesn't need to be shared with LUP as there will always be a
selectable LUP subject.

When calculating the subject_symbols for LUP/TRI we return an empty
array if the itt year is earlier than the previous 5 years, however we
only show the previous 5 years as options for selecting the itt year,
and if the user chooses "none of the above", they're kicked out of the
journey before this screen by the `ineligible_cohory?` check.

`Policies::TargetedRetentionIncentivePayments.subject_symbols` should
just reduce to
`Policies::TargetedRetentionIncentivePayments.fixed_subject_symbols` but
we'll refactor towards that in a separate commit.
