### PR TITLE
provider dashboard skeleton

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -41,7 +41,12 @@ module Admin
     end
 
     def developer_session
-      DfeSignIn::AuthenticatedSession.new(nil, nil, params[:roles])
+      DfeSignIn::AuthenticatedSession.new(
+        user_id: nil,
+        organisation_id: nil,
+        organisation_ukprn: nil,
+        role_codes: params[:roles]
+      )
     end
   end
 end

--- a/app/controllers/further_education_payments/providers/authorisation_failures_controller.rb
+++ b/app/controllers/further_education_payments/providers/authorisation_failures_controller.rb
@@ -1,0 +1,12 @@
+module FurtherEducationPayments
+  module Providers
+    class AuthorisationFailuresController < BaseController
+      skip_before_action :authorize_user!, only: [:show]
+      skip_before_action :authenticate_user!, only: [:show]
+
+      def show
+        @reason = params.fetch(:reason) { raise ActiveRecord::RecordNotFound }
+      end
+    end
+  end
+end

--- a/app/controllers/further_education_payments/providers/base_controller.rb
+++ b/app/controllers/further_education_payments/providers/base_controller.rb
@@ -22,6 +22,16 @@ module FurtherEducationPayments
         end
       end
 
+      def claim_scope
+        eligibilities = Policies::FurtherEducationPayments::Eligibility
+          .joins(:school)
+          .merge(School.where(ukprn: current_user.current_organisation.ukprn))
+
+        Claim
+          .by_policy(Policies::FurtherEducationPayments)
+          .where(eligibility_id: eligibilities.select(:id))
+      end
+
       def current_user
         @current_user ||= DfeSignIn::User
           .not_deleted

--- a/app/controllers/further_education_payments/providers/base_controller.rb
+++ b/app/controllers/further_education_payments/providers/base_controller.rb
@@ -1,0 +1,39 @@
+module FurtherEducationPayments
+  module Providers
+    class BaseController < ApplicationController
+      before_action :authenticate_user!
+      before_action :authorize_user!, if: :current_user
+
+      private
+
+      def authenticate_user!
+        unless current_user
+          redirect_to new_further_education_payments_providers_session_path
+        end
+      end
+
+      def authorize_user!
+        unless current_user.role_codes.include?(
+          Journeys::FurtherEducationPayments::Provider::CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE
+        )
+          redirect_to further_education_payments_providers_authorisation_failure_path(
+            reason: :incorrect_role
+          )
+        end
+      end
+
+      def current_user
+        @current_user ||= DfeSignIn::User
+          .not_deleted
+          .find_by(id: session[:user_id], session_token: session[:token])
+      end
+
+      # FIXME RL: decide if this is the right approach
+      # Required to get application layout to render
+      def current_journey_routing_name
+        "further-education-payments-provider"
+      end
+      helper_method :current_journey_routing_name
+    end
+  end
+end

--- a/app/controllers/further_education_payments/providers/claims_controller.rb
+++ b/app/controllers/further_education_payments/providers/claims_controller.rb
@@ -1,0 +1,9 @@
+module FurtherEducationPayments
+  module Providers
+    class ClaimsController < BaseController
+      def index
+      end
+    end
+  end
+end
+

--- a/app/controllers/further_education_payments/providers/claims_controller.rb
+++ b/app/controllers/further_education_payments/providers/claims_controller.rb
@@ -2,8 +2,8 @@ module FurtherEducationPayments
   module Providers
     class ClaimsController < BaseController
       def index
+        @claims = claim_scope
       end
     end
   end
 end
-

--- a/app/controllers/further_education_payments/providers/sessions_controller.rb
+++ b/app/controllers/further_education_payments/providers/sessions_controller.rb
@@ -9,4 +9,3 @@ module FurtherEducationPayments
     end
   end
 end
-

--- a/app/controllers/further_education_payments/providers/sessions_controller.rb
+++ b/app/controllers/further_education_payments/providers/sessions_controller.rb
@@ -1,0 +1,12 @@
+module FurtherEducationPayments
+  module Providers
+    class SessionsController < BaseController
+      skip_before_action :authorize_user!, only: [:new]
+      skip_before_action :authenticate_user!, only: [:new]
+
+      def new
+      end
+    end
+  end
+end
+

--- a/app/models/dfe_sign_in/user.rb
+++ b/app/models/dfe_sign_in/user.rb
@@ -25,6 +25,7 @@ module DfeSignIn
       return if user.deleted?
 
       user.role_codes = session.role_codes
+      user.current_organisation_ukprn = session.organisation_ukprn
       user
     end
 
@@ -62,6 +63,14 @@ module DfeSignIn
     def mark_as_deleted!
       super
       unassign_claims
+    end
+
+    class Organisation < Struct.new(:ukprn, keyword_init: true); end
+
+    def current_organisation
+      @current_organisation ||= Organisation.new(
+        ukprn: current_organisation_ukprn
+      )
     end
 
     private

--- a/app/views/further_education_payments/providers/authorisation_failures/show.html.erb
+++ b/app/views/further_education_payments/providers/authorisation_failures/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for(:page_title, page_title("Unauthorised")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      You cannot verify this claim
+    </h1>
+
+    <p>FIXME RL - show reason here</p>
+  </div>
+</div>

--- a/app/views/further_education_payments/providers/claims/index.html.erb
+++ b/app/views/further_education_payments/providers/claims/index.html.erb
@@ -1,1 +1,12 @@
 dashboard place holder
+
+<ul>
+<% @claims.each do |claim| %>
+  <li>
+    <%= link_to(
+      "Claim #{claim.reference}",
+      edit_further_education_payments_providers_claim_verification_path(claim)
+    ) %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/further_education_payments/providers/claims/index.html.erb
+++ b/app/views/further_education_payments/providers/claims/index.html.erb
@@ -1,0 +1,1 @@
+dashboard place holder

--- a/app/views/further_education_payments/providers/sessions/_dfe_sign_in_by_pass.html.erb
+++ b/app/views/further_education_payments/providers/sessions/_dfe_sign_in_by_pass.html.erb
@@ -1,0 +1,79 @@
+<h2 class="govuk-heading-m">
+  Set DfE sign in payload details
+</h2>
+
+<p class="govuk-body">
+  In environments where DfE Sign-in is not enabled you can use this form to
+  set payload parameters to test different DfE Sign-in scenarios.
+</p>
+
+<%= form_with(
+  url: "/further-education-payments-provider/auth/callback",
+  method: :get,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
+  <div class="govuk-form-group">
+    <%= f.govuk_text_field(
+      "extra[raw_info][organisation][ukprn]",
+      label: { text: "UKPRN" },
+      value: "12345678"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "extra[raw_info][organisation][id]",
+      label: { text: "Organisation id" },
+      value: "12345678"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "extra[raw_info][organisation][name]",
+      label: { text: "Organisation id" },
+      value: "Springfield Elementary School"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "uid",
+      label: { text: "DfE sign in UID" },
+      value: "12345678"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "info[first_name]",
+      label: { text: "First name" },
+      value: "Seymoure"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "info[last_name]",
+      label: { text: "Last name" },
+      value: "Skinner"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "info[email]",
+      label: { text: "Email" },
+      value: "seymoure.skinner@springfield-elementary.edu"
+    ) %>
+
+    <%= f.govuk_text_field(
+      "roles[0]",
+      label: { text: "Role 1" },
+      value: Journeys::FurtherEducationPayments::Provider::CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE
+    ) %>
+
+    <%= f.govuk_text_field("[roles][1]", label: { text: "Role 2" }) %>
+
+    <%= f.govuk_text_field("[roles][2]", label: { text: "Role 3" }) %>
+
+    <%= f.govuk_check_box(
+      "service_access",
+      true,
+      false,
+      label: { text: "Claim service access"},
+      multiple: false,
+      checked: true
+    ) %>
+  </div>
+
+  <%= f.govuk_submit("Start now")%>
+<% end %>

--- a/app/views/further_education_payments/providers/sessions/new.html.erb
+++ b/app/views/further_education_payments/providers/sessions/new.html.erb
@@ -1,0 +1,28 @@
+<h1 class="govuk-heading-xl">
+  Sign in
+</h1>
+
+<% if DfESignIn.bypass? %>
+  <%= render "dfe_sign_in_by_pass" %>
+<% else %>
+  <%= button_to(
+    "/further-education-payments-provider/auth/dfe_fe_provider",
+    class: "govuk-button govuk-button--start",
+    data: {
+      module: "govuk-button"
+    }
+  ) do %>
+    Start now
+    <svg
+      class="govuk-button__start-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      width="17.5"
+      height="19"
+      viewBox="0 0 33 40"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+    </svg>
+  <% end %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -262,6 +262,7 @@ shared:
     - updated_at
     - role_codes
     - deleted_at
+    - current_organisation_ukprn
   :targeted_retention_incentive_payments_awards:
     - id
     - academic_year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,14 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :further_education_payments do
+    namespace :providers do
+      resources :sessions, only: %i[new]
+      resources :authorisation_failures, only: [:show], param: :reason
+      resources :claims, only: %i[index]
+    end
+  end
+
   # We still want to know about 404s in case of missing a route, but silence a whitelist instead to reduce the noise in Rollbar
   # This is not exhastive, so add more if there are obvious requests to ignore
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,7 +190,9 @@ Rails.application.routes.draw do
     namespace :providers do
       resources :sessions, only: %i[new]
       resources :authorisation_failures, only: [:show], param: :reason
-      resources :claims, only: %i[index]
+      resources :claims, only: %i[index] do
+        resource :verification, only: %i[edit update], module: :claims
+      end
     end
   end
 

--- a/db/migrate/20250627101949_add_current_organisation_ukprn_to_dfe_sign_in_users.rb
+++ b/db/migrate/20250627101949_add_current_organisation_ukprn_to_dfe_sign_in_users.rb
@@ -1,0 +1,5 @@
+class AddCurrentOrganisationUkprnToDfeSignInUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :dfe_sign_in_users, :current_organisation_ukprn, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_23_153207) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_27_101949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -153,6 +153,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_23_153207) do
     t.string "role_codes", default: [], array: true
     t.datetime "deleted_at", precision: nil
     t.string "session_token"
+    t.string "current_organisation_ukprn"
     t.index ["deleted_at"], name: "index_dfe_sign_in_users_on_deleted_at"
     t.index ["dfe_sign_in_id"], name: "index_dfe_sign_in_users_on_dfe_sign_in_id", unique: true
     t.index ["session_token"], name: "index_dfe_sign_in_users_on_session_token", unique: true

--- a/lib/dfe_sign_in/authenticated_session.rb
+++ b/lib/dfe_sign_in/authenticated_session.rb
@@ -1,19 +1,22 @@
 module DfeSignIn
   class AuthenticatedSession
-    attr_reader :user_id, :organisation_id, :role_codes
+    attr_reader :user_id, :organisation_id, :organisation_ukprn, :role_codes
 
-    def initialize(user_id, organisation_id, role_codes)
+    def initialize(user_id:, organisation_id:, organisation_ukprn:, role_codes:)
       @user_id = user_id
       @organisation_id = organisation_id
+      @organisation_ukprn = organisation_ukprn
       @role_codes = role_codes
     end
 
     def self.from_auth_hash(auth_hash)
       user_id = auth_hash["uid"]
-      organisation_id = auth_hash.dig("extra", "raw_info", "organisation", "id")
+      organisation_hash = auth_hash.dig("extra", "raw_info", "organisation")
+      organisation_id = organisation_hash.dig("id")
+      organisation_ukprn = organisation_hash.dig("ukprn")
       role_codes = DfeSignIn::Api::User.new(user_id: user_id, organisation_id: organisation_id).role_codes
 
-      new(user_id, organisation_id, role_codes)
+      new(user_id:, organisation_id:, organisation_ukprn:, role_codes:)
     end
   end
 end

--- a/spec/features/further_education_payments/provider/provider_verifying_claims_in_2024_ay_spec.rb
+++ b/spec/features/further_education_payments/provider/provider_verifying_claims_in_2024_ay_spec.rb
@@ -7,7 +7,11 @@ RSpec.feature "Provider verifying claims" do
       enabled: true
     )
 
-    create(:journey_configuration, :further_education_payments_provider)
+    create(
+      :journey_configuration,
+      :further_education_payments_provider,
+      current_academic_year: AcademicYear.new(2024)
+    )
     # Stub fetching name from DSI, not required for these tests
     stub_request(
       :get,

--- a/spec/models/dfe_sign_in/user_spec.rb
+++ b/spec/models/dfe_sign_in/user_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe DfeSignIn::User, type: :model do
   let(:user) { build(:dfe_signin_user) }
 
   describe ".from_session" do
-    let(:session) { DfeSignIn::AuthenticatedSession.new(123, 456, ["some-role"]) }
+    let(:session) do
+      DfeSignIn::AuthenticatedSession.new(
+        user_id: 123,
+        organisation_id: 456,
+        organisation_ukprn: "10000000",
+        role_codes: ["some-role"]
+      )
+    end
     let(:user) { DfeSignIn::User.from_session(session) }
 
     it "initializes a user when the user does not exist" do


### PR DESCRIPTION
Shared base branch for work on the provider dashboard.

We've modified `DfeSignIn::User` to have a new column `current_organisation_ukprn`.
`current_organisation_ukprn` is set when the user returns to the callback controller from DSI, allowing the user to use DSI to manage switching organisations.
Controllers for in the `FutherEducation::Providers` namespace should inherit from the `BaseController` that handles auth an claim scoping. We have a `claim_scope` method that returns all claims an organisation has access to. We may want to consider adding a guard (À la Pundit) to check any claim instance variables set are included in the `claim_scope`.
There's a few fixmes I'm keeping track of which we'll address in future commits.
There are feature specs for the DSI flow but they're tied to testing the claim verification wizard which we don't want to pull in at the minute.

The feature flag `FeatureFlag.enabled?(:provider_dashboard)` needs to be set for the DSI callback to work with the provider dashboard. We can lose this feature once we delete all the old provider verification specs.
