### PR TITLE
CAPT 2637/claim summary screen

### DIFF
--- a/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
+++ b/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
@@ -21,6 +21,10 @@ module FurtherEducationPayments
                   information: :progress_saved
                 )
               )
+            elsif wizard.completed?
+              flash[:success] = "Claim Verified for #{@form.claimant_name}"
+
+              redirect_to further_education_payments_providers_claims_path
             else
               redirect_to(
                 edit_further_education_payments_providers_claim_verification_path(

--- a/app/models/further_education_payments/providers/claims/verification/wizard.rb
+++ b/app/models/further_education_payments/providers/claims/verification/wizard.rb
@@ -63,6 +63,16 @@ module FurtherEducationPayments
             end
           end
 
+          def completable?
+            build_forms(
+              reachable_steps.excluding(CheckAnswersForm)
+            ).none?(&:incomplete?)
+          end
+
+          def completed?
+            reachable_forms.none?(&:incomplete?)
+          end
+
           private
 
           attr_reader :claim, :user, :current_slug

--- a/app/views/further_education_payments/providers/claims/verifications/check_answers.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/check_answers.html.erb
@@ -168,5 +168,40 @@
         <% end %>
       <% end %>
     <% end %>
+
+    <%= form_with(
+      model: @form,
+      url: further_education_payments_providers_claim_verification_path(
+        @form.claim,
+        @form.provider,
+        slug: @form.slug,
+      ),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_check_boxes_fieldset(
+        :provider_verification_declaration,
+        multiple: false,
+        legend: {
+          text: "Declaration",
+          size: "l"
+        }
+      ) do %>
+
+        <%= f.govuk_check_box(
+          :provider_verification_declaration,
+          1,
+          0,
+          multiple: false,
+          link_errors: true,
+          label: {
+            text: "To the best of my knowledge, I confirm that the " \
+                  "information provided in this form is correct."
+          }
+        ) %>
+      <% end %>
+
+      <%= f.govuk_submit("Continue") %>
+    <% end %>
   </div>
 </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -341,6 +341,10 @@ shared:
     - provider_verification_half_teaching_hours
     - provider_verification_subjects_taught
     - provider_verification_contracted_hours_section_completed
+    - provider_verification_declaration
+    - provider_verification_completed_at
+    - provider_verification_verified_by_id
+
   :eligible_ey_providers:
     - id
     - nursery_name

--- a/db/migrate/20250710131813_add_verification_fields_to_fe_eligibility.rb
+++ b/db/migrate/20250710131813_add_verification_fields_to_fe_eligibility.rb
@@ -1,0 +1,25 @@
+class AddVerificationFieldsToFeEligibility < ActiveRecord::Migration[8.0]
+  def change
+    add_column(
+      :further_education_payments_eligibilities,
+      :provider_verification_declaration,
+      :boolean
+    )
+
+    add_column(
+      :further_education_payments_eligibilities,
+      :provider_verification_completed_at,
+      :timestamp
+    )
+
+    add_reference(
+      :further_education_payments_eligibilities,
+      :provider_verification_verified_by,
+      type: :uuid,
+      foreign_key: {
+        to_table: :dfe_sign_in_users
+      },
+      null: true
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_09_125318) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_10_131813) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -326,7 +326,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_09_125318) do
     t.boolean "provider_verification_half_teaching_hours"
     t.boolean "provider_verification_subjects_taught"
     t.boolean "provider_verification_contracted_hours_section_completed"
+    t.boolean "provider_verification_declaration"
+    t.datetime "provider_verification_completed_at", precision: nil
+    t.uuid "provider_verification_verified_by_id"
     t.index ["possible_school_id"], name: "index_fe_payments_eligibilities_on_possible_school_id"
+    t.index ["provider_verification_verified_by_id"], name: "idx_on_provider_verification_verified_by_id_c38aef7b6c"
     t.index ["school_id"], name: "index_fe_payments_eligibilities_on_school_id"
   end
 
@@ -798,6 +802,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_09_125318) do
   add_foreign_key "eligible_ey_providers", "file_uploads"
   add_foreign_key "eligible_ey_providers", "local_authorities"
   add_foreign_key "eligible_fe_providers", "file_uploads"
+  add_foreign_key "further_education_payments_eligibilities", "dfe_sign_in_users", column: "provider_verification_verified_by_id"
   add_foreign_key "further_education_payments_eligibilities", "schools"
   add_foreign_key "further_education_payments_eligibilities", "schools", column: "possible_school_id"
   add_foreign_key "international_relocation_payments_eligibilities", "schools", column: "current_school_id"

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -146,5 +146,24 @@ FactoryBot.define do
       claimant_passport_number { "123456789" }
       claimant_identity_verified_at { Time.zone.now }
     end
+
+    trait :provider_verifiable do
+      provider_verification_teaching_responsibilities { true }
+      provider_verification_in_first_five_years { true }
+      provider_verification_teaching_qualification { "yes" }
+      provider_verification_contract_type { "fixed_term" }
+      provider_verification_contract_covers_full_academic_year { true }
+      provider_verification_taught_at_least_one_academic_term { nil }
+      provider_verification_role_and_experience_section_completed { true }
+      provider_verification_contract_covers_section_completed { true }
+      provider_verification_taught_one_term_section_completed { true }
+      provider_verification_performance_measures { false }
+      provider_verification_disciplinary_action { false }
+      provider_verification_performance_section_completed { true }
+      provider_verification_teaching_hours_per_week { "more_than_12" }
+      provider_verification_half_teaching_hours { true }
+      provider_verification_subjects_taught { true }
+      provider_verification_contracted_hours_section_completed { true }
+    end
   end
 end

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -142,6 +142,15 @@ RSpec.feature "Provider verifying claims" do
       expect(
         summary_row("Teaches approved qualification in maths and physics")
       ).to have_content("yes")
+
+      check(
+        "To the best of my knowledge, I confirm that the information " \
+        "provided in this form is correct."
+      )
+
+      click_on "Continue"
+
+      expect(page).to have_content("Claim Verified for Edna Krabappel")
     end
   end
 
@@ -297,6 +306,15 @@ RSpec.feature "Provider verifying claims" do
       expect(
         summary_row("Teaches approved qualification in building and construction")
       ).to have_content("yes")
+
+      check(
+        "To the best of my knowledge, I confirm that the information " \
+        "provided in this form is correct."
+      )
+
+      click_on "Continue"
+
+      expect(page).to have_content("Claim Verified for Edna Krabappel")
     end
   end
 
@@ -448,6 +466,15 @@ RSpec.feature "Provider verifying claims" do
           "and ict and chemistry"
         )
       ).to have_content("yes")
+
+      check(
+        "To the best of my knowledge, I confirm that the information " \
+        "provided in this form is correct."
+      )
+
+      click_on "Continue"
+
+      expect(page).to have_content("Claim Verified for Edna Krabappel")
     end
   end
 

--- a/spec/forms/further_education_payments/providers/claims/verification/check_answers_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/check_answers_form_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::CheckAnswersForm, type: :model do
+  let(:user) { create(:dfe_signin_user) }
+
+  let(:claim) do
+    create(
+      :claim,
+      :further_education,
+      eligibility_trait: :provider_verifiable
+    )
+  end
+
+  let(:params) { {} }
+
+  subject(:form) do
+    described_class.new(
+      claim: claim,
+      user: user,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    it do
+      is_expected.to(validate_presence_of(:provider_verification_declaration))
+    end
+  end
+
+  describe "#save" do
+    let(:params) do
+      {
+        provider_verification_declaration: true
+      }
+    end
+
+    context "with an incomplete form" do
+      before do
+        claim.eligibility.update!(
+          provider_verification_teaching_responsibilities: nil
+        )
+      end
+
+      it "throws an error" do
+        expect { form.save }.to raise_error(
+          described_class::IncompleteWizardError
+        )
+      end
+    end
+
+    context "with a complete form" do
+      let(:verified_at) { DateTime.new(2025, 1, 1, 0, 0, 0) }
+
+      before do
+        travel_to(verified_at) do
+          form.save
+        end
+      end
+
+      it "sets the claim as verified" do
+        expect(
+          claim.eligibility.provider_verification_completed_at
+        ).to eq(verified_at)
+      end
+
+      it "records who verified the claim" do
+        expect(
+          claim.eligibility.provider_verification_verified_by_id
+        ).to eq(user.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the verification declaration

Upon completing the wizard we store the verifier and set the field
`provider_verification_completed_at` timestamp. We've agreed that a non
null value for `provider_verification_completed_at` represents a claim
as having been verified.

Note we use a presence validation, rather than an acceptance validation,
for the declaration checkbox as the acceptance validation doesn't run if
the attribute is `nil` so the wizard always thinks this form is
complete.

