### PR TITLE
Add additional questions for fixed term

### DIFF
--- a/app/models/journeys/further_education_payments/answers_presenter.rb
+++ b/app/models/journeys/further_education_payments/answers_presenter.rb
@@ -38,6 +38,7 @@ module Journeys
           a << teaching_responsibilities
           a << school
           a << contract_type
+          a << fixed_term_contract
           a << taught_at_least_one_term
           a << teaching_hours_per_week_next_term
           a << teaching_hours_per_week
@@ -103,6 +104,16 @@ module Journeys
           t("further_education_payments.forms.contract_type.question", school_name: answers.school.name),
           t(answers.contract_type, scope: "further_education_payments.forms.contract_type.options"),
           "contract-type"
+        ]
+      end
+
+      def fixed_term_contract
+        return nil unless answers.contract_type == "fixed_term"
+
+        [
+          t("further_education_payments.forms.fixed_term_contract.question", academic_year: answers.academic_year),
+          t(answers.fixed_term_full_year, scope: "further_education_payments.forms.fixed_term_contract.options", current_academic_year: answers.academic_year),
+          "fixed-term-contract"
         ]
       end
 

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -139,9 +139,9 @@ module Journeys
             array << SLUGS_HASH["taught-at-least-one-term"]
           end
 
+          array << SLUGS_HASH["teaching-hours-per-week-next-term"]
           array << SLUGS_HASH["teaching-hours-per-week"]
           array << SLUGS_HASH["half-teaching-hours"]
-          array << SLUGS_HASH["teaching-hours-per-week-next-term"]
         when "variable_hours"
           array << SLUGS_HASH["taught-at-least-one-term"]
 

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -135,11 +135,13 @@ module Journeys
         when "fixed_term"
           array << SLUGS_HASH["fixed-term-contract"]
 
-          if answers.fixed_term_full_year == true
-            array << SLUGS_HASH["teaching-hours-per-week"]
-            array << SLUGS_HASH["half-teaching-hours"]
-            array << SLUGS_HASH["teaching-hours-per-week-next-term"]
+          if answers.fixed_term_full_year == false
+            array << SLUGS_HASH["taught-at-least-one-term"]
           end
+
+          array << SLUGS_HASH["teaching-hours-per-week"]
+          array << SLUGS_HASH["half-teaching-hours"]
+          array << SLUGS_HASH["teaching-hours-per-week-next-term"]
         when "variable_hours"
           array << SLUGS_HASH["taught-at-least-one-term"]
 

--- a/app/models/policies/further_education_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/further_education_payments/policy_eligibility_checker.rb
@@ -20,8 +20,6 @@ module Policies
           :fe_provider
         elsif answers.contract_type == "employed_by_another_organisation"
           :employed_by_another_organisation
-        elsif answers.fixed_term_full_year == false
-          :fixed_term_must_cover_full_academic_year
         elsif answers.taught_at_least_one_term == false
           :must_teach_at_least_one_term
         elsif !answers.recent_further_education_teacher?

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -322,14 +322,6 @@ RSpec.feature "Further education payments ineligible paths" do
     choose("Yes")
     click_button "Continue"
 
-    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{eligible_college.name} during the current term?")
-    choose("More than 12 hours per week")
-    click_button "Continue"
-
-    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours working with students aged 16 to 19?")
-    choose "Yes"
-    click_button "Continue"
-
     expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term?")
     choose("No")
     click_button "Continue"
@@ -942,14 +934,6 @@ RSpec.feature "Further education payments ineligible paths" do
 
     expect(page).to have_content("Does your fixed-term contract cover the full #{current_academic_year.to_s(:long)} academic year?")
     choose "Yes, it covers the full #{current_academic_year.to_s(:long)} academic year"
-    click_button "Continue"
-
-    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{eligible_college.name} during the current term?")
-    choose "More than 12 hours per week"
-    click_button "Continue"
-
-    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours working with students aged 16 to 19?")
-    choose "Yes"
     click_button "Continue"
 
     expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term?")

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -213,7 +213,7 @@ RSpec.feature "Further education payments ineligible paths" do
     expect(page).to have_content("What type of contract do you have directly with #{eligible_college.name}?")
   end
 
-  scenario "when fixed term contract and fixed term contract does not cover full academic year" do
+  scenario "when fixed term contract and has not taught one term" do
     when_further_education_payments_journey_configuration_exists
     and_eligible_college_exists
 
@@ -261,10 +261,80 @@ RSpec.feature "Further education payments ineligible paths" do
     choose("No, it does not cover the full #{current_academic_year.to_s(:long)} academic year")
     click_button "Continue"
 
+    expect(page).to have_content("Have you taught at #{eligible_college.name} for at least one academic term?")
+    choose("No")
+    click_button "Continue"
+
     expect(page).to have_content(
-      "In order to claim a targeted retention incentive payment, " \
-      "you must be employed for the full academic year."
+      "You are not eligible for a targeted retention incentive payment yet"
     )
+  end
+
+  scenario "when fixed term contract and has not teaching 2.5 hours" do
+    when_further_education_payments_journey_configuration_exists
+    and_eligible_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    expect(page).to have_link("Start now")
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content("Did you apply for a")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    expect(page).to have_content("Answer the questions in the next section")
+    click_button "Start eligibility check"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Which FE provider directly employs you?")
+    fill_in "claim[provision_search]", with: eligible_college.name
+    click_button "Continue"
+
+    expect(page).to have_content("Select where you are employed")
+    choose eligible_college.name
+    click_button "Continue"
+
+    expect(page).to have_content("What type of contract do you have directly with #{eligible_college.name}?")
+    choose("Fixed-term")
+    click_button "Continue"
+
+    expect(page).to have_content("Does your fixed-term contract cover the full #{current_academic_year.to_s(:long)} academic year?")
+    choose("No, it does not cover the full #{current_academic_year.to_s(:long)} academic year")
+    click_button "Continue"
+
+    expect(page).to have_content("Have you taught at #{eligible_college.name} for at least one academic term?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{eligible_college.name} during the current term?")
+    choose("More than 12 hours per week")
+    click_button "Continue"
+
+    expect(page).to have_content("Do you spend at least half of your timetabled teaching hours working with students aged 16 to 19?")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{eligible_college.name} next term?")
+    choose("No")
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
   end
 
   scenario "when contract_type is Employed by another organisation" do

--- a/spec/features/further_education_payments/variable_contract_spec.rb
+++ b/spec/features/further_education_payments/variable_contract_spec.rb
@@ -271,16 +271,16 @@ RSpec.feature "Further education payments" do
     choose("Yes")
     click_button "Continue"
 
+    expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{college.name} next term?")
+    choose("Yes")
+    click_button "Continue"
+
     expect(page).to have_content("On average, how many hours per week are you timetabled to teach at #{college.name} during the current term?")
     choose("More than 12 hours per week")
     click_button "Continue"
 
     expect(page).to have_content("Do you spend at least half of your timetabled teaching hours working with students aged 16 to 19?")
     choose "Yes"
-    click_button "Continue"
-
-    expect(page).to have_content("Are you timetabled to teach at least 2.5 hours per week at #{college.name} next term?")
-    choose("Yes")
     click_button "Continue"
 
     expect(page).to have_content("Which subject areas do you teach?")


### PR DESCRIPTION
If the claimant has a fixed term contract but hasn't taught for the full
term we need to ask some additional questions (the same ones as on the
variable hours journey)
