### PR TITLE
Extract DateOfBirth concern

### DIFF
--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -1,36 +1,6 @@
 class DateOfBirthForm < Form
-  include ActiveModel::Dirty
-
-  InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
-    def future?
-      false
-    end
-  end
-
-  DOB_PARAM_CONVERSION = {
-    "date_of_birth(3i)" => "day",
-    "date_of_birth(2i)" => "month",
-    "date_of_birth(1i)" => "year"
-  }
-
-  attribute :day
-  attribute :month
-  attribute :year
-  attribute :date_of_birth
-
-  validate :date_of_birth_criteria
-
-  def initialize(journey_session:, journey:, params:, session: {})
-    super
-    assign_date_attributes
-  end
-
-  def date_of_birth
-    date_hash = {year:, month:, day:}
-    date_args = date_hash.values.map(&:to_i)
-
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
-  end
+  include DateOfBirth
+  self.date_of_birth_field = :date_of_birth
 
   def save
     return false if invalid?
@@ -41,41 +11,5 @@ class DateOfBirthForm < Form
     journey_session.save!
 
     true
-  end
-
-  private
-
-  def permitted_params
-    @permitted_params ||= params.fetch(:claim, {})
-      .permit(*attributes, *DOB_PARAM_CONVERSION.keys)
-      .transform_keys { |key| DOB_PARAM_CONVERSION.has_key?(key) ? DOB_PARAM_CONVERSION[key] : key }
-  end
-
-  def assign_date_attributes
-    self.day = permitted_params.fetch(:day, answers.date_of_birth&.day)
-    self.month = permitted_params.fetch(:month, answers.date_of_birth&.month)
-    self.year = permitted_params.fetch(:year, answers.date_of_birth&.year)
-  end
-
-  def date_of_birth_criteria
-    if date_of_birth.future?
-      errors.add(:date_of_birth, "Date of birth must be in the past")
-    elsif number_of_date_components.between?(1, 2)
-      errors.add(:date_of_birth, "Date of birth must include a day, month and year in the correct format, for example 01 01 1980")
-    elsif number_of_date_components.zero?
-      errors.add(:date_of_birth, "Enter your date of birth")
-    elsif date_of_birth.is_a?(InvalidDate)
-      errors.add(:date_of_birth, "Enter a date of birth in the correct format")
-    elsif date_of_birth.year < 1000
-      errors.add(:date_of_birth, "Year must include 4 numbers")
-    elsif date_of_birth.year <= 1900
-      errors.add(:date_of_birth, "Year must be after 1900")
-    end
-
-    errors[:date_of_birth].empty?
-  end
-
-  def number_of_date_components
-    [day, month, year].compact_blank.size
   end
 end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -20,6 +20,7 @@ class Form
   include ActiveModel::Model
   include ActiveModel::Attributes
   include ActiveModel::Serialization
+  extend ActiveModel::Callbacks
   include ActiveModel::Validations::Callbacks
   include FormHelpers
   include Rails.application.routes.url_helpers
@@ -31,6 +32,8 @@ class Form
 
   delegate :answers, to: :journey_session
 
+  define_model_callbacks :initialize, only: :after
+
   def self.model_name
     Claim.model_name
   end
@@ -41,9 +44,11 @@ class Form
 
   # TODO RL: remove journey param and pull it from the journey_session
   def initialize(journey_session:, journey:, params:, session: {})
-    super
+    run_callbacks :initialize do
+      super
 
-    assign_attributes(attributes_with_current_value)
+      assign_attributes(attributes_with_current_value)
+    end
   end
 
   # by default does nothing

--- a/app/models/concerns/date_of_birth.rb
+++ b/app/models/concerns/date_of_birth.rb
@@ -1,0 +1,112 @@
+# Include this module in a journey form to handle date of birth multipart
+# parameters and validations.
+#
+# Usage
+# ```
+#    class MyJourneyForm < Form
+#      include DateOfBirth
+#      self.date_of_birth_field = :date_of_birth
+# ```
+
+module DateOfBirth
+  extend ActiveSupport::Concern
+
+  InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
+    def future?
+      false
+    end
+  end
+
+  included do
+    attribute :day
+    attribute :month
+    attribute :year
+    validate :date_of_birth_criteria
+    after_initialize :assign_date_attributes
+  end
+
+  class_methods do
+    def date_of_birth_field=(field_name)
+      define_method(:date_of_birth_field) { field_name }
+
+      define_method("#{field_name}=") do |value|
+        instance_variable_set("@#{field_name}", value)
+      end
+
+      define_method(field_name) do
+        date_hash = {year:, month:, day:}
+        date_args = date_hash.values.map(&:to_i)
+
+        Date.valid_date?(*date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
+      end
+
+      define_method(:dob_param_conversion) do
+        {
+          "#{date_of_birth_field}(3i)" => "day",
+          "#{date_of_birth_field}(2i)" => "month",
+          "#{date_of_birth_field}(1i)" => "year"
+        }
+      end
+    end
+  end
+
+  private
+
+  def permitted_params
+    @permitted_params ||= params.fetch(:claim, {})
+      .permit(*attributes, *dob_param_conversion.keys)
+      .transform_keys { |key| dob_param_conversion.has_key?(key) ? dob_param_conversion[key] : key }
+  end
+
+  def assign_date_attributes
+    self.day = permitted_params.fetch(:day, answers.public_send(date_of_birth_field)&.day)
+    self.month = permitted_params.fetch(:month, answers.public_send(date_of_birth_field)&.month)
+    self.year = permitted_params.fetch(:year, answers.public_send(date_of_birth_field)&.year)
+  end
+
+  def date_of_birth_criteria
+    if public_send(date_of_birth_field).future?
+      errors.add(:"#{date_of_birth_field}", date_of_birth_future_error_message)
+    elsif number_of_date_components.between?(1, 2)
+      errors.add(:"#{date_of_birth_field}", date_of_birth_missing_components_error_message)
+    elsif number_of_date_components.zero?
+      errors.add(:"#{date_of_birth_field}", date_of_birth_blank_error_message)
+    elsif public_send(date_of_birth_field).is_a?(InvalidDate)
+      errors.add(:"#{date_of_birth_field}", date_of_birth_invalid_error_message)
+    elsif public_send(date_of_birth_field).year < 1000
+      errors.add(:"#{date_of_birth_field}", date_of_birth_three_digit_year_error_message)
+    elsif public_send(date_of_birth_field).year <= 1900
+      errors.add(:"#{date_of_birth_field}", date_of_birth_before_1900_error_message)
+    end
+
+    errors[:"#{date_of_birth_field}"].empty?
+  end
+
+  def number_of_date_components
+    [day, month, year].compact_blank.size
+  end
+
+  def date_of_birth_future_error_message
+    "Date of birth must be in the past"
+  end
+
+  def date_of_birth_missing_components_error_message
+    "Date of birth must include a day, month and year in the correct format, for example 01 01 1980"
+  end
+
+  def date_of_birth_blank_error_message
+    "Enter your date of birth"
+  end
+
+  def date_of_birth_invalid_error_message
+    "Enter a date of birth in the correct format"
+  end
+
+  def date_of_birth_three_digit_year_error_message
+    "Year must include 4 numbers"
+  end
+
+  def date_of_birth_before_1900_error_message
+    "Year must be after 1900"
+  end
+end


### PR DESCRIPTION
Extract DateOfBirth concern

We have some rules around validation errors we show to users that are
tricky to implement when we parse multipart date params using
ActiveRecord::AttributeAssignment.
We will want to share this date of birth validation handling with other
forms so we're extracting a concern.
To avoid having to overwrite the initializer in the module (other
forms may need to reopen the initializer) we've introduce active model
callbacks allowing us to define an after initializer callback the DoB
handling can hook into.

Customising the error messages is done by overwriting methods in the
including class. We've taken this approach rather than dealing with i18n
as some consumers of the module will need to pass variables to i18n (eg
`claimant_name`) which is a pain to handle in the module!

Going to need this for the date of birth field in the EY alt IDV journey.

Introduced as part of the work in [this pr](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4006)