### PR TITLE
[CAPT-2417] Refactor TSLR subjects taught page

### DIFF
--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -2,44 +2,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: @form, errored_field_id_overrides: { "subjects_taught": "claim_biology_taught" }) if @form.errors.any? %>
+    <%= form_for @form, url: claim_path(current_journey_routing_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <%= form_for @form, url: claim_path(current_journey_routing_name) do |f| %>
-
-      <%= form_group_tag @form do %>
-        <fieldset class="govuk-fieldset">
-
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              <%= subjects_taught_question(school_name: f.object.claim_school_name) %>
-            </h1>
-          </legend>
-
-          <%= errors_tag f.object, :subjects_taught %>
-
-          <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-
-            <%- f.object.subject_attributes.each do |subject| %>
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :subjects_taught, { class: "govuk-checkboxes__input", id: "claim_#{subject}", include_hidden: false, checked: f.object.subject_taught_selected?(subject), multiple: true }, subject %>
-                <%= f.label :subjects_taught, t("student_loans.forms.subjects_taught.answers.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "claim_#{subject}" %>
-              </div>
-            <% end %>
-
-            <div class="govuk-checkboxes__divider">or</div>
-
-            <div class="govuk-checkboxes__item">
-              <%= f.check_box :subjects_taught, { class: "govuk-checkboxes__input", id: "claim_taught_eligible_subjects", include_hidden: false, multiple: true, data: { behaviour: "exclusive" } }, "none_taught" %>
-              <%= f.label :subjects_taught, t("student_loans.forms.subjects_taught.answers.none_taught"), class: "govuk-label govuk-checkboxes__label", for: "claim_taught_eligible_subjects" %>
-            </div>
-
-          </div>
-
-        </fieldset>
+      <%= f.govuk_check_boxes_fieldset :subjects_taught,
+        legend: {
+          text: subjects_taught_question(school_name: f.object.claim_school_name),
+          tag: "h1",
+          size: "xl"
+        } do %>
+        <% f.object.eligible_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subjects_taught, subject, label: { text: t("student_loans.forms.subjects_taught.answers.#{subject}") }, link_errors: f.object.eligible_subjects.first == subject %>
+        <% end %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :subjects_taught, "none_taught", exclusive: true, label: { text: t("student_loans.forms.subjects_taught.answers.none_taught") } %>
       <% end %>
 
-      <%= f.submit "Continue", class: "govuk-button" %>
-
+      <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>
 </div>

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -26,9 +26,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     )
 
     click_link "Change which of the following subjects did you teach at #{session.answers.claim_school.name.downcase} between 6 april 2022 and 5 april 2023?"
-
-    expect(find("#claim_physics_taught").checked?).to eq(true)
-
+    expect(page).to have_checked_field("Physics", visible: false)
     check "Biology"
     click_on "Continue"
 
@@ -100,9 +98,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     expect(current_path).to eq(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "subjects-taught"))
 
-    check I18n.t("student_loans.forms.subjects_taught.answers.biology_taught"), visible: false
-    check I18n.t("student_loans.forms.subjects_taught.answers.chemistry_taught"), visible: false
-
+    check "Biology", visible: false
+    check "Chemistry", visible: false
     click_on "Continue"
 
     session.reload
@@ -169,14 +166,11 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     click_link "Change which of the following subjects did you teach at #{session.answers.claim_school.name.downcase} between 6 april 2022 and 5 april 2023?"
 
-    expect(find("#claim_physics_taught").checked?).to eq(true)
-
+    expect(page).to have_checked_field("Physics", visible: false)
     click_on "Continue"
 
     expect(current_path).to eq(claim_path(Journeys::TeacherStudentLoanReimbursement::ROUTING_NAME, "check-your-answers"))
-
     expect(page).to have_text("Physics")
-
     expect(page).not_to have_text("Biology")
     expect(page).not_to have_text("Chemistry")
     expect(page).not_to have_text("Computing")

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -14,17 +14,13 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
     scenario "checks subjects and then chooses not applicable" do
       check "Biology"
       check "Physics"
-
-      expect(page).to have_checked_field("claim_biology_taught", visible: false)
-      expect(page).to have_checked_field("claim_physics_taught", visible: false)
+      expect(page).to have_checked_field("Biology", visible: false)
+      expect(page).to have_checked_field("Physics", visible: false)
 
       check I18n.t("student_loans.forms.subjects_taught.answers.none_taught")
-
-      expect(page).to have_checked_field("claim_taught_eligible_subjects", visible: false)
-
-      expect(page).to_not have_checked_field("claim_biology_taught", visible: false)
-      expect(page).to_not have_checked_field("claim_physics_taught", visible: false)
-
+      expect(page).to have_checked_field(I18n.t("student_loans.forms.subjects_taught.answers.none_taught"), visible: false)
+      expect(page).to_not have_checked_field("Biology", visible: false)
+      expect(page).to_not have_checked_field("Physics", visible: false)
       click_on "Continue"
 
       expect(page).to have_text("You did not select an eligible subject")
@@ -33,14 +29,10 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
 
     scenario "checks not applicable and then chooses a subject" do
       check I18n.t("student_loans.forms.subjects_taught.answers.none_taught")
-
-      expect(page).to have_checked_field("claim_taught_eligible_subjects", visible: false)
-
+      expect(page).to have_checked_field(I18n.t("student_loans.forms.subjects_taught.answers.none_taught"), visible: false)
       check "Biology"
-
-      expect(page).to have_checked_field("claim_biology_taught", visible: false)
-      expect(page).to_not have_checked_field("claim_taught_eligible_subjects", visible: false)
-
+      expect(page).to have_checked_field("Biology", visible: false)
+      expect(page).to_not have_checked_field(I18n.t("student_loans.forms.subjects_taught.answers.none_taught"), visible: false)
       click_on "Continue"
 
       choose "Yes, at #{school.name}"
@@ -54,7 +46,6 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
     scenario "checks subjects and then chooses not applicable" do
       check "Biology"
       check "Physics"
-
       check I18n.t("student_loans.forms.subjects_taught.answers.none_taught")
       click_on "Continue"
 

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/subjects_taught_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
 
   describe "validations" do
     context "when no options are selected" do
-      let(:claim_params) { {"subjects_taught" => []} }
+      let(:claim_params) { {"subjects_taught" => [""]} }
 
       it do
         aggregate_failures do
@@ -39,13 +39,13 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
     end
 
     context "when one or more subjects are selected" do
-      let(:claim_params) { {"subjects_taught" => ["biology_taught", "chemistry_taught"]} }
+      let(:claim_params) { {"subjects_taught" => ["", "biology_taught", "chemistry_taught"]} }
 
       it { is_expected.to be_valid }
     end
 
     context "when 'I did not teach any of these subjects' is selected" do
-      let(:claim_params) { {"subjects_taught" => ["none_taught"]} }
+      let(:claim_params) { {"subjects_taught" => ["", "none_taught"]} }
 
       it { is_expected.to be_valid }
     end
@@ -56,7 +56,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
 
     context "valid params" do
       context "when multiple subject are selected" do
-        let(:claim_params) { {"subjects_taught" => ["biology_taught", "chemistry_taught"]} }
+        let(:claim_params) { {"subjects_taught" => ["", "biology_taught", "chemistry_taught"]} }
 
         it "updates the answers" do
           journey_session.reload
@@ -73,7 +73,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
       end
 
       context "when no subjects are selected" do
-        let(:claim_params) { {"subjects_taught" => ["none_taught"]} }
+        let(:claim_params) { {"subjects_taught" => ["", "none_taught"]} }
 
         it "updates the answers" do
           journey_session.reload
@@ -105,31 +105,5 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::SubjectsTaughtForm, ty
     subject { form.claim_school_name }
 
     it { is_expected.to eq("test school") }
-  end
-
-  describe "#subject_attributes" do
-    it { expect(form.subject_attributes).to eq(Policies::StudentLoans::Eligibility::SUBJECT_ATTRIBUTES) }
-  end
-
-  describe "#subject_taught_selected?" do
-    context "when the subject is invalid" do
-      it { expect(form.subject_taught_selected?(:invalid_subject_taught)).to be_nil }
-    end
-
-    context "when the subject is taught" do
-      before do
-        journey_session.answers.biology_taught = true
-      end
-
-      it { expect(form.subject_taught_selected?(:biology_taught)).to eq(true) }
-    end
-
-    context "when the subject is not taught" do
-      before do
-        journey_session.answers.biology_taught = false
-      end
-
-      it { expect(form.subject_taught_selected?(:biology_taught)).to eq(false) }
-    end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2417

# Notes

- Changes TSLR journey subjects taught form
- This is to aid in migrating TSLR journey to use navigator
- `subjects_taught` is now the public api of the form as this in the input from the HTML form
- `taught_eligible_subjects` and all the `_taught` fields are now part of the `private` api as these are part of backend data structures
- Also now use govuk form builder for this form