### PR TITLE
Remove callback

### DIFF
--- a/app/controllers/claims_form_callbacks.rb
+++ b/app/controllers/claims_form_callbacks.rb
@@ -1,15 +1,5 @@
 module ClaimsFormCallbacks
-  def teaching_subject_now_before_show
-    redirect_to_slug("eligible-itt-subject") if no_eligible_itt_subject?
-  end
-
   def check_your_answers_after_form_save_success
     create_and_save_claim_form
-  end
-
-  private
-
-  def no_eligible_itt_subject?
-    !journey_session.answers.eligible_itt_subject
   end
 end


### PR DESCRIPTION
This callback is no longer required now we're using the navigator.
`spec/features/targeted_retention_incentives/changing_answers_spec.rb:242`
already covers this logic, so no need for a new spec.
