### PR TITLE
[CAPT-2411] Better a11y for address related forms

### DIFF
--- a/app/forms/postcode_search_form.rb
+++ b/app/forms/postcode_search_form.rb
@@ -3,7 +3,7 @@ class PostcodeSearchForm < Form
   attribute :skip_postcode_search, :boolean
 
   validates :postcode,
-    presence: {message: "Enter a real postcode"},
+    presence: {message: "Enter a real postcode, for example NE1 6EE"},
     length: {maximum: 11, message: "Postcode must be 11 characters or less"},
     if: -> { !skip_postcode_search? }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,7 +274,7 @@ en:
         address_line_2: Building and street
         address_line_2_visually_hidden: line 2 of 2
         address_line_3: Town or city
-        address_line_4: County
+        address_line_4: County (optional)
         postcode: Postcode
       errors:
         address_line_1_blank: Enter a house number or name
@@ -282,7 +282,7 @@ en:
         address_line_3_blank: Enter a town or city
         address_line_max_chars: Address lines must be 100 characters or less
         address_format: Address lines cannot contain special characters
-        postcode_blank: Enter a real postcode
+        postcode_blank: Enter a real postcode, for example NE1 6EE
         postcode_max_chars: Postcode must be 11 characters or less
         postcode_format: Enter a postcode in the correct format
     select_email:

--- a/spec/forms/postcode_search_form_spec.rb
+++ b/spec/forms/postcode_search_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PostcodeSearchForm, type: :model do
     allow_any_instance_of(OrdnanceSurvey::Client).to receive_message_chain(:api, :search_places, :index).and_return([double])
   end
 
-  it { is_expected.to validate_presence_of(:postcode).with_message("Enter a real postcode") }
+  it { is_expected.to validate_presence_of(:postcode).with_message("Enter a real postcode, for example NE1 6EE") }
 
   context "when the postcode is too long" do
     let(:params) { ActionController::Parameters.new(claim: {postcode: "SW1A1AAAAAAA"}) }


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2411
- Mark optional address fields with `optional`
- Give example of valid postcode in error message