### PR TITLE
CAPT-2621: Limit Slack notifications to admin users

### DIFF
--- a/app/models/dfe_sign_in/user.rb
+++ b/app/models/dfe_sign_in/user.rb
@@ -8,7 +8,7 @@ module DfeSignIn
 
     has_secure_token :session_token
 
-    after_create :send_slack_notification
+    after_save :send_slack_notification
 
     def self.table_name
       "dfe_sign_in_users"
@@ -71,7 +71,14 @@ module DfeSignIn
     end
 
     def send_slack_notification
-      SlackNotificationJob.perform_later(id) if has_admin_access? && (ENV.fetch("ENVIRONMENT_NAME") == "production")
+      SlackNotificationJob.perform_later(id) if granted_admin_access? && (ENV.fetch("ENVIRONMENT_NAME") == "production")
+    end
+
+    def granted_admin_access?
+      return false unless saved_change_to_role_codes.present?
+
+      new_roles = saved_change_to_role_codes.last - saved_change_to_role_codes.first
+      (new_roles & [SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, SERVICE_ADMIN_DFE_SIGN_IN_ROLE_CODE]).any?
     end
   end
 end

--- a/spec/models/dfe_sign_in/user_spec.rb
+++ b/spec/models/dfe_sign_in/user_spec.rb
@@ -167,15 +167,55 @@ RSpec.describe DfeSignIn::User, type: :model do
         allow(ENV).to receive(:fetch).with("ENVIRONMENT_NAME").and_return("production")
       end
 
-      context "when the user has admin access" do
-        it "sends a notification on record creation" do
-          expect { described_class.create!(role_codes: [described_class::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }.to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+      context "creating a new user" do
+        context "when the user has admin access" do
+          it "sends a notification" do
+            expect { described_class.create!(role_codes: [described_class::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }.to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+          end
+        end
+
+        context "when the user does not have admin access" do
+          it "does not send a notification" do
+            expect { described_class.create!(role_codes: []) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+          end
         end
       end
 
-      context "when the user does not have admin access" do
-        it "sends a notification on record creation" do
-          expect { described_class.create!(role_codes: []) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+      context "updating a user" do
+        context "user previously had admin access" do
+          subject(:existing_user) { create(:dfe_signin_user, :service_operator) }
+
+          context "when the user has admin access" do
+            it "does not send a notification" do
+              existing_user
+              expect { existing_user.update!(role_codes: [described_class::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+            end
+          end
+
+          context "when the user does not have admin access" do
+            it "does not send a notification" do
+              existing_user
+              expect { existing_user.update!(role_codes: []) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+            end
+          end
+        end
+
+        context "user previously did not have admin access" do
+          subject(:existing_user) { create(:dfe_signin_user) }
+
+          context "when the user has admin access" do
+            it "sends a notification" do
+              existing_user
+              expect { existing_user.update!(role_codes: [described_class::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }.to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+            end
+          end
+
+          context "when the user does not have admin access" do
+            it "does not send a notification" do
+              existing_user
+              expect { existing_user.update!(role_codes: []) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+            end
+          end
         end
       end
     end
@@ -188,6 +228,11 @@ RSpec.describe DfeSignIn::User, type: :model do
 
         it "does not send a notification on record creation" do
           expect { described_class.create!(role_codes: [described_class::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
+        end
+
+        it "does not send a notification on record update" do
+          existing_user = create(:dfe_signin_user)
+          expect { existing_user.update!(role_codes: [described_class::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE]) }.not_to have_enqueued_job(DfeSignIn::SlackNotificationJob)
         end
       end
     end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-2621

* Limits Slack notifications to users with admin access
* Also notifies if an existing user who previously did not have admin access is granted admin access