### PR TITLE
CAPT 2849/ey alt idv automated task passing

### DIFF
--- a/app/forms/admin/tasks/ey_alternative_verification_form.rb
+++ b/app/forms/admin/tasks/ey_alternative_verification_form.rb
@@ -163,6 +163,10 @@ class Admin::Tasks::EyAlternativeVerificationForm
     task.persisted? && task.data["personal_details_were_passed_automatically"] == true
   end
 
+  def bank_details_were_passed_automatically?
+    task.persisted? && task.data["bank_details_were_passed_automatically"] == true
+  end
+
   def task_completed?
     task.persisted? && !task.passed.nil?
   end

--- a/app/forms/admin/tasks/ey_alternative_verification_form.rb
+++ b/app/forms/admin/tasks/ey_alternative_verification_form.rb
@@ -134,14 +134,16 @@ class Admin::Tasks::EyAlternativeVerificationForm
   def save
     return false if invalid?
 
+    task_data = task.data || {}
+
+    task_data["personal_details_match"] = personal_details_match
+    task_data["bank_details_match"] = bank_details_match
+
     task.update(
       passed: personal_details_match && bank_details_match,
       created_by: admin_user,
       manual: true,
-      data: {
-        personal_details_match: personal_details_match,
-        bank_details_match: bank_details_match
-      }
+      data: task_data
     )
   end
 
@@ -155,6 +157,14 @@ class Admin::Tasks::EyAlternativeVerificationForm
 
   def claimant_name
     claim.full_name
+  end
+
+  def personal_details_were_passed_automatically?
+    task.persisted? && task.data["personal_details_were_passed_automatically"] == true
+  end
+
+  def task_completed?
+    task.persisted? && !task.passed.nil?
   end
 
   private

--- a/app/forms/admin/tasks/ey_alternative_verification_form.rb
+++ b/app/forms/admin/tasks/ey_alternative_verification_form.rb
@@ -102,6 +102,22 @@ class Admin::Tasks::EyAlternativeVerificationForm
     ]
   end
 
+  def personal_details_result
+    # If the task has been auto failed because bank details were not confirmed
+    # by provider, we don't have a personal_details_match value saved.
+    return not_applicable_answer if personal_details_match.nil?
+
+    I18n.t(personal_details_match, scope: :boolean)
+  end
+
+  def bank_details_result
+    # If the task has been auto failed because bank details were not confirmed
+    # by provider, we don't have a bank_details_match value saved.
+    return not_applicable_answer if bank_details_match.nil?
+
+    I18n.t(bank_details_match, scope: :boolean)
+  end
+
   def bank_details_match_options
     [
       Form::Option.new(id: true, name: "Yes"),
@@ -159,12 +175,12 @@ class Admin::Tasks::EyAlternativeVerificationForm
     claim.full_name
   end
 
-  def personal_details_were_passed_automatically?
-    task.persisted? && task.data["personal_details_were_passed_automatically"] == true
+  def personal_details_task_completed_automatically?
+    task.persisted? && task.data["personal_details_task_completed_automatically"] == true
   end
 
-  def bank_details_were_passed_automatically?
-    task.persisted? && task.data["bank_details_were_passed_automatically"] == true
+  def bank_details_task_completed_automatically?
+    task.persisted? && task.data["bank_details_task_completed_automatically"] == true
   end
 
   def task_completed?

--- a/app/jobs/tasks/ey_alternative_verification_job.rb
+++ b/app/jobs/tasks/ey_alternative_verification_job.rb
@@ -1,0 +1,10 @@
+module Tasks
+  class EyAlternativeVerificationJob < ApplicationJob
+    def perform(claim)
+      task = AutomatedChecks::ClaimVerifiers::EyAlternativeVerification
+        .new(claim:)
+
+      task.perform
+    end
+  end
+end

--- a/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
+++ b/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
@@ -18,6 +18,11 @@ module AutomatedChecks
           data[:personal_details_match] = true
         end
 
+        if bank_details_match?
+          data[:bank_details_were_passed_automatically] = true
+          data[:bank_details_match] = true
+        end
+
         task = claim.tasks.build(
           name: TASK_NAME,
           data: data
@@ -25,6 +30,9 @@ module AutomatedChecks
 
         if failable?
           task.passed = false
+          task.manual = false
+        elsif passable?
+          task.passed = true
           task.manual = false
         end
 
@@ -35,20 +43,46 @@ module AutomatedChecks
 
       attr_accessor :claim
 
+      def eligibility
+        claim.eligibility
+      end
+
       def existing_task_persisted?
         claim.tasks.any? { |task| task.name == TASK_NAME }
       end
 
       def personal_details_match?
-        claim.eligibility.alternative_idv_claimant_employed_by_nursery == true &&
-          claim.eligibility.alternative_idv_claimant_date_of_birth == claim.date_of_birth &&
-          claim.eligibility.alternative_idv_claimant_postcode.downcase == claim.postcode.downcase &&
-          claim.eligibility.alternative_idv_claimant_national_insurance_number.downcase == claim.national_insurance_number.downcase &&
-          claim.eligibility.alternative_idv_claimant_email.downcase == claim.email_address.downcase
+        eligibility.alternative_idv_claimant_employed_by_nursery == true &&
+          eligibility.alternative_idv_claimant_date_of_birth == claim.date_of_birth &&
+          eligibility.alternative_idv_claimant_postcode.downcase == claim.postcode.downcase &&
+          eligibility.alternative_idv_claimant_national_insurance_number.downcase == claim.national_insurance_number.downcase &&
+          eligibility.alternative_idv_claimant_email.downcase == claim.email_address.downcase
+      end
+
+      def bank_details_match?
+        return false unless eligibility.alternative_idv_claimant_employed_by_nursery == true
+        return false unless eligibility.alternative_idv_claimant_bank_details_match
+        return false unless claim.hmrc_name_match?
+        return false unless banking_names_match?
+
+        true
+      end
+
+      def banking_names_match?
+        normalised_banking_name = claim.banking_name.strip.downcase
+        normalised_first_name = claim.first_name.strip.downcase
+        normalised_surname = claim.surname.strip.downcase
+
+        normalised_banking_name.start_with?(normalised_first_name) &&
+          normalised_banking_name.end_with?(normalised_surname)
+      end
+
+      def passable?
+        personal_details_match? && bank_details_match?
       end
 
       def failable?
-        claim.eligibility.alternative_idv_claimant_employed_by_nursery == false
+        eligibility.alternative_idv_claimant_employed_by_nursery == false
       end
     end
   end

--- a/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
+++ b/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
@@ -1,0 +1,55 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    class EyAlternativeVerification
+      TASK_NAME = "ey_alternative_verification".freeze
+      private_constant :TASK_NAME
+
+      def initialize(claim:)
+        self.claim = claim
+      end
+
+      def perform
+        return if existing_task_persisted?
+
+        data = {}
+
+        if personal_details_match?
+          data[:personal_details_were_passed_automatically] = true
+          data[:personal_details_match] = true
+        end
+
+        task = claim.tasks.build(
+          name: TASK_NAME,
+          data: data
+        )
+
+        if failable?
+          task.passed = false
+          task.manual = false
+        end
+
+        task.save!(context: :claim_verifier)
+      end
+
+      private
+
+      attr_accessor :claim
+
+      def existing_task_persisted?
+        claim.tasks.any? { |task| task.name == TASK_NAME }
+      end
+
+      def personal_details_match?
+        claim.eligibility.alternative_idv_claimant_employed_by_nursery == true &&
+          claim.eligibility.alternative_idv_claimant_date_of_birth == claim.date_of_birth &&
+          claim.eligibility.alternative_idv_claimant_postcode.downcase == claim.postcode.downcase &&
+          claim.eligibility.alternative_idv_claimant_national_insurance_number.downcase == claim.national_insurance_number.downcase &&
+          claim.eligibility.alternative_idv_claimant_email.downcase == claim.email_address.downcase
+      end
+
+      def failable?
+        claim.eligibility.alternative_idv_claimant_employed_by_nursery == false
+      end
+    end
+  end
+end

--- a/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
+++ b/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
@@ -70,11 +70,9 @@ module AutomatedChecks
 
       def banking_names_match?
         normalised_banking_name = claim.banking_name.strip.downcase
-        normalised_first_name = claim.first_name.strip.downcase
-        normalised_surname = claim.surname.strip.downcase
+        normalised_claim_name = claim.full_name.strip.downcase
 
-        normalised_banking_name.start_with?(normalised_first_name) &&
-          normalised_banking_name.end_with?(normalised_surname)
+        normalised_banking_name == normalised_claim_name
       end
 
       def passable?

--- a/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
+++ b/app/models/automated_checks/claim_verifiers/ey_alternative_verification.rb
@@ -14,13 +14,19 @@ module AutomatedChecks
         data = {}
 
         if personal_details_match?
-          data[:personal_details_were_passed_automatically] = true
+          data[:personal_details_task_completed_automatically] = true
           data[:personal_details_match] = true
+        elsif personal_details_failable?
+          data[:personal_details_task_completed_automatically] = true
+          data[:personal_details_match] = false
         end
 
         if bank_details_match?
-          data[:bank_details_were_passed_automatically] = true
+          data[:bank_details_task_completed_automatically] = true
           data[:bank_details_match] = true
+        elsif bank_details_failable?
+          data[:bank_details_task_completed_automatically] = true
+          data[:bank_details_match] = false
         end
 
         task = claim.tasks.build(
@@ -60,8 +66,8 @@ module AutomatedChecks
       end
 
       def bank_details_match?
-        return false unless eligibility.alternative_idv_claimant_employed_by_nursery == true
-        return false unless eligibility.alternative_idv_claimant_bank_details_match
+        return false if personal_details_failable?
+        return false if bank_details_failable?
         return false unless claim.hmrc_name_match?
         return false unless banking_names_match?
 
@@ -79,8 +85,16 @@ module AutomatedChecks
         personal_details_match? && bank_details_match?
       end
 
-      def failable?
+      def personal_details_failable?
         eligibility.alternative_idv_claimant_employed_by_nursery == false
+      end
+
+      def bank_details_failable?
+        eligibility.alternative_idv_claimant_bank_details_match == false
+      end
+
+      def failable?
+        personal_details_failable? || bank_details_failable?
       end
     end
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -476,6 +476,10 @@ class Claim < ApplicationRecord
     end.last
   end
 
+  def hmrc_name_match?
+    hmrc_name_match == "yes"
+  end
+
   private
 
   def one_login_idv_name_match?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -477,7 +477,7 @@ class Claim < ApplicationRecord
   end
 
   def hmrc_name_match?
-    hmrc_name_match == "yes"
+    hmrc_name_match&.downcase == "yes"
   end
 
   private

--- a/app/models/policies/early_years_payments.rb
+++ b/app/models/policies/early_years_payments.rb
@@ -102,7 +102,7 @@ module Policies
     end
 
     def alternative_idv_completed!(claim)
-      # NOOP
+      Tasks::EyAlternativeVerificationJob.perform_later(claim)
     end
   end
 end

--- a/app/models/tasks.rb
+++ b/app/models/tasks.rb
@@ -5,6 +5,8 @@ module Tasks
     case task_name
     when "alternative_identity_verification"
       _alternative_identity_verification(task: task, claim: claim)
+    when "ey_alternative_verification"
+      _ey_alternative_verification(task: task, claim: claim)
     else
       _generic(task)
     end
@@ -42,6 +44,23 @@ module Tasks
       status = "No match"
       status_colour = "red"
     elsif task.nil?
+      status = "Incomplete"
+      status_colour = "grey"
+    elsif task.passed?
+      status = "Passed"
+      status_colour = "green"
+    elsif task.passed == false
+      status = "Failed"
+      status_colour = "red"
+    else
+      fail "Unknown status for task #{task.inspect}"
+    end
+
+    [status, status_colour]
+  end
+
+  def self._ey_alternative_verification(task:, claim:)
+    if task.nil? || task.passed.nil?
       status = "Incomplete"
       status_colour = "grey"
     elsif task.passed?

--- a/app/views/admin/tasks/ey_alternative_verification.html.erb
+++ b/app/views/admin/tasks/ey_alternative_verification.html.erb
@@ -41,14 +41,14 @@
         ) %>
 
         <div class="govuk-!-width-one-half">
-          <% if f.object.task_completed? || f.object.personal_details_were_passed_automatically? %>
+          <% if f.object.task_completed? || f.object.personal_details_task_completed_automatically? %>
             <p class="govuk-body">
               <span class="govuk-fieldset__legend govuk-fieldset__legend--s">
                 Do the personal details provided by the claimant match the 
                 details from the provider?
               </span>
 
-              <%= I18n.t(f.object.personal_details_match, scope: :boolean) %>
+              <%= f.object.personal_details_result %>
             </p>
           <% else %>
             <%= f.govuk_collection_radio_buttons(
@@ -80,14 +80,14 @@
         ) %>
 
         <div class="govuk-!-width-one-half">
-          <% if f.object.task_completed? || f.object.bank_details_were_passed_automatically? %>
+          <% if f.object.task_completed? || f.object.bank_details_task_completed_automatically? %>
             <p class="govuk-body">
               <span class="govuk-fieldset__legend govuk-fieldset__legend--s">
                 Has <%= f.object.claimant_name %> provided their own bank
                 account details?
               </span>
 
-              <%= I18n.t(f.object.bank_details_match, scope: :boolean) %>
+              <%= f.object.bank_details_result %>
             </p>
           <% else %>
             <%= f.govuk_collection_radio_buttons(

--- a/app/views/admin/tasks/ey_alternative_verification.html.erb
+++ b/app/views/admin/tasks/ey_alternative_verification.html.erb
@@ -41,7 +41,7 @@
         ) %>
 
         <div class="govuk-!-width-one-half">
-          <% if f.object.task.completed? %>
+          <% if f.object.task_completed? || f.object.personal_details_were_passed_automatically? %>
             <p class="govuk-body">
               <span class="govuk-fieldset__legend govuk-fieldset__legend--s">
                 Do the personal details provided by the claimant match the 
@@ -80,7 +80,7 @@
         ) %>
 
         <div class="govuk-!-width-one-half">
-          <% if f.object.task.completed? %>
+          <% if f.object.task_completed? %>
             <p class="govuk-body">
               <span class="govuk-fieldset__legend govuk-fieldset__legend--s">
                 Has <%= f.object.claimant_name %> provided their own bank
@@ -106,27 +106,10 @@
       </section>
 
       <section id="task-outcome">
-        <% if @form.task.completed? %>
-          <div class="govuk-inset-text task-outcome">
-            <p class="govuk-body">
-              <%= task_status_tag(@form.task.claim, @form.task.name) %>
-            </p>
-            <p class="govuk-body">
-              This task was performed by
-              <%= user_details(@form.task.created_by, include_line_break: false) %>
-              on <%= l(@form.task.updated_at) %>
-            </p>
-          </div>
+        <% if @form.task_completed? %>
+          <%= render "admin/tasks/task_outcome" %>
         <% else %>
           <%= f.govuk_submit "Save and continue" %>
-        <% end %>
-
-        <% if @notes.present? %>
-          <div class="hmcts-timeline">
-            <% @notes.each do |note| %>
-              <%= render "admin/notes/note", note: note, display_description: true %>
-            <% end %>
-          </div>
         <% end %>
       </section>
 

--- a/app/views/admin/tasks/ey_alternative_verification.html.erb
+++ b/app/views/admin/tasks/ey_alternative_verification.html.erb
@@ -80,7 +80,7 @@
         ) %>
 
         <div class="govuk-!-width-one-half">
-          <% if f.object.task_completed? %>
+          <% if f.object.task_completed? || f.object.bank_details_were_passed_automatically? %>
             <p class="govuk-body">
               <span class="govuk-fieldset__legend govuk-fieldset__legend--s">
                 Has <%= f.object.claimant_name %> provided their own bank

--- a/spec/features/admin/early_years/alternative_verification_spec.rb
+++ b/spec/features/admin/early_years/alternative_verification_spec.rb
@@ -36,48 +36,42 @@ RSpec.describe "EY claim and alternative verification task" do
       )
     end
 
-    scenario "awaiting provider response" do
-      visit admin_claim_path(claim)
-      click_on "View tasks"
+    context "when awaiting provider response" do
+      it "shows the correct status and next steps" do
+        visit admin_claim_path(claim)
+        click_on "View tasks"
 
-      expect(task_status("One Login identity check")).to eql "No data"
-      expect(task_status("Alternative verification")).to eql "Incomplete"
-      click_link "Confirm the claimant made the claim"
+        expect(task_status("One Login identity check")).to eql "No data"
+        expect(task_status("Alternative verification")).to eql "Incomplete"
+        click_link "Confirm the provider has verified the claimant’s identity"
 
-      click_link "Confirm the provider has verified the claimant’s employment"
-
-      expect(page).to have_text "Awaiting provider response"
-      expect(page).to have_text "Do the personal details provided by the claimant match the details from the provider?"
+        expect(page).to have_text "Awaiting provider response"
+        expect(page).to have_text "Do the personal details provided by the claimant match the details from the provider?"
+      end
     end
 
-    context "provider agrees with claimant personal and bank details answers" do
+    context "when provider has responded" do
       let(:claim) do
         create(
           :claim,
           :submitted,
           :with_failed_ol_idv,
           policy: Policies::EarlyYearsPayments,
-          eligibility:,
+          eligibility: eligibility,
           date_of_birth: Date.new(1970, 1, 1),
           postcode: "ec1n 2td",
           national_insurance_number: "ab123456c",
           email_address: "claimant@example.com",
           first_name: "Edna",
-          surname: "Krabapple"
-        )
-      end
-
-      let(:eligibility) do
-        create(
-          :early_years_payments_eligibility,
-          :with_eligible_ey_provider,
-          :provider_claim_submitted,
-          alternative_idv_claimant_employed_by_nursery: true,
-          alternative_idv_claimant_date_of_birth: Date.new(1970, 1, 1),
-          alternative_idv_claimant_postcode: "EC1N 2TD",
-          alternative_idv_claimant_national_insurance_number: "AB123456C",
-          alternative_idv_claimant_bank_details_match: true,
-          alternative_idv_claimant_email: "CLAIMANT@example.com"
+          surname: "Krabappel",
+          banking_name: "Edna J Krabappel",
+          hmrc_bank_validation_responses: [
+            {
+              "body" => {
+                "nameMatches" => "yes"
+              }
+            }
+          ]
         )
       end
 
@@ -87,110 +81,276 @@ RSpec.describe "EY claim and alternative verification task" do
         end
       end
 
-      scenario "admin passes the task" do
-        visit admin_claim_path(claim)
-        click_on "View tasks"
-
-        expect(task_status("One Login identity check")).to eql "No data"
-        expect(task_status("Alternative verification")).to eql "Incomplete"
-        click_link "Confirm the provider has verified the claimant’s identity"
-
-        expect(page).to have_text(
-          "The provider told us that they employ Edna Krabapple"
-        )
-
-        within_fieldset(
-          "Do the personal details provided by the claimant match the details " \
-          "from the provider?"
-        ) do
-          choose "Yes"
+      context "when provider says claimant is not employed by them" do
+        let(:eligibility) do
+          create(
+            :early_years_payments_eligibility,
+            :with_eligible_ey_provider,
+            :provider_claim_submitted,
+            alternative_idv_claimant_employed_by_nursery: false,
+            alternative_idv_claimant_date_of_birth: nil,
+            alternative_idv_claimant_postcode: nil,
+            alternative_idv_claimant_national_insurance_number: nil,
+            alternative_idv_claimant_bank_details_match: nil,
+            alternative_idv_claimant_email: nil,
+            alternative_idv_claimant_employment_check_declaration: nil,
+            alternative_idv_completed_at: 2.days.ago
+          )
         end
 
-        expect(page).to have_text(
-          "The provider told us that they recognise the bank account details " \
-          "that Edna Krabapple submitted."
-        )
+        it "fails the task" do
+          visit admin_claim_path(claim)
+          click_on "View tasks"
 
-        within_fieldset(
-          "Has Edna Krabapple provided their own bank account details?"
-        ) do
-          choose "Yes"
+          expect(task_status("One Login identity check")).to eql "No data"
+          expect(task_status("Alternative verification")).to eql "Failed"
+          click_link "Confirm the provider has verified the claimant’s identity"
+
+          within "#personal-details" do
+            expect(page).to have_content(
+              "The provider told us that they do not employ Edna Krabappel."
+            )
+
+            expect(table_row("Date of birth")).to eq([
+              "1 January 1970",
+              "N/A"
+            ])
+
+            expect(table_row("Postcode")).to eq([
+              "ec1n 2td",
+              "N/A"
+            ])
+
+            expect(table_row("National Insurance number")).to eq([
+              "AB123456C",
+              "N/A"
+            ])
+
+            expect(table_row("Email")).to eq([
+              "claimant@example.com",
+              "N/A"
+            ])
+          end
+
+          within "#bank-details" do
+            expect(page).to have_content("Not applicable")
+
+            expect(table_row("Edna J Krabappel")).to eq([
+              "Edna Krabappel", # Claimant's name
+              "yes" # From HMRC response
+            ])
+          end
+
+          within "#task-outcome" do
+            expect(page).to have_content("Failed")
+            expect(page).to have_content(
+              "This task was performed by an automated check"
+            )
+          end
         end
-
-        click_button "Save and continue"
-
-        visit admin_claim_tasks_path(claim)
-
-        expect(task_status("Alternative verification")).to eq "Passed"
       end
-    end
 
-    context "provider disagrees with claimant bank details answers" do
-      let(:claim) do
-        create(
-          :claim,
-          :submitted,
-          :with_failed_ol_idv,
-          policy: Policies::EarlyYearsPayments,
-          eligibility:,
-          date_of_birth: Date.new(1970, 1, 1),
-          postcode: "ec1n 2td",
-          national_insurance_number: "ab123456c",
-          email_address: "claimant@example.com",
-          first_name: "Edna",
-          surname: "Krabapple"
-        )
-      end
-
-      let(:eligibility) do
-        create(
-          :early_years_payments_eligibility,
-          :with_eligible_ey_provider,
-          :provider_claim_submitted,
-          alternative_idv_claimant_employed_by_nursery: true,
-          alternative_idv_claimant_date_of_birth: Date.new(1970, 1, 1),
-          alternative_idv_claimant_postcode: "EC1N 2TD",
-          alternative_idv_claimant_national_insurance_number: "AB123456C",
-          alternative_idv_claimant_email: "claimant-2@example.com",
-          alternative_idv_claimant_bank_details_match: false
-        )
-      end
-
-      scenario "admin chooses no for one of the questions" do
-        visit admin_claim_path(claim)
-        click_on "View tasks"
-
-        expect(task_status("One Login identity check")).to eql "No data"
-        expect(task_status("Alternative verification")).to eql "Incomplete"
-        click_link "Confirm the provider has verified the claimant’s identity"
-
-        expect(page).to have_text(
-          "The provider told us that they employ Edna Krabapple"
-        )
-
-        within_fieldset(
-          "Do the personal details provided by the claimant match the details " \
-          "from the provider?"
-        ) do
-          choose "Yes"
+      context "when provider and claimant personal details match" do
+        let(:eligibility) do
+          create(
+            :early_years_payments_eligibility,
+            :with_eligible_ey_provider,
+            :provider_claim_submitted,
+            alternative_idv_claimant_employed_by_nursery: true,
+            alternative_idv_claimant_date_of_birth: Date.new(1970, 1, 1),
+            alternative_idv_claimant_postcode: "EC1N 2TD",
+            alternative_idv_claimant_national_insurance_number: "AB123456C",
+            alternative_idv_claimant_bank_details_match: true,
+            alternative_idv_claimant_email: "CLAIMANT@example.com",
+            alternative_idv_claimant_employment_check_declaration: true,
+            alternative_idv_completed_at: 2.days.ago
+          )
         end
 
-        expect(page).to have_text(
-          "The provider told us that they do not recognise the bank account " \
-          "details that Edna Krabapple submitted."
-        )
+        it "requires the admin to complete only the bank details section" do
+          visit admin_claim_path(claim)
+          click_on "View tasks"
 
-        within_fieldset(
-          "Has Edna Krabapple provided their own bank account details?"
-        ) do
-          choose "No"
+          expect(task_status("One Login identity check")).to eql "No data"
+          expect(task_status("Alternative verification")).to eql "Incomplete"
+          click_link "Confirm the provider has verified the claimant’s identity"
+
+          within "#personal-details" do
+            expect(page).to have_content(
+              "The provider told us that they employ Edna Krabappel."
+            )
+
+            expect(table_row("Date of birth")).to eq([
+              "1 January 1970",
+              "1 January 1970"
+            ])
+
+            expect(table_row("Postcode")).to eq([
+              "ec1n 2td",
+              "EC1N 2TD"
+            ])
+
+            expect(table_row("National Insurance number")).to eq([
+              "AB123456C",
+              "AB123456C"
+            ])
+
+            expect(table_row("Email")).to eq([
+              "claimant@example.com",
+              "CLAIMANT@example.com"
+            ])
+
+            # Expect no radio button
+            expect(page).not_to have_selector("input[type=radio]")
+          end
+
+          within "#bank-details" do
+            expect(page).to have_content(
+              "The provider told us that they recognise the bank account details that Edna Krabappel submitted."
+            )
+
+            expect(table_row("Edna J Krabappel")).to eq([
+              "Edna Krabappel", # Claimant's name
+              "yes" # From HMRC response
+            ])
+
+            within_fieldset(
+              "Has Edna Krabappel provided their own bank account details?"
+            ) do
+              choose "Yes"
+            end
+          end
+
+          click_button "Save and continue"
+
+          visit admin_claim_path(claim)
+          click_on "View tasks"
+          expect(task_status("Alternative verification")).to eql "Passed"
+          click_link "Confirm the provider has verified the claimant’s identity"
+
+          within "#task-outcome" do
+            expect(page).to have_content("Passed")
+            expect(page).to have_content("This task was performed by Aaron Admin")
+          end
+        end
+      end
+
+      context "when the provider and claimant personal details do not match" do
+        let(:eligibility) do
+          create(
+            :early_years_payments_eligibility,
+            :with_eligible_ey_provider,
+            :provider_claim_submitted,
+            alternative_idv_claimant_employed_by_nursery: true,
+            alternative_idv_claimant_date_of_birth: Date.new(1970, 1, 1),
+            alternative_idv_claimant_postcode: "TE57 1NG",
+            alternative_idv_claimant_national_insurance_number: "AB123456C",
+            alternative_idv_claimant_bank_details_match: true,
+            alternative_idv_claimant_email: "CLAIMANT@example.com",
+            alternative_idv_claimant_employment_check_declaration: true,
+            alternative_idv_completed_at: 2.days.ago
+          )
         end
 
-        click_button "Save and continue"
+        it "allows the admin to make a decision" do
+          visit admin_claim_path(claim)
+          click_on "View tasks"
 
-        visit admin_claim_tasks_path(claim)
+          expect(task_status("One Login identity check")).to eql "No data"
+          expect(task_status("Alternative verification")).to eql "Incomplete"
+          click_link "Confirm the provider has verified the claimant’s identity"
 
-        expect(task_status("Alternative verification")).to eq "Failed"
+          within_fieldset(
+            "Has Edna Krabappel provided their own bank account details?"
+          ) do
+            choose "Yes"
+          end
+
+          # Try submitting without selecting an option for personal details
+          click_button "Save and continue"
+
+          expect(page).to have_content("You must select ‘Yes’ or ‘No’")
+
+          within_fieldset(
+            "Do the personal details provided by the claimant match the details from the provider?"
+          ) do
+            choose "Yes"
+          end
+
+          click_button "Save and continue"
+
+          visit admin_claim_path(claim)
+          click_on "View tasks"
+          expect(task_status("Alternative verification")).to eql "Passed"
+          click_link "Confirm the provider has verified the claimant’s identity"
+
+          within "#task-outcome" do
+            expect(page).to have_content("Passed")
+            expect(page).to have_content("This task was performed by Aaron Admin")
+          end
+        end
+      end
+
+      context "when the provider says the bank details do not match" do
+        let(:eligibility) do
+          create(
+            :early_years_payments_eligibility,
+            :with_eligible_ey_provider,
+            :provider_claim_submitted,
+            alternative_idv_claimant_employed_by_nursery: true,
+            alternative_idv_claimant_date_of_birth: Date.new(1970, 1, 1),
+            alternative_idv_claimant_postcode: "TE57 1NG",
+            alternative_idv_claimant_national_insurance_number: "AB123456C",
+            alternative_idv_claimant_bank_details_match: false,
+            alternative_idv_claimant_email: "CLAIMANT@example.com",
+            alternative_idv_claimant_employment_check_declaration: true,
+            alternative_idv_completed_at: 2.days.ago
+          )
+        end
+
+        it "shows that the provider does not recognise the bank details" do
+          visit admin_claim_path(claim)
+          click_on "View tasks"
+
+          expect(task_status("One Login identity check")).to eql "No data"
+          expect(task_status("Alternative verification")).to eql "Incomplete"
+          click_link "Confirm the provider has verified the claimant’s identity"
+
+          within_fieldset(
+            "Do the personal details provided by the claimant match the details from the provider?"
+          ) do
+            choose "Yes"
+          end
+
+          within "#bank-details" do
+            expect(page).to have_content(
+              "The provider told us that they do not recognise the bank account details that Edna Krabappel submitted."
+            )
+
+            expect(table_row("Edna J Krabappel")).to eq([
+              "Edna Krabappel", # Claimant's name
+              "yes" # From HMRC response
+            ])
+
+            within_fieldset(
+              "Has Edna Krabappel provided their own bank account details?"
+            ) do
+              choose "No"
+            end
+          end
+
+          click_button "Save and continue"
+
+          visit admin_claim_path(claim)
+          click_on "View tasks"
+          expect(task_status("Alternative verification")).to eql "Failed"
+          click_link "Confirm the provider has verified the claimant’s identity"
+
+          within "#task-outcome" do
+            expect(page).to have_content("Failed")
+            expect(page).to have_content("This task was performed by Aaron Admin")
+          end
+        end
       end
     end
 
@@ -207,7 +367,7 @@ RSpec.describe "EY claim and alternative verification task" do
           national_insurance_number: "ab123456c",
           email_address: "claimant@example.com",
           first_name: "Edna",
-          surname: "Krabapple"
+          surname: "Krabappel"
         )
       end
 
@@ -250,7 +410,7 @@ RSpec.describe "EY claim and alternative verification task" do
         )
 
         expect(page).to have_content(
-          "Has Edna Krabapple provided their own bank account details? No"
+          "Has Edna Krabappel provided their own bank account details? No"
         )
 
         # expect there to be no radio buttons and no submit button
@@ -258,5 +418,9 @@ RSpec.describe "EY claim and alternative verification task" do
         expect(page).not_to have_button("Save and continue")
       end
     end
+  end
+
+  def table_row(first_column_text)
+    find("tr", text: first_column_text).all("td").map(&:text)
   end
 end

--- a/spec/features/admin/early_years/alternative_verification_spec.rb
+++ b/spec/features/admin/early_years/alternative_verification_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "EY claim and alternative verification task" do
           email_address: "claimant@example.com",
           first_name: "Edna",
           surname: "Krabappel",
-          banking_name: "Edna J Krabappel",
+          banking_name: "Edna Krabappel",
           hmrc_bank_validation_responses: hmrc_bank_validation_responses
         )
       end
@@ -139,7 +139,7 @@ RSpec.describe "EY claim and alternative verification task" do
           within "#bank-details" do
             expect(page).to have_content("Not applicable")
 
-            expect(table_row("Edna J Krabappel")).to eq([
+            expect(table_row("Edna Krabappel")).to eq([
               "Edna Krabappel", # Claimant's name
               "yes" # From HMRC response
             ])
@@ -224,7 +224,7 @@ RSpec.describe "EY claim and alternative verification task" do
               "The provider told us that they recognise the bank account details that Edna Krabappel submitted."
             )
 
-            expect(table_row("Edna J Krabappel")).to eq([
+            expect(table_row("Edna Krabappel")).to eq([
               "Edna Krabappel", # Claimant's name
               "partial" # From HMRC response
             ])
@@ -336,7 +336,7 @@ RSpec.describe "EY claim and alternative verification task" do
               "The provider told us that they do not recognise the bank account details that Edna Krabappel submitted."
             )
 
-            expect(table_row("Edna J Krabappel")).to eq([
+            expect(table_row("Edna Krabappel")).to eq([
               "Edna Krabappel", # Claimant's name
               "yes" # From HMRC response
             ])

--- a/spec/models/automated_checks/claim_verifiers/ey_alternative_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/ey_alternative_verification_spec.rb
@@ -1,0 +1,633 @@
+require "rails_helper"
+
+module AutomatedChecks
+  module ClaimVerifiers
+    RSpec.describe EyAlternativeVerification do
+      subject(:verifier) { described_class.new(claim: claim) }
+
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          eligibility: eligibility,
+          date_of_birth: Date.new(1990, 1, 15),
+          postcode: "SW1A 1AA",
+          national_insurance_number: "QQ123456C",
+          email_address: "teacher@example.com",
+          first_name: "John",
+          surname: "Smith",
+          banking_name: banking_name,
+          hmrc_bank_validation_responses: hmrc_bank_validation_responses
+        )
+      end
+
+      let(:banking_name) { "John Smith" }
+      let(:hmrc_bank_validation_responses) do
+        [
+          {
+            "body" => {
+              "nameMatches" => "yes"
+            }
+          }
+        ]
+      end
+
+      let(:eligibility) do
+        create(
+          :early_years_payments_eligibility,
+          :with_eligible_ey_provider,
+          alternative_idv_claimant_employed_by_nursery: employed_by_nursery,
+          alternative_idv_claimant_date_of_birth: provider_date_of_birth,
+          alternative_idv_claimant_postcode: provider_postcode,
+          alternative_idv_claimant_national_insurance_number: provider_nino,
+          alternative_idv_claimant_email: provider_email,
+          alternative_idv_claimant_bank_details_match: provider_bank_details_match
+        )
+      end
+
+      let(:employed_by_nursery) { true }
+      let(:provider_date_of_birth) { Date.new(1990, 1, 15) }
+      let(:provider_postcode) { "SW1A 1AA" }
+      let(:provider_nino) { "QQ123456C" }
+      let(:provider_email) { "teacher@example.com" }
+      let(:provider_bank_details_match) { true }
+
+      describe "#perform" do
+        context "when task already exists" do
+          before do
+            create(:task, name: "ey_alternative_verification", claim: claim)
+          end
+
+          it "does not create a new task" do
+            expect { verifier.perform }.not_to change { claim.tasks.count }
+          end
+
+          it "returns nil" do
+            expect(verifier.perform).to be_nil
+          end
+        end
+
+        context "when provider says claimant is not employed by nursery" do
+          let(:employed_by_nursery) { false }
+
+          it "creates a failed task" do
+            verifier.perform
+            task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+            expect(task).to be_present
+            expect(task.passed).to eq(false)
+            expect(task.manual).to eq(false)
+            expect(task.data).to eq({})
+          end
+        end
+
+        context "when provider says claimant is employed by nursery" do
+          let(:employed_by_nursery) { true }
+
+          context "when personal details match" do
+            let(:provider_date_of_birth) { Date.new(1990, 1, 15) }
+            let(:provider_postcode) { "SW1A 1AA" }
+            let(:provider_nino) { "QQ123456C" }
+            let(:provider_email) { "teacher@example.com" }
+
+            context "and bank details match" do
+              let(:provider_bank_details_match) { true }
+              let(:banking_name) { "John Smith" }
+
+              it "creates a passed task with auto-pass flags" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to eq(true)
+                expect(task.manual).to eq(false)
+                expect(task.data).to eq({
+                  "personal_details_were_passed_automatically" => true,
+                  "personal_details_match" => true,
+                  "bank_details_were_passed_automatically" => true,
+                  "bank_details_match" => true
+                })
+              end
+            end
+
+            context "and bank details do not match (provider says no)" do
+              let(:provider_bank_details_match) { false }
+
+              it "creates an incomplete task with personal details auto-passed" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({
+                  "personal_details_were_passed_automatically" => true,
+                  "personal_details_match" => true
+                })
+              end
+            end
+
+            context "and HMRC name check fails" do
+              let(:hmrc_bank_validation_responses) do
+                [
+                  {
+                    "body" => {
+                      "nameMatches" => "no"
+                    }
+                  }
+                ]
+              end
+
+              it "creates an incomplete task with personal details auto-passed" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({
+                  "personal_details_were_passed_automatically" => true,
+                  "personal_details_match" => true
+                })
+              end
+            end
+
+            context "banking name matching scenarios" do
+              let(:provider_bank_details_match) { true }
+
+              context "when banking name exactly matches first and last name" do
+                let(:claim) do
+                  create(
+                    :claim,
+                    :submitted,
+                    policy: Policies::EarlyYearsPayments,
+                    eligibility: eligibility,
+                    first_name: "John",
+                    surname: "Smith",
+                    banking_name: "John Smith",
+                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                  )
+                end
+
+                it "passes bank details check" do
+                  verifier.perform
+                  task = claim.tasks.find_by(name: "ey_alternative_verification")
+                  expect(task.data["bank_details_match"]).to eq(true)
+                end
+              end
+
+              context "when banking name has middle name/initial" do
+                let(:claim) do
+                  create(
+                    :claim,
+                    :submitted,
+                    policy: Policies::EarlyYearsPayments,
+                    eligibility: eligibility,
+                    first_name: "John",
+                    surname: "Smith",
+                    banking_name: "John Robert Smith",
+                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                  )
+                end
+
+                it "passes bank details check" do
+                  verifier.perform
+                  task = claim.tasks.find_by(name: "ey_alternative_verification")
+                  expect(task.data["bank_details_match"]).to eq(true)
+                end
+              end
+
+              context "when banking name has extra spaces" do
+                let(:claim) do
+                  create(
+                    :claim,
+                    :submitted,
+                    policy: Policies::EarlyYearsPayments,
+                    eligibility: eligibility,
+                    first_name: "John",
+                    surname: "Smith",
+                    banking_name: "  John   Smith  ",
+                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                  )
+                end
+
+                it "passes bank details check (strips spaces)" do
+                  verifier.perform
+                  task = claim.tasks.find_by(name: "ey_alternative_verification")
+                  expect(task.data["bank_details_match"]).to eq(true)
+                end
+              end
+
+              context "when banking name case differs" do
+                let(:claim) do
+                  create(
+                    :claim,
+                    :submitted,
+                    policy: Policies::EarlyYearsPayments,
+                    eligibility: eligibility,
+                    first_name: "John",
+                    surname: "Smith",
+                    banking_name: "JOHN SMITH",
+                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                  )
+                end
+
+                it "passes bank details check (case insensitive)" do
+                  verifier.perform
+                  task = claim.tasks.find_by(name: "ey_alternative_verification")
+                  expect(task.data["bank_details_match"]).to eq(true)
+                end
+              end
+
+              context "pathological banking name cases" do
+                context "when banking name is in reverse order (surname first)" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "Smith John",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when banking name only has first name" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "John",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when banking name only has surname" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "Smith",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when banking name is completely different" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "Jane Doe",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when banking name has prefix (Mr, Mrs, etc)" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "Mr John Smith",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when banking name has suffix (Jr, Sr, etc)" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "John Smith Jr",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when banking name is hyphenated" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "Mary",
+                      surname: "Smith-Jones",
+                      banking_name: "Mary Smith-Jones",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "passes bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to eq(true)
+                  end
+                end
+
+                context "when banking name has apostrophe" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "O'Brien",
+                      banking_name: "John O'Brien",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "passes bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to eq(true)
+                  end
+                end
+
+                context "when banking name has accented characters" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "José",
+                      surname: "García",
+                      banking_name: "José García",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "passes bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to eq(true)
+                  end
+                end
+
+                context "when banking name is a substring match but doesn't start/end correctly" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "John",
+                      surname: "Smith",
+                      banking_name: "Johnny Smithson",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+
+                context "when name contains embedded match" do
+                  let(:claim) do
+                    create(
+                      :claim,
+                      :submitted,
+                      policy: Policies::EarlyYearsPayments,
+                      eligibility: eligibility,
+                      first_name: "Ann",
+                      surname: "Smith",
+                      banking_name: "Joanne Blacksmith",
+                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
+                    )
+                  end
+
+                  it "fails bank details check" do
+                    verifier.perform
+                    task = claim.tasks.find_by(name: "ey_alternative_verification")
+                    expect(task.data["bank_details_match"]).to be_nil
+                  end
+                end
+              end
+            end
+          end
+
+          context "when personal details do not match" do
+            context "when date of birth differs" do
+              let(:provider_date_of_birth) { Date.new(1990, 2, 15) }
+
+              it "creates an incomplete task with bank details auto-passed" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({
+                  "bank_details_were_passed_automatically" => true,
+                  "bank_details_match" => true
+                })
+              end
+            end
+
+            context "when postcode differs (case sensitive check)" do
+              let(:provider_postcode) { "sw1a 1aa" }
+
+              it "passes when case differs (case insensitive)" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task.data["personal_details_match"]).to eq(true)
+              end
+            end
+
+            context "when postcode actually differs" do
+              let(:provider_postcode) { "SW1A 2AA" }
+
+              it "creates an incomplete task with bank details auto-passed" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({
+                  "bank_details_were_passed_automatically" => true,
+                  "bank_details_match" => true
+                })
+              end
+            end
+
+            context "when national insurance number differs (case sensitive check)" do
+              let(:provider_nino) { "qq123456c" }
+
+              it "passes when case differs (case insensitive)" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task.data["personal_details_match"]).to eq(true)
+              end
+            end
+
+            context "when national insurance number actually differs" do
+              let(:provider_nino) { "QQ654321C" }
+
+              it "creates an incomplete task with bank details auto-passed" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({
+                  "bank_details_were_passed_automatically" => true,
+                  "bank_details_match" => true
+                })
+              end
+            end
+
+            context "when email differs (case sensitive check)" do
+              let(:provider_email) { "TEACHER@example.com" }
+
+              it "passes when case differs (case insensitive)" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task.data["personal_details_match"]).to eq(true)
+              end
+            end
+
+            context "when email actually differs" do
+              let(:provider_email) { "different@example.com" }
+
+              it "creates an incomplete task with bank details auto-passed" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({
+                  "bank_details_were_passed_automatically" => true,
+                  "bank_details_match" => true
+                })
+              end
+            end
+
+            context "when employed_by_nursery is nil" do
+              let(:employed_by_nursery) { nil }
+
+              it "creates an incomplete task without auto-pass flags" do
+                verifier.perform
+                task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+                expect(task).to be_present
+                expect(task.passed).to be_nil
+                expect(task.manual).to be_nil
+                expect(task.data).to eq({})
+              end
+            end
+          end
+
+          context "when HMRC validation responses are empty" do
+            let(:hmrc_bank_validation_responses) { [] }
+
+            it "creates an incomplete task with personal details only" do
+              verifier.perform
+              task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+              expect(task).to be_present
+              expect(task.passed).to be_nil
+              expect(task.data["personal_details_match"]).to eq(true)
+              expect(task.data["bank_details_match"]).to be_nil
+            end
+          end
+
+          context "when HMRC validation response has partial name match" do
+            let(:hmrc_bank_validation_responses) do
+              [
+                {
+                  "body" => {
+                    "nameMatches" => "partial"
+                  }
+                }
+              ]
+            end
+
+            it "creates an incomplete task" do
+              verifier.perform
+              task = claim.tasks.find_by(name: "ey_alternative_verification")
+
+              expect(task).to be_present
+              expect(task.passed).to be_nil
+              expect(task.data["bank_details_match"]).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/automated_checks/claim_verifiers/ey_alternative_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/ey_alternative_verification_spec.rb
@@ -5,10 +5,12 @@ module AutomatedChecks
     RSpec.describe EyAlternativeVerification do
       subject(:verifier) { described_class.new(claim: claim) }
 
+      let(:banking_name) { "John Smith" }
+      let(:hmrc_bank_validation_responses) { [{"body" => {"nameMatches" => "yes"}}] }
+
       let(:claim) do
         create(
-          :claim,
-          :submitted,
+          :claim, :submitted,
           policy: Policies::EarlyYearsPayments,
           eligibility: eligibility,
           date_of_birth: Date.new(1990, 1, 15),
@@ -20,17 +22,6 @@ module AutomatedChecks
           banking_name: banking_name,
           hmrc_bank_validation_responses: hmrc_bank_validation_responses
         )
-      end
-
-      let(:banking_name) { "John Smith" }
-      let(:hmrc_bank_validation_responses) do
-        [
-          {
-            "body" => {
-              "nameMatches" => "yes"
-            }
-          }
-        ]
       end
 
       let(:eligibility) do
@@ -54,27 +45,20 @@ module AutomatedChecks
       let(:provider_bank_details_match) { true }
 
       describe "#perform" do
-        context "when task already exists" do
-          before do
-            create(:task, name: "ey_alternative_verification", claim: claim)
-          end
+        context "when a task already exists" do
+          before { create(:task, name: "ey_alternative_verification", claim: claim) }
 
           it "does not create a new task" do
             expect { verifier.perform }.not_to change { claim.tasks.count }
           end
-
-          it "returns nil" do
-            expect(verifier.perform).to be_nil
-          end
         end
 
-        context "when provider says claimant is not employed by nursery" do
+        context "when provider says claimant is not employed by the nursery" do
           let(:employed_by_nursery) { false }
 
-          it "creates a failed task" do
+          it "creates a failed, non-manual task with empty data" do
             verifier.perform
             task = claim.tasks.find_by(name: "ey_alternative_verification")
-
             expect(task).to be_present
             expect(task.passed).to eq(false)
             expect(task.manual).to eq(false)
@@ -82,549 +66,84 @@ module AutomatedChecks
           end
         end
 
-        context "when provider says claimant is employed by nursery" do
-          let(:employed_by_nursery) { true }
-
-          context "when personal details match" do
-            let(:provider_date_of_birth) { Date.new(1990, 1, 15) }
-            let(:provider_postcode) { "SW1A 1AA" }
-            let(:provider_nino) { "QQ123456C" }
-            let(:provider_email) { "teacher@example.com" }
-
-            context "and bank details match" do
-              let(:provider_bank_details_match) { true }
-              let(:banking_name) { "John Smith" }
-
-              it "creates a passed task with auto-pass flags" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to eq(true)
-                expect(task.manual).to eq(false)
-                expect(task.data).to eq({
-                  "personal_details_were_passed_automatically" => true,
-                  "personal_details_match" => true,
-                  "bank_details_were_passed_automatically" => true,
-                  "bank_details_match" => true
-                })
-              end
-            end
-
-            context "and bank details do not match (provider says no)" do
-              let(:provider_bank_details_match) { false }
-
-              it "creates an incomplete task with personal details auto-passed" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({
-                  "personal_details_were_passed_automatically" => true,
-                  "personal_details_match" => true
-                })
-              end
-            end
-
-            context "and HMRC name check fails" do
-              let(:hmrc_bank_validation_responses) do
-                [
-                  {
-                    "body" => {
-                      "nameMatches" => "no"
-                    }
-                  }
-                ]
-              end
-
-              it "creates an incomplete task with personal details auto-passed" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({
-                  "personal_details_were_passed_automatically" => true,
-                  "personal_details_match" => true
-                })
-              end
-            end
-
-            context "banking name matching scenarios" do
-              let(:provider_bank_details_match) { true }
-
-              context "when banking name exactly matches first and last name" do
-                let(:claim) do
-                  create(
-                    :claim,
-                    :submitted,
-                    policy: Policies::EarlyYearsPayments,
-                    eligibility: eligibility,
-                    first_name: "John",
-                    surname: "Smith",
-                    banking_name: "John Smith",
-                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                  )
-                end
-
-                it "passes bank details check" do
-                  verifier.perform
-                  task = claim.tasks.find_by(name: "ey_alternative_verification")
-                  expect(task.data["bank_details_match"]).to eq(true)
-                end
-              end
-
-              context "when banking name has middle name/initial" do
-                let(:claim) do
-                  create(
-                    :claim,
-                    :submitted,
-                    policy: Policies::EarlyYearsPayments,
-                    eligibility: eligibility,
-                    first_name: "John",
-                    surname: "Smith",
-                    banking_name: "John Robert Smith",
-                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                  )
-                end
-
-                it "passes bank details check" do
-                  verifier.perform
-                  task = claim.tasks.find_by(name: "ey_alternative_verification")
-                  expect(task.data["bank_details_match"]).to eq(true)
-                end
-              end
-
-              context "when banking name has extra spaces" do
-                let(:claim) do
-                  create(
-                    :claim,
-                    :submitted,
-                    policy: Policies::EarlyYearsPayments,
-                    eligibility: eligibility,
-                    first_name: "John",
-                    surname: "Smith",
-                    banking_name: "  John   Smith  ",
-                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                  )
-                end
-
-                it "passes bank details check (strips spaces)" do
-                  verifier.perform
-                  task = claim.tasks.find_by(name: "ey_alternative_verification")
-                  expect(task.data["bank_details_match"]).to eq(true)
-                end
-              end
-
-              context "when banking name case differs" do
-                let(:claim) do
-                  create(
-                    :claim,
-                    :submitted,
-                    policy: Policies::EarlyYearsPayments,
-                    eligibility: eligibility,
-                    first_name: "John",
-                    surname: "Smith",
-                    banking_name: "JOHN SMITH",
-                    hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                  )
-                end
-
-                it "passes bank details check (case insensitive)" do
-                  verifier.perform
-                  task = claim.tasks.find_by(name: "ey_alternative_verification")
-                  expect(task.data["bank_details_match"]).to eq(true)
-                end
-              end
-
-              context "pathological banking name cases" do
-                context "when banking name is in reverse order (surname first)" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "Smith John",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when banking name only has first name" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "John",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when banking name only has surname" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "Smith",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when banking name is completely different" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "Jane Doe",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when banking name has prefix (Mr, Mrs, etc)" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "Mr John Smith",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when banking name has suffix (Jr, Sr, etc)" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "John Smith Jr",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when banking name is hyphenated" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "Mary",
-                      surname: "Smith-Jones",
-                      banking_name: "Mary Smith-Jones",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "passes bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to eq(true)
-                  end
-                end
-
-                context "when banking name has apostrophe" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "O'Brien",
-                      banking_name: "John O'Brien",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "passes bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to eq(true)
-                  end
-                end
-
-                context "when banking name has accented characters" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "José",
-                      surname: "García",
-                      banking_name: "José García",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "passes bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to eq(true)
-                  end
-                end
-
-                context "when banking name is a substring match but doesn't start/end correctly" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "John",
-                      surname: "Smith",
-                      banking_name: "Johnny Smithson",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-
-                context "when name contains embedded match" do
-                  let(:claim) do
-                    create(
-                      :claim,
-                      :submitted,
-                      policy: Policies::EarlyYearsPayments,
-                      eligibility: eligibility,
-                      first_name: "Ann",
-                      surname: "Smith",
-                      banking_name: "Joanne Blacksmith",
-                      hmrc_bank_validation_responses: hmrc_bank_validation_responses
-                    )
-                  end
-
-                  it "fails bank details check" do
-                    verifier.perform
-                    task = claim.tasks.find_by(name: "ey_alternative_verification")
-                    expect(task.data["bank_details_match"]).to be_nil
-                  end
-                end
-              end
-            end
-          end
-
-          context "when personal details do not match" do
-            context "when date of birth differs" do
-              let(:provider_date_of_birth) { Date.new(1990, 2, 15) }
-
-              it "creates an incomplete task with bank details auto-passed" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({
-                  "bank_details_were_passed_automatically" => true,
-                  "bank_details_match" => true
-                })
-              end
-            end
-
-            context "when postcode differs (case sensitive check)" do
-              let(:provider_postcode) { "sw1a 1aa" }
-
-              it "passes when case differs (case insensitive)" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task.data["personal_details_match"]).to eq(true)
-              end
-            end
-
-            context "when postcode actually differs" do
-              let(:provider_postcode) { "SW1A 2AA" }
-
-              it "creates an incomplete task with bank details auto-passed" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({
-                  "bank_details_were_passed_automatically" => true,
-                  "bank_details_match" => true
-                })
-              end
-            end
-
-            context "when national insurance number differs (case sensitive check)" do
-              let(:provider_nino) { "qq123456c" }
-
-              it "passes when case differs (case insensitive)" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task.data["personal_details_match"]).to eq(true)
-              end
-            end
-
-            context "when national insurance number actually differs" do
-              let(:provider_nino) { "QQ654321C" }
-
-              it "creates an incomplete task with bank details auto-passed" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({
-                  "bank_details_were_passed_automatically" => true,
-                  "bank_details_match" => true
-                })
-              end
-            end
-
-            context "when email differs (case sensitive check)" do
-              let(:provider_email) { "TEACHER@example.com" }
-
-              it "passes when case differs (case insensitive)" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task.data["personal_details_match"]).to eq(true)
-              end
-            end
-
-            context "when email actually differs" do
-              let(:provider_email) { "different@example.com" }
-
-              it "creates an incomplete task with bank details auto-passed" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({
-                  "bank_details_were_passed_automatically" => true,
-                  "bank_details_match" => true
-                })
-              end
-            end
-
-            context "when employed_by_nursery is nil" do
-              let(:employed_by_nursery) { nil }
-
-              it "creates an incomplete task without auto-pass flags" do
-                verifier.perform
-                task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-                expect(task).to be_present
-                expect(task.passed).to be_nil
-                expect(task.manual).to be_nil
-                expect(task.data).to eq({})
-              end
-            end
-          end
-
-          context "when HMRC validation responses are empty" do
-            let(:hmrc_bank_validation_responses) { [] }
-
-            it "creates an incomplete task with personal details only" do
+        context "when personal details match" do
+          context "when bank details match" do
+            let(:banking_name) { "  JOHN smith  " }
+
+            it "auto-passes personal and bank checks and marks task passed" do
               verifier.perform
               task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-              expect(task).to be_present
-              expect(task.passed).to be_nil
-              expect(task.data["personal_details_match"]).to eq(true)
-              expect(task.data["bank_details_match"]).to be_nil
+              expect(task.passed).to eq(true)
+              expect(task.manual).to eq(false)
+              expect(task.data).to eq(
+                "personal_details_were_passed_automatically" => true,
+                "personal_details_match" => true,
+                "bank_details_were_passed_automatically" => true,
+                "bank_details_match" => true
+              )
             end
           end
 
-          context "when HMRC validation response has partial name match" do
+          context "when bank details don't match what the provider has" do
+            let(:provider_bank_details_match) { false }
+
+            it "is incomplete with personal auto-pass only" do
+              verifier.perform
+              task = claim.tasks.find_by(name: "ey_alternative_verification")
+              expect(task.passed).to be_nil
+              expect(task.manual).to be_nil
+              expect(task.data).to eq(
+                "personal_details_were_passed_automatically" => true,
+                "personal_details_match" => true
+              )
+            end
+          end
+
+          context "when bank name doesn't match" do
+            let(:banking_name) { "Jane Smith" }
+
+            it "is incomplete with personal auto-pass only" do
+              verifier.perform
+              task = claim.tasks.find_by(name: "ey_alternative_verification")
+              expect(task.passed).to be_nil
+              expect(task.manual).to be_nil
+              expect(task.data).to eq(
+                "personal_details_were_passed_automatically" => true,
+                "personal_details_match" => true
+              )
+            end
+          end
+
+          context "when hmrc response is not a pass" do
             let(:hmrc_bank_validation_responses) do
-              [
-                {
-                  "body" => {
-                    "nameMatches" => "partial"
-                  }
-                }
-              ]
+              [{"body" => {"nameMatches" => "no"}}]
             end
 
-            it "creates an incomplete task" do
+            it "is incomplete with personal auto-pass only" do
               verifier.perform
               task = claim.tasks.find_by(name: "ey_alternative_verification")
-
-              expect(task).to be_present
               expect(task.passed).to be_nil
-              expect(task.data["bank_details_match"]).to be_nil
+              expect(task.manual).to be_nil
+              expect(task.data).to eq(
+                "personal_details_were_passed_automatically" => true,
+                "personal_details_match" => true
+              )
             end
+          end
+        end
+
+        context "when personal details do not match but bank does" do
+          let(:provider_date_of_birth) { Date.new(1991, 1, 15) }
+
+          it "is incomplete and sets only the bank auto-pass flags" do
+            verifier.perform
+            task = claim.tasks.find_by(name: "ey_alternative_verification")
+            expect(task.passed).to be_nil
+            expect(task.manual).to be_nil
+            expect(task.data).to eq(
+              "bank_details_were_passed_automatically" => true,
+              "bank_details_match" => true
+            )
           end
         end
       end

--- a/spec/models/automated_checks/claim_verifiers/ey_alternative_verification_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/ey_alternative_verification_spec.rb
@@ -62,7 +62,10 @@ module AutomatedChecks
             expect(task).to be_present
             expect(task.passed).to eq(false)
             expect(task.manual).to eq(false)
-            expect(task.data).to eq({})
+            expect(task.data).to eq({
+              "personal_details_match" => false,
+              "personal_details_task_completed_automatically" => true
+            })
           end
         end
 
@@ -76,9 +79,9 @@ module AutomatedChecks
               expect(task.passed).to eq(true)
               expect(task.manual).to eq(false)
               expect(task.data).to eq(
-                "personal_details_were_passed_automatically" => true,
+                "personal_details_task_completed_automatically" => true,
                 "personal_details_match" => true,
-                "bank_details_were_passed_automatically" => true,
+                "bank_details_task_completed_automatically" => true,
                 "bank_details_match" => true
               )
             end
@@ -87,14 +90,16 @@ module AutomatedChecks
           context "when bank details don't match what the provider has" do
             let(:provider_bank_details_match) { false }
 
-            it "is incomplete with personal auto-pass only" do
+            it "fails the task" do
               verifier.perform
               task = claim.tasks.find_by(name: "ey_alternative_verification")
-              expect(task.passed).to be_nil
-              expect(task.manual).to be_nil
+              expect(task.passed).to eq false
+              expect(task.manual).to eq false
               expect(task.data).to eq(
-                "personal_details_were_passed_automatically" => true,
-                "personal_details_match" => true
+                "personal_details_task_completed_automatically" => true,
+                "personal_details_match" => true,
+                "bank_details_task_completed_automatically" => true,
+                "bank_details_match" => false
               )
             end
           end
@@ -108,7 +113,7 @@ module AutomatedChecks
               expect(task.passed).to be_nil
               expect(task.manual).to be_nil
               expect(task.data).to eq(
-                "personal_details_were_passed_automatically" => true,
+                "personal_details_task_completed_automatically" => true,
                 "personal_details_match" => true
               )
             end
@@ -125,7 +130,7 @@ module AutomatedChecks
               expect(task.passed).to be_nil
               expect(task.manual).to be_nil
               expect(task.data).to eq(
-                "personal_details_were_passed_automatically" => true,
+                "personal_details_task_completed_automatically" => true,
                 "personal_details_match" => true
               )
             end
@@ -141,7 +146,7 @@ module AutomatedChecks
             expect(task.passed).to be_nil
             expect(task.manual).to be_nil
             expect(task.data).to eq(
-              "bank_details_were_passed_automatically" => true,
+              "bank_details_task_completed_automatically" => true,
               "bank_details_match" => true
             )
           end


### PR DESCRIPTION

Auto pass the personal details sub task

Brings back some of Phil's code for passing the ey task but modifies it
to handle passing the sub tasks.

This task is a bit weird in that there are two "sub tasks" associated.
Usually a task is considered completed when it's persisted, however the
ey_alternative_verification_form can be persisted without being
completed.

If the ey_alternative_verification verifier passes the personal details
section of the task, indidicated by the
`personal_details_were_completed_automatically` attribute, then we don't
show the personal details radio button in the form.
Similarly if the verifier passes the bank details sub task then we don't show
the bank details radio button.

Bank details matching is intentionally really strict (exact name match) most of
the time we want the check to fall through to the ops team to make the decision.

We likely need to revisit how `Task`s work, and introduce a proper
notion of subtasks.

