### PR TITLE
Increase test postgres server to B2s

### DIFF
--- a/terraform/application/config/test.tfvars.json
+++ b/terraform/application/config/test.tfvars.json
@@ -13,5 +13,6 @@
   "enable_logit": true,
   "enable_postgres_backup_storage": true,
   "dataset_name": "claim_events_test",
-  "enable_dfe_analytics_federated_auth": true
+  "enable_dfe_analytics_federated_auth": true,
+  "postgres_flexible_server_sku": "B_Standard_B2s"
 }


### PR DESCRIPTION
Increase the test postgres server from B1ms to B2s to improve performance.