### PR TITLE
Replace decision warning with submitted date

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -13,6 +13,16 @@ module Admin
       claims.map { |claim| link_to(claim.reference, admin_claim_path(claim), class: "govuk-link") }.to_sentence.html_safe
     end
 
+    def claim_submitted_at(claim)
+      submitted_at = if claim.policy == Policies::EarlyYearsPayments
+        claim.eligibility.provider_claim_submitted_at
+      else
+        claim.submitted_at
+      end
+
+      l(submitted_at.to_date)
+    end
+
     def confirming_identity_playbook_url
       "https://docs.google.com/document/d/1wZh68_RV_FTJLxXIDPr3XFtJHW3vRgiXGaBDUo1Q1ZU"
     end

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -56,8 +56,6 @@
     <% end %>
 
     <% if @claims.any? %>
-      <% claims_with_warning = Claim.approaching_decision_deadline.count + Claim.passed_decision_deadline.count %>
-
       <h2 class="govuk-heading-m"><%= pluralize(@filter_form.count, "claim") %> <%= index_status_filter(@filter_form.status) %></h2>
 
       <table class="govuk-table">
@@ -67,9 +65,7 @@
             <th scope="col" class="govuk-table__header">Applicant Name</th>
             <th scope="col" class="govuk-table__header">ID Verification</th>
             <th scope="col" class="govuk-table__header">Policy</th>
-            <% if claims_with_warning.nonzero? %>
-              <th scope="col" class="govuk-table__header">Decision warning</th>
-            <% end %>
+            <th scope="col" class="govuk-table__header">Submitted</th>
             <th scope="col" class="govuk-table__header">Decision deadline</th>
             <th scope="col" class="govuk-table__header">Assigned to</th>
           </tr>
@@ -81,9 +77,7 @@
               <td class="govuk-table__cell"><%= claim.full_name %></td>
               <td class="govuk-table__cell"><%= identity_confirmation_task_claim_verifier_match_status_tag(claim) %></td>
               <td class="govuk-table__cell"><%= I18n.t("#{claim.policy.locale_key}.policy_acronym") %></td>
-              <% if claims_with_warning.nonzero? %>
-                <td class="govuk-table__cell"><%= decision_deadline_warning(claim) %></td>
-              <% end %>
+              <td class="govuk-table__cell"><%= claim_submitted_at(claim) %></td>
               <td class="govuk-table__cell"><%= l(claim.decision_deadline_date) if claim.decision_deadline_date %></td>
               <td class="govuk-table__cell"><%= claim.assigned_to.present? ? claim.assigned_to.full_name.titleize : nil %></td>
             </tr>

--- a/spec/factories/policies/early_years_payments/eligibilities.rb
+++ b/spec/factories/policies/early_years_payments/eligibilities.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
       child_facing_confirmation_given { true }
       returning_within_6_months { false }
       with_eligible_ey_provider
+      provider_claim_submitted_at { Time.zone.now }
     end
 
     trait :with_eligible_ey_provider do


### PR DESCRIPTION
If we're dealing with an EY claim we can't use the `submitted_at` time
stamp as that isn't set until the provider completes their journey.
The eligibility is already eager loaded
(`app/forms/admin/claims_filter_form.rb`) so we can call attributes on
it.
