### PR TITLE
FE taught_at_least_one_term earlier in sequence

### DIFF
--- a/app/forms/journeys/further_education_payments/contract_type_form.rb
+++ b/app/forms/journeys/further_education_payments/contract_type_form.rb
@@ -14,7 +14,7 @@ module Journeys
           Option.new(
             id: "permanent",
             name: t("options.permanent"),
-            hint: "This includes full-time and part-time contracts"
+            hint: "This includes full-time and part-time permanent contracts"
           ),
           Option.new(
             id: "fixed_term",

--- a/app/models/journeys/further_education_payments/answers_presenter.rb
+++ b/app/models/journeys/further_education_payments/answers_presenter.rb
@@ -38,6 +38,8 @@ module Journeys
           a << teaching_responsibilities
           a << school
           a << contract_type
+          a << taught_at_least_one_term
+          a << teaching_hours_per_week_next_term
           a << teaching_hours_per_week
           a << further_education_teaching_start_year
           a << subjects_taught
@@ -96,6 +98,26 @@ module Journeys
           t(answers.contract_type, scope: "further_education_payments.forms.contract_type.options"),
           "contract-type"
         ]
+      end
+
+      def taught_at_least_one_term
+        if !answers.taught_at_least_one_term.nil?
+          [
+            t("further_education_payments.forms.taught_at_least_one_term.question", school_name: answers.school.name),
+            t(answers.taught_at_least_one_term, scope: "further_education_payments.forms.taught_at_least_one_term.options"),
+            "taught-at-least-one-term"
+          ]
+        end
+      end
+
+      def teaching_hours_per_week_next_term
+        if !answers.teaching_hours_per_week_next_term.nil?
+          [
+            t("further_education_payments.forms.teaching_hours_per_week_next_term.question", school_name: answers.school.name),
+            t(answers.teaching_hours_per_week_next_term, scope: "further_education_payments.forms.teaching_hours_per_week_next_term.options", school_name: answers.school.name),
+            "teaching-hours-per-week-next-term"
+          ]
+        end
       end
 
       def teaching_hours_per_week

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -135,10 +135,10 @@ module Journeys
           select_provision_form = form_for_slug(SLUGS_HASH["select-provision"])
 
           if select_provision_form.completed_or_valid? && answers.taught_at_least_one_term == true
+            array << SLUGS_HASH["teaching-hours-per-week-next-term"]
             array << SLUGS_HASH["teaching-hours-per-week"]
 
             if select_provision_form.completed_or_valid? && ["more_than_12", "between_2_5_and_12"].include?(answers.teaching_hours_per_week)
-              array << SLUGS_HASH["teaching-hours-per-week-next-term"]
               array << SLUGS_HASH["further-education-teaching-start-year"]
             end
           end

--- a/config/initializers/govuk_design_system_formbuilder.rb
+++ b/config/initializers/govuk_design_system_formbuilder.rb
@@ -1,0 +1,3 @@
+GOVUKDesignSystemFormBuilder.configure do |c|
+  c.default_collection_radio_buttons_auto_bold_labels = false
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -862,9 +862,9 @@ en:
           contract_type:
             label: "Contract of employment"
             claimant_answers:
-              permanent: "Permanent"
-              fixed_term: "Fixed term"
-              variable_hours: "Variable hours"
+              permanent: "Permanent contract"
+              fixed_term: "Fixed term contract"
+              variable_hours: "Variable hours contract"
           teaching_responsibilities:
             label: "Teaching responsibilities"
             claimant_answers:
@@ -990,10 +990,10 @@ en:
       taught_at_least_one_term:
         question: Have you taught at %{school_name} for at least one academic term?
         options:
-          true: Yes, I have taught at %{school_name} for at least one academic term
-          false: No, I have not taught at %{school_name} for at least one academic term
+          true: "Yes"
+          false: "No"
         errors:
-          inclusion: Select yes if you have taught at %{school_name} for at least one academic term
+          inclusion: Tell us if you have taught at %{school_name} for more than one academic term
       teaching_hours_per_week:
         question:
           On average, how many hours per week are you timetabled to teach at %{school_name} during the current term?
@@ -1006,12 +1006,12 @@ en:
           inclusion: Select the number of hours you are timetabled to teach per week at %{school_name} during the current term
       teaching_hours_per_week_next_term:
         question: Are you timetabled to teach at least 2.5 hours per week at %{school_name} next term?
-        hint: If you are unsure, you should speak to HR or apply when you know your arrangements for next term.
+        hint: If you don’t know, you should speak to HR or apply when you know your arrangements for next term.
         options:
-          at_least_2_5: Yes, I am timetabled to teach at least 2.5 hours per week at %{school_name} next term
-          less_than_2_5: No, I’m not timetabled to teach at least 2.5 hours per week at %{school_name} next term
+          at_least_2_5: "Yes"
+          less_than_2_5: "No"
         errors:
-          inclusion: Select yes if you are timetabled to teach at least 2.5 hours per week next term at %{school_name}
+          inclusion: Tell us if you are timetabled to teach for at least 2.5 hours per week at %{school_name} next term
       further_education_teaching_start_year:
         question: Which academic year did you start teaching in further education (FE) in England?
         options:

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -202,7 +202,7 @@ RSpec.feature "Further education payments ineligible paths" do
     click_button "Continue"
 
     expect(page).to have_content("Have you taught at #{eligible_college.name} for at least one academic term?")
-    choose("No, I have not taught at #{eligible_college.name} for at least one academic term")
+    choose("No")
     click_button "Continue"
 
     expect(page).to have_content("You are not eligible for a targeted retention incentive payment yet")
@@ -289,7 +289,7 @@ RSpec.feature "Further education payments ineligible paths" do
     click_button "Continue"
 
     expect(page).to have_content("Have you taught at #{eligible_college.name} for at least one academic term?")
-    choose("No, I have not taught at #{eligible_college.name} for at least one academic term")
+    choose("No")
     click_button "Continue"
 
     expect(page).to have_content("You are not eligible for a targeted retention incentive payment yet")
@@ -740,7 +740,7 @@ RSpec.feature "Further education payments ineligible paths" do
     click_button "Continue"
 
     expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term?")
-    choose("No, I’m not timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term")
+    choose("No")
     click_button "Continue"
 
     expect(page).to have_content("You are not eligible")
@@ -780,15 +780,11 @@ RSpec.feature "Further education payments ineligible paths" do
     click_button "Continue"
 
     expect(page).to have_content("Have you taught at #{eligible_college.name} for at least one academic term?")
-    choose("Yes, I have taught at #{eligible_college.name} for at least one academic term")
-    click_button "Continue"
-
-    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{eligible_college.name} during the current term?")
-    choose("12 hours or more per week")
+    choose("Yes")
     click_button "Continue"
 
     expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term?")
-    choose("No, I’m not timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term")
+    choose("No")
     click_button "Continue"
 
     expect(page).to have_content("You are not eligible")

--- a/spec/features/further_education_payments/variable_contract_spec.rb
+++ b/spec/features/further_education_payments/variable_contract_spec.rb
@@ -1,0 +1,223 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments" do
+  include ActionView::Helpers::NumberHelper
+
+  let(:college) { create(:school, :further_education, :fe_eligible) }
+  let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
+
+  scenario "variable contract" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Have you previously")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider are you employed by?")
+    fill_in "Which FE provider are you employed by?", with: college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have with #{college.name}?")
+    choose("Variable hours contract")
+    click_button "Continue"
+
+    expect(page).to have_content("Have you taught at #{college.name} for at least one academic term?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{college.name} next term?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
+    choose("12 hours or more per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education (FE) in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Which subject areas do you teach?")
+    check("Building and construction")
+    check("Chemistry")
+    check("Computing, including digital and ICT")
+    check("Early years")
+    check("Engineering and manufacturing, including transport engineering and electronics")
+    check("Maths")
+    check("Physics")
+    click_button "Continue"
+
+    expect(page).to have_content("Which building and construction courses do you teach?")
+    check "T Level in building services engineering for construction"
+    click_button "Continue"
+
+    expect(page).to have_content("Which chemistry courses do you teach?")
+    check "GCSE chemistry"
+    click_button "Continue"
+
+    expect(page).to have_content("Which computing courses do you teach?")
+    check "T Level in digital support services"
+    click_button "Continue"
+
+    expect(page).to have_content("Which early years courses do you teach?")
+    check "T Level in education and early years (early years educator)"
+    click_button "Continue"
+
+    expect(page).to have_content("Which engineering and manufacturing courses do you teach?")
+    check "T Level in design and development for engineering and manufacturing"
+    click_button "Continue"
+
+    expect(page).to have_content("Which maths courses do you teach?")
+
+    check("claim-maths-courses-approved-level-321-maths-field")
+    click_button "Continue"
+
+    expect(page).to have_content("Which physics courses do you teach?")
+    check "A or AS level physics"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours teaching these eligible courses?")
+    expect(page).to have_content("T Level in building services engineering for construction")
+    expect(page).to have_content("GCSE chemistry")
+    expect(page).to have_content("T Level in digital support services")
+    expect(page).to have_content("T Level in education and early years (early years educator)")
+    expect(page).to have_content("T Level in design and development for engineering and manufacturing")
+    expect(page).to have_content("Qualifications approved for funding at level 3 and below in the")
+    expect(page).to have_content("A or AS level physics")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are at least half of your timetabled teaching hours spent teaching 16 to 19-year-olds, including those up to age 25 with an Education, Health and Care Plan (EHCP)?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you subject to any formal performance measures as a result of continuous poor teaching standards")
+    within all(".govuk-fieldset")[0] do
+      choose("No")
+    end
+    expect(page).to have_content("Are you currently subject to disciplinary action?")
+    within all(".govuk-fieldset")[1] do
+      choose("No")
+    end
+    click_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+    expect(page).to have_summary_item(
+      key: "Have you taught at #{college.name} for at least one academic term?",
+      value: "Yes"
+    )
+    expect(page).to have_summary_item(
+      key: "Are you timetabled to teach at least 2.5 hours per week at #{college.name} next term?",
+      value: "Yes"
+    )
+    click_button "Continue"
+
+    expect(page).to have_content("You’re eligible for a targeted retention incentive payment")
+    expect(page).to have_content(number_to_currency(expected_award_amount, precision: 0))
+    expect(page).to have_content("Apply now")
+    click_button "Apply now"
+
+    sign_in_with_one_login
+
+    expect(page).to have_content("How we will use the information you provide")
+    expect(page).to have_content("the Student Loans Company")
+    click_button "Continue"
+
+    expect(page).to have_content("Personal details")
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Day", with: "28"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: "1988"
+    fill_in "National Insurance number", with: "PX321499A " # deliberate trailing space
+    click_on "Continue"
+
+    expect(page).to have_content("What is your home address?")
+    click_button("Enter your address manually")
+
+    expect(page).to have_content("What is your address?")
+    fill_in "House number or name", with: "57"
+    fill_in "Building and street", with: "Walthamstow Drive"
+    fill_in "Town or city", with: "Derby"
+    fill_in "County", with: "City of Derby"
+    fill_in "Postcode", with: "DE22 4BS"
+    click_on "Continue"
+
+    expect(page).to have_content("Email address")
+    fill_in "Email address", with: "john.doe@example.com"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter the 6-digit passcode")
+    mail = ActionMailer::Base.deliveries.last
+    otp_in_mail_sent = mail.personalisation[:one_time_password]
+    fill_in "claim-one-time-password-field", with: otp_in_mail_sent
+    click_on "Confirm"
+
+    expect(page).to have_content("Would you like to provide your mobile number?")
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_content("Enter your personal bank account details")
+    fill_in "Name on your account", with: "Jo Bloggs"
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    expect(page).to have_content("How is your gender recorded on your employer’s payroll system?")
+    choose "Female"
+    click_on "Continue"
+
+    expect(page).to have_content("Teacher reference number (TRN)")
+    fill_in "claim-teacher-reference-number-field", with: "1234567"
+    click_on "Continue"
+
+    expect(page).to have_content("Check your answers before sending your application")
+    expect(page).not_to have_content("Do you have a valid passport?")
+    expect(page).not_to have_content("Passport number")
+
+    expect do
+      click_on "Accept and send"
+    end.to change { Claim.count }.by(1)
+      .and change { Policies::FurtherEducationPayments::Eligibility.count }.by(1)
+      .and have_enqueued_mail(ClaimMailer, :submitted).with(Claim.last)
+
+    claim = Claim.last
+
+    expect(claim.first_name).to eql("John")
+    expect(claim.surname).to eql("Doe")
+    expect(claim.onelogin_idv_full_name).to eql("TEST USER")
+    expect(claim.student_loan_plan).to eq "plan_1"
+
+    eligibility = Policies::FurtherEducationPayments::Eligibility.last
+
+    expect(eligibility.teacher_reference_number).to eql("1234567")
+
+    expect(page).to have_content("You applied for a further education targeted retention incentive payment")
+  end
+
+  def and_college_exists
+    college
+  end
+end

--- a/spec/forms/journeys/further_education_payments/taught_at_least_one_term_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/taught_at_least_one_term_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Journeys::FurtherEducationPayments::TaughtAtLeastOneTermForm, typ
       is_expected.not_to(
         allow_value(nil)
         .for(:taught_at_least_one_term)
-        .with_message("Select yes if you have taught at #{school.name} for at least one academic term")
+        .with_message("Tell us if you have taught at #{school.name} for more than one academic term")
       )
     end
   end

--- a/spec/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form_spec.rb
+++ b/spec/forms/journeys/further_education_payments/teaching_hours_per_week_next_term_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Journeys::FurtherEducationPayments::TeachingHoursPerWeekNextTermF
       is_expected.not_to(
         allow_value(nil)
         .for(:teaching_hours_per_week_next_term)
-        .with_message("Select yes if you are timetabled to teach at least 2.5 hours per week next term at #{college.name}")
+        .with_message("Tell us if you are timetabled to teach for at least 2.5 hours per week at #{college.name} next term")
       )
     end
   end

--- a/spec/models/policies/further_education_payments/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/policies/further_education_payments/eligibility_admin_answers_presenter_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresen
             ],
             [
               "Have you taught at Springfield Elementary for at least one academic term?",
-              "Yes, I have taught at Springfield Elementary for at least one academic term"
+              "Yes"
             ],
             [
               "On average, how many hours per week are you timetabled to teach at Springfield Elementary during the current term?",
@@ -113,7 +113,7 @@ RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresen
             ],
             [
               "Are you timetabled to teach at least 2.5 hours per week at Springfield Elementary next term?",
-              "Yes, I am timetabled to teach at least 2.5 hours per week at Springfield Elementary next term"
+              "Yes"
             ]
           ]
         )
@@ -145,7 +145,7 @@ RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresen
               ],
               [
                 "Are you timetabled to teach at least 2.5 hours per week at Springfield Elementary next term?",
-                "Yes, I am timetabled to teach at least 2.5 hours per week at Springfield Elementary next term"
+                "Yes"
               ]
             ]
           )
@@ -166,7 +166,7 @@ RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresen
               ],
               [
                 "Have you taught at Springfield Elementary for at least one academic term?",
-                "No, I have not taught at Springfield Elementary for at least one academic term"
+                "No"
               ],
               [
                 "Does your fixed-term contract cover the full 2024 to 2025 academic year?",
@@ -178,7 +178,7 @@ RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminAnswersPresen
               ],
               [
                 "Are you timetabled to teach at least 2.5 hours per week at Springfield Elementary next term?",
-                "No, I’m not timetabled to teach at least 2.5 hours per week at Springfield Elementary next term"
+                "No"
               ]
             ]
           )


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2751
- In FE claimant journey move page `taught_at_least_one_term` to earlier in the sequence
- Add missing answers to check answers page
- Answer copy has been simplified