### PR TITLE
Remove ineligible check from slug sequence

### DIFF
--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -169,14 +169,6 @@ module Journeys
         )
       end
 
-      def ineligible?
-        eligibility_checker.ineligible?
-      end
-
-      def eligibility_checker
-        @eligibility_checker ||= Policies::StudentLoans::PolicyEligibilityChecker.new(answers: answers)
-      end
-
       def signed_in_with_dfe_identity_and_details_match?
         !!answers.dqt_teacher_status
       end


### PR DESCRIPTION
This is no longer required as navigator handles ineligible slugs

