### PR TITLE
CAPT 1897/retain fe and irp data

### DIFF
--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -40,23 +40,10 @@ module Policies
     # Attributes to delete from claims submitted before the current academic
     # year
     PERSONAL_DATA_ATTRIBUTES_TO_DELETE = [
-      :first_name,
-      :middle_name,
-      :surname,
-      :date_of_birth,
-      :address_line_1,
-      :address_line_2,
-      :address_line_3,
-      :address_line_4,
-      :postcode,
-      :payroll_gender,
-      :national_insurance_number,
       :bank_sort_code,
       :bank_account_number,
       :building_society_roll_number,
       :banking_name,
-      :hmrc_bank_validation_responses,
-      :mobile_number,
       :teacher_id_user_info,
       :dqt_teacher_status,
       :claimant_date_of_birth,
@@ -67,11 +54,26 @@ module Policies
     ]
 
     # Attributes to retain on submitted claims until EXTENDED_PERIOD_END_DATE
-    PERSONAL_DATA_ATTRIBUTES_TO_RETAIN_FOR_EXTENDED_PERIOD = []
+    PERSONAL_DATA_ATTRIBUTES_TO_RETAIN_FOR_EXTENDED_PERIOD = [
+      :first_name,
+      :middle_name,
+      :surname,
+      :date_of_birth,
+      :address_line_1,
+      :address_line_2,
+      :address_line_3,
+      :address_line_4,
+      :postcode,
+      :national_insurance_number,
+      :mobile_number,
+      :hmrc_bank_validation_responses,
+      :payroll_gender
+    ]
 
     # Claims from before this date will have their retained attributes deleted
-    # NOOP as PERSONAL_DATA_ATTRIBUTES_TO_RETAIN_FOR_EXTENDED_PERIOD is empty
-    EXTENDED_PERIOD_END_DATE = ->(start_of_academic_year) {}
+    EXTENDED_PERIOD_END_DATE = ->(start_of_academic_year) {
+      start_of_academic_year - 5.years
+    }
 
     def notify_reply_to_id
       "89939786-7078-4267-b197-ee505dfad8ae"

--- a/app/models/policies/international_relocation_payments.rb
+++ b/app/models/policies/international_relocation_payments.rb
@@ -32,7 +32,6 @@ module Policies
     # Attributes to delete from claims submitted before the current academic
     # year
     PERSONAL_DATA_ATTRIBUTES_TO_DELETE = [
-      :date_of_birth,
       :address_line_1,
       :address_line_2,
       :address_line_3,
@@ -54,6 +53,7 @@ module Policies
       :first_name,
       :middle_name,
       :surname,
+      :date_of_birth,
       :national_insurance_number,
       :passport_number
     ]

--- a/spec/models/policies/international_relocation_payments/claim_personal_data_scrubber_spec.rb
+++ b/spec/models/policies/international_relocation_payments/claim_personal_data_scrubber_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Policies::InternationalRelocationPayments::ClaimPersonalDataScrub
     Policies::InternationalRelocationPayments
   )
 
-  it "retains name, passport, and national insurance number for 2 years" do
+  it "retains name, passport, date of birth, and national insurance number for 2 years" do
     last_academic_year = Time.zone.local(AcademicYear.current.start_year, 8, 1, 12)
 
     approved_claim = create(
@@ -17,6 +17,7 @@ RSpec.describe Policies::InternationalRelocationPayments::ClaimPersonalDataScrub
       first_name: "John",
       middle_name: "James",
       surname: "Doe",
+      date_of_birth: Date.new(1980, 1, 1),
       eligibility_attributes: {
         passport_number: "123456789"
       }
@@ -61,6 +62,7 @@ RSpec.describe Policies::InternationalRelocationPayments::ClaimPersonalDataScrub
       national_insurance_number: "AB123456D",
       first_name: "Jane",
       surname: "Smith",
+      date_of_birth: Date.new(1980, 1, 1),
       eligibility_attributes: {
         passport_number: "987654321"
       }
@@ -101,6 +103,8 @@ RSpec.describe Policies::InternationalRelocationPayments::ClaimPersonalDataScrub
       ).and(
         not_change { approved_claim.reload.surname }
       ).and(
+        not_change { approved_claim.reload.date_of_birth }
+      ).and(
         not_change { approved_claim.reload.national_insurance_number }
       ).and(
         not_change { approved_claim.reload.eligibility.passport_number }
@@ -121,6 +125,8 @@ RSpec.describe Policies::InternationalRelocationPayments::ClaimPersonalDataScrub
         ).and(
           change { approved_claim.reload.surname }.to(nil)
         ).and(
+          change { approved_claim.reload.date_of_birth }.to(nil)
+        ).and(
           change { approved_claim.reload.national_insurance_number }.to(nil)
         ).and(
           change { approved_claim.reload.eligibility.passport_number }.to(nil)
@@ -136,6 +142,8 @@ RSpec.describe Policies::InternationalRelocationPayments::ClaimPersonalDataScrub
           not_change { claim_expected_not_to_change_1.reload.middle_name }
         ).and(
           not_change { claim_expected_not_to_change_1.reload.surname }
+        ).and(
+          not_change { claim_expected_not_to_change_1.reload.date_of_birth }
         ).and(
           not_change { claim_expected_not_to_change_1.reload.national_insurance_number }
         ).and(

--- a/spec/support/claim_personal_data_scrubber_shared_examples.rb
+++ b/spec/support/claim_personal_data_scrubber_shared_examples.rb
@@ -170,8 +170,6 @@ RSpec.shared_examples "a claim personal data scrubber" do |policy|
     travel_to last_academic_year - 1.week do
       claim = create(:claim, :submitted, policy: policy)
       claim_changes = {
-        "payroll_gender" => ["male", claim.payroll_gender],
-        "date_of_birth" => [25.years.ago.to_date, claim.date_of_birth],
         "student_loan_plan" => ["plan_1", claim.student_loan_plan],
         "bank_sort_code" => ["457288", claim.bank_sort_code],
         "bank_account_number" => ["84818482", claim.bank_account_number],
@@ -195,8 +193,6 @@ RSpec.shared_examples "a claim personal data scrubber" do |policy|
       cleaned_amendment = Amendment.find(amendment.id)
 
       expected_claim_changed_attributes = %w[
-        payroll_gender
-        date_of_birth
         student_loan_plan
         bank_sort_code
         bank_account_number
@@ -212,8 +208,6 @@ RSpec.shared_examples "a claim personal data scrubber" do |policy|
       if claim.eligibility.has_attribute?(:teacher_reference_number)
         expect(cleaned_amendment.claim_changes["teacher_reference_number"]).to eq(original_trn_change)
       end
-      expect(cleaned_amendment.claim_changes["date_of_birth"]).to eq(nil)
-      expect(cleaned_amendment.claim_changes["payroll_gender"]).to eq(nil)
       expect(cleaned_amendment.claim_changes["bank_sort_code"]).to eq(nil)
       expect(cleaned_amendment.claim_changes["bank_account_number"]).to eq(nil)
       expect(cleaned_amendment.claim_changes["building_society_roll_number"]).to eq(nil)


### PR DESCRIPTION
Update pii scrubbing for FE and IRP

https://dfedigital.atlassian.net/browse/CAPT-1897

We want to retain attributes for matching with previous year claims for the life
of the policy.
