### PR TITLE
Provider dashboard QOL updates

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -92,6 +92,7 @@ jobs:
             | Targeted Retention Payments | <${{ env.APP_URL }}/targeted-retention-incentive-payments/landing-page>   |
             | Student Loans               | <${{ env.APP_URL }}/student-loans/claim>                                  |
             | Further Education           | <${{ env.APP_URL }}/further-education-payments/landing-page>              |
+            | Further Education Providers | <${{ env.APP_URL }}/further-education-payments/providers/claims>          |
             | Early Years Payment         | <${{ env.APP_URL }}/early-years-payment/landing-page>                     |
             | Relocation Payments         | <${{ env.APP_URL }}/get-a-teacher-relocation-payment/landing-page>        |
             | Admin                       | <${{ env.APP_URL }}/admin>                                                |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,7 +187,7 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :further_education_payments do
+  namespace :further_education_payments, path: "further-education-payments" do
     namespace :providers do
       resource :session, only: %i[new destroy]
       resources :authorisation_failures, only: [:show], param: :reason

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,7 @@ if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")
   Journeys::Configuration.create!(routing_name: Journeys::EarlyYearsPayment::Practitioner::ROUTING_NAME, current_academic_year: AcademicYear.current)
 
   FeatureFlag.enable!(:tri_only_journey)
+  FeatureFlag.enable!(:provider_dashboard)
 
   ENV["FIXTURES_PATH"] = "spec/fixtures"
   ENV["FIXTURES"] = "local_authorities,local_authority_districts,schools"

--- a/spec/features/further_education_payments/providers/sessions_spec.rb
+++ b/spec/features/further_education_payments/providers/sessions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Provider session and authentication", feature_flag: :provider_da
   end
 
   scenario "when authed can visit auth walled areas", js: true do
-    visit "/further_education_payments/providers/session/new"
+    visit "/further-education-payments/providers/session/new"
     click_button "Start now"
 
     expect(page).to have_selector("h1", text: "Unverified claims")
@@ -17,10 +17,10 @@ RSpec.describe "Provider session and authentication", feature_flag: :provider_da
 
     expect(page).to have_text "Sign in"
 
-    visit "/further_education_payments/providers/claims"
+    visit "/further-education-payments/providers/claims"
     expect(page).to have_text "Sign in"
 
-    visit "/further_education_payments/providers/verified-claims"
+    visit "/further-education-payments/providers/verified-claims"
     expect(page).to have_text "Sign in"
   end
 end

--- a/spec/features/further_education_payments/providers/unverified_dashboard_spec.rb
+++ b/spec/features/further_education_payments/providers/unverified_dashboard_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Provider unverified claims dashboard", feature_flag: :provider_d
   end
 
   scenario "when no claims" do
-    visit "/further_education_payments/providers/claims"
+    visit "/further-education-payments/providers/claims"
     expect(page).to have_text "Sign in"
     click_button "Start now"
 
@@ -26,7 +26,7 @@ RSpec.describe "Provider unverified claims dashboard", feature_flag: :provider_d
       created_at: Date.new(2024, 12, 13)
     )
 
-    visit "/further_education_payments/providers/claims"
+    visit "/further-education-payments/providers/claims"
     expect(page).to have_text "Sign in"
     click_button "Start now"
 


### PR DESCRIPTION
# Context

- Some QOL updates around FE provider dashboard
- Update deploy comment to include link to provider dashboard (pushed after deployment which is why you don't see it below)
- change underscore URLs to hyphens, see https://insidegovuk.blog.gov.uk/url-standards-for-gov-uk/
- enable `provider_dashboard` feature flag in seeds so review apps always get this feature