### PR TITLE
Only show the commit subject

### DIFF
--- a/.github/workflows/notify-schema-change.yml
+++ b/.github/workflows/notify-schema-change.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get commit details
         id: commit-info
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          COMMIT_MSG=$(git log -1 --pretty=%s)
           COMMIT_AUTHOR=$(git log -1 --pretty=%an)
           COMMIT_LINK="https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
           echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_ENV


### PR DESCRIPTION
We don't need to show the whole commit message in slack and `GITHUB_ENV`
evidently has trouble with multi line strings.
