### PR TITLE
CAPT 2619/previously received irp payment

### DIFF
--- a/app/forms/journeys/get_a_teacher_relocation_payment/previous_payment_received_form.rb
+++ b/app/forms/journeys/get_a_teacher_relocation_payment/previous_payment_received_form.rb
@@ -1,0 +1,36 @@
+module Journeys
+  module GetATeacherRelocationPayment
+    class PreviousPaymentReceivedForm < Form
+      attribute :previous_payment_received, :boolean
+
+      validates :previous_payment_received,
+        inclusion: {
+          in: ->(form) { form.radio_options.map(&:id) },
+          message: i18n_error_message(:inclusion)
+        }
+
+      def radio_options
+        [
+          Option.new(
+            id: true,
+            name: "Yes"
+          ),
+          Option.new(
+            id: false,
+            name: "No"
+          )
+        ]
+      end
+
+      def save
+        return false unless valid?
+
+        journey_session.answers.assign_attributes(
+          previous_payment_received: previous_payment_received
+        )
+
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/get_a_teacher_relocation_payment.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment.rb
@@ -9,6 +9,7 @@ module Journeys
     POLICIES = [Policies::InternationalRelocationPayments]
     FORMS = {
       "claims" => {
+        "previous-payment-received" => PreviousPaymentReceivedForm,
         "application-route" => ApplicationRouteForm,
         "state-funded-secondary-school" => StateFundedSecondarySchoolForm,
         "contract-details" => ContractDetailsForm,

--- a/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/answers_presenter.rb
@@ -5,6 +5,7 @@ module Journeys
 
       def eligibility_answers
         [].tap do |a|
+          a << previous_payment_received
           a << application_route
           a << state_funded_secondary_school
           a << current_school
@@ -30,6 +31,14 @@ module Journeys
 
       def show_trn?
         false
+      end
+
+      def previous_payment_received
+        [
+          t("get_a_teacher_relocation_payment.forms.previous_payment_received.question"),
+          t("get_a_teacher_relocation_payment.forms.previous_payment_received.answers.#{answers.previous_payment_received}.answer"),
+          "previous-payment-received"
+        ]
       end
 
       def application_route

--- a/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/session_answers.rb
@@ -1,6 +1,7 @@
 module Journeys
   module GetATeacherRelocationPayment
     class SessionAnswers < Journeys::SessionAnswers
+      attribute :previous_payment_received, :boolean, pii: false
       attribute :application_route, :string, pii: false
       attribute :state_funded_secondary_school, :boolean, pii: false
       attribute :one_year, :boolean, pii: false

--- a/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
+++ b/app/models/journeys/get_a_teacher_relocation_payment/slug_sequence.rb
@@ -2,6 +2,7 @@ module Journeys
   module GetATeacherRelocationPayment
     class SlugSequence
       SLUGS = [
+        "previous-payment-received",
         "application-route",
         "state-funded-secondary-school",
         "current-school",
@@ -66,6 +67,7 @@ module Journeys
 
       def eligibility_slugs
         [].tap do |slugs|
+          slugs << "previous-payment-received"
           slugs << "application-route"
           slugs << "state-funded-secondary-school"
           slugs << "current-school"

--- a/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/international_relocation_payments/policy_eligibility_checker.rb
@@ -28,6 +28,8 @@ module Policies
 
       def ineligible_reason
         case answers.attributes.symbolize_keys
+        in previous_payment_received: false
+          "previous payment not received"
         in application_route: "salaried_trainee"
           "application route salaried trainee not accecpted"
         in application_route: "other"

--- a/app/views/get_a_teacher_relocation_payment/claims/ineligible.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/ineligible.html.erb
@@ -1,8 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      We’re sorry, but you are not currently eligible
-      for the international relocation payment
+      You are not currently eligible for the international relocation payment.
     </h1>
   </div>
 </div>

--- a/app/views/get_a_teacher_relocation_payment/claims/previous_payment_received.html.erb
+++ b/app/views/get_a_teacher_relocation_payment/claims/previous_payment_received.html.erb
@@ -1,0 +1,36 @@
+<% content_for(
+  :page_title,
+  page_title(
+    @form.t("question"),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(
+      @form,
+      url: @form.url,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :previous_payment_received,
+        f.object.radio_options,
+        :id,
+        :name,
+        legend: {
+          text: f.object.t("question"),
+          size: "l",
+          tag: "h1"
+        },
+        inline: true,
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -630,6 +630,15 @@ en:
     claim_subject: "International relocation payment"
     support_email_address: "international.RELOCATIONPAYMENT@education.gov.uk"
     forms:
+      previous_payment_received:
+        question: "Have you previously received an international relocation payment?"
+        answers:
+          true:
+            answer: "Yes"
+          false:
+            answer: "No"
+        errors:
+          inclusion: "Select Yes if you have previously received an international relocation payment"
       application_route:
         question: "What is your employment status?"
         hint: "Select one of the following options"

--- a/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
+++ b/spec/factories/journeys/get_a_teacher_relocation_payment/get_a_teacher_relocation_payment_answers.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
       national_insurance_number { generate(:national_insurance_number) }
     end
 
+    trait :with_previous_payment_received do
+      previous_payment_received { true }
+    end
+
     trait :with_teacher_application_route do
       application_route { "teacher" }
     end

--- a/spec/features/get_a_teacher_relocation_payment/admin_employment_history_task_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/admin_employment_history_task_spec.rb
@@ -281,6 +281,7 @@ RSpec.describe "Admin employment history task" do
     entry_date = contract_start_date - 1.week
 
     when_i_start_the_form
+    and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
     and_i_complete_application_route_question_with(
       option: "I am employed as a teacher in a school in England"
     )

--- a/spec/features/get_a_teacher_relocation_payment/admin_first_year_payment_task_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/admin_first_year_payment_task_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "Admin first year payment task" do
     entry_date = contract_start_date - 1.week
 
     when_i_start_the_form
+    and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
     and_i_complete_application_route_question_with(
       option: "I am employed as a teacher in a school in England"
     )

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "ineligible route: completing the form" do
 
   def then_i_see_the_ineligible_page
     expect(page).to have_content(
-      "We’re sorry, but you are not currently eligible for the international relocation payment"
+      "You are not currently eligible for the international relocation payment."
     )
   end
 end

--- a/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/ineligible_route_completing_the_form_spec.rb
@@ -17,10 +17,19 @@ RSpec.describe "ineligible route: completing the form" do
   end
 
   describe "navigating forward" do
+    context "ineligible - previous irp payment" do
+      it "shows the ineligible page" do
+        when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "No")
+        then_i_see_the_ineligible_page
+      end
+    end
+
     context "ineligible - application route" do
       context "when choosing other" do
         it "shows the ineligible page" do
           when_i_start_the_form
+          and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
           and_i_complete_application_route_question_with(option: "Other")
           then_i_see_the_ineligible_page
         end
@@ -29,6 +38,7 @@ RSpec.describe "ineligible route: completing the form" do
       context "when choosing trainee" do
         it "shows the ineligible page" do
           when_i_start_the_form
+          and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
           and_i_complete_application_route_question_with(
             option: "I am enrolled on a salaried teacher training course in England"
           )
@@ -40,6 +50,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - non state funded school" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )
@@ -51,6 +62,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - school-choice" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )
@@ -63,6 +75,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - contract details" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )
@@ -77,6 +90,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - contract start date" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )
@@ -95,6 +109,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - subject" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )
@@ -113,6 +128,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - visa" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )
@@ -134,6 +150,7 @@ RSpec.describe "ineligible route: completing the form" do
     context "ineligible - entry date" do
       it "shows the ineligible page" do
         when_i_start_the_form
+        and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
         and_i_complete_application_route_question_with(
           option: "I am employed as a teacher in a school in England"
         )

--- a/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/teacher_route_completing_the_form_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "teacher route: completing the form" do
   describe "navigating forward", flaky: true do
     before do
       when_i_start_the_form
+      and_i_complete_the_previous_irp_payment_question_with(option: "Yes")
       and_i_complete_application_route_question_with(
         option: "I am employed as a teacher in a school in England"
       )
@@ -110,6 +111,10 @@ RSpec.describe "teacher route: completing the form" do
 
   def then_the_check_your_answers_part_one_page_shows_my_answers
     assert_on_check_your_answers_part_one_page!
+
+    expect(page).to have_text(
+      /Have you previously received an international relocation payment\?\s?Yes/
+    )
 
     expect(page).to have_text(
       /What is your employment status\?\s?I am employed as a teacher in a school in England/

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Switching policies" do
       click_on "Continue"
 
       expect(page.title).to include(
-        "What is your employment status? — Get a teacher relocation payment"
+        "Have you previously received an international relocation payment? — Get a teacher relocation payment"
       )
     end
 

--- a/spec/forms/journeys/get_a_teacher_relocation_payment/previous_payment_received_form_spec.rb
+++ b/spec/forms/journeys/get_a_teacher_relocation_payment/previous_payment_received_form_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Journeys::GetATeacherRelocationPayment::PreviousPaymentReceivedForm, type: :model do
+  let(:journey_session) { create(:get_a_teacher_relocation_payment_session) }
+
+  let(:params) do
+    ActionController::Parameters.new(claim: {previous_payment_received: option})
+  end
+
+  let(:form) do
+    described_class.new(
+      journey_session: journey_session,
+      journey: Journeys::GetATeacherRelocationPayment,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    subject { form }
+    let(:option) { nil }
+
+    it do
+      is_expected.not_to(
+        allow_value(nil).for(:previous_payment_received).with_message(
+          "Select Yes if you have previously received an international " \
+          "relocation payment"
+        )
+      )
+    end
+  end
+
+  describe "#save" do
+    let(:option) { "Yes" }
+
+    it "updates the journey session" do
+      expect { expect(form.save).to be(true) }.to(
+        change {
+          journey_session.reload.answers.previous_payment_received
+        }.to(true)
+      )
+    end
+  end
+end

--- a/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/answers_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
     let(:answers) do
       build(
         :get_a_teacher_relocation_payment_answers,
+        :with_previous_payment_received,
         :with_teacher_application_route,
         :with_state_funded_secondary_school,
         :with_current_school,
@@ -30,6 +31,11 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::AnswersPresenter do
 
     it do
       is_expected.to include(
+        [
+          "Have you previously received an international relocation payment?",
+          "Yes",
+          "previous-payment-received"
+        ],
         [
           "What is your employment status?",
           "I am employed as a teacher in a school in England",

--- a/spec/models/journeys/get_a_teacher_relocation_payment/slug_sequence_spec.rb
+++ b/spec/models/journeys/get_a_teacher_relocation_payment/slug_sequence_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Journeys::GetATeacherRelocationPayment::SlugSequence do
       context "with default settings" do
         it do
           is_expected.to match_array %w[
+            previous-payment-received
             application-route
             state-funded-secondary-school
             current-school

--- a/spec/models/policies/international_relocation_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/international_relocation_payments/policy_eligibility_checker_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Policies::InternationalRelocationPayments::PolicyEligibilityCheck
   describe "#ineligible?" do
     subject { checker.ineligible? }
 
+    context "when the previous IRP payment question is answered 'no'" do
+      let(:attributes) do
+        {
+          previous_payment_received: false
+        }
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
     context "when the application route is 'other'" do
       let(:attributes) do
         {

--- a/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
+++ b/spec/support/get_a_teacher_relocation_payment/step_helpers.rb
@@ -12,6 +12,16 @@ module GetATeacherRelocationPayment
       click_button("Confirm and send")
     end
 
+    def and_i_complete_the_previous_irp_payment_question_with(option:)
+      expect(page).to have_text(
+        "Have you previously received an international relocation payment?"
+      )
+
+      choose(option)
+
+      click_button("Continue")
+    end
+
     def and_i_complete_application_route_question_with(option:)
       choose(option)
 


### PR DESCRIPTION
Add new first page to IRP

Requirement is for a new first page in the IRP journey asking if the
claimant has already received an IRP payment, if they haven't they're
not eligible for this year's payment.

