### PR TITLE
Increase worker and web pod memory

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -44,7 +44,9 @@ module "web_application" {
   docker_image = var.docker_image
   command      = var.startup_command
 
-  replicas = var.web_replicas
+  replicas   = var.web_replicas
+  max_memory = var.web_memory
+
 
   enable_logit = var.enable_logit
 }
@@ -66,7 +68,8 @@ module "worker_application" {
   docker_image = var.docker_image
   command      = var.worker_command
 
-  replicas = var.worker_replicas
+  replicas   = var.worker_replicas
+  max_memory = var.worker_memory
 
   enable_logit = var.enable_logit
   enable_gcp_wif = true

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -6,6 +6,8 @@
     "canonical_hostname": "www.claim-additional-teaching-payment.service.gov.uk",
     "web_replicas": 2,
     "worker_replicas": 2,
+    "web_memory": "2Gi",
+    "worker_memory": "2Gi",
     "startup_command":
     [
         "/bin/sh",

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -72,6 +72,14 @@ variable "worker_replicas" {
   description = "Number of replicas of the worker"
   default     = 1
 }
+variable "web_memory" {
+  description = "Max memory for web pods"
+  default     = "1Gi"
+}
+variable "worker_memory" {
+  description = "Max memory for worker podsr"
+  default     = "1Gi"
+}
 variable "azure_maintenance_window" {
   default = null
 }


### PR DESCRIPTION
Increase worker and web pod memory for production.

From 1Gi to 2Gi

Review using make production terraform-plan, although already manually applied to production

