### PR TITLE
Remove redirect to first slug

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -14,7 +14,6 @@ module FormSubmittable
   #
   # Default behaviour summary for each action:
   #
-  #   controller#new: `redirect_to_first_slug`
   #   controller#show: `before_show` -> `render_template_for_current_slug`
   #   controller#update: `before_update` -> `handle_form_submission` ->
   #     -> `form#save` succeded? ->
@@ -47,7 +46,7 @@ module FormSubmittable
     around_action :handle_form_submission, only: [:update, :create]
 
     def new
-      redirect_to_first_slug
+      redirect_to_next_slug
     end
 
     def show
@@ -98,10 +97,6 @@ module FormSubmittable
       redirect_to_slug(next_slug)
     end
 
-    def redirect_to_first_slug
-      redirect_to_slug(first_slug)
-    end
-
     def path_helper_resource
       controller_name.singularize
     end
@@ -112,10 +107,6 @@ module FormSubmittable
 
     def current_template
       current_slug.underscore
-    end
-
-    def first_slug
-      slug_sequence.slugs.first.to_sym
     end
 
     def execute_callback_if_exists(callback_name)
@@ -152,11 +143,7 @@ module FormSubmittable
     end
 
     def no_form_fallback
-      if action_name == "create"
-        redirect_to_first_slug
-      elsif action_name == "update"
-        redirect_to_next_slug
-      end
+      redirect_to_next_slug
     end
 
     def log_event(callback_name)

--- a/app/models/policies/early_years_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/early_years_payments/policy_eligibility_checker.rb
@@ -20,7 +20,7 @@ module Policies
       def start_ineligibility_reason
         return nil unless answers.is_a?(Journeys::EarlyYearsPayment::Provider::Start::SessionAnswers)
 
-        if !EligibleEyProvider.eligible_email?(answers.email_address)
+        if answers.email_address && !EligibleEyProvider.eligible_email?(answers.email_address)
           :email_not_on_whitelist
         end
       end

--- a/spec/requests/form_submittable_spec.rb
+++ b/spec/requests/form_submittable_spec.rb
@@ -83,13 +83,6 @@ RSpec.describe FormSubmittable, type: :request do
     end
   end
 
-  describe "GET #new" do
-    it "redirects to the first slug" do
-      get "/targeted-retention-incentive-payments/claim"
-      expect(response).to redirect_to("/targeted-retention-incentive-payments/first-slug")
-    end
-  end
-
   describe "GET #show" do
     context "when the `{current_slug}_before_show` filter is defined" do
       include_context :define_filter, :first_slug_before_show


### PR DESCRIPTION
We want to keep all navigation logic in the navigator rather than
referencing the slug sequence directly in the controller.

To support this we need to update the EY policy eligibility checker to
handle the email not yet being provided.

Have deleted the form submissable test, fixing the test would require
implementing a journey and using the real navigator (test's `next_slug`
just pulls the next slug from the array).
