### PR TITLE
CAPT 2701/split role and experience form

### DIFF
--- a/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
+++ b/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
@@ -86,7 +86,7 @@ module FurtherEducationPayments
           Verification::Wizard.new(
             claim: claim,
             user: current_user,
-            current_slug: params[:slug] || Verification::Wizard.first_slug
+            current_slug: params[:slug]
           )
         end
 

--- a/app/forms/further_education_payments/providers/claims/verification/base_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/base_form.rb
@@ -67,6 +67,10 @@ module FurtherEducationPayments
             claim.eligibility.school
           end
 
+          def provider_name
+            provider.name
+          end
+
           def claimant_name
             claim.full_name
           end

--- a/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
@@ -29,6 +29,8 @@ module FurtherEducationPayments
             when "fixed_term" then "Fixed-term"
             when "variable_hours" then "Variable hours"
             when "permanent" then "Permanent"
+            when "employed_by_another_organisation"
+              "Employed by another organisation (for example, an agency or contractor)"
             else fail "Unknown contract type"
             end
           end

--- a/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
@@ -49,6 +49,12 @@ module FurtherEducationPayments
             end.map(&:downcase).to_sentence
           end
 
+          def teaching_qualification
+            TeachingQualificationForm::TEACHING_QUALIFICATION_OPTIONS
+              .find { it.id == provider_verification_teaching_qualification }
+              .name
+          end
+
           def save
             return false unless valid?
 

--- a/app/forms/further_education_payments/providers/claims/verification/contract_type_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/contract_type_form.rb
@@ -1,0 +1,27 @@
+module FurtherEducationPayments
+  module Providers
+    module Claims
+      module Verification
+        class ContractTypeForm < BaseForm
+          attribute :provider_verification_contract_type, :string
+
+          validates(
+            :provider_verification_contract_type,
+            included: {
+              in: ->(form) { form.contract_type_options.map(&:id) }
+            },
+            allow_nil: :save_and_exit?
+          )
+
+          def contract_type_options
+            [
+              Form::Option.new(id: "permanent", name: "Permanent"),
+              Form::Option.new(id: "fixed_term", name: "Fixed-term"),
+              Form::Option.new(id: "variable_hours", name: "Variable hours")
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/further_education_payments/providers/claims/verification/contract_type_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/contract_type_form.rb
@@ -8,7 +8,8 @@ module FurtherEducationPayments
           validates(
             :provider_verification_contract_type,
             included: {
-              in: ->(form) { form.contract_type_options.map(&:id) }
+              in: ->(form) { form.contract_type_options.map(&:id) },
+              message: "Enter the type of contract they have"
             },
             allow_nil: :save_and_exit?
           )

--- a/app/forms/further_education_payments/providers/claims/verification/contract_type_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/contract_type_form.rb
@@ -17,7 +17,11 @@ module FurtherEducationPayments
             [
               Form::Option.new(id: "permanent", name: "Permanent"),
               Form::Option.new(id: "fixed_term", name: "Fixed-term"),
-              Form::Option.new(id: "variable_hours", name: "Variable hours")
+              Form::Option.new(id: "variable_hours", name: "Variable hours"),
+              Form::Option.new(
+                id: "employed_by_another_organisation",
+                name: "Employed by another organisation (for example, an agency or contractor)"
+              )
             ]
           end
         end

--- a/app/forms/further_education_payments/providers/claims/verification/in_first_five_years_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/in_first_five_years_form.rb
@@ -1,0 +1,28 @@
+module FurtherEducationPayments
+  module Providers
+    module Claims
+      module Verification
+        class InFirstFiveYearsForm < BaseForm
+          attribute :provider_verification_in_first_five_years, :boolean
+
+          validates(
+            :provider_verification_in_first_five_years,
+            included: {
+              in: ->(form) { form.in_first_five_years_options.map(&:id) },
+              message: "Tell us if they are in the first 5 years of their " \
+                       "further education (FE) teaching career in England"
+            },
+            allow_nil: :save_and_exit?
+          )
+
+          def in_first_five_years_options
+            [
+              Form::Option.new(id: true, name: "Yes"),
+              Form::Option.new(id: false, name: "No")
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/further_education_payments/providers/claims/verification/qualification_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/qualification_form.rb
@@ -2,19 +2,9 @@ module FurtherEducationPayments
   module Providers
     module Claims
       module Verification
-        class RoleAndExperienceForm < BaseForm
-          attribute :provider_verification_teaching_responsibilities, :boolean
+        class QualificationForm < BaseForm
           attribute :provider_verification_in_first_five_years, :boolean
           attribute :provider_verification_teaching_qualification, :string
-          attribute :provider_verification_contract_type, :string
-
-          validates(
-            :provider_verification_teaching_responsibilities,
-            included: {
-              in: ->(form) { form.teaching_responsibilities_options.map(&:id) }
-            },
-            allow_nil: :save_and_exit?
-          )
 
           validates(
             :provider_verification_in_first_five_years,
@@ -31,25 +21,6 @@ module FurtherEducationPayments
             },
             allow_nil: :save_and_exit?
           )
-
-          validates(
-            :provider_verification_contract_type,
-            included: {
-              in: ->(form) { form.contract_type_options.map(&:id) }
-            },
-            allow_nil: :save_and_exit?
-          )
-
-          def provider_name
-            provider.name
-          end
-
-          def teaching_responsibilities_options
-            [
-              Form::Option.new(id: true, name: "Yes"),
-              Form::Option.new(id: false, name: "No")
-            ]
-          end
 
           def in_first_five_years_options
             [
@@ -76,14 +47,6 @@ module FurtherEducationPayments
                 id: "no_not_planned",
                 name: "No, and has no plan to enrol on one in the next 12 months"
               )
-            ]
-          end
-
-          def contract_type_options
-            [
-              Form::Option.new(id: "permanent", name: "Permanent"),
-              Form::Option.new(id: "fixed_term", name: "Fixed-term"),
-              Form::Option.new(id: "variable_hours", name: "Variable hours")
             ]
           end
         end

--- a/app/forms/further_education_payments/providers/claims/verification/teaching_qualification_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/teaching_qualification_form.rb
@@ -2,32 +2,17 @@ module FurtherEducationPayments
   module Providers
     module Claims
       module Verification
-        class QualificationForm < BaseForm
-          attribute :provider_verification_in_first_five_years, :boolean
+        class TeachingQualificationForm < BaseForm
           attribute :provider_verification_teaching_qualification, :string
-
-          validates(
-            :provider_verification_in_first_five_years,
-            included: {
-              in: ->(form) { form.in_first_five_years_options.map(&:id) }
-            },
-            allow_nil: :save_and_exit?
-          )
 
           validates(
             :provider_verification_teaching_qualification,
             included: {
-              in: ->(form) { form.teaching_qualification_options.map(&:id) }
+              in: ->(form) { form.teaching_qualification_options.map(&:id) },
+              message: "Tell us if they have a teaching qualification"
             },
             allow_nil: :save_and_exit?
           )
-
-          def in_first_five_years_options
-            [
-              Form::Option.new(id: true, name: "Yes"),
-              Form::Option.new(id: false, name: "No")
-            ]
-          end
 
           def teaching_qualification_options
             [

--- a/app/forms/further_education_payments/providers/claims/verification/teaching_qualification_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/teaching_qualification_form.rb
@@ -3,6 +3,25 @@ module FurtherEducationPayments
     module Claims
       module Verification
         class TeachingQualificationForm < BaseForm
+          TEACHING_QUALIFICATION_OPTIONS = [
+            Form::Option.new(
+              id: "yes",
+              name: "Yes"
+            ),
+            Form::Option.new(
+              id: "not_yet",
+              name: "Not yet, but is enrolled on one"
+            ),
+            Form::Option.new(
+              id: "no_but_planned",
+              name: "No, but is planning to enrol on one"
+            ),
+            Form::Option.new(
+              id: "no_not_planned",
+              name: "No, and has no plan to enrol on one in the next 12 months"
+            )
+          ]
+
           attribute :provider_verification_teaching_qualification, :string
 
           validates(
@@ -15,24 +34,7 @@ module FurtherEducationPayments
           )
 
           def teaching_qualification_options
-            [
-              Form::Option.new(
-                id: "yes",
-                name: "Yes"
-              ),
-              Form::Option.new(
-                id: "not_yet",
-                name: "Not yet, but is enrolled on one"
-              ),
-              Form::Option.new(
-                id: "no_but_planned",
-                name: "No, but is planning to enrol on one"
-              ),
-              Form::Option.new(
-                id: "no_not_planned",
-                name: "No, and has no plan to enrol on one in the next 12 months"
-              )
-            ]
+            TEACHING_QUALIFICATION_OPTIONS
           end
         end
       end

--- a/app/forms/further_education_payments/providers/claims/verification/teaching_responsibilities_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/teaching_responsibilities_form.rb
@@ -8,7 +8,9 @@ module FurtherEducationPayments
           validates(
             :provider_verification_teaching_responsibilities,
             included: {
-              in: ->(form) { form.teaching_responsibilities_options.map(&:id) }
+              in: ->(form) { form.teaching_responsibilities_options.map(&:id) },
+              message: "Tell us if they are a member of staff with teaching " \
+                       "responsibilities"
             },
             allow_nil: :save_and_exit?
           )

--- a/app/forms/further_education_payments/providers/claims/verification/teaching_responsibilities_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/teaching_responsibilities_form.rb
@@ -1,0 +1,26 @@
+module FurtherEducationPayments
+  module Providers
+    module Claims
+      module Verification
+        class TeachingResponsibilitiesForm < BaseForm
+          attribute :provider_verification_teaching_responsibilities, :boolean
+
+          validates(
+            :provider_verification_teaching_responsibilities,
+            included: {
+              in: ->(form) { form.teaching_responsibilities_options.map(&:id) }
+            },
+            allow_nil: :save_and_exit?
+          )
+
+          def teaching_responsibilities_options
+            [
+              Form::Option.new(id: true, name: "Yes"),
+              Form::Option.new(id: false, name: "No")
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/further_education_payments/providers/claims/verification/wizard.rb
+++ b/app/models/further_education_payments/providers/claims/verification/wizard.rb
@@ -5,7 +5,8 @@ module FurtherEducationPayments
         class Wizard
           FORMS = [
             TeachingResponsibilitiesForm,
-            QualificationForm,
+            InFirstFiveYearsForm,
+            TeachingQualificationForm,
             ContractTypeForm,
             ContractCoversFullAcademicYearForm,
             TaughtAtLeastOneAcademicTermForm,
@@ -90,7 +91,8 @@ module FurtherEducationPayments
             @reachable_steps = []
 
             @reachable_steps << TeachingResponsibilitiesForm
-            @reachable_steps << QualificationForm
+            @reachable_steps << InFirstFiveYearsForm
+            @reachable_steps << TeachingQualificationForm
             @reachable_steps << ContractTypeForm
 
             if eligibility.provider_verification_contract_type == "fixed_term"

--- a/app/models/further_education_payments/providers/claims/verification/wizard.rb
+++ b/app/models/further_education_payments/providers/claims/verification/wizard.rb
@@ -12,14 +12,10 @@ module FurtherEducationPayments
             CheckAnswersForm
           ]
 
-          def self.first_slug
-            "role_and_experience"
-          end
-
           def initialize(claim:, user:, current_slug:)
             @claim = claim
             @user = user
-            @current_slug = current_slug
+            @current_slug = current_slug || next_form.slug
           end
 
           def current_form
@@ -27,20 +23,6 @@ module FurtherEducationPayments
           end
 
           def next_form
-            # These guards are required to support changing the role and
-            # experience answers. If the contract type is non permanent, we need
-            # to show the additional screen, even if no answers were changed on
-            # the first screen.
-            if current_slug == "role_and_experience"
-              if reachable_steps.include?(ContractCoversFullAcademicYearForm)
-                return find_form("contract_covers_full_academic_year")
-              end
-
-              if reachable_steps.include?(TaughtAtLeastOneAcademicTermForm)
-                return find_form("taught_at_least_one_academic_term")
-              end
-            end
-
             reachable_forms.detect(&:incomplete?)
           end
 

--- a/app/models/further_education_payments/providers/claims/verification/wizard.rb
+++ b/app/models/further_education_payments/providers/claims/verification/wizard.rb
@@ -4,7 +4,9 @@ module FurtherEducationPayments
       module Verification
         class Wizard
           FORMS = [
-            RoleAndExperienceForm,
+            TeachingResponsibilitiesForm,
+            QualificationForm,
+            ContractTypeForm,
             ContractCoversFullAcademicYearForm,
             TaughtAtLeastOneAcademicTermForm,
             PerformanceAndDisciplineForm,
@@ -87,7 +89,9 @@ module FurtherEducationPayments
 
             @reachable_steps = []
 
-            @reachable_steps << RoleAndExperienceForm
+            @reachable_steps << TeachingResponsibilitiesForm
+            @reachable_steps << QualificationForm
+            @reachable_steps << ContractTypeForm
 
             if eligibility.provider_verification_contract_type == "fixed_term"
               @reachable_steps << ContractCoversFullAcademicYearForm

--- a/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
@@ -48,9 +48,7 @@
 
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Teaching qualification") %>
-      <%= row.with_value(
-        text: form.provider_verification_teaching_qualification,
-      ) %>
+      <%= row.with_value(text: form.teaching_qualification) %>
       <% if editable %>
         <%= row.with_action(
           text: "Change",

--- a/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
@@ -21,7 +21,7 @@
           text: "Change",
           href: edit_further_education_payments_providers_claim_verification_path(
             form.claim,
-            slug: "role_and_experience"
+            slug: "teaching_responsibilities"
           )
         ) %>
       <% end %>
@@ -40,7 +40,7 @@
           text: "Change",
           href: edit_further_education_payments_providers_claim_verification_path(
             form.claim,
-            slug: "role_and_experience"
+            slug: "qualification"
           )
         ) %>
       <% end %>
@@ -56,7 +56,7 @@
           text: "Change",
           href: edit_further_education_payments_providers_claim_verification_path(
             form.claim,
-            slug: "role_and_experience"
+            slug: "qualification"
           )
         ) %>
       <% end %>
@@ -70,7 +70,7 @@
           text: "Change",
           href: edit_further_education_payments_providers_claim_verification_path(
             form.claim,
-            slug: "role_and_experience"
+            slug: "contract_type"
           )
         ) %>
       <% end %>

--- a/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
@@ -7,17 +7,6 @@
 </h1>
 
 <%= govuk_summary_card(title: "Role and experience") do |card| %>
-  <% if editable %>
-    <%= card.with_action do %>
-      <%= govuk_link_to(
-        "Change",
-        edit_further_education_payments_providers_claim_verification_path(
-          form.claim,
-          slug: "role_and_experience"
-        )
-      ) %>
-    <% end %>
-  <% end %>
   <%= card.with_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Teaching responsibilities") %>
@@ -27,6 +16,15 @@
           scope: :boolean
         )
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "role_and_experience"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -37,6 +35,15 @@
           scope: :boolean
         )
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "role_and_experience"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -44,11 +51,29 @@
       <%= row.with_value(
         text: form.provider_verification_teaching_qualification,
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "role_and_experience"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Type of contract") %>
       <%= row.with_value(text: form.contract_type) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "role_and_experience"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <% case form.provider_verification_contract_type %>
@@ -61,6 +86,15 @@
             scope: :boolean
           )
         ) %>
+        <% if editable %>
+          <%= row.with_action(
+            text: "Change",
+            href: edit_further_education_payments_providers_claim_verification_path(
+              form.claim,
+              slug: "contract_covers_full_academic_year"
+            )
+          ) %>
+        <% end %>
       <% end %>
     <% when "variable_hours" %>
       <%= summary_list.with_row do |row| %>
@@ -71,6 +105,15 @@
             scope: :boolean
           )
         ) %>
+        <% if editable %>
+          <%= row.with_action(
+            text: "Change",
+            href: edit_further_education_payments_providers_claim_verification_path(
+              form.claim,
+              slug: "taught_at_least_one_academic_term"
+            )
+          ) %>
+        <% end %>
       <% end %>
     <% else %>
       <%# noop %>
@@ -79,17 +122,6 @@
 <% end %>
 
 <%= govuk_summary_card(title: "Performance and discipline") do |card| %>
-  <% if editable %>
-    <%= card.with_action do %>
-      <%= govuk_link_to(
-        "Change",
-        edit_further_education_payments_providers_claim_verification_path(
-          form.claim,
-          slug: "performance_and_discipline"
-        )
-      ) %>
-    <% end %>
-  <% end %>
   <%= card.with_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Subject to performance measures") %>
@@ -99,6 +131,15 @@
           scope: :boolean
         )
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "performance_and_discipline"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -109,22 +150,20 @@
           scope: :boolean
         )
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "performance_and_discipline"
+          )
+        ) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>
 
 <%= govuk_summary_card(title: "Contracted hours") do |card| %>
-  <% if editable %>
-    <%= card.with_action do %>
-      <%= govuk_link_to(
-        "Change",
-        edit_further_education_payments_providers_claim_verification_path(
-          form.claim,
-          slug: "contracted_hours"
-        )
-      ) %>
-    <% end %>
-  <% end %>
   <%= card.with_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Timetabled hours per week") %>
@@ -139,6 +178,15 @@
           ]
         )
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "contracted_hours"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -149,6 +197,15 @@
           scope: :boolean
         )
       ) %>
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "contracted_hours"
+          )
+        ) %>
+      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -162,6 +219,16 @@
           scope: :boolean
         )
       ) %>
+
+      <% if editable %>
+        <%= row.with_action(
+          text: "Change",
+          href: edit_further_education_payments_providers_claim_verification_path(
+            form.claim,
+            slug: "contracted_hours"
+          )
+        ) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
@@ -61,7 +61,11 @@
         ) %>
       <% end %>
     <% end %>
+  <% end %>
+<% end %>
 
+<%= govuk_summary_card(title: "Type of contract") do |card| %>
+  <%= card.with_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Type of contract") %>
       <%= row.with_value(text: form.contract_type) %>

--- a/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
@@ -40,7 +40,7 @@
           text: "Change",
           href: edit_further_education_payments_providers_claim_verification_path(
             form.claim,
-            slug: "qualification"
+            slug: "in_first_five_years"
           )
         ) %>
       <% end %>
@@ -56,7 +56,7 @@
           text: "Change",
           href: edit_further_education_payments_providers_claim_verification_path(
             form.claim,
-            slug: "qualification"
+            slug: "teaching_qualification"
           )
         ) %>
       <% end %>

--- a/app/views/further_education_payments/providers/claims/verifications/contract_covers_full_academic_year.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/contract_covers_full_academic_year.html.erb
@@ -28,7 +28,7 @@
       <%= render partial: "claim_summary", locals: { claim: f.object.claim } %>
 
       <h2 class="govuk-heading-m">
-        Role and experience
+        Type of contract
       </h2>
 
       <%= f.govuk_collection_radio_buttons(

--- a/app/views/further_education_payments/providers/claims/verifications/contract_covers_full_academic_year.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/contract_covers_full_academic_year.html.erb
@@ -39,6 +39,7 @@
         legend: {
           text: "Does #{f.object.claimant_name} fixed-term contract cover " \
                 "the full #{f.object.academic_year.to_s(:long)} academic year?",
+          size: "s",
         },
         hint: {
           text: "This academic year runs from #{f.object.academic_year_start_to_end}"

--- a/app/views/further_education_payments/providers/claims/verifications/contract_type.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/contract_type.html.erb
@@ -26,7 +26,7 @@
       <%= render partial: "claim_summary", locals: { claim: f.object.claim } %>
 
       <h2 class="govuk-heading-m">
-        Role and experience
+        Type of contract
       </h2>
 
       <%= f.govuk_collection_radio_buttons(

--- a/app/views/further_education_payments/providers/claims/verifications/contract_type.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/contract_type.html.erb
@@ -3,7 +3,9 @@
   "Review a targeted retention incentive payment claim"
 ) %>
 
-<%= govuk_back_link href: backlink_path %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: backlink_path %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/further_education_payments/providers/claims/verifications/contract_type.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/contract_type.html.erb
@@ -1,0 +1,57 @@
+<%= content_for(
+  :page_title,
+  "Review a targeted retention incentive payment claim"
+) %>
+
+<%= govuk_back_link href: backlink_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Review a targeted retention incentive payment claim
+    </h1>
+
+    <%= form_with(
+      model: @form,
+      url: further_education_payments_providers_claim_verification_path(
+        @form.claim,
+        @form.provider,
+        slug: @form.slug
+      ),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render partial: "claim_summary", locals: { claim: f.object.claim } %>
+
+      <h2 class="govuk-heading-m">
+        Role and experience
+      </h2>
+
+      <%= f.govuk_collection_radio_buttons(
+        :provider_verification_contract_type,
+        f.object.contract_type_options,
+        :id,
+        :name,
+        legend: {
+          text: "What type of contract does #{f.object.claimant_name} have with #{f.object.provider_name}?",
+          size: "s",
+        },
+        hint: {
+          text: "This includes full-time and part-time contracts"
+        }
+      ) %>
+
+      <%= f.govuk_submit("Continue") %>
+
+      <%= f.govuk_submit(
+        "Save and come back later",
+        secondary: true,
+        name: "save_and_exit",
+        value: true,
+        class: "govuk-!-margin-left-2"
+      ) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/further_education_payments/providers/claims/verifications/contracted_hours.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/contracted_hours.html.erb
@@ -39,6 +39,7 @@
         legend: {
           text: "On average, how many hours per week is "\
           "#{f.object.claimant_name} timetabled to teach during the current term?",
+          size: "s",
         }
       ) %>
 
@@ -50,7 +51,8 @@
         legend: {
           text: "For at least half of their timetabled teaching hours, does " \
           "#{f.object.claimant_name} teach 16- to 19-year-olds, including " \
-          "those up to age 25 with an Education, Health and Care Plan (EHCP)?"
+          "those up to age 25 with an Education, Health and Care Plan (EHCP)?",
+          size: "s",
         }
       ) %>
 
@@ -61,7 +63,8 @@
         :name,
         legend: {
           text: "For at least half of their timetabled teaching hours, does " \
-          "#{f.object.claimant_name} teach:"
+          "#{f.object.claimant_name} teach:",
+          size: "s",
         },
         hint: -> do
           govuk_list(

--- a/app/views/further_education_payments/providers/claims/verifications/in_first_five_years.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/in_first_five_years.html.erb
@@ -58,17 +58,6 @@
         </p>
       <% end %>
 
-      <%= f.govuk_collection_radio_buttons(
-        :provider_verification_teaching_qualification,
-        f.object.teaching_qualification_options,
-        :id,
-        :name,
-        legend: {
-          text: "Does #{f.object.claimant_name} have a teaching qualification?",
-          size: "s",
-        }
-      ) %>
-
       <%= f.govuk_submit("Continue") %>
 
       <%= f.govuk_submit(

--- a/app/views/further_education_payments/providers/claims/verifications/in_first_five_years.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/in_first_five_years.html.erb
@@ -4,7 +4,7 @@
 ) %>
 
 <% content_for :back_link do %>
-  <%= govuk_back_link href: further_education_payments_providers_claims_path %>
+  <%= govuk_back_link href: backlink_path %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/further_education_payments/providers/claims/verifications/performance_and_discipline.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/performance_and_discipline.html.erb
@@ -38,7 +38,8 @@
         :name,
         legend: {
           text: "Is #{f.object.claimant_name} currently subject to any " \
-                "performance measures?"
+                "performance measures?",
+          size: "s",
         }
       ) %>
 
@@ -49,7 +50,8 @@
         :name,
         legend: {
           text: "Is #{f.object.claimant_name} currently subject to any " \
-                "disciplinary action?"
+                "disciplinary action?",
+          size: "s",
         }
       ) %>
 

--- a/app/views/further_education_payments/providers/claims/verifications/qualification.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/qualification.html.erb
@@ -1,0 +1,83 @@
+<%= content_for(
+  :page_title,
+  "Review a targeted retention incentive payment claim"
+) %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: further_education_payments_providers_claims_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Review a targeted retention incentive payment claim
+    </h1>
+
+    <%= form_with(
+      model: @form,
+      url: further_education_payments_providers_claim_verification_path(
+        @form.claim,
+        @form.provider,
+        slug: @form.slug
+      ),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render partial: "claim_summary", locals: { claim: f.object.claim } %>
+
+      <h2 class="govuk-heading-m">
+        Role and experience
+      </h2>
+
+      <%= f.govuk_collection_radio_buttons(
+        :provider_verification_in_first_five_years,
+        f.object.in_first_five_years_options,
+        :id,
+        :name,
+        legend: {
+          text: "Is #{f.object.claimant_name} in the first 5 years of their " \
+                "further education (FE) teaching career in England?",
+          size: "s",
+        }
+      ) %>
+
+      <%= govuk_details(
+        summary_text: "What counts torwards the first 5 years of an FE " \
+                      "teaching career",
+      ) do %>
+        <p class="govuk-body">
+          Only teaching at post-16 providers in England counts. It includes
+          independent training providers. Teaching in schools, outside England
+          or overseas does not count.
+          <br />
+          <br />
+          Teachers who taught in FE before August 2020 are not eligible, even if
+          they've since returned.
+        </p>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :provider_verification_teaching_qualification,
+        f.object.teaching_qualification_options,
+        :id,
+        :name,
+        legend: {
+          text: "Does #{f.object.claimant_name} have a teaching qualification?",
+          size: "s",
+        }
+      ) %>
+
+      <%= f.govuk_submit("Continue") %>
+
+      <%= f.govuk_submit(
+        "Save and come back later",
+        secondary: true,
+        name: "save_and_exit",
+        value: true,
+        class: "govuk-!-margin-left-2"
+      ) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/further_education_payments/providers/claims/verifications/taught_at_least_one_academic_term.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/taught_at_least_one_academic_term.html.erb
@@ -28,7 +28,7 @@
       <%= render partial: "claim_summary", locals: { claim: f.object.claim } %>
 
       <h2 class="govuk-heading-m">
-        Role and experience
+        Type of contract
       </h2>
 
       <%= f.govuk_collection_radio_buttons(

--- a/app/views/further_education_payments/providers/claims/verifications/taught_at_least_one_academic_term.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/taught_at_least_one_academic_term.html.erb
@@ -39,6 +39,7 @@
         legend: {
           text: "Has #{f.object.claim.full_name} taught at "\
                 "#{f.object.provider.name} for at least one academic term?",
+          size: "s",
         }
       ) %>
 

--- a/app/views/further_education_payments/providers/claims/verifications/teaching_qualification.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/teaching_qualification.html.erb
@@ -3,7 +3,9 @@
   "Review a targeted retention incentive payment claim"
 ) %>
 
-<%= govuk_back_link href: backlink_path %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: backlink_path %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/further_education_payments/providers/claims/verifications/teaching_qualification.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/teaching_qualification.html.erb
@@ -1,0 +1,54 @@
+<%= content_for(
+  :page_title,
+  "Review a targeted retention incentive payment claim"
+) %>
+
+<%= govuk_back_link href: backlink_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Review a targeted retention incentive payment claim
+    </h1>
+
+    <%= form_with(
+      model: @form,
+      url: further_education_payments_providers_claim_verification_path(
+        @form.claim,
+        @form.provider,
+        slug: @form.slug
+      ),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render partial: "claim_summary", locals: { claim: f.object.claim } %>
+
+      <h2 class="govuk-heading-m">
+        Role and experience
+      </h2>
+
+      <%= f.govuk_collection_radio_buttons(
+        :provider_verification_teaching_qualification,
+        f.object.teaching_qualification_options,
+        :id,
+        :name,
+        legend: {
+          text: "Does #{f.object.claimant_name} have a teaching qualification?",
+          size: "s",
+        }
+      ) %>
+
+      <%= f.govuk_submit("Continue") %>
+
+      <%= f.govuk_submit(
+        "Save and come back later",
+        secondary: true,
+        name: "save_and_exit",
+        value: true,
+        class: "govuk-!-margin-left-2"
+      ) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/further_education_payments/providers/claims/verifications/teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/teaching_responsibilities.html.erb
@@ -3,7 +3,9 @@
   "Review a targeted retention incentive payment claim"
 ) %>
 
-<%= govuk_back_link href: further_education_payments_providers_claims_path %>
+<% content_for :back_link do %>
+  <%= govuk_back_link href: further_education_payments_providers_claims_path %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/further_education_payments/providers/claims/verifications/teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/teaching_responsibilities.html.erb
@@ -3,9 +3,7 @@
   "Review a targeted retention incentive payment claim"
 ) %>
 
-<% content_for :back_link do %>
-  <%= govuk_back_link href: further_education_payments_providers_claims_path %>
-<% end %>
+<%= govuk_back_link href: further_education_payments_providers_claims_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -37,37 +35,13 @@
         :id,
         :name,
         legend: {
-          text: "Is #{f.object.claimant_name} a member of staff with teaching responsibilities?",
-        }
-      ) %>
-
-      <%= f.govuk_collection_radio_buttons(
-        :provider_verification_in_first_five_years,
-        f.object.in_first_five_years_options,
-        :id,
-        :name,
-        legend: {
-          text: "Is #{f.object.claimant_name} in the first 5 years of their further education (FE) teaching career in England?",
-        }
-      ) %>
-
-      <%= f.govuk_collection_radio_buttons(
-        :provider_verification_teaching_qualification,
-        f.object.teaching_qualification_options,
-        :id,
-        :name,
-        legend: {
-          text: "Does #{f.object.claimant_name} have a teaching qualification?",
-        }
-      ) %>
-
-      <%= f.govuk_collection_radio_buttons(
-        :provider_verification_contract_type,
-        f.object.contract_type_options,
-        :id,
-        :name,
-        legend: {
-          text: "What type of contract does #{f.object.claimant_name} have with #{f.object.provider_name}?",
+          text: "Is #{f.object.claimant_name} a member of staff with teaching " \
+                "responsibilities?",
+          size: "s",
+        },
+        hint: {
+          text: "This includes all job titles where the role involves teaching " \
+                "further education students"
         }
       ) %>
 
@@ -80,6 +54,19 @@
         value: true,
         class: "govuk-!-margin-left-2"
       ) %>
+
+      <%= govuk_details(
+        summary_text: "Who counts as a teacher for this payment",
+      ) do %>
+        <p class="govuk-body">
+          An FE teacher is someone who teaches, even if it's not their main job.
+          This payment isn't for support staff like assistants or technicians.
+          <br />
+          <br />
+          They're likely to have a teaching contract, teach groups of students,
+          plan and mark work, or be working towards a teaching qualification.
+        </p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,8 +31,8 @@
 
 en:
   boolean:
-    true: 'yes'
-    false: 'no'
+    true: 'Yes'
+    false: 'No'
   date:
     formats:
       default: "%-d %B %Y"

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -749,10 +749,10 @@ RSpec.feature "Provider verifying claims" do
 
       click_on "Continue"
 
-      within_fieldset(
+      expect(page).to have_content(
         "Does Edna Krabappel fixed-term contract cover the full 2025 to 2026 " \
         "academic year?"
-      ) { choose "Yes" }
+      )
 
       click_on "Save and come back later"
 
@@ -762,8 +762,11 @@ RSpec.feature "Provider verifying claims" do
         edit_further_education_payments_providers_claim_verification_path(claim)
       )
 
-      # Role and experience form
-      click_on "Continue"
+      # First incomplete form
+      expect(page).to have_content(
+        "Does Edna Krabappel fixed-term contract cover the full 2025 to 2026 " \
+        "academic year?"
+      )
     end
   end
 

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -521,10 +521,9 @@ RSpec.feature "Provider verifying claims" do
 
       click_on "Continue"
 
-      # Check answers page
       expect(summary_row("Type of contract")).to have_content("Variable hours")
 
-      within(summary_card("Role and experience")) do
+      within(summary_row("Type of contract")) do
         click_on "Change"
       end
 
@@ -538,7 +537,7 @@ RSpec.feature "Provider verifying claims" do
       expect(summary_row("Type of contract")).to have_content("Permanent")
 
       # Change contract type to Fixed-term
-      within(summary_card("Role and experience")) do
+      within(summary_row("Type of contract")) do
         click_on "Change"
       end
 
@@ -563,30 +562,30 @@ RSpec.feature "Provider verifying claims" do
         summary_row("Contract covers full academic year")
       ).to have_content "no"
 
-      # Change answer on second page of fixed term contract
-      within(summary_card("Role and experience")) do
+      # Change contract type to Variable hours
+
+      within(summary_row("Type of contract")) do
         click_on "Change"
       end
 
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
         "Springfield College?"
-      ) { expect(page).to have_checked_field("Fixed-term") }
+      ) { choose "Variable hours" }
 
       click_on "Continue"
 
       within_fieldset(
-        "Does Edna Krabappel fixed-term contract cover the full 2025 to 2026 " \
-        "academic year?"
+        "Has Edna Krabappel taught at Springfield College for at least one " \
+        "academic term?"
       ) { choose "Yes" }
 
       click_on "Continue"
 
-      expect(summary_row("Type of contract")).to have_content("Fixed-term")
-
+      expect(summary_row("Type of contract")).to have_content("Variable hours")
       expect(
-        summary_row("Contract covers full academic year")
-      ).to have_content "yes"
+        summary_row("Variable hours in academic year")
+      ).to have_content("yes")
     end
   end
 
@@ -765,11 +764,6 @@ RSpec.feature "Provider verifying claims" do
 
       # Role and experience form
       click_on "Continue"
-
-      expect(page).to have_content(
-        "Does Edna Krabappel fixed-term contract cover the full 2025 to 2026 " \
-        "academic year?"
-      )
     end
   end
 
@@ -804,17 +798,7 @@ RSpec.feature "Provider verifying claims" do
   end
 
   def summary_row(label)
-    find("dt", text: label).sibling("dd")
-  end
-
-  def summary_card(heading)
-    match = all(".govuk-summary-card").detect do |card|
-      card.find(".govuk-summary-card__title").text == heading
-    end
-
-    raise "Couldn't find summary card with title #{heading}" unless match
-
-    match
+    find("div.govuk-summary-list__row", text: label)
   end
 
   context "status badge display" do

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -53,6 +53,8 @@ RSpec.feature "Provider verifying claims" do
         "(FE) teaching career in England?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
@@ -192,6 +194,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
       ) { choose "Yes" }
+
+      click_on "Continue"
 
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
@@ -345,6 +349,8 @@ RSpec.feature "Provider verifying claims" do
         "(FE) teaching career in England?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
@@ -485,6 +491,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
       ) { choose "Yes" }
+
+      click_on "Continue"
 
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
@@ -668,6 +676,8 @@ RSpec.feature "Provider verifying claims" do
         "(FE) teaching career in England?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
@@ -760,6 +770,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
       ) { choose "Yes" }
+
+      click_on "Continue"
 
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -46,6 +46,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel a member of staff with teaching responsibilities?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset(
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
@@ -54,6 +56,8 @@ RSpec.feature "Provider verifying claims" do
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
+
+      click_on "Continue"
 
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
@@ -182,6 +186,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel a member of staff with teaching responsibilities?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset(
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
@@ -190,6 +196,8 @@ RSpec.feature "Provider verifying claims" do
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
+
+      click_on "Continue"
 
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
@@ -330,6 +338,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel a member of staff with teaching responsibilities?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset(
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
@@ -338,6 +348,8 @@ RSpec.feature "Provider verifying claims" do
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
+
+      click_on "Continue"
 
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
@@ -467,6 +479,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel a member of staff with teaching responsibilities?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset(
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
@@ -475,6 +489,8 @@ RSpec.feature "Provider verifying claims" do
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
+
+      click_on "Continue"
 
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
@@ -622,6 +638,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel a member of staff with teaching responsibilities?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset(
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
@@ -630,6 +648,8 @@ RSpec.feature "Provider verifying claims" do
       within_fieldset("Does Edna Krabappel have a teaching qualification?") do
         choose "Yes"
       end
+
+      click_on "Continue"
 
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
@@ -646,6 +666,7 @@ RSpec.feature "Provider verifying claims" do
 
       click_on "Back"
 
+      # Now we're back to the contract type page
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
         "Springfield College?"
@@ -710,6 +731,8 @@ RSpec.feature "Provider verifying claims" do
         "Is Edna Krabappel a member of staff with teaching responsibilities?"
       ) { choose "Yes" }
 
+      click_on "Continue"
+
       within_fieldset(
         "Is Edna Krabappel in the first 5 years of their further education " \
         "(FE) teaching career in England?"
@@ -729,19 +752,7 @@ RSpec.feature "Provider verifying claims" do
         edit_further_education_payments_providers_claim_verification_path(claim)
       )
 
-      within_fieldset(
-        "Is Edna Krabappel a member of staff with teaching responsibilities?"
-      ) { expect(page).to have_checked_field("Yes") }
-
-      within_fieldset(
-        "Is Edna Krabappel in the first 5 years of their further education " \
-        "(FE) teaching career in England?"
-      ) { expect(page).to have_checked_field("Yes") }
-
-      within_fieldset("Does Edna Krabappel have a teaching qualification?") do
-        expect(page).to have_checked_field("Yes")
-      end
-
+      # Should go to the contract type page since the first two pages are completed
       within_fieldset(
         "What type of contract does Edna Krabappel have with " \
         "Springfield College?"

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -103,15 +103,15 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Teaching responsibilities")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       expect(
         summary_row("In first 5 years of FE teaching")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       expect(
         summary_row("Teaching qualification")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       expect(
         summary_row("Type of contract")
@@ -119,11 +119,11 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Subject to performance measures")
-      ).to have_content("no")
+      ).to have_content("No")
 
       expect(
         summary_row("Subject to disciplinary action")
-      ).to have_content("no")
+      ).to have_content("No")
 
       expect(
         summary_row("Timetabled hours per week")
@@ -131,11 +131,11 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Teaches 16-19-year-olds or those with EHCP")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       expect(
         summary_row("Teaches approved qualification in maths and physics")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       check(
         "To the best of my knowledge, I confirm that the information " \
@@ -253,15 +253,15 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Teaching responsibilities")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("In first 5 years of FE teaching")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("Teaching qualification")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("Type of contract")
@@ -269,15 +269,15 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Contract covers full academic year")
-      ).to have_content "no"
+      ).to have_content "No"
 
       expect(
         summary_row("Subject to performance measures")
-      ).to have_content("no")
+      ).to have_content("No")
 
       expect(
         summary_row("Subject to disciplinary action")
-      ).to have_content("no")
+      ).to have_content("No")
 
       expect(
         summary_row("Timetabled hours per week")
@@ -285,11 +285,11 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Teaches 16-19-year-olds or those with EHCP")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       expect(
         summary_row("Teaches approved qualification in building and construction")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       check(
         "To the best of my knowledge, I confirm that the information " \
@@ -408,15 +408,15 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Teaching responsibilities")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("In first 5 years of FE teaching")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("Teaching qualification")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("Type of contract")
@@ -424,22 +424,22 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Variable hours in academic year")
-      ).to have_content "yes"
+      ).to have_content "Yes"
 
       expect(
         summary_row("Subject to performance measures")
-      ).to have_content("no")
+      ).to have_content("No")
 
       expect(
         summary_row("Subject to disciplinary action")
-      ).to have_content("no")
+      ).to have_content("No")
 
       expect(
         summary_row(
           "Teaches approved qualification in computing, including digital " \
           "and ict and chemistry"
         )
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       check(
         "To the best of my knowledge, I confirm that the information " \
@@ -584,7 +584,7 @@ RSpec.feature "Provider verifying claims" do
 
       expect(
         summary_row("Contract covers full academic year")
-      ).to have_content "no"
+      ).to have_content "No"
 
       # Change contract type to Variable hours
       within(summary_row("Type of contract")) do
@@ -608,7 +608,7 @@ RSpec.feature "Provider verifying claims" do
       expect(summary_row("Type of contract")).to have_content("Variable hours")
       expect(
         summary_row("Variable hours in academic year")
-      ).to have_content("yes")
+      ).to have_content("Yes")
 
       # Change contract type to Employed by another organisation
       within(summary_row("Type of contract")) do

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -579,7 +579,6 @@ RSpec.feature "Provider verifying claims" do
       ).to have_content "no"
 
       # Change contract type to Variable hours
-
       within(summary_row("Type of contract")) do
         click_on "Change"
       end
@@ -602,6 +601,30 @@ RSpec.feature "Provider verifying claims" do
       expect(
         summary_row("Variable hours in academic year")
       ).to have_content("yes")
+
+      # Change contract type to Employed by another organisation
+      within(summary_row("Type of contract")) do
+        click_on "Change"
+      end
+
+      within_fieldset(
+        "What type of contract does Edna Krabappel have with " \
+        "Springfield College?"
+      ) do
+        choose(
+          "Employed by another organisation (for example, an agency or contractor)"
+        )
+      end
+
+      click_on "Continue"
+
+      expect(summary_row("Type of contract")).to have_content(
+        "Employed by another organisation (for example, an agency or contractor)"
+      )
+
+      expect(page).not_to have_content("Variable hours in academic year")
+
+      expect(page).not_to have_content("Contract covers full academic year")
     end
   end
 

--- a/spec/forms/further_education_payments/providers/claims/verification/contract_type_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/contract_type_form_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::ContractTypeForm, type: :model do
+  let(:fe_provider) do
+    create(:school, :fe_eligible, name: "Springfield College")
+  end
+
+  let(:user) { create(:dfe_signin_user) }
+
+  let(:claim) { create(:claim, :further_education) }
+
+  let(:params) { {} }
+
+  subject(:form) do
+    described_class.new(
+      claim: claim,
+      user: user,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    context "when submission" do
+      it do
+        is_expected.to(
+          validate_inclusion_of(:provider_verification_contract_type)
+            .in_array(%w[permanent fixed_term variable_hours])
+        )
+      end
+    end
+
+    context "when saving progress" do
+      before do
+        allow(form).to receive(:save_and_exit?).and_return(true)
+      end
+
+      it do
+        is_expected.to(
+          validate_inclusion_of(:provider_verification_contract_type)
+            .in_array(["permanent", "fixed_term", "variable_hours", nil])
+        )
+      end
+    end
+  end
+
+  describe "#incomplete?" do
+    context "when form is valid" do
+      let(:params) do
+        {
+          provider_verification_contract_type: "permanent"
+        }
+      end
+
+      it "returns false" do
+        expect(form.incomplete?).to be(false)
+      end
+    end
+
+    context "when form is invalid" do
+      let(:params) { {} }
+
+      it "returns true" do
+        expect(form.incomplete?).to be(true)
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when form is valid" do
+      let(:params) do
+        {
+          provider_verification_contract_type: "permanent"
+        }
+      end
+
+      it "updates the claim eligibility and returns true" do
+        expect(form.save).to be(true)
+
+        claim.eligibility.reload
+
+        expect(
+          claim.eligibility.provider_verification_contract_type
+        ).to eq("permanent")
+      end
+    end
+
+    context "when form is invalid" do
+      let(:params) { {} }
+
+      it "returns false" do
+        expect(form.save).to be(false)
+      end
+    end
+  end
+end

--- a/spec/forms/further_education_payments/providers/claims/verification/in_first_five_years_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/in_first_five_years_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::ContractTypeForm, type: :model do
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::InFirstFiveYearsForm, type: :model do
   let(:fe_provider) do
     create(:school, :fe_eligible, name: "Springfield College")
   end
@@ -22,10 +22,20 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Contra
   describe "validations" do
     context "when submission" do
       it do
+        is_expected.not_to(
+          allow_value(nil).for(:provider_verification_in_first_five_years)
+        )
+      end
+
+      it do
         is_expected.to(
-          validate_inclusion_of(:provider_verification_contract_type)
-            .in_array(%w[permanent fixed_term variable_hours])
-            .with_message("Enter the type of contract they have")
+          allow_value(true).for(:provider_verification_in_first_five_years)
+        )
+      end
+
+      it do
+        is_expected.to(
+          allow_value(false).for(:provider_verification_in_first_five_years)
         )
       end
     end
@@ -37,9 +47,7 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Contra
 
       it do
         is_expected.to(
-          validate_inclusion_of(:provider_verification_contract_type)
-            .in_array(["permanent", "fixed_term", "variable_hours", nil])
-            .with_message("Enter the type of contract they have")
+          allow_value(nil).for(:provider_verification_in_first_five_years)
         )
       end
     end
@@ -49,7 +57,7 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Contra
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_contract_type: "permanent"
+          provider_verification_in_first_five_years: true
         }
       end
 
@@ -71,7 +79,7 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Contra
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_contract_type: "permanent"
+          provider_verification_in_first_five_years: true
         }
       end
 
@@ -81,8 +89,8 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Contra
         claim.eligibility.reload
 
         expect(
-          claim.eligibility.provider_verification_contract_type
-        ).to eq("permanent")
+          claim.eligibility.provider_verification_in_first_five_years
+        ).to be(true)
       end
     end
 

--- a/spec/forms/further_education_payments/providers/claims/verification/qualification_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/qualification_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAndExperienceForm, type: :model do
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::QualificationForm, type: :model do
   let(:fe_provider) do
     create(:school, :fe_eligible, name: "Springfield College")
   end
@@ -23,13 +23,19 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAn
     context "when submission" do
       it do
         is_expected.not_to(
-          allow_value(nil).for(:provider_verification_teaching_responsibilities)
+          allow_value(nil).for(:provider_verification_in_first_five_years)
         )
       end
 
       it do
-        is_expected.not_to(
-          allow_value(nil).for(:provider_verification_in_first_five_years)
+        is_expected.to(
+          allow_value(true).for(:provider_verification_in_first_five_years)
+        )
+      end
+
+      it do
+        is_expected.to(
+          allow_value(false).for(:provider_verification_in_first_five_years)
         )
       end
 
@@ -39,24 +45,11 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAn
             .in_array(%w[yes not_yet no_but_planned no_not_planned])
         )
       end
-
-      it do
-        is_expected.to(
-          validate_inclusion_of(:provider_verification_contract_type)
-            .in_array(%w[permanent fixed_term variable_hours])
-        )
-      end
     end
 
     context "when saving progress" do
       before do
         allow(form).to receive(:save_and_exit?).and_return(true)
-      end
-
-      it do
-        is_expected.to(
-          allow_value(nil).for(:provider_verification_teaching_responsibilities)
-        )
       end
 
       it do
@@ -71,13 +64,6 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAn
             .in_array(["yes", "not_yet", "no_but_planned", "no_not_planned", nil])
         )
       end
-
-      it do
-        is_expected.to(
-          validate_inclusion_of(:provider_verification_contract_type)
-            .in_array(["permanent", "fixed_term", "variable_hours", nil])
-        )
-      end
     end
   end
 
@@ -85,10 +71,8 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAn
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_teaching_responsibilities: true,
           provider_verification_in_first_five_years: true,
-          provider_verification_teaching_qualification: "yes",
-          provider_verification_contract_type: "permanent"
+          provider_verification_teaching_qualification: "yes"
         }
       end
 
@@ -110,10 +94,8 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAn
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_teaching_responsibilities: true,
           provider_verification_in_first_five_years: true,
-          provider_verification_teaching_qualification: "yes",
-          provider_verification_contract_type: "permanent"
+          provider_verification_teaching_qualification: "yes"
         }
       end
 
@@ -123,20 +105,20 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::RoleAn
         claim.eligibility.reload
 
         expect(
-          claim.eligibility.provider_verification_teaching_responsibilities
-        ).to be(true)
-
-        expect(
           claim.eligibility.provider_verification_in_first_five_years
         ).to be(true)
 
         expect(
           claim.eligibility.provider_verification_teaching_qualification
         ).to eq("yes")
+      end
+    end
 
-        expect(
-          claim.eligibility.provider_verification_contract_type
-        ).to eq("permanent")
+    context "when form is invalid" do
+      let(:params) { {} }
+
+      it "returns false" do
+        expect(form.save).to be(false)
       end
     end
   end

--- a/spec/forms/further_education_payments/providers/claims/verification/teaching_qualification_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/teaching_qualification_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::QualificationForm, type: :model do
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::TeachingQualificationForm, type: :model do
   let(:fe_provider) do
     create(:school, :fe_eligible, name: "Springfield College")
   end
@@ -22,27 +22,10 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Qualif
   describe "validations" do
     context "when submission" do
       it do
-        is_expected.not_to(
-          allow_value(nil).for(:provider_verification_in_first_five_years)
-        )
-      end
-
-      it do
-        is_expected.to(
-          allow_value(true).for(:provider_verification_in_first_five_years)
-        )
-      end
-
-      it do
-        is_expected.to(
-          allow_value(false).for(:provider_verification_in_first_five_years)
-        )
-      end
-
-      it do
         is_expected.to(
           validate_inclusion_of(:provider_verification_teaching_qualification)
             .in_array(%w[yes not_yet no_but_planned no_not_planned])
+            .with_message("Tell us if they have a teaching qualification")
         )
       end
     end
@@ -54,14 +37,9 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Qualif
 
       it do
         is_expected.to(
-          allow_value(nil).for(:provider_verification_in_first_five_years)
-        )
-      end
-
-      it do
-        is_expected.to(
           validate_inclusion_of(:provider_verification_teaching_qualification)
             .in_array(["yes", "not_yet", "no_but_planned", "no_not_planned", nil])
+            .with_message("Tell us if they have a teaching qualification")
         )
       end
     end
@@ -71,7 +49,6 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Qualif
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_in_first_five_years: true,
           provider_verification_teaching_qualification: "yes"
         }
       end
@@ -94,7 +71,6 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Qualif
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_in_first_five_years: true,
           provider_verification_teaching_qualification: "yes"
         }
       end
@@ -103,10 +79,6 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Qualif
         expect(form.save).to be(true)
 
         claim.eligibility.reload
-
-        expect(
-          claim.eligibility.provider_verification_in_first_five_years
-        ).to be(true)
 
         expect(
           claim.eligibility.provider_verification_teaching_qualification

--- a/spec/forms/further_education_payments/providers/claims/verification/teaching_responsibilities_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/teaching_responsibilities_form_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::TeachingResponsibilitiesForm, type: :model do
+  let(:fe_provider) do
+    create(:school, :fe_eligible, name: "Springfield College")
+  end
+
+  let(:user) { create(:dfe_signin_user) }
+
+  let(:claim) { create(:claim, :further_education) }
+
+  let(:params) { {} }
+
+  subject(:form) do
+    described_class.new(
+      claim: claim,
+      user: user,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    context "when submission" do
+      it do
+        is_expected.not_to(
+          allow_value(nil).for(:provider_verification_teaching_responsibilities)
+        )
+      end
+
+      it do
+        is_expected.to(
+          allow_value(true).for(:provider_verification_teaching_responsibilities)
+        )
+      end
+
+      it do
+        is_expected.to(
+          allow_value(false).for(:provider_verification_teaching_responsibilities)
+        )
+      end
+    end
+
+    context "when saving progress" do
+      before do
+        allow(form).to receive(:save_and_exit?).and_return(true)
+      end
+
+      it do
+        is_expected.to(
+          allow_value(nil).for(:provider_verification_teaching_responsibilities)
+        )
+      end
+    end
+  end
+
+  describe "#incomplete?" do
+    context "when form is valid" do
+      let(:params) do
+        {
+          provider_verification_teaching_responsibilities: true
+        }
+      end
+
+      it "returns false" do
+        expect(form.incomplete?).to be(false)
+      end
+    end
+
+    context "when form is invalid" do
+      let(:params) { {} }
+
+      it "returns true" do
+        expect(form.incomplete?).to be(true)
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when form is valid" do
+      let(:params) do
+        {
+          provider_verification_teaching_responsibilities: true
+        }
+      end
+
+      it "updates the claim eligibility and returns true" do
+        expect(form.save).to be(true)
+
+        claim.eligibility.reload
+
+        expect(
+          claim.eligibility.provider_verification_teaching_responsibilities
+        ).to be(true)
+      end
+    end
+
+    context "when form is invalid" do
+      let(:params) { {} }
+
+      it "returns false" do
+        expect(form.save).to be(false)
+      end
+    end
+  end
+
+  describe "#teaching_responsibilities_options" do
+    it "returns the correct options" do
+      expect(form.teaching_responsibilities_options.map(&:id)).to eq([true, false])
+      expect(form.teaching_responsibilities_options.map(&:name)).to eq(["Yes", "No"])
+    end
+  end
+end


### PR DESCRIPTION
# Split role and experience form

Quite a few changes required in this ticket, might be easier to review each
commit separately.

At a high level we
* Switch check answers to have change links next to each answer
* Break up the role and experience form into 3 separate forms
* Add a new option for contract type


https://github.com/user-attachments/assets/9f5f7563-298c-4c4a-9ffd-eb9128c0e184


