### PR TITLE
Remove attempting to enable plpgsql extension

### DIFF
--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -11,7 +11,7 @@ module "postgres" {
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
   azure_enable_backup_storage    = var.enable_postgres_backup_storage
-  azure_extensions               = ["citext", "pg_trgm", "pgcrypto", "plpgsql"]
+  azure_extensions               = ["citext", "pg_trgm", "pgcrypto"]
   server_version                 = "16"
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_enable_high_availability = var.postgres_enable_high_availability


### PR DESCRIPTION
plpgsql extension is available by default. Azure is rejecting terraform
updates that are attempting to enable this extension as it doesn't
exist.
