### PR TITLE
Remove renamed temporary columns from dfe-analytics blocklist

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -214,6 +214,3 @@
   - concurrency_key
   - expires_at
   - created_at
-  :early_career_payments_eligibilities:
-  - qualification_string
-  - eligible_itt_subject_string


### PR DESCRIPTION
Forgot to remove these after renaming the columns