### PR TITLE
Display the ey_alt verification task if it exists

### DIFF
--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -16,6 +16,7 @@ module Policies
 
         if year_1_of_ey?
           tasks << "identity_confirmation"
+          tasks << "ey_alternative_verification" if claim.tasks.exists?(name: "ey_alternative_verification")
         else
           tasks << "ey_eoi_cross_reference"
           tasks << "one_login_identity"

--- a/spec/models/policies/early_years_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/early_years_payments/claim_checking_tasks_spec.rb
@@ -1,18 +1,67 @@
 require "rails_helper"
 
 RSpec.describe Policies::EarlyYearsPayments::ClaimCheckingTasks do
-  let(:claim) do
-    build(
-      :claim,
-      policy: Policies::EarlyYearsPayments
-    )
-  end
-
   subject { described_class.new(claim) }
 
   describe "#applicable_task_names" do
-    it "includes employment task" do
-      expect(subject.applicable_task_names).to include("employment")
+    describe "employment task" do
+      let(:claim) do
+        build(
+          :claim,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      it "includes employment task" do
+        expect(subject.applicable_task_names).to include("employment")
+      end
+    end
+
+    describe "ey_alternative_verification task" do
+      let(:claim) do
+        build(
+          :claim,
+          policy: Policies::EarlyYearsPayments,
+          onelogin_idv_at: DateTime.new(2025, 7, 1),
+          identity_confirmed_with_onelogin: identity_confirmed_with_onelogin,
+          academic_year: academic_year
+        )
+      end
+
+      context "when the claim passed one login idv" do
+        let(:identity_confirmed_with_onelogin) { true }
+        let(:academic_year) { AcademicYear.new("2025/2026") }
+
+        it "does not include the task" do
+          expect(subject.applicable_task_names).not_to include(
+            "ey_alternative_verification"
+          )
+        end
+      end
+
+      context "when the claim failed one login idv" do
+        let(:identity_confirmed_with_onelogin) { false }
+
+        context "when a year 1 claim" do
+          let(:academic_year) { AcademicYear.new("2024/2025") }
+
+          it "does not include the task" do
+            expect(subject.applicable_task_names).not_to include(
+              "ey_alternative_verification"
+            )
+          end
+        end
+
+        context "when not a year 1 claim" do
+          let(:academic_year) { AcademicYear.new("2025/2026") }
+
+          it "includes the task" do
+            expect(subject.applicable_task_names).to include(
+              "ey_alternative_verification"
+            )
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Display the ey_alt verification task if it exists

We have a claim that has completed the Y1 provider journey but failed
alt idv. We want to send the claimant a link to complete the
practitioner journey however as the claim is a Y1 claim the alt idv task
wont show. When the provider has completed the alt idv the background
job we kick off will create the task, see
`Policies::EarlyYearsPayments#alternative_idv_completed`

