### PR TITLE
CAPT-2810 - Provider verificaton - change success banner

### DIFF
--- a/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
+++ b/app/controllers/further_education_payments/providers/claims/verifications_controller.rb
@@ -22,7 +22,7 @@ module FurtherEducationPayments
 
             wizard.clear_impermissible_answers!
 
-            flash[:success] = wizard.message if wizard.message
+            flash[:done] = wizard.message if wizard.message
 
             if @form.read_only?
               redirect_to(

--- a/app/models/further_education_payments/providers/claims/verification/wizard.rb
+++ b/app/models/further_education_payments/providers/claims/verification/wizard.rb
@@ -68,16 +68,16 @@ module FurtherEducationPayments
 
           def message
             if completed? && eligibility.claimant_not_employed_by_college?
-              return "Employment check for #{claim.full_name} submitted"
+              return "Employment check for #{claim.full_name} complete"
             end
 
             if completed?
-              return "Claim Verified for #{claim.full_name}"
+              return "Verification form for #{claim.full_name} sent to DfE"
             end
 
             # We've just finished the employyment check section of the wizard
             if current_slug == "claimant_employment_check_declaration"
-              "Employment check for #{claim.full_name} submitted"
+              "Employment check for #{claim.full_name} complete"
             end
           end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,6 +78,8 @@
         <% flash.each do |name, msg| %>
           <% if name == "success" %>
             <%= govuk_notification_banner(title_text: "Success", success: true) { |nb| nb.with_heading(text: msg) } %>
+          <% elsif name == "done" %>
+            <%= govuk_notification_banner(title_text: "Done", success: true) { |nb| nb.with_heading(text: msg) } %>
           <% else %>
             <div class="govuk-body-l govuk-flash__<%= name %>">
               <%= msg %>

--- a/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_claims_spec.rb
@@ -313,7 +313,7 @@ RSpec.feature "Provider verifying claims" do
 
       click_on "Continue"
 
-      expect(page).to have_content("Claim Verified for Edna Krabappel")
+      expect(page).to have_content("Verification form for Edna Krabappel sent to DfE")
       expect(
         page.current_path
       ).to eql("/further-education-payments/providers/verified-claims")
@@ -490,7 +490,7 @@ RSpec.feature "Provider verifying claims" do
 
       click_on "Continue"
 
-      expect(page).to have_content("Claim Verified for Edna Krabappel")
+      expect(page).to have_content("Verification form for Edna Krabappel sent to DfE")
     end
   end
 
@@ -671,7 +671,7 @@ RSpec.feature "Provider verifying claims" do
 
       click_on "Continue"
 
-      expect(page).to have_content("Claim Verified for Edna Krabappel")
+      expect(page).to have_content("Verification form for Edna Krabappel sent to DfE")
     end
   end
 
@@ -1189,6 +1189,10 @@ RSpec.feature "Provider verifying claims" do
 
           click_on "Continue"
 
+          expect(page).to have_content("Done")
+          expect(page).to have_content(
+            "Employment check for Edna Krabappel complete"
+          )
           expect(page).to have_content(
             "You've told us this applicant does not work at Springfield College"
           )
@@ -1283,9 +1287,9 @@ RSpec.feature "Provider verifying claims" do
 
           click_on "Confirm and send"
 
-          expect(page).to have_content("Success")
+          expect(page).to have_content("Done")
           expect(page).to have_content(
-            "Employment check for Edna Krabappel submitted"
+            "Employment check for Edna Krabappel complete"
           )
 
           # Expect to be on the first page of the verification journey

--- a/spec/features/further_education_payments/providers/provider_verifying_with_claimant_courses_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_with_claimant_courses_spec.rb
@@ -160,7 +160,7 @@ RSpec.feature "Provider verifying claims", feature_flag: :provider_dashboard do
 
     click_on "Continue"
 
-    expect(page).to have_content("Claim Verified for Edna Krabappel")
+    expect(page).to have_content("Verification form for Edna Krabappel sent to DfE")
   end
 
   scenario "with custom subjects and courses - No to teaching listed courses" do
@@ -323,7 +323,7 @@ RSpec.feature "Provider verifying claims", feature_flag: :provider_dashboard do
 
     click_on "Continue"
 
-    expect(page).to have_content("Claim Verified for Edna Krabappel")
+    expect(page).to have_content("Verification form for Edna Krabappel sent to DfE")
   end
 
   def summary_row(label)


### PR DESCRIPTION
* Change title to Done instead of Success for the banner
* Update success banner content for employment checks complete
* Update success banner content for form sent to DfE

