### PR TITLE
[CAPT-2305] Allow empty rows in payment confirmation CSV

### DIFF
--- a/app/models/payment_confirmation_upload.rb
+++ b/app/models/payment_confirmation_upload.rb
@@ -28,6 +28,9 @@ class PaymentConfirmationUpload
 
       csv.rows.each do |row|
         @line_number += 1
+
+        next if row.fields.all? { |cell| cell.nil? }
+
         payment = fetch_payment_by_id(row["Payment ID"])
         if payment
           update_payment_fields(payment, confirmation, row)

--- a/spec/models/payment_confirmation_upload_spec.rb
+++ b/spec/models/payment_confirmation_upload_spec.rb
@@ -305,5 +305,21 @@ RSpec.describe PaymentConfirmationUpload do
 
       it_behaves_like "unsuccessful upload"
     end
+
+    context "when CSV has superfluous empty rows" do
+      let(:csv) do
+        <<~CSV
+          Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay,Claim Policies,Postgraduate Loans,Payment Date
+          DFE00001,448.5,#{first_payment.id},33.9,38.98,0,89.6,325,StudentLoans,0,17/07/2023
+
+          DFE00002,814.64,#{second_payment.id},77.84,89.51,40,162.8,534,"EarlyCareerPayments,StudentLoans",0,17/07/2023
+
+          DFE00003,9710.83,#{third_payment.id},268.84,1316.63,839,1942,6660.99,EarlyCareerPayments,9710.83,17/07/2023
+
+        CSV
+      end
+
+      it_behaves_like "successful upload"
+    end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2305
- Allow empty rows in payment confirmation CSV