### PR TITLE
Scale down production instances

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -4,8 +4,8 @@
     "config": "production",
     "environment": "production",
     "canonical_hostname": "www.claim-additional-teaching-payment.service.gov.uk",
-    "web_replicas": 4,
-    "worker_replicas": 4,
+    "web_replicas": 2,
+    "worker_replicas": 2,
     "startup_command":
     [
         "/bin/sh",


### PR DESCRIPTION
Now that the claim windows have closed, we can scale down to reduce running costs.