### PR TITLE
Rename task

### DIFF
--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -14,7 +14,7 @@ module Policies
       def applicable_task_names
         tasks = []
 
-        tasks << "first_year_payment" unless claim.tasks.previous_payment.exists?
+        tasks << "first_year_application" unless claim.tasks.previous_payment.exists?
         tasks << "previous_payment" if claim.tasks.previous_payment.exists?
         tasks << "identity_confirmation"
         tasks << "visa"

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -31,7 +31,7 @@ class Task < ApplicationRecord
     payroll_details
     matching_details
     payroll_gender
-    first_year_payment
+    first_year_application
     continuous_employment
   ].freeze
 

--- a/app/views/admin/tasks/first_year_application.html.erb
+++ b/app/views/admin/tasks/first_year_application.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "First year payment" } %>
+<% content_for(:page_title) { @form.task.name.humanize } %>
 
 <% content_for :back_link do %>
   <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
@@ -14,7 +14,7 @@
   <%= render(
     claim_summary_view,
     claim: @claim,
-    heading: "First year payment"
+    heading: @form.task.name.humanize
   ) %>
 
   <div class="govuk-grid-column-two-thirds">
@@ -137,7 +137,7 @@
     <% if !@form.task.passed.nil? %>
       <%= render "task_outcome", task: @form.task %>
     <% else %>
-      <%= render "form", task_name: "first_year_payment", claim: @claim %>
+      <%= render "form", task_name: @form.task.name, claim: @claim %>
     <% end %>
 
     <%= render partial: "admin/task_pagination", locals: { task_pagination: @task_pagination } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,8 +218,8 @@ en:
       teaching_hours:
         name: Teaching hours
         title: "Check teaching hours"
-      first_year_payment:
-        name: First year payment
+      first_year_application:
+        name: First year application
         title: "Confirm this user has claimed their first year payment"
       continuous_employment:
         name: Continuous employment
@@ -778,7 +778,7 @@ en:
         identity_confirmation:
           title: Verify claimants’ identity
       task_questions:
-        first_year_payment:
+        first_year_application:
           title: "Did the claimant receive their first payment for the 2024 to 2025 academic year?"
         previous_payment:
           title: The claimant has not received an IRP payment in AY 2023/24?

--- a/spec/features/get_a_teacher_relocation_payment/admin_first_year_payment_task_spec.rb
+++ b/spec/features/get_a_teacher_relocation_payment/admin_first_year_payment_task_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Admin first year payment task" do
       visit admin_claim_tasks_path(second_year_claim)
 
       within ".app-task-list" do
-        expect(page).to have_content("First year payment")
+        expect(page).to have_content("First year application")
       end
 
       click_on "Confirm this user has claimed their first year payment"
@@ -62,7 +62,7 @@ RSpec.describe "Admin first year payment task" do
 
       visit admin_claim_tasks_path(second_year_claim)
 
-      expect(task_status("First year payment")).to eq("Passed")
+      expect(task_status("First year application")).to eq("Passed")
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe "Admin first year payment task" do
       visit admin_claim_tasks_path(claim)
 
       within ".app-task-list" do
-        expect(page).to have_content("First year payment")
+        expect(page).to have_content("First year application")
       end
 
       click_on "Confirm this user has claimed their first year payment"
@@ -97,7 +97,7 @@ RSpec.describe "Admin first year payment task" do
 
       visit admin_claim_tasks_path(claim)
 
-      expect(task_status("First year payment")).to eq("Failed")
+      expect(task_status("First year application")).to eq("Failed")
     end
   end
 

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -159,7 +159,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::EarlyCareerPayments
       ["Identity confirmation", "Qualifications", "Induction confirmation", "Census subjects taught", "Employment", "Student loan plan", "Decision"]
     when Policies::InternationalRelocationPayments
-      ["First year payment", "Identity confirmation", "Visa", "Employment", "Teaching hours", "Continuous employment", "Decision"]
+      ["First year application", "Identity confirmation", "Visa", "Employment", "Teaching hours", "Continuous employment", "Decision"]
     when Policies::FurtherEducationPayments
       ["Identity confirmation", "Provider verification", "Student loan plan", "Decision"]
     when Policies::EarlyYearsPayments


### PR DESCRIPTION
Renames the first year payment task to first year application.
As there's no claims on production with this task we may as well rename
the task rather than just changing the locales file.
