### PR TITLE
tslr ineligibility reason

### DIFF
--- a/app/models/concerns/eligibility_checkable.rb
+++ b/app/models/concerns/eligibility_checkable.rb
@@ -18,10 +18,6 @@ module EligibilityCheckable
     end
   end
 
-  def ineligible?
-    common_ineligible_attributes? || specific_ineligible_attributes?
-  end
-
   # It's not good to call either `eligible_now?` or `eligible_later?` directly
   # because of the following business rule which is captured in the `status`
   # method above: if a claim is both eligible now and eligible later, it's
@@ -43,17 +39,6 @@ module EligibilityCheckable
   end
 
   private
-
-  def common_ineligible_attributes?
-    [
-      policy_closed?,
-      indicated_ineligible_school?,
-      supply_teacher_lacking_either_long_contract_or_direct_employment?,
-      poor_performance?,
-      ineligible_cohort?,
-      insufficient_teaching?
-    ].any?
-  end
 
   def policy_closed?
     policy.closed?(claim_year)

--- a/app/models/policies/early_career_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/early_career_payments/policy_eligibility_checker.rb
@@ -36,6 +36,21 @@ module Policies
         end
       end
 
+      def ineligible?
+        [
+          policy_closed?,
+          indicated_ineligible_school?,
+          supply_teacher_lacking_either_long_contract_or_direct_employment?,
+          poor_performance?,
+          ineligible_cohort?,
+          insufficient_teaching?,
+          trainee_teacher?,
+          induction_not_completed? && !any_future_policy_years?,
+          itt_subject_ineligible_now_and_in_the_future?,
+          no_selectable_subjects?
+        ].any?
+      end
+
       private
 
       def trainee_teacher?
@@ -55,10 +70,6 @@ module Policies
           claim_year: claim_year,
           itt_year: itt_academic_year
         ).include?(itt_subject.to_sym)
-      end
-
-      def specific_ineligible_attributes?
-        trainee_teacher? || (induction_not_completed? && !any_future_policy_years?) || itt_subject_ineligible_now_and_in_the_future? || no_selectable_subjects?
       end
 
       def itt_subject_ineligible_now_and_in_the_future?

--- a/spec/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker_spec.rb
@@ -3,6 +3,165 @@ require "rails_helper"
 RSpec.describe Policies::TargetedRetentionIncentivePayments::PolicyEligibilityChecker, type: :model do
   let(:policy_eligibility_checker) { described_class.new(answers: answers) }
 
+  describe "#ineligibility_reason" do
+    subject { policy_eligibility_checker.ineligibility_reason }
+
+    let!(:journey_configuration) do
+      create(
+        :journey_configuration,
+        :additional_payments,
+        open_for_submissions: true
+      )
+    end
+
+    context "when the policy is closed" do
+      let(:answers) do
+        build(:additional_payments_answers)
+      end
+
+      before do
+        journey_configuration.update!(
+          current_academic_year: AcademicYear.new(2086)
+        )
+      end
+
+      it { is_expected.to eq(:policy_closed) }
+    end
+
+    context "when school is tlsr ineligible" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          current_school_id: create(:school).id
+        )
+      end
+
+      it { is_expected.to eq(:school_ineligible) }
+    end
+
+    context "when a supply teacher" do
+      context "when lacking entire term contract" do
+        let(:answers) do
+          build(
+            :additional_payments_answers,
+            employed_as_supply_teacher: true,
+            has_entire_term_contract: false
+          )
+        end
+
+        it { is_expected.to eq(:supply_teacher_contract_ineligible) }
+      end
+
+      context "when not employed directly" do
+        let(:answers) do
+          build(
+            :additional_payments_answers,
+            employed_as_supply_teacher: true,
+            has_entire_term_contract: true,
+            employed_directly: false
+          )
+        end
+
+        it { is_expected.to eq(:supply_teacher_contract_ineligible) }
+      end
+    end
+
+    context "when subject to formal performance action" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          subject_to_formal_performance_action: true
+        )
+      end
+
+      it { is_expected.to eq(:poor_performance) }
+    end
+
+    context "when subject to disciplinary action" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          subject_to_disciplinary_action: true
+        )
+      end
+
+      it { is_expected.to eq(:poor_performance) }
+    end
+
+    # For TSLR you can't really get this ineligibility reason as
+    # both subject symbols and ineligible_cohort check the itt year is in the
+    # past 5 years. We're stubbing subject symbols here so we can test this
+    # as it's in the `common_ineligible_attributes?` method. We'll be removing
+    # `common_ineligible_attributes` once we switch to the TSLR only journey
+    # so can remove this then.
+    context "when ineligible cohort" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          itt_academic_year: AcademicYear.new(2000)
+        )
+      end
+
+      before do
+        allow(Policies::TargetedRetentionIncentivePayments).to(
+          receive(:fixed_subject_symbols).and_return([:mathematics])
+        )
+      end
+
+      it { is_expected.to eq(:ineligible_cohort) }
+    end
+
+    context "when insufficient teaching" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          teaching_subject_now: false
+        )
+      end
+
+      it { is_expected.to eq(:insufficient_teaching) }
+    end
+
+    context "when not a tslr subject" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          eligible_itt_subject: :foreign_languages
+        )
+      end
+
+      it { is_expected.to eq(:subject_invalid_for_tslr) }
+    end
+
+    context "when ineligible subject and no eligible degree subject" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          eligible_itt_subject: :none_of_the_above,
+          eligible_degree_subject: false
+        )
+      end
+
+      it { is_expected.to eq(:subject_and_degree_ineligible) }
+    end
+
+    context "when trainee teacher in the last policy year" do
+      let(:answers) do
+        build(
+          :additional_payments_answers,
+          :trainee_teacher
+        )
+      end
+
+      before do
+        policy_end_year = Policies::TargetedRetentionIncentivePayments::POLICY_END_YEAR
+        journey_configuration.update!(current_academic_year: policy_end_year)
+      end
+
+      it { is_expected.to eq(:trainee_in_last_policy_year) }
+    end
+  end
+
   describe "#ineligible?" do
     subject { policy_eligibility_checker.ineligible? }
 


### PR DESCRIPTION
Change TSLR ineligibility to use reason

Update the definition of TSLR `ineligible` to use a reason rather than
checking common / specific ineligible attributes. We'll want to use the
reason when we have the TSLR only journey to replace the usage of
`lib/ineligibility_reason_checker.rb`

