### PR TITLE
Remove admin back links on root pages

### DIFF
--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -1,9 +1,5 @@
 <% content_for(:page_title) { page_title("View claims") } %>
 
-<% content_for :back_link do %>
-  <%= govuk_back_link href: admin_root_path %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -1,9 +1,5 @@
 <% content_for(:page_title) { page_title("Search claims") } %>
 
-<% content_for :back_link do %>
-  <%= govuk_back_link href: admin_root_path %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -1,9 +1,5 @@
 <% content_for(:page_title) { page_title("Download Reports") } %>
 
-<% content_for :back_link do %>
-  <%= govuk_back_link href: admin_claims_path %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">


### PR DESCRIPTION
# Context

- Remove superfluous back links on admin root pages. they don't really make sense since they are linked to a main navigation item