### PR TITLE
Remove arrival_date and previous_residency tasks

### DIFF
--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -18,8 +18,8 @@ module Policies
         tasks << "previous_payment" if claim.tasks.previous_payment.exists?
         tasks << "identity_confirmation"
         tasks << "visa"
-        tasks << "arrival_date"
-        tasks << "previous_residency"
+        tasks << "arrival_date" if claim.tasks.arrival_date.exists?
+        tasks << "previous_residency" if claim.tasks.previous_residency.exists?
         tasks << "employment"
         tasks << "employment_contract" if claim.tasks.exists?(name: "employment_contract")
         tasks << "employment_start" if claim.tasks.exists?(name: "employment_start")

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -159,7 +159,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["First year payment", "Identity confirmation", "Visa", "Arrival date", "Previous residency", "Employment", "Teaching hours", "Continuous employment", "Decision"]
+      ["First year payment", "Identity confirmation", "Visa", "Employment", "Teaching hours", "Continuous employment", "Decision"]
     when Policies::FurtherEducationPayments
       ["Identity confirmation", "Provider verification", "Student loan plan", "Decision"]
     when Policies::EarlyYearsPayments


### PR DESCRIPTION
On new IRP claims we don't want to include these tasks, on old IRP
claims we want to include them. Tasks are persisted when they have been
completed so we check that to determine if we should show the task or
not.
