### PR TITLE
[CAPT-2394] Remove payroll operator role as no longer used

### DIFF
--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -34,10 +34,6 @@ module Admin
       admin_user.is_service_operator?
     end
 
-    def payroll_operator_signed_in?
-      admin_user.is_payroll_operator?
-    end
-
     def support_agent_signed_in?
       admin_user.is_support_agent?
     end
@@ -48,10 +44,6 @@ module Admin
 
     def ensure_service_operator
       render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in?
-    end
-
-    def ensure_payroll_operator
-      render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in? || payroll_operator_signed_in?
     end
 
     def update_last_seen_at

--- a/app/controllers/admin/payroll_run_downloads_controller.rb
+++ b/app/controllers/admin/payroll_run_downloads_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PayrollRunDownloadsController < Admin::BaseAdminController
-  before_action :ensure_payroll_operator, :find_payroll_run
+  before_action :ensure_service_operator, :find_payroll_run
 
   before_action :ensure_download_has_been_triggered, only: :show
 

--- a/app/models/dfe_sign_in/user.rb
+++ b/app/models/dfe_sign_in/user.rb
@@ -5,7 +5,6 @@ module DfeSignIn
     SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_access"
     SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_admin"
     SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_support"
-    PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_payroll"
 
     has_secure_token :session_token
 
@@ -39,16 +38,12 @@ module DfeSignIn
       role_codes.include?(SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
     end
 
-    def is_payroll_operator?
-      role_codes.include?(PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-    end
-
     def is_service_admin?
       role_codes.include?(SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE)
     end
 
     def has_admin_access?
-      is_service_operator? || is_support_agent? || is_payroll_operator?
+      is_service_operator? || is_support_agent?
     end
 
     def self.options_for_select

--- a/app/models/journeys/further_education_payments/provider/authorisation.rb
+++ b/app/models/journeys/further_education_payments/provider/authorisation.rb
@@ -38,8 +38,7 @@ module Journeys
         def claim_admin_roles
           [
             DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE,
-            DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE,
-            DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE
+            DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE
           ]
         end
       end

--- a/db/test_seeders/base_importer.rb
+++ b/db/test_seeders/base_importer.rb
@@ -98,7 +98,6 @@ class BaseImporter
     user = DfeSignIn::User.find { |u| u.role_codes.include?("teacher_payments_access") }
     if user.nil?
       logger.warn "#{WARN} - No Admin User found with 'teacher_payments_access' role"
-      logger.warn "#{WARN} - Please sign-out of Claims Admin DfE Payroll ('teacher_payments_payroll')"
       logger.warn "#{WARN} - Please sign-in as Department for Education Admin user ('teacher_payments_access')"
       exit 100
     end

--- a/spec/factories/dfe_sign_in/users.rb
+++ b/spec/factories/dfe_sign_in/users.rb
@@ -21,11 +21,6 @@ FactoryBot.define do
       role_codes { [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE] }
     end
 
-    trait :payroll_operator do
-      role_codes { [DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE] }
-      organisation_name { "DfE Payroll" }
-    end
-
     trait :service_admin do
       role_codes do
         [

--- a/spec/features/admin/admin_claim_allocation_spec.rb
+++ b/spec/features/admin/admin_claim_allocation_spec.rb
@@ -108,7 +108,6 @@ RSpec.feature "Claims awaiting a decision" do
   let!(:frank) { create(:dfe_signin_user, given_name: "Frank", family_name: "Yee", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
   let!(:abdul) { create(:dfe_signin_user, given_name: "Abdul", family_name: "Rafiq", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
   let!(:deleted_user) { create(:dfe_signin_user, :deleted, given_name: "Deleted", family_name: "User", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
-  let!(:tripti) { create(:dfe_signin_user, given_name: "Tripti", family_name: "Kumar", organisation_name: "DfE Payroll", role_codes: [DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
 
   context "with more than 25 claims" do
     scenario "assign first 25 to one Claim's checker" do
@@ -402,12 +401,12 @@ RSpec.feature "Claims awaiting a decision" do
     end
 
     scenario "when zero claims for policy" do
-      Claim.awaiting_decision.update_all(assigned_to_id: tripti.id)
+      Claim.awaiting_decision.update_all(assigned_to_id: sarah.id)
 
       click_on "View claims"
 
       @submitted_claims.each do |claim|
-        expect(claim.reload.assigned_to.full_name).to eq "Tripti Kumar"
+        expect(claim.reload.assigned_to.full_name).to eq "Sarah Strawbridge"
       end
 
       expect(page).to have_button "Allocate claims", disabled: true
@@ -425,7 +424,7 @@ RSpec.feature "Claims awaiting a decision" do
       end
 
       student_loan_claims.each do |claim|
-        expect(claim.reload.assigned_to.full_name).to eq "Tripti Kumar"
+        expect(claim.reload.assigned_to.full_name).to eq "Sarah Strawbridge"
       end
     end
   end

--- a/spec/features/admin/admin_claim_check_spec.rb
+++ b/spec/features/admin/admin_claim_check_spec.rb
@@ -120,18 +120,16 @@ RSpec.feature "Admin checks a claim" do
     end
   end
 
-  context "User is logged in as a payroll operator or a support user" do
-    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-      scenario "User cannot view claims" do
-        sign_in_to_admin_with_role(role)
+  context "User is logged in as a support user" do
+    scenario "User cannot view claims" do
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        expect(page).to_not have_link(nil, href: admin_claims_path)
+      expect(page).to_not have_link(nil, href: admin_claims_path)
 
-        visit admin_claims_path
+      visit admin_claims_path
 
-        expect(page.status_code).to eq(401)
-        expect(page).to have_content("Not authorised")
-      end
+      expect(page.status_code).to eq(401)
+      expect(page).to have_content("Not authorised")
     end
   end
 end

--- a/spec/features/admin/admin_claims_filtering_spec.rb
+++ b/spec/features/admin/admin_claims_filtering_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "Admin claim filtering" do
   let!(:valentino) { create(:dfe_signin_user, given_name: "Valentino", family_name: "Ricci", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
   let!(:mette) { create(:dfe_signin_user, given_name: "Mette", family_name: "Jørgensen", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
   let!(:deleted_user) { create(:dfe_signin_user, :deleted, given_name: "Deleted", family_name: "User", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
-  let!(:raj) { create(:dfe_signin_user, given_name: "raj", family_name: "sathikumar", organisation_name: "DfE Payroll", role_codes: [DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
 
   let(:student_loans_claims_for_mette) { create_list(:claim, 4, :submitted, policy: Policies::StudentLoans, assigned_to: mette) }
   let(:student_loans_claims_for_valentino) { create_list(:claim, 1, :submitted, policy: Policies::StudentLoans, assigned_to: valentino) }

--- a/spec/features/admin/admin_payroll_run_download_spec.rb
+++ b/spec/features/admin/admin_payroll_run_download_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Payroll run download" do
   scenario "User can download a payroll run file" do
-    sign_in_to_admin_with_role(DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
     payroll_run = create(:payroll_run, claims_counts: {Policies::StudentLoans => 4, Policies::EarlyCareerPayments => 3, Policies::TargetedRetentionIncentivePayments => 2})
 

--- a/spec/models/dfe_sign_in/user_spec.rb
+++ b/spec/models/dfe_sign_in/user_spec.rb
@@ -66,11 +66,6 @@ RSpec.describe DfeSignIn::User, type: :model do
       expect(user.has_admin_access?).to eq true
     end
 
-    it "returns true when user is a payroll operator" do
-      user.role_codes = [DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE]
-      expect(user.has_admin_access?).to eq true
-    end
-
     it "returns true when user has multiple roles" do
       user.role_codes = [
         DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE,
@@ -91,7 +86,6 @@ RSpec.describe DfeSignIn::User, type: :model do
     let!(:davide) { create(:dfe_signin_user, :service_operator, given_name: "Davide", family_name: "Muzani") }
     let!(:tina) { create(:dfe_signin_user, :service_operator, given_name: "Tina", family_name: "Dee") }
     let!(:muhammad) { create(:dfe_signin_user, :service_operator, given_name: "Muhammad", family_name: "Khan") }
-    let!(:tripti) { create(:dfe_signin_user, :payroll_operator, given_name: "Tripti", family_name: "Kumar") }
     let!(:deleted_user) { create(:dfe_signin_user, :service_operator, :deleted) }
 
     it "returns an array of 'Service Operators' for use with select helper" do
@@ -102,10 +96,6 @@ RSpec.describe DfeSignIn::User, type: :model do
           [muhammad.full_name.titleize, muhammad.id]
         ]
       )
-    end
-
-    it "does not include 'Payroll Operator' role" do
-      expect(described_class.options_for_select).not_to include([tripti.full_name.titleize, tripti.id])
     end
 
     it "does not include deleted users" do

--- a/spec/requests/admin/admin_amendments_spec.rb
+++ b/spec/requests/admin/admin_amendments_spec.rb
@@ -214,28 +214,26 @@ RSpec.describe "Admin claim amendments" do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
-    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-      before do
-        sign_in_to_admin_with_role(role)
+  context "when signed in as a support agent" do
+    before do
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+    end
+
+    describe "admin_amendments#new" do
+      it "returns a unauthorized response" do
+        get new_admin_claim_amendment_url(claim)
+
+        expect(response).to have_http_status(:unauthorized)
       end
+    end
 
-      describe "admin_amendments#new" do
-        it "returns a unauthorized response" do
-          get new_admin_claim_amendment_url(claim)
+    describe "admin_amendments#create" do
+      it "returns a unauthorized response and does not create an amendment or change the claim" do
+        expect {
+          post admin_claim_amendments_url(claim, amendment: {claim: {eligibility_attributes: {teacher_reference_number: "7654321"}}})
+        }.not_to change { [claim.eligibility.reload.teacher_reference_number, claim.amendments.size] }
 
-          expect(response).to have_http_status(:unauthorized)
-        end
-      end
-
-      describe "admin_amendments#create" do
-        it "returns a unauthorized response and does not create an amendment or change the claim" do
-          expect {
-            post admin_claim_amendments_url(claim, amendment: {claim: {eligibility_attributes: {teacher_reference_number: "7654321"}}})
-          }.not_to change { [claim.eligibility.reload.teacher_reference_number, claim.amendments.size] }
-
-          expect(response).to have_http_status(:unauthorized)
-        end
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/admin/admin_claims_spec.rb
+++ b/spec/requests/admin/admin_claims_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Admin claims", type: :request do
     let!(:mary) { create(:dfe_signin_user, given_name: "mary", family_name: "wasu-wabi", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
     let!(:valentino) { create(:dfe_signin_user, given_name: "Valentino", family_name: "Ricci", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
     let!(:mette) { create(:dfe_signin_user, given_name: "Mette", family_name: "Jørgensen", organisation_name: "Department for Education", role_codes: [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
-    let!(:raj) { create(:dfe_signin_user, given_name: "raj", family_name: "sathikumar", organisation_name: "DfE Payroll", role_codes: [DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }
 
     it "lists all claims awaiting a decision" do
       get admin_claims_path

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -19,16 +19,14 @@ RSpec.describe "Service configuration" do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
+  context "when signed in as a support agent" do
     describe "admin_journey_configurations#update" do
-      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-        it "returns a unauthorized response" do
-          sign_in_to_admin_with_role(role)
+      it "returns a unauthorized response" do
+        sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {open_for_submissions: false, availability_message: "Test message"})
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {open_for_submissions: false, availability_message: "Test message"})
 
-          expect(response).to have_http_status(:unauthorized)
-        end
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/admin/admin_decisions_spec.rb
+++ b/spec/requests/admin/admin_decisions_spec.rb
@@ -254,17 +254,15 @@ RSpec.describe "Admin decisions", type: :request do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
+  context "when signed in as a support agent" do
     describe "decisions#create" do
       let(:claim) { create(:claim, :submitted) }
 
-      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-        it "does not allow a claim to be approved" do
-          sign_in_to_admin_with_role(role)
-          post admin_claim_decisions_path(claim_id: claim.id, approved: true)
+      it "does not allow a claim to be approved" do
+        sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+        post admin_claim_decisions_path(claim_id: claim.id, approved: true)
 
-          expect(response.code).to eq("401")
-        end
+        expect(response.code).to eq("401")
       end
     end
   end

--- a/spec/requests/admin/admin_notes_spec.rb
+++ b/spec/requests/admin/admin_notes_spec.rb
@@ -17,14 +17,12 @@ RSpec.describe "admin/notes controller" do
     end
 
     it "refuses requests from users without the service operator role" do
-      non_service_operator_roles.each do |role|
-        sign_in_to_admin_with_role(role)
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        get admin_claim_notes_path(claim)
+      get admin_claim_notes_path(claim)
 
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.body).to include("Not authorised")
-      end
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to include("Not authorised")
     end
   end
 
@@ -52,14 +50,12 @@ RSpec.describe "admin/notes controller" do
     end
 
     it "refuses requests from users without the service operator role" do
-      non_service_operator_roles.each do |role|
-        sign_in_to_admin_with_role(role)
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        post admin_claim_notes_path(claim), params: {note: {body: "Some note"}}
+      post admin_claim_notes_path(claim), params: {note: {body: "Some note"}}
 
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.body).to include("Not authorised")
-      end
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to include("Not authorised")
     end
   end
 end

--- a/spec/requests/admin/admin_page_spec.rb
+++ b/spec/requests/admin/admin_page_spec.rb
@@ -1,13 +1,4 @@
 require "rails_helper"
 
 RSpec.describe "Admin page" do
-  context "when signed in as a payroll operator" do
-    it "returns a unauthorized response" do
-      sign_in_to_admin_with_role(DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-
-      get admin_root_path
-
-      expect(response).to have_http_status(:unauthorized)
-    end
-  end
 end

--- a/spec/requests/admin/admin_payment_confirmation_report_upload_spec.rb
+++ b/spec/requests/admin/admin_payment_confirmation_report_upload_spec.rb
@@ -75,16 +75,14 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
+  context "when signed in as a support agent" do
     describe "payment_confirmation_report_uploads#new" do
-      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-        it "returns an unauthorized response" do
-          sign_in_to_admin_with_role(role)
+      it "returns an unauthorized response" do
+        sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-          get new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run)
+        get new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run)
 
-          expect(response).to have_http_status(:unauthorized)
-        end
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/admin/admin_payroll_gender_tasks_spec.rb
+++ b/spec/requests/admin/admin_payroll_gender_tasks_spec.rb
@@ -68,17 +68,15 @@ RSpec.describe "Admin tasks", type: :request do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
+  context "when signed in as a support agent" do
     let(:claim) { create(:claim, :submitted) }
 
     describe "payroll_gender_tasks#create" do
-      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-        it "does not allow the task to be created" do
-          sign_in_to_admin_with_role(role)
-          post admin_claim_tasks_path(claim_id: claim.id)
+      it "does not allow the task to be created" do
+        sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+        post admin_claim_tasks_path(claim_id: claim.id)
 
-          expect(response.code).to eq("401")
-        end
+        expect(response.code).to eq("401")
       end
     end
   end

--- a/spec/requests/admin/admin_payroll_run_downloads_spec.rb
+++ b/spec/requests/admin/admin_payroll_run_downloads_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Admin payroll run downloads" do
   let(:admin) { create(:dfe_signin_user) }
 
   before do
-    sign_in_to_admin_with_role(DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
   end
 
   describe "downloads#new" do
@@ -109,25 +109,20 @@ RSpec.describe "Admin payroll run downloads" do
   end
 
   describe "access restriction" do
-    context "when signed is as service operator or a payroll operator" do
-      [DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-        it "responds with success", :aggregate_failures do
-          payroll_run = create(:payroll_run)
+    context "when signed is as service operator" do
+      it "responds with success", :aggregate_failures do
+        payroll_run = create(:payroll_run)
 
-          sign_in_to_admin_with_role(role)
+        sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
-          get new_admin_payroll_run_download_path(payroll_run)
+        get new_admin_payroll_run_download_path(payroll_run)
+        expect(response.code).to eq("200")
 
-          expect(response.code).to eq("200")
+        get admin_payroll_run_download_path(payroll_run)
+        expect(response).to redirect_to(new_admin_payroll_run_download_path)
 
-          get admin_payroll_run_download_path(payroll_run)
-
-          expect(response).to redirect_to(new_admin_payroll_run_download_path)
-
-          post admin_payroll_run_download_path(payroll_run)
-
-          expect(response).to redirect_to(admin_payroll_run_download_path)
-        end
+        post admin_payroll_run_download_path(payroll_run)
+        expect(response).to redirect_to(admin_payroll_run_download_path)
       end
     end
 

--- a/spec/requests/admin/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin/admin_payroll_runs_spec.rb
@@ -63,36 +63,34 @@ RSpec.describe "Admin payroll runs" do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
-    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-      before do
-        sign_in_to_admin_with_role(role)
+  context "when signed in as a support agent" do
+    before do
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+    end
+
+    describe "admin_payroll_runs#new" do
+      it "returns a unauthorized response" do
+        get new_admin_payroll_run_path
+
+        expect(response).to have_http_status(:unauthorized)
       end
+    end
 
-      describe "admin_payroll_runs#new" do
-        it "returns a unauthorized response" do
-          get new_admin_payroll_run_path
+    describe "admin_payroll_runs#create" do
+      it "does not create a payroll run and returns a unauthorized response" do
+        expect { post admin_payroll_runs_path }.to_not change { PayrollRun.count }
 
-          expect(response).to have_http_status(:unauthorized)
-        end
+        expect(response).to have_http_status(:unauthorized)
       end
+    end
 
-      describe "admin_payroll_runs#create" do
-        it "does not create a payroll run and returns a unauthorized response" do
-          expect { post admin_payroll_runs_path }.to_not change { PayrollRun.count }
+    describe "admin_payroll_runs#show" do
+      it "does not view a payroll run and returns a unauthorized response" do
+        payroll_run = create(:payroll_run)
 
-          expect(response).to have_http_status(:unauthorized)
-        end
-      end
+        get admin_payroll_run_path(payroll_run)
 
-      describe "admin_payroll_runs#show" do
-        it "does not view a payroll run and returns a unauthorized response" do
-          payroll_run = create(:payroll_run)
-
-          get admin_payroll_run_path(payroll_run)
-
-          expect(response).to have_http_status(:unauthorized)
-        end
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/admin/admin_school_workforce_data_upload_spec.rb
+++ b/spec/requests/admin/admin_school_workforce_data_upload_spec.rb
@@ -36,14 +36,12 @@ RSpec.describe "School workforce census data upload" do
       end
     end
 
-    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-      it "returns a unauthorized response for #{role} users" do
-        sign_in_to_admin_with_role(role)
+    it "returns a unauthorized response for support agents" do
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        post admin_school_workforce_census_data_uploads_path
+      post admin_school_workforce_census_data_uploads_path
 
-        expect(response).to have_http_status(:unauthorized)
-      end
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/requests/admin/admin_student_loans_data_upload_spec.rb
+++ b/spec/requests/admin/admin_student_loans_data_upload_spec.rb
@@ -36,14 +36,12 @@ RSpec.describe "SLC (Student Loans Company) data upload " do
       end
     end
 
-    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-      it "returns a unauthorized response for #{role} users" do
-        sign_in_to_admin_with_role(role)
+    it "returns a unauthorized response for support agents" do
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        post admin_student_loans_data_uploads_path
+      post admin_student_loans_data_uploads_path
 
-        expect(response).to have_http_status(:unauthorized)
-      end
+      expect(response).to have_http_status(:unauthorized)
     end
 
     context "when a valid CSV is uploaded" do

--- a/spec/requests/admin/admin_support_tickets_spec.rb
+++ b/spec/requests/admin/admin_support_tickets_spec.rb
@@ -24,14 +24,12 @@ RSpec.describe "admin/support_tickets controller" do
     end
 
     it "refuses requests from users without the service operator role" do
-      non_service_operator_roles.each do |role|
-        sign_in_to_admin_with_role(role)
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        post admin_claim_support_tickets_path(claim), params: {support_ticket: {url: "https://some/ticket/url"}}
+      post admin_claim_support_tickets_path(claim), params: {support_ticket: {url: "https://some/ticket/url"}}
 
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.body).to include("Not authorised")
-      end
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to include("Not authorised")
     end
   end
 end

--- a/spec/requests/admin/admin_tasks_spec.rb
+++ b/spec/requests/admin/admin_tasks_spec.rb
@@ -119,15 +119,13 @@ RSpec.describe "Admin tasks", type: :request do
     end
   end
 
-  context "when signed in as a payroll operator or a support agent" do
+  context "when signed in as a support agent" do
     describe "tasks#index" do
-      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-        it "does not allow the claim tasks to be viewed" do
-          sign_in_to_admin_with_role(role)
-          get admin_claim_tasks_path(claim_id: claim.id)
+      it "does not allow the claim tasks to be viewed" do
+        sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+        get admin_claim_tasks_path(claim_id: claim.id)
 
-          expect(response.code).to eq("401")
-        end
+        expect(response.code).to eq("401")
       end
     end
   end

--- a/spec/requests/admin/admin_tps_data_upload_spec.rb
+++ b/spec/requests/admin/admin_tps_data_upload_spec.rb
@@ -39,14 +39,12 @@ RSpec.describe "TPS data upload" do
       end
     end
 
-    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
-      it "returns a unauthorized response for #{role} users" do
-        sign_in_to_admin_with_role(role)
+    it "returns a unauthorized response for support agents" do
+      sign_in_to_admin_with_role(DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
 
-        post admin_tps_data_uploads_path
+      post admin_tps_data_uploads_path
 
-        expect(response).to have_http_status(:unauthorized)
-      end
+      expect(response).to have_http_status(:unauthorized)
     end
 
     context "when a valid CSV is uploaded" do

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -7,13 +7,6 @@ module RequestHelpers
     post claims_path(routing_name)
   end
 
-  def non_service_operator_roles
-    [
-      DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE,
-      DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE
-    ]
-  end
-
   # Signs in as a user with the service operator role. Returns the signed-in User record.
   def sign_in_as_service_operator
     user = create(:dfe_signin_user)


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2394
- Pre-requisite for this ticket, to remove payroll operator role which is longer used and has been the case for some time