### PR TITLE
CAPT 2476/employment task changes

### DIFF
--- a/app/models/admin/presenter_methods.rb
+++ b/app/models/admin/presenter_methods.rb
@@ -3,11 +3,14 @@ module Admin
     include ActionView::Helpers::UrlHelper
     include ActionView::Helpers::TranslationHelper
 
-    def display_school(school)
-      html = [
-        link_to_school(school),
-        tag.span("(#{school.dfe_number})", class: "govuk-body-s")
-      ].join(" ").html_safe
+    def display_school(school, include_dfe_number: true)
+      tags = [link_to_school(school)]
+
+      if include_dfe_number
+        tags << tag.span("(#{school.dfe_number})", class: "govuk-body-s")
+      end
+
+      html = tags.join(" ").html_safe
       ActionController::Base.helpers.sanitize(html, tags: %w[span a], attributes: %w[href class])
     end
 

--- a/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/international_relocation_payments/admin_tasks_presenter.rb
@@ -18,7 +18,10 @@ module Policies
 
       def employment
         [
-          [translate("admin.current_school"), display_school(eligibility.current_school)]
+          ["Workplace", display_school(eligibility.current_school, include_dfe_number: false)],
+          ["Employment contract of at least one year", eligibility.one_year? ? "Yes" : "No"],
+          ["Employment start date", eligibility.start_date&.to_fs(:govuk_date)],
+          ["Subject employed to teach", eligibility.subject.humanize]
         ]
       end
 

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -20,9 +20,9 @@ module Policies
         tasks << "arrival_date"
         tasks << "previous_residency"
         tasks << "employment"
-        tasks << "employment_contract"
-        tasks << "employment_start"
-        tasks << "subject"
+        tasks << "employment_contract" if claim.tasks.exists?(name: "employment_contract")
+        tasks << "employment_start" if claim.tasks.exists?(name: "employment_start")
+        tasks << "subject" if claim.tasks.exists?(name: "subject")
         tasks << "teaching_hours"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "matching_details" if matching_claims.exists?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -757,7 +757,7 @@ en:
         arrival_date:
           title: Has the claimant arrived in the UK within 3 months of contract start date?
         employment:
-          title: "Does the claimant’s current school match the above information from their claim?"
+          title: "Have you confirmed with the claimant’s current employer that the details in their application are correct?"
         employment_contract:
           title: "Does the claimant’s employment contract match the above information from their claim?"
         employment_start:

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -159,7 +159,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["Previous payment", "Identity confirmation", "Visa", "Arrival date", "Previous residency", "Employment", "Employment contract", "Employment start", "Subject", "Teaching hours", "Decision"]
+      ["Previous payment", "Identity confirmation", "Visa", "Arrival date", "Previous residency", "Employment", "Teaching hours", "Decision"]
     when Policies::FurtherEducationPayments
       ["Identity confirmation", "Provider verification", "Student loan plan", "Decision"]
     when Policies::EarlyYearsPayments


### PR DESCRIPTION
Updates to employment task

New designs consolidate the separate employment tasks into a single
task. In order to preserve the tasks completed on previous years claims
we add the other employment tasks to the tasks array only if they are
persisted. The employment task on old claims will now show some extra
information it's not worth the complexity to avoid this.

We likely want to rethink the task model.
Currently tasks are only persisted when they are completed ("passed",
"failed"), switching to an approach where when the claim is submitted we
persist the list of tasks that need completing would allow us to change
the tasks list on future claims without effecting the task list of
claims in previous years.

