### PR TITLE
CAPT-1475 - STEP 2 - Rename the string enum column to the original column

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -15,7 +15,7 @@ class School < ApplicationRecord
   validates :school_type_group, presence: true
   validates :school_type, presence: true
 
-  scope :fe_only, -> { where(phase: 6) } # PhaseOfEducation == 16 plus
+  scope :fe_only, -> { where(phase: "sixteen_plus") }
 
   PHASES = {
     not_applicable: 0,
@@ -118,13 +118,9 @@ class School < ApplicationRecord
     academy_alternative_provision_sponsor_led
   ].freeze
 
-  enum :phase, PHASES
-  enum :school_type_group, SCHOOL_TYPE_GROUPS
-  enum :school_type, SCHOOL_TYPES
-
-  enum :phase_string, PHASE_STRINGS, prefix: true
-  enum :school_type_group_string, SCHOOL_TYPE_GROUP_STRINGS, prefix: true
-  enum :school_type_string, SCHOOL_TYPE_STRINGS, prefix: true
+  enum :phase, PHASE_STRINGS
+  enum :school_type_group, SCHOOL_TYPE_GROUP_STRINGS
+  enum :school_type, SCHOOL_TYPE_STRINGS
 
   scope :open, -> { where("(open_date IS NULL OR open_date <= ?) AND (close_date IS NULL OR close_date >= ?)", Date.current, Date.current) }
   scope :closed, -> { where.not("(open_date IS NULL OR open_date <= ?) AND (close_date IS NULL OR close_date >= ?)", Date.current, Date.current) }
@@ -151,6 +147,18 @@ class School < ApplicationRecord
     sql = sql.fe_only if fe_only
 
     sql
+  end
+
+  def self.phase_code_to_enum(code)
+    PHASES.invert[code]
+  end
+
+  def self.school_type_group_code_to_enum(code)
+    SCHOOL_TYPE_GROUPS.invert[code]
+  end
+
+  def self.school_type_code_to_enum(code)
+    SCHOOL_TYPES.invert[code]
   end
 
   def eligible_fe_provider(academic_year: AcademicYear.current)
@@ -214,45 +222,6 @@ class School < ApplicationRecord
       secondary_equivalent_special? ||
       secondary_equivalent_alternative_provision? ||
       secondary_equivalent_city_technology_college?
-  end
-
-  # NOTE - remove once string column is renamed
-  def phase=(value)
-    normalised_value = if value.is_a?(Integer)
-      self.class.phases.invert[value].to_s
-    else
-      value.to_s
-    end
-
-    self.phase_string = normalised_value
-
-    super
-  end
-
-  # NOTE - remove once string column is renamed
-  def school_type_group=(value)
-    normalised_value = if value.is_a?(Integer)
-      self.class.school_type_groups.invert[value].to_s
-    else
-      value.to_s
-    end
-
-    self.school_type_group_string = normalised_value
-
-    super
-  end
-
-  # NOTE - remove once string column is renamed
-  def school_type=(value)
-    normalised_value = if value.is_a?(Integer)
-      self.class.school_types.invert[value].to_s
-    else
-      value.to_s
-    end
-
-    self.school_type_string = normalised_value
-
-    super
   end
 
   private

--- a/app/models/school_data_importer.rb
+++ b/app/models/school_data_importer.rb
@@ -36,9 +36,9 @@ class SchoolDataImporter
     school.town = row.fetch("Town")
     school.county = row.fetch("County (name)")
     school.postcode = row.fetch("Postcode")
-    school.phase = row.fetch("PhaseOfEducation (code)").to_i
-    school.school_type_group = row.fetch("EstablishmentTypeGroup (code)").to_i
-    school.school_type = row.fetch("TypeOfEstablishment (code)").to_i
+    school.phase = School.phase_code_to_enum(row.fetch("PhaseOfEducation (code)").to_i)
+    school.school_type_group = School.school_type_group_code_to_enum(row.fetch("EstablishmentTypeGroup (code)").to_i)
+    school.school_type = School.school_type_code_to_enum(row.fetch("TypeOfEstablishment (code)").to_i)
     school.local_authority = local_authority
     school.local_authority_district = local_authority_district
     school.close_date = row.fetch("CloseDate")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -239,9 +239,6 @@ shared:
     - phone_number
     - open_date
     - ukprn
-    - phase_string
-    - school_type_group_string
-    - school_type_string
   :support_tickets:
     - id
     - url

--- a/db/migrate/20250415153908_rename_schools_enum_columns.rb
+++ b/db/migrate/20250415153908_rename_schools_enum_columns.rb
@@ -1,0 +1,19 @@
+class RenameSchoolsEnumColumns < ActiveRecord::Migration[8.0]
+  def up
+    remove_column :schools, :phase
+    remove_column :schools, :school_type_group
+    remove_column :schools, :school_type
+
+    School.reset_column_information
+
+    rename_column :schools, :phase_string, :phase
+    rename_column :schools, :school_type_group_string, :school_type_group
+    rename_column :schools, :school_type_string, :school_type
+
+    School.reset_column_information
+
+    change_column_null :schools, :phase, false
+    change_column_null :schools, :school_type_group, false
+    change_column_null :schools, :school_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_12_125328) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_15_153908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -519,9 +519,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_12_125328) do
     t.string "town"
     t.string "county"
     t.string "postcode"
-    t.integer "phase", null: false
-    t.integer "school_type_group", null: false
-    t.integer "school_type", null: false
     t.uuid "local_authority_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -533,9 +530,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_12_125328) do
     t.date "open_date"
     t.string "postcode_sanitised"
     t.text "ukprn"
-    t.string "phase_string"
-    t.string "school_type_group_string"
-    t.string "school_type_string"
+    t.string "phase", null: false
+    t.string "school_type_group", null: false
+    t.string "school_type", null: false
     t.index ["close_date"], name: "index_schools_on_close_date"
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -136,7 +136,7 @@ FactoryBot.define do
 
     trait :further_education do
       ukprn { rand(10_000_000..19_000_000) }
-      phase { 6 }
+      phase { :sixteen_plus }
     end
 
     trait :fe_eligible do

--- a/spec/models/school_data_importer_spec.rb
+++ b/spec/models/school_data_importer_spec.rb
@@ -45,10 +45,6 @@ RSpec.describe SchoolDataImporter do
         expect(imported_school.phone_number).to eq("01226762114")
         expect(imported_school.open_date).to be_nil
         expect(imported_school.ukprn).to eql("10005034")
-
-        expect(imported_school.phase_string).to eql("secondary")
-        expect(imported_school.school_type_string).to eql("community_school")
-        expect(imported_school.school_type_group_string).to eql("la_maintained")
       end
 
       it "imports a closed school with the date it closed" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -46,6 +46,95 @@ RSpec.describe School, type: :model do
     end
   end
 
+  describe ".phase_code_to_enum" do
+    describe ".phase_code_to_enum" do
+      it "returns the correct symbol for a valid phase code" do
+        expect(School.phase_code_to_enum(0)).to eq(:not_applicable)
+        expect(School.phase_code_to_enum(1)).to eq(:nursery)
+        expect(School.phase_code_to_enum(2)).to eq(:primary)
+        expect(School.phase_code_to_enum(3)).to eq(:middle_deemed_primary)
+        expect(School.phase_code_to_enum(4)).to eq(:secondary)
+        expect(School.phase_code_to_enum(5)).to eq(:middle_deemed_secondary)
+        expect(School.phase_code_to_enum(6)).to eq(:sixteen_plus)
+        expect(School.phase_code_to_enum(7)).to eq(:all_through)
+      end
+
+      it "returns nil for an unknown phase code" do
+        expect(School.phase_code_to_enum(999)).to be_nil
+        expect(School.phase_code_to_enum(nil)).to be_nil
+      end
+    end
+  end
+
+  describe ".school_type_group_code_to_enum" do
+    it "returns the correct symbol for a valid school type group code" do
+      expect(School.school_type_group_code_to_enum(1)).to eq(:colleges)
+      expect(School.school_type_group_code_to_enum(2)).to eq(:universities)
+      expect(School.school_type_group_code_to_enum(3)).to eq(:independent_schools)
+      expect(School.school_type_group_code_to_enum(4)).to eq(:la_maintained)
+      expect(School.school_type_group_code_to_enum(5)).to eq(:special_schools)
+      expect(School.school_type_group_code_to_enum(6)).to eq(:welsh_schools)
+      expect(School.school_type_group_code_to_enum(9)).to eq(:other)
+      expect(School.school_type_group_code_to_enum(10)).to eq(:academies)
+      expect(School.school_type_group_code_to_enum(11)).to eq(:free_schools)
+      expect(School.school_type_group_code_to_enum(13)).to eq(:online)
+    end
+
+    it "returns nil for an unknown school type group code" do
+      expect(School.school_type_group_code_to_enum(999)).to be_nil
+      expect(School.school_type_group_code_to_enum(nil)).to be_nil
+    end
+  end
+
+  describe ".school_type_code_to_enum" do
+    it "returns the correct symbol for a valid school type code" do
+      expect(School.school_type_code_to_enum(1)).to eq(:community_school)
+      expect(School.school_type_code_to_enum(2)).to eq(:voluntary_aided_school)
+      expect(School.school_type_code_to_enum(3)).to eq(:voluntary_controlled_school)
+      expect(School.school_type_code_to_enum(5)).to eq(:foundation_school)
+      expect(School.school_type_code_to_enum(6)).to eq(:city_technology_college)
+      expect(School.school_type_code_to_enum(7)).to eq(:community_special_school)
+      expect(School.school_type_code_to_enum(8)).to eq(:non_maintained_special_school)
+      expect(School.school_type_code_to_enum(10)).to eq(:other_independent_special_school)
+      expect(School.school_type_code_to_enum(11)).to eq(:other_independent_school)
+      expect(School.school_type_code_to_enum(12)).to eq(:foundation_special_school)
+      expect(School.school_type_code_to_enum(14)).to eq(:pupil_referral_unit)
+      expect(School.school_type_code_to_enum(15)).to eq(:local_authority_nursery_school)
+      expect(School.school_type_code_to_enum(18)).to eq(:further_education)
+      expect(School.school_type_code_to_enum(24)).to eq(:secure_unit)
+      expect(School.school_type_code_to_enum(25)).to eq(:offshore_school)
+      expect(School.school_type_code_to_enum(26)).to eq(:service_childrens_education)
+      expect(School.school_type_code_to_enum(27)).to eq(:miscellaneous)
+      expect(School.school_type_code_to_enum(28)).to eq(:academy_sponsor_led)
+      expect(School.school_type_code_to_enum(29)).to eq(:higher_education_institution)
+      expect(School.school_type_code_to_enum(30)).to eq(:welsh_establishment)
+      expect(School.school_type_code_to_enum(31)).to eq(:sixth_form_centre)
+      expect(School.school_type_code_to_enum(32)).to eq(:special_post_16_institutions)
+      expect(School.school_type_code_to_enum(33)).to eq(:academy_special_sponsor_led)
+      expect(School.school_type_code_to_enum(34)).to eq(:academy_converter)
+      expect(School.school_type_code_to_enum(35)).to eq(:free_school)
+      expect(School.school_type_code_to_enum(36)).to eq(:free_school_special)
+      expect(School.school_type_code_to_enum(37)).to eq(:british_school_oversea)
+      expect(School.school_type_code_to_enum(38)).to eq(:free_school_alternative_provider)
+      expect(School.school_type_code_to_enum(39)).to eq(:free_school_16_to_19)
+      expect(School.school_type_code_to_enum(40)).to eq(:university_technical_college)
+      expect(School.school_type_code_to_enum(41)).to eq(:studio_school)
+      expect(School.school_type_code_to_enum(42)).to eq(:academy_alternative_provision_converter)
+      expect(School.school_type_code_to_enum(43)).to eq(:academy_alternative_provision_sponsor_led)
+      expect(School.school_type_code_to_enum(44)).to eq(:academy_special_converter)
+      expect(School.school_type_code_to_enum(45)).to eq(:academy_16_to_19_converter)
+      expect(School.school_type_code_to_enum(46)).to eq(:academy_16_to_19_sponsor_led)
+      expect(School.school_type_code_to_enum(49)).to eq(:online_provider)
+      expect(School.school_type_code_to_enum(56)).to eq(:institution_funded_by_other_government_department)
+      expect(School.school_type_code_to_enum(57)).to eq(:academy_secure_16_to_19)
+    end
+
+    it "returns nil for an unknown school type code" do
+      expect(School.school_type_code_to_enum(999)).to be_nil
+      expect(School.school_type_code_to_enum(nil)).to be_nil
+    end
+  end
+
   describe "#address" do
     it "returns a formatted address string" do
       school = School.new(
@@ -270,38 +359,6 @@ RSpec.describe School, type: :model do
       it "strips space characters and saves it to postcode_sanitised" do
         school.save!
         expect(school.postcode_sanitised).to eq("AB123CD")
-      end
-    end
-  end
-
-  describe "enum_methods" do
-    context "when set by name" do
-      it "sets the string column" do
-        school = create(
-          :school,
-          phase: :secondary,
-          school_type_group: :free_schools,
-          school_type: :free_school
-        )
-
-        expect(school.phase_string).to eq("secondary")
-        expect(school.school_type_group_string).to eq("free_schools")
-        expect(school.school_type_string).to eq("free_school")
-      end
-    end
-
-    context "when set by value" do
-      it "sets the string column" do
-        school = create(
-          :school,
-          phase: 4,
-          school_type_group: 11,
-          school_type: 35
-        )
-
-        expect(school.phase_string).to eq("secondary")
-        expect(school.school_type_group_string).to eq("free_schools")
-        expect(school.school_type_string).to eq("free_school")
       end
     end
   end


### PR DESCRIPTION
This relies on STEP 1 deployment and instructions being run first: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3722

This drops the old column and renames the new columns back to original names.

I've tested this on a [Review App](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3738) doing the all the steps.