### PR TITLE
[CAPT-2177] Move policy from eligibility to claim

### DIFF
--- a/app/forms/claim_submission_base_form.rb
+++ b/app/forms/claim_submission_base_form.rb
@@ -42,6 +42,7 @@ class ClaimSubmissionBaseForm
   def build_claim
     Claim.new.tap do |claim|
       claim.eligibility ||= main_eligibility
+      claim.policy ||= main_eligibility.policy
       claim.started_at = journey_session.created_at
       answers.attributes.each do |name, value|
         if claim.respond_to?(:"#{name}=")

--- a/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
+++ b/app/forms/journeys/early_years_payment/practitioner/claim_submission_form.rb
@@ -25,6 +25,7 @@ module Journeys
         def build_claim
           existing_or_new_claim.tap do |claim|
             claim.eligibility ||= main_eligibility
+            claim.policy ||= main_eligibility.policy
             claim.eligibility.practitioner_claim_started_at = journey_session.answers.practitioner_claim_started_at
             answers.attributes.each do |name, value|
               if claim.respond_to?(:"#{name}=")

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -41,4 +41,8 @@ module Policies
   def self.with_attribute(attr)
     POLICIES.select { |policy| policy::Eligibility.has_attribute?(attr) }
   end
+
+  def self.from_policy_string(string)
+    Policies.all.find { |p| p.name == string }
+  end
 end

--- a/app/models/policies/active_record_type.rb
+++ b/app/models/policies/active_record_type.rb
@@ -1,0 +1,32 @@
+module Policies
+  class ActiveRecordType < ActiveRecord::Type::Value
+    def cast(value)
+      case value
+      when String
+        Policies.from_policy_string(value)
+      when *Policies.all
+        value
+      end
+    end
+
+    def serialize(value)
+      case value
+      when String
+        Policies.from_policy_string(value).name
+      when *Policies.all
+        value.name
+      end
+    end
+
+    def deserialize(value)
+      case value
+      when String
+        Policies.from_policy_string(value)
+      end
+    end
+
+    def type
+      :policy
+    end
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -85,6 +85,7 @@ shared:
     - started_at
     - verified_at
     - onelogin_idv_return_codes
+    - policy
   :decisions:
     - id
     - claim_id

--- a/db/migrate/20250515103756_add_policy_to_claim.rb
+++ b/db/migrate/20250515103756_add_policy_to_claim.rb
@@ -1,0 +1,15 @@
+class AddPolicyToClaim < ActiveRecord::Migration[8.0]
+  def up
+    add_column :claims, :policy, :text, null: true
+    add_index :claims, :policy
+
+    Claim.reset_column_information
+
+    Claim
+      .update_all("policy= regexp_replace(eligibility_type, '::\\w+$', '')")
+  end
+
+  def down
+    remove_column :claims, :policy, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_12_180542) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_15_103756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -115,11 +115,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_12_180542) do
     t.datetime "verified_at"
     t.text "onelogin_idv_full_name"
     t.text "onelogin_idv_return_codes", array: true
+    t.text "policy"
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["held"], name: "index_claims_on_held"
     t.index ["journeys_session_id"], name: "index_claims_on_journeys_session_id"
+    t.index ["policy"], name: "index_claims_on_policy"
     t.index ["qa_required", "qa_completed_at"], name: "index_claims_on_qa_required_and_qa_completed_at", where: "qa_required"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -6,13 +6,17 @@ FactoryBot.define do
   factory :claim do
     started_at { Time.zone.now }
     reference { Reference.new.to_s }
+    policy { Policies::StudentLoans }
 
     trait :current_academic_year do
       academic_year { AcademicYear.current }
     end
 
+    trait :further_education do
+      policy { Policies::FurtherEducationPayments }
+    end
+
     transient do
-      policy { Policies::StudentLoans }
       eligibility_factory { :"#{policy.to_s.underscore}_eligibility" }
       eligibility_trait { nil }
       eligibility_attributes { nil }
@@ -31,6 +35,7 @@ FactoryBot.define do
       end
 
       claim.eligibility = build(evaluator.eligibility_factory, evaluator.eligibility_trait, **evaluator.eligibility_attributes || {}) unless claim.eligibility
+      claim.policy = claim.eligibility.policy
 
       raise "Policy of Claim (#{evaluator.policy}) must match Eligibility class (#{claim.eligibility.policy})" if evaluator.policy != claim.eligibility.policy
 

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :further_education_payments_eligibility, class: "Policies::FurtherEducationPayments::Eligibility" do
-    claim
     school { create(:school, :further_education) }
 
     trait :eligible do

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -25,8 +25,18 @@ RSpec.feature "Admin claim further education payments" do
               name: "Springfield A and M"
             )
 
+            eligibility = create(
+              :further_education_payments_eligibility,
+              contract_type: "fixed_term",
+              school: fe_provider,
+              award_amount: 1500,
+              flagged_as_duplicate: true
+            )
+
             claim = create(
               :claim,
+              :further_education,
+              eligibility:,
               first_name: "Edna",
               surname: "Krabappel",
               email_address: "edna.krabappel@springfield-elementary.edu",
@@ -34,15 +44,6 @@ RSpec.feature "Admin claim further education payments" do
               reference: "AB123456",
               created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
               submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
-            )
-
-            create(
-              :further_education_payments_eligibility,
-              contract_type: "fixed_term",
-              claim: claim,
-              school: fe_provider,
-              award_amount: 1500,
-              flagged_as_duplicate: true
             )
 
             visit admin_claim_path(claim)
@@ -97,8 +98,18 @@ RSpec.feature "Admin claim further education payments" do
                 name: "Springfield A and M"
               )
 
+              eligibility = create(
+                :further_education_payments_eligibility,
+                contract_type: "fixed_term",
+                school: fe_provider,
+                award_amount: 1500,
+                provider_verification_email_last_sent_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+              )
+
               claim = create(
                 :claim,
+                :further_education,
+                eligibility:,
                 first_name: "Edna",
                 surname: "Krabappel",
                 email_address: "edna.krabappel@springfield-elementary.edu",
@@ -106,15 +117,6 @@ RSpec.feature "Admin claim further education payments" do
                 reference: "AB123456",
                 created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
                 submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
-              )
-
-              create(
-                :further_education_payments_eligibility,
-                contract_type: "fixed_term",
-                claim: claim,
-                school: fe_provider,
-                award_amount: 1500,
-                provider_verification_email_last_sent_at: DateTime.new(2024, 8, 1, 9, 0, 0)
               )
 
               create(
@@ -177,8 +179,18 @@ RSpec.feature "Admin claim further education payments" do
                 name: "Springfield A and M"
               )
 
+              eligibility = create(
+                :further_education_payments_eligibility,
+                contract_type: "fixed_term",
+                school: fe_provider,
+                award_amount: 1500,
+                provider_verification_email_last_sent_at: DateTime.new(2024, 8, 1, 9, 0, 0)
+              )
+
               claim = create(
                 :claim,
+                :further_education,
+                eligibility:,
                 first_name: "Edna",
                 surname: "Krabappel",
                 email_address: "edna.krabappel@springfield-elementary.edu",
@@ -186,15 +198,6 @@ RSpec.feature "Admin claim further education payments" do
                 reference: "AB123456",
                 created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
                 submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
-              )
-
-              create(
-                :further_education_payments_eligibility,
-                contract_type: "fixed_term",
-                claim: claim,
-                school: fe_provider,
-                award_amount: 1500,
-                provider_verification_email_last_sent_at: DateTime.new(2024, 8, 1, 9, 0, 0)
               )
 
               visit admin_claim_path(claim)
@@ -249,8 +252,19 @@ RSpec.feature "Admin claim further education payments" do
                 name: "Springfield A and M"
               )
 
+              eligibility = create(
+                :further_education_payments_eligibility,
+                contract_type: "fixed_term",
+                school: fe_provider,
+                award_amount: 1500,
+                provider_verification_email_last_sent_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+                provider_verification_email_count: 1
+              )
+
               claim = create(
                 :claim,
+                :further_education,
+                eligibility:,
                 first_name: "Edna",
                 surname: "Krabappel",
                 email_address: "edna.krabappel@springfield-elementary.edu",
@@ -258,16 +272,6 @@ RSpec.feature "Admin claim further education payments" do
                 reference: "AB123456",
                 created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
                 submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
-              )
-
-              create(
-                :further_education_payments_eligibility,
-                contract_type: "fixed_term",
-                claim: claim,
-                school: fe_provider,
-                award_amount: 1500,
-                provider_verification_email_last_sent_at: DateTime.new(2024, 8, 1, 9, 0, 0),
-                provider_verification_email_count: 1
               )
 
               perform_enqueued_jobs do
@@ -297,8 +301,18 @@ RSpec.feature "Admin claim further education payments" do
           it "shows the verification information and allows the admin to complete the task" do
             fe_provider = create(:school, :further_education, name: "Springfield A and M")
 
+            eligibility = create(
+              :further_education_payments_eligibility,
+              :verified,
+              contract_type: "fixed_term",
+              school: fe_provider,
+              award_amount: 1500
+            )
+
             claim = create(
               :claim,
+              :further_education,
+              eligibility:,
               first_name: "Edna",
               surname: "Krabappel",
               email_address: "edna.krabappel@springfield-elementary.edu",
@@ -306,15 +320,6 @@ RSpec.feature "Admin claim further education payments" do
               reference: "AB123456",
               created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
               submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
-            )
-
-            create(
-              :further_education_payments_eligibility,
-              :verified,
-              contract_type: "fixed_term",
-              claim: claim,
-              school: fe_provider,
-              award_amount: 1500
             )
 
             visit admin_claim_path(claim)
@@ -381,7 +386,6 @@ RSpec.feature "Admin claim further education payments" do
             click_on "Save and continue"
 
             visit admin_claim_tasks_path(claim)
-
             expect(task_status("Provider verification")).to eq "Passed"
           end
         end
@@ -390,8 +394,17 @@ RSpec.feature "Admin claim further education payments" do
           it "shows the verification information and allows the admin to complete the task" do
             fe_provider = create(:school, :further_education, name: "Springfield A and M")
 
+            eligibility = create(
+              :further_education_payments_eligibility,
+              :verified_variable_hours,
+              school: fe_provider,
+              award_amount: 1500
+            )
+
             claim = create(
               :claim,
+              :further_education,
+              eligibility:,
               first_name: "Edna",
               surname: "Krabappel",
               email_address: "edna.krabappel@springfield-elementary.edu",
@@ -401,16 +414,7 @@ RSpec.feature "Admin claim further education payments" do
               submitted_at: DateTime.new(2024, 8, 1, 9, 0, 0)
             )
 
-            create(
-              :further_education_payments_eligibility,
-              :verified_variable_hours,
-              claim: claim,
-              school: fe_provider,
-              award_amount: 1500
-            )
-
             visit admin_claim_path(claim)
-
             click_on "View tasks"
 
             click_on(

--- a/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_full_claim_further_education_payments_spec.rb
@@ -14,26 +14,8 @@ RSpec.feature "Admin views claim details for FurtherEducationPayments" do
         name: "Springfield Elementary"
       )
 
-      claim = create(
-        :claim,
-        first_name: "Edna",
-        surname: "Krabappel",
-        date_of_birth: Date.new(1945, 7, 3),
-        reference: "AB123456",
-        national_insurance_number: "QQ123456C",
-        address_line_1: "82 Evergreen Terrace",
-        address_line_2: "Springfield",
-        address_line_4: "Oregon",
-        postcode: "AB12 3CD",
-        email_address: "edna.krabappel@springfield-elementary.edu",
-        started_at: DateTime.new(2024, 8, 1, 9, 0, 0),
-        submitted_at: DateTime.new(2024, 8, 1, 11, 0, 0),
-        academic_year: AcademicYear.new(2024)
-      )
-
-      create(
+      eligibility = create(
         :further_education_payments_eligibility,
-        claim: claim,
         school: school,
         teacher_reference_number: nil,
         teaching_responsibilities: true,
@@ -50,6 +32,25 @@ RSpec.feature "Admin views claim details for FurtherEducationPayments" do
         subject_to_formal_performance_action: false,
         subject_to_disciplinary_action: false,
         award_amount: 6_000
+      )
+
+      claim = create(
+        :claim,
+        :further_education,
+        eligibility:,
+        first_name: "Edna",
+        surname: "Krabappel",
+        date_of_birth: Date.new(1945, 7, 3),
+        reference: "AB123456",
+        national_insurance_number: "QQ123456C",
+        address_line_1: "82 Evergreen Terrace",
+        address_line_2: "Springfield",
+        address_line_4: "Oregon",
+        postcode: "AB12 3CD",
+        email_address: "edna.krabappel@springfield-elementary.edu",
+        started_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+        submitted_at: DateTime.new(2024, 8, 1, 11, 0, 0),
+        academic_year: AcademicYear.new(2024)
       )
 
       sign_in_as_service_operator

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_spec.rb
@@ -943,20 +943,8 @@ RSpec.feature "Provider verifying claims" do
       ukprn: fe_provider.ukprn
     )
 
-    claim = create(
-      :claim,
-      first_name: "Edna",
-      surname: "Krabappel",
-      date_of_birth: Date.new(1945, 7, 3),
-      reference: "AB123456",
-      created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
-      onelogin_idv_at: DateTime.new(2024, 8, 1, 9, 0, 0),
-      identity_confirmed_with_onelogin: false
-    )
-
-    create(
+    eligibility = create(
       :further_education_payments_eligibility,
-      claim: claim,
       school: fe_provider,
       teaching_hours_per_week: "between_2_5_and_12",
       contract_type: "fixed_term",
@@ -967,6 +955,19 @@ RSpec.feature "Provider verifying claims" do
         "level2_3_apprenticeship"
       ],
       teacher_reference_number: "1234567"
+    )
+
+    claim = create(
+      :claim,
+      :further_education,
+      eligibility:,
+      first_name: "Edna",
+      surname: "Krabappel",
+      date_of_birth: Date.new(1945, 7, 3),
+      reference: "AB123456",
+      created_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+      onelogin_idv_at: DateTime.new(2024, 8, 1, 9, 0, 0),
+      identity_confirmed_with_onelogin: false
     )
 
     mock_dfe_sign_in_auth_session(

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       it "returns the expected claims" do
         claim_awaiting_provider_verification_1 = build(
           :claim,
-          :submitted
+          :submitted,
+          :further_education
         )
 
         create(
@@ -39,7 +40,8 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
 
         claim_awaiting_provider_verification_2 = build(
           :claim,
-          :submitted
+          :submitted,
+          :further_education
         )
 
         create(

--- a/spec/forms/journeys/early_years_payment/practitioner/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/practitioner/claim_submission_form_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Journeys::EarlyYearsPayment::Practitioner::ClaimSubmissionForm do
     it "saves some answers into the Claim model" do
       subject.save
 
+      expect(claim.policy).to eql(Policies::EarlyYearsPayments)
       expect(claim.submitted_at).to be_present
       expect(claim.eligibility_type).to eq "Policies::EarlyYearsPayments::Eligibility"
       expect(claim.first_name).to eq answers.first_name

--- a/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/early_years_payment/provider/authenticated/claim_submission_form_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Journeys::EarlyYearsPayment::Provider::Authenticated::ClaimSubmis
 
     it "saves some answers into the Claim model" do
       subject
+
+      expect(claim.policy).to eql(Policies::EarlyYearsPayments)
       expect(claim.email_address).to be nil
       expect(claim.submitted_at).to be_nil
       expect(claim.eligibility_type).to eq "Policies::EarlyYearsPayments::Eligibility"

--- a/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/claim_submission_form_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Journeys::FurtherEducationPayments::ClaimSubmissionForm do
       claim = form.claim
       eligibility = form.claim.eligibility
 
+      expect(claim.policy).to eql(Policies::FurtherEducationPayments)
+
       expect(claim.identity_confirmed_with_onelogin).to eq(answers.identity_confirmed_with_onelogin)
       expect(claim.logged_in_with_onelogin).to eq(answers.logged_in_with_onelogin)
       expect(claim.onelogin_credentials).to eq(answers.onelogin_credentials)

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/claim_submission_form_spec.rb
@@ -81,10 +81,10 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::ClaimSubmissionForm do
         expect(claim.public_send(attribute)).to eq(value)
       end
 
+      expect(claim.policy).to eql(Policies::InternationalRelocationPayments)
+
       expect(claim.submitted_at).to be_present
-
       expect(claim.reference).to be_present
-
       expect(claim.started_at).to eq(journey_session.created_at)
 
       eligibility_answers.each do |attribute, value|

--- a/spec/forms/journeys/teacher_student_loan_reimbursement/claim_submission_form_spec.rb
+++ b/spec/forms/journeys/teacher_student_loan_reimbursement/claim_submission_form_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe Journeys::TeacherStudentLoanReimbursement::ClaimSubmissionForm do
       expect(claim.reference).to match(/([A-HJ-NP-Z]|\d){8}/)
       expect(claim.submitted_at).to eq DateTime.new(2024, 3, 1, 9, 0, 0)
 
+      expect(claim.policy).to eql(Policies::StudentLoans)
       expect(claim.eligibility_type).to(
         eq("Policies::StudentLoans::Eligibility")
       )

--- a/spec/models/automated_checks/claim_verifiers/alternative_identity_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/alternative_identity_verification_spec.rb
@@ -4,10 +4,16 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification 
   describe "#perform" do
     context "when the claimant's identity has not been verified" do
       it "doesn't create a task" do
-        claim = create(
+        eligibility = create(
           :further_education_payments_eligibility,
           claimant_identity_verified_at: nil
-        ).claim
+        )
+
+        claim = create(
+          :claim,
+          :further_education,
+          eligibility:
+        )
 
         expect { described_class.new(claim: claim).perform }.not_to(
           change { claim.tasks.count }
@@ -18,10 +24,16 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::AlternativeIdentityVerification 
     context "when the claimant's identity has been verified" do
       context "when the task has already been performed" do
         it "doesn't create a new task" do
-          claim = create(
+          eligibility = create(
             :further_education_payments_eligibility,
             claimant_identity_verified_at: DateTime.now
-          ).claim
+          )
+
+          claim = create(
+            :claim,
+            :further_education,
+            eligibility:
+          )
 
           create(
             :task,

--- a/spec/models/automated_checks/claim_verifiers/provider_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/provider_verification_spec.rb
@@ -18,10 +18,16 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
       let(:verification) { {} }
 
       it "doesn't create a task" do
-        claim = create(
+        eligibility = create(
           :further_education_payments_eligibility,
           verification: verification
-        ).claim
+        )
+
+        claim = create(
+          :claim,
+          :further_education,
+          eligibility:
+        )
 
         expect { described_class.new(claim: claim).perform }.not_to(
           change { claim.tasks.count }
@@ -32,10 +38,16 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
     context "when the claim has been verified by the provider" do
       context "when the task has already been performed" do
         it "does not alter the task or create a new one" do
+          eligibility = create(
+            :further_education_payments_eligibility
+          )
+
           claim = create(
-            :further_education_payments_eligibility,
-            :verified
-          ).claim
+            :claim,
+            :further_education,
+            :verified,
+            eligibility:
+          )
 
           task = create(
             :task,
@@ -55,7 +67,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
       context "when the task has not been performed" do
         context "when the provider has not confirmed the claimants answers" do
           it "fails the task" do
-            claim = create(
+            eligibility = create(
               :further_education_payments_eligibility,
               verification: {
                 assertions: [
@@ -71,7 +83,13 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
                 },
                 created_at: Time.zone.now
               }
-            ).claim
+            )
+
+            claim = create(
+              :claim,
+              :further_education,
+              eligibility:
+            )
 
             expect { described_class.new(claim: claim).perform }.to(
               change { claim.tasks.count }.from(0).to(1).and(
@@ -104,7 +122,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
 
         context "when the provider has confirmed the claimants answers" do
           it "passes the task" do
-            claim = create(
+            eligibility = create(
               :further_education_payments_eligibility,
               verification: {
                 assertions: [
@@ -120,7 +138,13 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
                 },
                 created_at: Time.zone.now
               }
-            ).claim
+            )
+
+            claim = create(
+              :claim,
+              :further_education,
+              eligibility:
+            )
 
             expect { described_class.new(claim: claim).perform }.to(
               change { claim.tasks.count }.from(0).to(1).and(
@@ -158,7 +182,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
               dfe_sign_in_id: "123"
             )
 
-            claim = create(
+            eligibility = create(
               :further_education_payments_eligibility,
               verification: {
                 assertions: [
@@ -174,7 +198,13 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::ProviderVerification do
                 },
                 created_at: Time.zone.now
               }
-            ).claim
+            )
+
+            claim = create(
+              :claim,
+              :further_education,
+              eligibility:
+            )
 
             expect { described_class.new(claim: claim).perform }.to(
               change { claim.tasks.count }.from(0).to(1).and(

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -155,12 +155,26 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "#policy" do
-    it "returns the claim’s policy namespace" do
-      expect(Claim.new(eligibility: Policies::StudentLoans::Eligibility.new).policy).to eq Policies::StudentLoans
+    context "when policy string set" do
+      subject do
+        described_class.new(
+          policy: Policies::StudentLoans.name
+        )
+      end
+
+      it "returns the claim’s policy namespace" do
+        expect(subject.policy).to eq Policies::StudentLoans
+      end
     end
 
-    it "returns nil if no eligibility is set" do
-      expect(Claim.new.policy).to be_nil
+    context "when policy string set" do
+      subject do
+        described_class.new
+      end
+
+      it "returns nil if no eligibility is set" do
+        expect(subject.policy).to be_nil
+      end
     end
   end
 

--- a/spec/models/journeys/further_education_payments/provider/authorisation_spec.rb
+++ b/spec/models/journeys/further_education_payments/provider/authorisation_spec.rb
@@ -2,10 +2,8 @@ require "rails_helper"
 
 RSpec.describe Journeys::FurtherEducationPayments::Provider::Authorisation do
   let(:eligibility) { create(:further_education_payments_eligibility) }
-
   let(:organisation) { eligibility.school }
-
-  let(:claim) { eligibility.claim }
+  let(:claim) { create(:claim, :further_education, eligibility:) }
 
   let(:journey_session) do
     create(

--- a/spec/models/policies/active_record_type_spec.rb
+++ b/spec/models/policies/active_record_type_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Policies::ActiveRecordType do
+  describe "#type" do
+    it "returns :policy" do
+      expect(subject.type).to eql(:policy)
+    end
+  end
+
+  describe "#cast" do
+    context "when string of policy" do
+      it "returns constant" do
+        expect(subject.cast("Policies::FurtherEducationPayments")).to eql(Policies::FurtherEducationPayments)
+      end
+    end
+
+    context "when string that is not a policy" do
+      it "returns constant" do
+        expect(subject.cast("Foo")).to be_nil
+      end
+    end
+
+    context "when a policy" do
+      it "returns constant" do
+        expect(subject.cast(Policies::FurtherEducationPayments)).to eql(Policies::FurtherEducationPayments)
+      end
+    end
+
+    context "when a random constant" do
+      it "returns constant" do
+        expect(subject.cast(Object)).to be_nil
+      end
+    end
+  end
+
+  describe "#serialize" do
+    it "converts constant to string" do
+      expect(subject.serialize(Policies::FurtherEducationPayments)).to eql("Policies::FurtherEducationPayments")
+    end
+
+    it "converts string to string" do
+      expect(subject.serialize("Policies::FurtherEducationPayments")).to eql("Policies::FurtherEducationPayments")
+    end
+
+    it "converts nil to nil" do
+      expect(subject.serialize(nil)).to be_nil
+    end
+  end
+
+  describe "#deserialize" do
+    it "converts string to Policy" do
+      expect(subject.deserialize("Policies::FurtherEducationPayments")).to eql(Policies::FurtherEducationPayments)
+    end
+
+    it "converts to nil when nil" do
+      expect(subject.deserialize(nil)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
# Context

- Pre-requisite for https://dfedigital.atlassian.net/browse/CAPT-2177
- this change is required as concept of eligibilities are to be removed
- as policy is inferred from eligibility
- this moves policy directly onto claim as I feel we will want this as first class citizen on the claim itself