### PR TITLE
[CAPT-2662] Add provider nav

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -79,5 +79,10 @@ module FormSubmittable
     def load_form_if_exists
       @form ||= journey.form(journey_session:, params:, session:)
     end
+
+    def current_user
+      DfeSignIn::NullUser.new
+    end
+    helper_method :current_user
   end
 end

--- a/app/controllers/further_education_payments/providers/base_controller.rb
+++ b/app/controllers/further_education_payments/providers/base_controller.rb
@@ -7,7 +7,7 @@ module FurtherEducationPayments
       private
 
       def authenticate_user!
-        unless current_user
+        if current_user.null_user?
           redirect_to new_further_education_payments_providers_session_path
         end
       end
@@ -39,8 +39,10 @@ module FurtherEducationPayments
       def current_user
         @current_user ||= DfeSignIn::User
           .not_deleted
-          .find_by(id: session[:user_id], session_token: session[:token])
+          .find_by(id: session[:user_id], session_token: session[:token]) ||
+          DfeSignIn::NullUser.new
       end
+      helper_method :current_user
 
       # FIXME RL: decide if this is the right approach
       # Required to get application layout to render
@@ -48,6 +50,11 @@ module FurtherEducationPayments
         "further-education-payments-provider"
       end
       helper_method :current_journey_routing_name
+
+      def journey
+        Journeys::FurtherEducationPayments::Provider
+      end
+      helper_method :journey
     end
   end
 end

--- a/app/controllers/further_education_payments/providers/sessions_controller.rb
+++ b/app/controllers/further_education_payments/providers/sessions_controller.rb
@@ -6,6 +6,12 @@ module FurtherEducationPayments
 
       def new
       end
+
+      def destroy
+        reset_session
+
+        redirect_to new_further_education_payments_providers_session_path
+      end
     end
   end
 end

--- a/app/controllers/further_education_payments/providers/verified_claims_controller.rb
+++ b/app/controllers/further_education_payments/providers/verified_claims_controller.rb
@@ -1,0 +1,9 @@
+module FurtherEducationPayments
+  module Providers
+    class VerifiedClaimsController < BaseController
+      def index
+        @claims = claim_scope
+      end
+    end
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -25,4 +25,11 @@ class StaticPagesController < BasePublicController
 
     render "#{journey::VIEW_PATH}/landing_page"
   end
+
+  private
+
+  def current_user
+    DfeSignIn::NullUser.new
+  end
+  helper_method :current_user
 end

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -30,8 +30,8 @@ class UnsubscribeController < ApplicationController
   end
   helper_method :current_journey_routing_name
 
-  def current_journey
+  def journey
     Journeys.for_routing_name(params[:journey])
   end
-  helper_method :current_journey
+  helper_method :journey
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 module ApplicationHelper
   def page_title(title, journey: nil, show_error: false)
     [].tap do |a|
@@ -139,5 +141,28 @@ module ApplicationHelper
         href: admin_accessibility_statement_path
       }
     ]
+  end
+
+  def provider_nav_items
+    if current_user.null_user?
+      []
+    else
+      [
+        {
+          text: "Unverified claims",
+          href: further_education_payments_providers_claims_path,
+          active_when: further_education_payments_providers_claims_path
+        },
+        {
+          text: "Verified claims",
+          href: further_education_payments_providers_verified_claims_path,
+          active_when: further_education_payments_providers_verified_claims_path
+        },
+        {
+          text: "Sign out",
+          href: further_education_payments_providers_session_path
+        }
+      ]
+    end
   end
 end

--- a/app/views/further_education_payments/provider/_header.html.erb
+++ b/app/views/further_education_payments/provider/_header.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_header(homepage_url: "https://www.gov.uk") %>
+
+<% nav_html = govuk_service_navigation(
+  navigation_items: provider_nav_items,
+  current_path: request.fullpath
+) %>
+
+<%
+  nav_document = Nokogiri::HTML.fragment(nav_html)
+  sign_out_link = nav_document.css("a").last
+  sign_out_link["data-method"] = "delete" if sign_out_link
+%>
+
+<%= nav_document.to_s.html_safe %>

--- a/app/views/further_education_payments/providers/verified_claims/index.html.erb
+++ b/app/views/further_education_payments/providers/verified_claims/index.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-l">
+  Verified claims
+</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,6 +56,8 @@
 
     <% if @journey_session&.answers&.logged_in_with_onelogin? %>
       <%= render "shared/one_login_header" %>
+    <% elsif lookup_context.exists?(Pathname.new(journey::VIEW_PATH).join("_header")) %>
+      <%= render Pathname.new(journey::VIEW_PATH).join("header").to_s %>
     <% else %>
       <%= render "shared/header" %>
     <% end %>

--- a/app/views/unsubscribe/subscription_not_found.html.erb
+++ b/app/views/unsubscribe/subscription_not_found.html.erb
@@ -9,7 +9,7 @@
     </p>
 
     <p class="govuk-body">
-      If you need more help, contact support at <%= govuk_mail_to I18n.t("support_email_address", scope: [current_journey::I18N_NAMESPACE]), I18n.t("support_email_address", scope: [current_journey::I18N_NAMESPACE]) %>
+      If you need more help, contact support at <%= govuk_mail_to I18n.t("support_email_address", scope: [journey::I18N_NAMESPACE]), I18n.t("support_email_address", scope: [journey::I18N_NAMESPACE]) %>
     </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,12 +189,13 @@ Rails.application.routes.draw do
 
   namespace :further_education_payments do
     namespace :providers do
-      resources :sessions, only: %i[new]
+      resource :session, only: %i[new destroy]
       resources :authorisation_failures, only: [:show], param: :reason
       resources :claims, only: %i[index] do
         resource :verification, only: %i[edit update], module: :claims
         resource :information, only: %i[show], module: :claims
       end
+      resources :verified_claims, path: "verified-claims", only: %i[index]
     end
   end
 

--- a/spec/features/further_education_payments/providers/sessions_spec.rb
+++ b/spec/features/further_education_payments/providers/sessions_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Provider session and authentication", feature_flag: :provider_dashboard do
+  before do
+    allow(DfESignIn).to receive(:bypass?).and_return(true)
+  end
+
+  scenario "when authed can visit auth walled areas", js: true do
+    visit "/further_education_payments/providers/session/new"
+    click_button "Start now"
+
+    expect(page).to have_selector("h1", text: "Unverified claims")
+    click_link "Verified claims"
+
+    expect(page).to have_selector("h1", text: "Verified claims")
+    click_link "Sign out"
+
+    expect(page).to have_text "Sign in"
+
+    visit "/further_education_payments/providers/claims"
+    expect(page).to have_text "Sign in"
+
+    visit "/further_education_payments/providers/verified-claims"
+    expect(page).to have_text "Sign in"
+  end
+end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "layouts/application.html.erb" do
 
     without_partial_double_verification do
       allow(view).to receive(:current_journey_routing_name).and_return("further-education-payments")
+      allow(view).to receive(:journey).and_return(Journeys::FurtherEducationPayments)
       allow(view).to receive(:journey_service_name).and_return("some-service")
     end
   end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2662
- Add provider nav
- Switched to us newly introduced `DfeSignIn::NullUser`
- Added sign out capability
- Added new controller for verified claims, we may want to rename other controller to `UnverifiedClaims`