### PR TITLE
Add uses_reminders? flag

### DIFF
--- a/app/models/journeys.rb
+++ b/app/models/journeys.rb
@@ -21,7 +21,7 @@ module Journeys
   end
 
   def all_routing_names
-    all.map { |journey| journey::ROUTING_NAME }
+    all.map(&:routing_name)
   end
 
   def for_routing_name(routing_name)

--- a/app/models/journeys/additional_payments_for_teaching.rb
+++ b/app/models/journeys/additional_payments_for_teaching.rb
@@ -48,5 +48,9 @@ module Journeys
         policy.selectable_itt_years_for_claim_year(claim_year)
       end.uniq
     end
+
+    def uses_reminders?
+      true
+    end
   end
 end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -96,6 +96,14 @@ module Journeys
         ServiceAccessCode.permits_access?(code: code, journey: self)
     end
 
+    def uses_reminders?
+      false
+    end
+
+    def routing_name
+      self::ROUTING_NAME
+    end
+
     private
 
     def all_forms

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -47,5 +47,9 @@ module Journeys
     def use_navigator?
       true
     end
+
+    def uses_reminders?
+      true
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,7 @@ Rails.application.routes.draw do
       constraints: {resource_class: /reminders/},
       only: [:create, :show]
 
-    scope constraints: {journey: /further-education-payments|additional-payments/} do
+    scope constraints: {journey: %r{#{Journeys.all.select(&:uses_reminders?).map(&:routing_name).join("|")}}} do
       resources :reminders,
         only: [:show, :update],
         param: :slug,


### PR DESCRIPTION
Enable the reminders routes based on a journey level config. We're going
to have an LUP only journey soon and updating the routes with the
specific routing name will start getting cumbersome. Also adds a
convenience method for routing name so we can use symbol to proc when
mapping.
