### PR TITLE
CAPT-2634 Continue verifying or read-only page

### DIFF
--- a/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
+++ b/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
@@ -22,7 +22,11 @@ module FurtherEducationPayments
 
             wizard.clear_impermissible_answers!
 
-            if @form.save_and_exit?
+            if @form.read_only?
+              redirect_to(
+                further_education_payments_providers_claim_verification_path(claim)
+              )
+            elsif @form.save_and_exit?
               redirect_to(
                 further_education_payments_providers_claim_information_path(
                   claim,

--- a/app/forms/further_education_payments/providers/claims/verification/base_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/base_form.rb
@@ -84,6 +84,10 @@ module FurtherEducationPayments
             !!@save_and_exit
           end
 
+          def read_only?
+            false
+          end
+
           private
 
           def attributes_to_save

--- a/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
@@ -4,6 +4,7 @@ module FurtherEducationPayments
       module Verification
         class CheckAnswersForm < BaseForm
           class IncompleteWizardError < StandardError; end
+          NOT_ANSWERED = "Not answered"
 
           attribute :provider_verification_declaration, :boolean
 
@@ -30,6 +31,22 @@ module FurtherEducationPayments
             to: :eligibility
           )
 
+          def teaching_responsibilities
+            if provider_verification_teaching_responsibilities.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_teaching_responsibilities, scope: :boolean)
+            end
+          end
+
+          def in_first_five_years
+            if provider_verification_in_first_five_years.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_in_first_five_years, scope: :boolean)
+            end
+          end
+
           def contract_type
             case provider_verification_contract_type
             when "fixed_term" then "Fixed-term"
@@ -37,20 +54,77 @@ module FurtherEducationPayments
             when "permanent" then "Permanent"
             when "employed_by_another_organisation"
               "Employed by another organisation (for example, an agency or contractor)"
+            when nil then NOT_ANSWERED
             else fail "Unknown contract type"
             end
           end
 
           def teaching_qualification
-            TeachingQualificationForm::TEACHING_QUALIFICATION_OPTIONS
-              .find { it.id == provider_verification_teaching_qualification }
-              .name
+            if provider_verification_teaching_qualification.nil?
+              NOT_ANSWERED
+            else
+              TeachingQualificationForm::TEACHING_QUALIFICATION_OPTIONS
+                .find { it.id == provider_verification_teaching_qualification }
+                .name
+            end
+          end
+
+          def contract_covers_full_academic_year
+            if provider_verification_contract_covers_full_academic_year.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_contract_covers_full_academic_year, scope: :boolean)
+            end
+          end
+
+          def taught_at_least_one_academic_term
+            if provider_verification_taught_at_least_one_academic_term.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_taught_at_least_one_academic_term, scope: :boolean)
+            end
+          end
+
+          def performance_measures
+            if provider_verification_performance_measures.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_performance_measures, scope: :boolean)
+            end
+          end
+
+          def disciplinary_action
+            if provider_verification_disciplinary_action.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_disciplinary_action, scope: :boolean)
+            end
+          end
+
+          def half_teaching_hours
+            if provider_verification_half_teaching_hours.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_half_teaching_hours, scope: :boolean)
+            end
+          end
+
+          def subjects_taught
+            if provider_verification_subjects_taught.nil?
+              NOT_ANSWERED
+            else
+              I18n.t(provider_verification_subjects_taught, scope: :boolean)
+            end
           end
 
           def teaching_hours_per_week
-            TeachingHoursPerWeekForm::TEACHING_HOURS_PER_WEEK_OPTIONS
-              .find { it.id == provider_verification_teaching_hours_per_week }
-              .name
+            if provider_verification_teaching_hours_per_week.nil?
+              NOT_ANSWERED
+            else
+              TeachingHoursPerWeekForm::TEACHING_HOURS_PER_WEEK_OPTIONS
+                .find { it.id == provider_verification_teaching_hours_per_week }
+                .name
+            end
           end
 
           def save
@@ -63,6 +137,11 @@ module FurtherEducationPayments
 
           def save_and_exit?
             false
+          end
+
+          def started_by
+            DfeSignIn::User
+              .find_by(id: claim.eligibility.provider_assigned_to_id)&.full_name
           end
 
           private

--- a/app/forms/further_education_payments/providers/claims/verification/continue_verification_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/continue_verification_form.rb
@@ -1,0 +1,56 @@
+module FurtherEducationPayments
+  module Providers
+    module Claims
+      module Verification
+        class ContinueVerificationForm < BaseForm
+          attribute :continue_verification, :boolean
+
+          validates(
+            :continue_verification,
+            included: {
+              in: ->(form) { form.continue_verification_options.map(&:id) },
+              message: "Tell us if you want to continue verifying this claim"
+            }
+          )
+
+          def continue_verification_options
+            [
+              Form::Option.new(id: true, name: "Yes"),
+              Form::Option.new(id: false, name: "No, I just want to see the claim")
+            ]
+          end
+
+          def save
+            return true if read_only?
+
+            super
+          end
+
+          def incomplete?
+            claim.eligibility.provider_assigned_to_id.present? &&
+              claim.eligibility.provider_assigned_to_id != provider_assigned_to_id
+          end
+
+          def read_only?
+            continue_verification == false
+          end
+
+          def started_by
+            DfeSignIn::User
+              .find_by(id: claim.eligibility.provider_assigned_to_id)&.full_name
+          end
+
+          private
+
+          def attributes_to_save
+            %w[provider_assigned_to_id]
+          end
+
+          def provider_assigned_to_id
+            user.id
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/further_education_payments/providers/claims/verification/wizard.rb
+++ b/app/models/further_education_payments/providers/claims/verification/wizard.rb
@@ -4,6 +4,7 @@ module FurtherEducationPayments
       module Verification
         class Wizard
           FORMS = [
+            ContinueVerificationForm,
             TeachingResponsibilitiesForm,
             InFirstFiveYearsForm,
             TeachingQualificationForm,
@@ -93,6 +94,7 @@ module FurtherEducationPayments
 
             @reachable_steps = []
 
+            @reachable_steps << ContinueVerificationForm
             @reachable_steps << TeachingResponsibilitiesForm
             @reachable_steps << InFirstFiveYearsForm
             @reachable_steps << TeachingQualificationForm

--- a/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/_summary.html.erb
@@ -6,15 +6,16 @@
   Claim reference: <%= form.claim.reference %>
 </h1>
 
+<%= govuk_inset_text(
+  text: "This claim was started by #{@form.started_by}"
+) %>
+
 <%= govuk_summary_card(title: "Role and experience") do |card| %>
   <%= card.with_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Teaching responsibilities") %>
       <%= row.with_value(
-        text: t(
-          form.provider_verification_teaching_responsibilities,
-          scope: :boolean
-        )
+        text: form.teaching_responsibilities
       ) %>
       <% if editable %>
         <%= row.with_action(
@@ -30,10 +31,7 @@
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "In first 5 years of FE teaching") %>
       <%= row.with_value(
-        text: t(
-          form.provider_verification_in_first_five_years,
-          scope: :boolean
-        )
+        text: form.in_first_five_years
       ) %>
       <% if editable %>
         <%= row.with_action(
@@ -83,10 +81,7 @@
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: "Contract covers full academic year") %>
         <%= row.with_value(
-          text: t(
-            form.provider_verification_contract_covers_full_academic_year,
-            scope: :boolean
-          )
+          text: form.contract_covers_full_academic_year
         ) %>
         <% if editable %>
           <%= row.with_action(
@@ -120,10 +115,7 @@
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: "Variable contract academic term") %>
         <%= row.with_value(
-          text: t(
-            form.provider_verification_taught_at_least_one_academic_term,
-            scope: :boolean
-          )
+          text: form.taught_at_least_one_academic_term
         ) %>
         <% if editable %>
           <%= row.with_action(
@@ -146,10 +138,7 @@
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Subject to performance measures") %>
       <%= row.with_value(
-        text: t(
-          form.provider_verification_performance_measures,
-          scope: :boolean
-        )
+        text: form.performance_measures
       ) %>
       <% if editable %>
         <%= row.with_action(
@@ -165,10 +154,7 @@
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Subject to disciplinary action") %>
       <%= row.with_value(
-        text: t(
-          form.provider_verification_disciplinary_action,
-          scope: :boolean
-        )
+        text: form.disciplinary_action
       ) %>
       <% if editable %>
         <%= row.with_action(
@@ -187,7 +173,9 @@
   <%= card.with_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Timetabled hours per week") %>
-      <%= row.with_value(text: form.teaching_hours_per_week) %>
+      <%= row.with_value(
+        text: form.teaching_hours_per_week
+      ) %>
       <% if editable %>
         <%= row.with_action(
           text: "Change",
@@ -202,10 +190,7 @@
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: "Teaches 16-19-year-olds or those with EHCP") %>
       <%= row.with_value(
-        text: t(
-          form.provider_verification_half_teaching_hours,
-          scope: :boolean
-        )
+        text: form.half_teaching_hours
       ) %>
       <% if editable %>
         <%= row.with_action(
@@ -226,10 +211,7 @@
       <%= row.with_key(text: "Teaches Level 3 courses") %>
 
       <%= row.with_value(
-        text: t(
-          form.provider_verification_subjects_taught,
-          scope: :boolean
-        )
+        text: form.subjects_taught
       ) %>
 
       <% if editable %>

--- a/app/views/further_education_payments/providers/claims/verifications/continue_verification.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/continue_verification.html.erb
@@ -1,0 +1,45 @@
+<%= content_for(
+  :page_title,
+  "Do you want to continue verifying this claim?"
+) %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: further_education_payments_providers_claims_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Do you want to continue verifying this claim?
+    </h1>
+
+    <%= form_with(
+      model: @form,
+      url: further_education_payments_providers_claim_verification_path(
+        @form.claim,
+        @form.provider,
+        slug: @form.slug
+      ),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= govuk_inset_text(
+        text: "This claim was started by #{@form.started_by}"
+      ) %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :continue_verification,
+        f.object.continue_verification_options,
+        :id,
+        :name,
+        legend: nil
+      ) %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit("Continue") %>
+        <%= govuk_link_to "Cancel", further_education_payments_providers_claims_path %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/spec/forms/further_education_payments/providers/claims/verification/continue_verification_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/continue_verification_form_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+
+RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::ContinueVerificationForm, type: :model do
+  let(:fe_provider) do
+    create(:school, :fe_eligible, name: "Springfield College")
+  end
+
+  let(:logged_in_user) { create(:dfe_signin_user) }
+  let(:another_user) { create(:dfe_signin_user, given_name: "Boris", family_name: "Admin") }
+  let(:provider_assigned_to_id) { another_user.id }
+
+  let(:claim) do
+    create(
+      :claim,
+      :further_education,
+      eligibility_attributes: {provider_assigned_to_id: provider_assigned_to_id}
+    )
+  end
+
+  let(:params) { {} }
+
+  subject(:form) do
+    described_class.new(
+      claim: claim,
+      user: logged_in_user,
+      params: params
+    )
+  end
+
+  describe "validations" do
+    context "when submission" do
+      it do
+        is_expected.not_to(
+          allow_value(nil).for(:continue_verification)
+        )
+      end
+
+      it do
+        is_expected.to(
+          allow_value(true).for(:continue_verification)
+        )
+      end
+
+      it do
+        is_expected.to(
+          allow_value(false).for(:continue_verification)
+        )
+      end
+    end
+  end
+
+  describe "#incomplete?" do
+    context "when not assigned" do
+      let(:provider_assigned_to_id) { nil }
+
+      it "returns false" do
+        expect(form.incomplete?).to be(false)
+      end
+    end
+
+    context "when assigned" do
+      context "when logged in user is not assigned user" do
+        it "returns true" do
+          expect(form.incomplete?).to be(true)
+        end
+      end
+
+      context "when logged in user is the assigned user" do
+        let(:provider_assigned_to_id) { logged_in_user.id }
+
+        it "returns false" do
+          expect(form.incomplete?).to be(false)
+        end
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when Yes is selected" do
+      let(:params) do
+        {continue_verification: true}
+      end
+
+      it "assigns the claim to the logged in user" do
+        expect(form.save).to be(true)
+
+        claim.eligibility.reload
+
+        expect(
+          claim.eligibility.provider_assigned_to_id
+        ).to eq(logged_in_user.id)
+      end
+    end
+
+    context "when No is selected" do
+      let(:params) do
+        {continue_verification: false}
+      end
+
+      it "the assignment remains unchanged" do
+        expect(form.save).to be(true)
+
+        claim.eligibility.reload
+
+        expect(
+          claim.eligibility.provider_assigned_to_id
+        ).to eq(another_user.id)
+      end
+    end
+  end
+
+  describe "read_only?" do
+    context "when Yes is selected" do
+      let(:params) do
+        {continue_verification: true}
+      end
+
+      it "returns true" do
+        expect(form.read_only?).to be(false)
+      end
+    end
+
+    context "when No is selected" do
+      let(:params) do
+        {continue_verification: false}
+      end
+
+      it "returns false" do
+        expect(form.read_only?).to be(true)
+      end
+    end
+  end
+
+  describe "#started_by" do
+    context "when assigned" do
+      it "returns the full name of user" do
+        expect(form.started_by).to eq("Boris Admin")
+      end
+    end
+
+    context "when unassigned" do
+      let(:provider_assigned_to_id) { nil }
+
+      it "returns nil" do
+        expect(form.started_by).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Verification journey - add `ContinueVerificationForm` as the first form, if the logged in user is the not the user assigned to claim, otherwise this form is skipped.

Selecting `Yes` will assign the logged in user to this claim.

Selecting `No` will take the user to the read-only summary of the claim.