### PR TITLE
[CAPT-2743] FE resume existing session

### DIFF
--- a/app/controllers/concerns/journey_concern.rb
+++ b/app/controllers/concerns/journey_concern.rb
@@ -56,7 +56,7 @@ module JourneyConcern
   private
 
   def find_journey_session
-    journey::Session.find_by(id: session[journey_session_key])
+    journey::Session.not_expired.find_by(id: session[journey_session_key])
   end
 
   def journey_session_key
@@ -65,7 +65,7 @@ module JourneyConcern
 
   def journey_sessions
     @journey_sessions ||= Journeys::JOURNEYS.map do |journey|
-      journey::Session.find_by(id: session[:"#{journey::ROUTING_NAME}_journeys_session_id"])
+      journey::Session.not_expired.find_by(id: session[:"#{journey::ROUTING_NAME}_journeys_session_id"])
     end.compact
   end
 

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -98,6 +98,10 @@ class Form
     end
   end
 
+  def resume?
+    false
+  end
+
   private
 
   def permitted_attributes

--- a/app/forms/journeys/further_education_payments/existing_progress_form.rb
+++ b/app/forms/journeys/further_education_payments/existing_progress_form.rb
@@ -49,8 +49,8 @@ module Journeys
 
       def existing_journey_session_to_migrate_from
         one_login_account
-          .journey_sessions(journey: Journeys::FurtherEducationPayments)
-          .where.not(id: journey_session.id)
+          .resumable_journey_sessions(journey: Journeys::FurtherEducationPayments)
+          .reject { |js| js.id == journey_session.id }
           .last
       end
 

--- a/app/forms/journeys/further_education_payments/existing_progress_form.rb
+++ b/app/forms/journeys/further_education_payments/existing_progress_form.rb
@@ -1,0 +1,64 @@
+module Journeys
+  module FurtherEducationPayments
+    class ExistingProgressForm < Form
+      attribute :start_new_claim, :boolean
+
+      validates :start_new_claim,
+        inclusion: {
+          in: ->(form) { form.radio_options.map(&:id) },
+          message: i18n_error_message(:inclusion)
+        }
+
+      def radio_options
+        [
+          Option.new(
+            id: false,
+            name: "Continue with the eligibility check that you have already started"
+          ),
+          Option.new(
+            id: true,
+            name: "Start a new eligibility check"
+          )
+        ]
+      end
+
+      def save
+        return false if invalid?
+
+        if start_new_claim == false
+          migrator = JourneySessionMigrator.new(
+            from: existing_journey_session_to_migrate_from,
+            to: journey_session
+          )
+          migrator.call
+        end
+
+        journey_session
+          .answers
+          .assign_attributes(start_new_claim:)
+        journey_session.save!
+
+        true
+      end
+
+      def resume?
+        start_new_claim == false
+      end
+
+      private
+
+      def existing_journey_session_to_migrate_from
+        one_login_account
+          .journey_sessions(journey: Journeys::FurtherEducationPayments)
+          .where.not(id: journey_session.id)
+          .last
+      end
+
+      def one_login_account
+        @one_login_account ||= OneLoginAccount.new(
+          uid: journey_session.answers.onelogin_uid
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/expire_journey_sessions_job.rb
+++ b/app/jobs/expire_journey_sessions_job.rb
@@ -1,0 +1,13 @@
+# expire journey sessions so they are no longer available to browsers
+# we still keep them persisted incase user wishes to resume
+class ExpireJourneySessionsJob < ApplicationJob
+  def perform
+    Journeys::JOURNEYS.each do |journey|
+      Rails.logger.info "Expiring #{journey::Session.purgeable.count} #{journey::Session} journeys from the database"
+      journey::Session
+        .where(journey: journey::ROUTING_NAME)
+        .expirable
+        .update_all(expired: true)
+    end
+  end
+end

--- a/app/jobs/purge_unsubmitted_claims_job.rb
+++ b/app/jobs/purge_unsubmitted_claims_job.rb
@@ -3,13 +3,9 @@
 # to.
 class PurgeUnsubmittedClaimsJob < ApplicationJob
   def perform
-    Rails.logger.info "Purging #{old_unsubmitted_journeys.count} old and unsubmitted journeys from the database"
-    old_unsubmitted_journeys.destroy_all
-  end
-
-  private
-
-  def old_unsubmitted_journeys
-    Journeys::Session.purgeable
+    Journeys::JOURNEYS.each do |journey|
+      Rails.logger.info "Purging #{journey::Session.purgeable.count} old and unsubmitted #{journey::Session} journeys from the database"
+      journey::Session.where(journey: journey::ROUTING_NAME).purgeable.destroy_all
+    end
   end
 end

--- a/app/models/journeys/further_education_payments.rb
+++ b/app/models/journeys/further_education_payments.rb
@@ -12,6 +12,7 @@ module Journeys
         "sign-in" => SignInForm,
         "previously-claimed" => PreviouslyClaimedForm,
         "have-one-login-account" => HaveOneLoginAccountForm,
+        "existing-progress" => ExistingProgressForm,
         "check-eligibility-intro" => CheckEligibilityIntroForm,
         "teaching-responsibilities" => TeachingResponsibilitiesForm,
         "further-education-provision-search" => FurtherEducationProvisionSearchForm,

--- a/app/models/journeys/further_education_payments/journey_session_migrator.rb
+++ b/app/models/journeys/further_education_payments/journey_session_migrator.rb
@@ -1,0 +1,20 @@
+module Journeys
+  module FurtherEducationPayments
+    # given an existing journey session
+    # transfer details to another journey session
+    # this allows users to continue from an existing journey session
+    class JourneySessionMigrator < Journeys::EligibilityChecker
+      attr_reader :from, :to
+
+      def initialize(from:, to:)
+        @from = from
+        @to = to
+      end
+
+      def call
+        to.answers.assign_attributes(from.answers.attributes)
+        to.save!
+      end
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/session.rb
+++ b/app/models/journeys/further_education_payments/session.rb
@@ -1,5 +1,9 @@
 module Journeys
   module FurtherEducationPayments
-    class Session < Journeys::Session; end
+    class Session < Journeys::Session
+      def self.purgeable_age
+        1.year.ago
+      end
+    end
   end
 end

--- a/app/models/journeys/further_education_payments/slug_sequence.rb
+++ b/app/models/journeys/further_education_payments/slug_sequence.rb
@@ -7,6 +7,7 @@ module Journeys
       ]
 
       ELIGIBILITY_SLUGS = %w[
+        existing-progress
         check-eligibility-intro
         further-education-teaching-start-year
         teaching-qualification
@@ -112,9 +113,12 @@ module Journeys
 
         array << SLUGS_HASH["sign-in"] if answers.previously_claimed?
 
-        # Show check-eligibility-intro if they explicitly answered "No" to previously claimed
-        # (not when they have One Login and skipped the question entirely)
-        array << SLUGS_HASH["check-eligibility-intro"] if !has_one_login_account? && !answers.previously_claimed?
+        # check if existing claim in progress
+        if Policies::FurtherEducationPayments.existing_in_progress_claim?(journey_session:)
+          array << SLUGS_HASH["existing-progress"]
+        end
+
+        array << SLUGS_HASH["check-eligibility-intro"]
 
         array << SLUGS_HASH["further-education-teaching-start-year"]
         array << SLUGS_HASH["teaching-qualification"]

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -70,6 +70,12 @@ module Journeys
             next
           end
 
+          # check if want to resume an existing session
+          # if so carry on where we left off
+          if form.resume?
+            return furthest_permissible_slug
+          end
+
           if current_slug == slug
             current_index = forms.index(form)
             next_index = current_index + 1

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -24,15 +24,31 @@ module Journeys
       inclusion: {in: Journeys.all_routing_names}
 
     scope :unsubmitted, -> { where.missing(:claim) }
-
     scope :submitted, -> { joins(:claim) }
 
     scope :purgeable, -> do
       unsubmitted.where(journeys_sessions: {updated_at: ..purgeable_age})
     end
 
+    scope :expired, -> { where(expired: true) }
+    scope :not_expired, -> { where(expired: false) }
+
+    scope :expirable, -> do
+      unsubmitted
+        .not_expired
+        .where(journeys_sessions: {updated_at: ..expirable_age})
+    end
+
     def self.purgeable_age
       24.hours.ago
+    end
+
+    def self.expirable_age
+      24.hours.ago
+    end
+
+    def not_expired?
+      !expired?
     end
 
     def journey_class

--- a/app/models/journeys/session.rb
+++ b/app/models/journeys/session.rb
@@ -28,7 +28,11 @@ module Journeys
     scope :submitted, -> { joins(:claim) }
 
     scope :purgeable, -> do
-      unsubmitted.where(journeys_sessions: {updated_at: ..24.hours.ago})
+      unsubmitted.where(journeys_sessions: {updated_at: ..purgeable_age})
+    end
+
+    def self.purgeable_age
+      24.hours.ago
     end
 
     def journey_class

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -13,6 +13,7 @@ module Journeys
 
     attribute :previously_claimed, :boolean, pii: false
     attribute :have_one_login_account, :string, pii: false # trinary option
+    attribute :start_new_claim, :boolean, pii: false
 
     attribute :current_school_id, :string, pii: false # UUID
     attribute :address_line_1, :string, pii: true

--- a/app/models/one_login_account.rb
+++ b/app/models/one_login_account.rb
@@ -1,0 +1,21 @@
+class OneLoginAccount
+  attr_reader :uid
+
+  def initialize(uid:)
+    @uid = uid
+  end
+
+  def journey_sessions(journey:, academic_year: nil)
+    academic_year ||= journey.configuration.current_academic_year
+
+    journey::Session
+      .where("answers -> 'onelogin_uid' ? :uid", uid:)
+      .where("answers #>> '{academic_year, start_year}' = :start_year", start_year: academic_year.start_year)
+      .where("answers #>> '{academic_year, end_year}' = :end_year", end_year: academic_year.end_year)
+      .order(updated_at: :asc)
+  end
+
+  def claims
+    raise NotImplementedError
+  end
+end

--- a/app/models/one_login_account.rb
+++ b/app/models/one_login_account.rb
@@ -15,6 +15,19 @@ class OneLoginAccount
       .order(updated_at: :asc)
   end
 
+  # ignore sessions that are ineligible
+  def resumable_journey_sessions(journey:, academic_year: nil)
+    academic_year ||= journey.configuration.current_academic_year
+
+    sessions = journey_sessions(journey:, academic_year:).to_a
+    sessions.reject! do |session|
+      journey.policies.all? do |policy|
+        policy::PolicyEligibilityChecker.new(answers: session.answers).ineligible?
+      end
+    end
+    sessions
+  end
+
   def claims
     raise NotImplementedError
   end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -147,7 +147,7 @@ module Policies
       return if journey_session.answers.onelogin_uid.blank?
 
       account = OneLoginAccount.new(uid: journey_session.answers.onelogin_uid)
-      journey_sessions = account.journey_sessions(journey: Journeys::FurtherEducationPayments)
+      journey_sessions = account.resumable_journey_sessions(journey: Journeys::FurtherEducationPayments)
       journey_sessions.count > 1
     end
   end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -139,5 +139,16 @@ module Policies
     def eligibility_page_url
       "https://www.gov.uk/guidance/targeted-retention-incentive-payments-for-fe-teachers"
     end
+
+    # given a journey session
+    # does the claimant have an existing journey session in play
+    # based on their one login uid
+    def existing_in_progress_claim?(journey_session:)
+      return if journey_session.answers.onelogin_uid.blank?
+
+      account = OneLoginAccount.new(uid: journey_session.answers.onelogin_uid)
+      journey_sessions = account.journey_sessions(journey: Journeys::FurtherEducationPayments)
+      journey_sessions.count > 1
+    end
   end
 end

--- a/app/views/further_education_payments/claims/existing_progress.html.erb
+++ b/app/views/further_education_payments/claims/existing_progress.html.erb
@@ -1,0 +1,34 @@
+<% content_for(
+  :page_title,
+  page_title(
+    @form.t(:question),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <div class="govuk-panel govuk-panel--interruption">
+        <%= f.govuk_collection_radio_buttons :start_new_claim, @form.radio_options, :id, :name,
+          legend: {
+            text: "You have already started an eligibility check",
+            tag: "h1",
+            size: "xl",
+            class: "govuk-!-margin-bottom-9"
+          } do %>
+          <h2 class="govuk-heading-m">
+            You can only have one eligibility check in progress at any time. If you want to start another check, we will delete the data on the check you have already started.
+          </h2>
+
+          <h2 class="govuk-heading-m">
+            Choose what you want to do:
+          </h2>
+        <% end %>
+
+        <%= f.govuk_submit "Continue" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -289,6 +289,7 @@ shared:
     - journey
     - created_at
     - updated_at
+    - expired
   :further_education_payments_eligibilities:
     - id
     - created_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -973,6 +973,10 @@ en:
           "i_dont_know": I don’t know
         errors:
           inclusion: 'Tell us if you have a GOV.UK One Login account'
+      existing_progress:
+        question: You have already started an eligibility check
+        errors:
+          inclusion: Choose if you want to continue your existing eligibility check or start a new eligibility check
       teaching_responsibilities:
         question: Are you a member of staff with teaching responsibilities?
         errors:

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -44,5 +44,8 @@ production: &production
   purge_old_jobs:
     class: PurgeOldJobsJob
     schedule: "0 4 * * *" # 4AM daily
+  expire_journey_sessions_jobs:
+    class: ExpireJourneySessionsJob
+    schedule: "0 * * * *" # hourly on the hour
 development:
   <<: *production

--- a/db/migrate/20250911092038_add_expired_to_journeys_sessions.rb
+++ b/db/migrate/20250911092038_add_expired_to_journeys_sessions.rb
@@ -1,0 +1,9 @@
+class AddExpiredToJourneysSessions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :journeys_sessions,
+      :expired,
+      :boolean,
+      null: false,
+      default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_083853) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_11_092038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -405,6 +405,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_083853) do
     t.string "journey", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "expired", default: false, null: false
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/further_education_payments/claimed_last_year_spec.rb
+++ b/spec/features/further_education_payments/claimed_last_year_spec.rb
@@ -25,6 +25,9 @@ RSpec.feature "Further education payments" do
 
     sign_in_with_one_login
 
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
     expect(page).to have_content("Which academic year did you start teaching in further education in England?")
     choose("September 2023 to August 2024")
     click_button "Continue"

--- a/spec/features/further_education_payments/existing_one_login_spec.rb
+++ b/spec/features/further_education_payments/existing_one_login_spec.rb
@@ -21,6 +21,9 @@ RSpec.feature "Further education payments" do
 
     sign_in_with_one_login
 
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
     expect(page).to have_content("Which academic year did you start teaching in further education in England?")
     choose("September 2023 to August 2024")
     click_button "Continue"

--- a/spec/features/further_education_payments/one_login_contiue_spec.rb
+++ b/spec/features/further_education_payments/one_login_contiue_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.feature "Further education payments" do
+  include ActionView::Helpers::NumberHelper
+
+  let(:college) { create(:school, :further_education, :fe_eligible) }
+  let(:expected_award_amount) { college.eligible_fe_provider.max_award_amount }
+  let(:one_login_uid) { SecureRandom.uuid }
+
+  scenario "has OL account with existing partial eligibility and continues" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    fill_in "One Login UID", with: one_login_uid
+    click_button "Continue"
+
+    expect(page).to have_content("You’ve successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    click_button "Sign out"
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    fill_in "One Login UID", with: one_login_uid
+    click_button "Continue"
+
+    expect(page).to have_content("You’ve successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("You have already started an eligibility check")
+    choose "Continue with the eligibility check that you have already started"
+    click_button "Continue"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+  end
+
+  scenario "has OL account with existing partial eligibility but starts anew" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    fill_in "One Login UID", with: one_login_uid
+    click_button "Continue"
+
+    expect(page).to have_content("You’ve successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_content("Are you a member of staff with teaching responsibilities?")
+    click_button "Sign out"
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    fill_in "One Login UID", with: one_login_uid
+    click_button "Continue"
+
+    expect(page).to have_content("You’ve successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("You have already started an eligibility check")
+    choose "Start a new eligibility check"
+    click_button "Continue"
+
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education in England?")
+  end
+
+  def and_college_exists
+    college
+  end
+end

--- a/spec/features/further_education_payments/one_login_contiue_spec.rb
+++ b/spec/features/further_education_payments/one_login_contiue_spec.rb
@@ -118,6 +118,59 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Which academic year did you start teaching in further education in England?")
   end
 
+  scenario "has OL account with existing ineligible check and continues" do
+    when_student_loan_data_exists
+    when_further_education_payments_journey_configuration_exists
+    and_college_exists
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    fill_in "One Login UID", with: one_login_uid
+    click_button "Continue"
+
+    expect(page).to have_content("You’ve successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_content("Do you have a teaching qualification?")
+    choose("No, and I do not plan to enrol on one in the next 12 months")
+    click_button "Continue"
+
+    expect(page).to have_content("You are not eligible")
+    click_button "Sign out"
+
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a")
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_content("Sign in with GOV.UK One Login")
+    fill_in "One Login UID", with: one_login_uid
+    click_button "Continue"
+
+    expect(page).to have_content("You’ve successfully signed in to GOV.UK One Login")
+    click_button "Continue"
+
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
+    expect(page).to have_content("Which academic year did you start teaching in further education in England?")
+  end
+
   def and_college_exists
     college
   end

--- a/spec/features/further_education_payments/one_login_contiue_spec.rb
+++ b/spec/features/further_education_payments/one_login_contiue_spec.rb
@@ -19,6 +19,8 @@ RSpec.feature "Further education payments" do
     choose "Yes"
     click_button "Continue"
 
+    mock_one_login_auth(uid: one_login_uid)
+
     expect(page).to have_content("Sign in with GOV.UK One Login")
     fill_in "One Login UID", with: one_login_uid
     click_button "Continue"
@@ -46,6 +48,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Do you have a")
     choose "Yes"
     click_button "Continue"
+
+    mock_one_login_auth(uid: one_login_uid)
 
     expect(page).to have_content("Sign in with GOV.UK One Login")
     fill_in "One Login UID", with: one_login_uid
@@ -73,6 +77,8 @@ RSpec.feature "Further education payments" do
     choose "Yes"
     click_button "Continue"
 
+    mock_one_login_auth(uid: one_login_uid)
+
     expect(page).to have_content("Sign in with GOV.UK One Login")
     fill_in "One Login UID", with: one_login_uid
     click_button "Continue"
@@ -100,6 +106,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Do you have a")
     choose "Yes"
     click_button "Continue"
+
+    mock_one_login_auth(uid: one_login_uid)
 
     expect(page).to have_content("Sign in with GOV.UK One Login")
     fill_in "One Login UID", with: one_login_uid
@@ -130,6 +138,8 @@ RSpec.feature "Further education payments" do
     choose "Yes"
     click_button "Continue"
 
+    mock_one_login_auth(uid: one_login_uid)
+
     expect(page).to have_content("Sign in with GOV.UK One Login")
     fill_in "One Login UID", with: one_login_uid
     click_button "Continue"
@@ -157,6 +167,8 @@ RSpec.feature "Further education payments" do
     expect(page).to have_content("Do you have a")
     choose "Yes"
     click_button "Continue"
+
+    mock_one_login_auth(uid: one_login_uid)
 
     expect(page).to have_content("Sign in with GOV.UK One Login")
     fill_in "One Login UID", with: one_login_uid

--- a/spec/features/further_education_payments/previously_claimed_spec.rb
+++ b/spec/features/further_education_payments/previously_claimed_spec.rb
@@ -21,6 +21,9 @@ RSpec.feature "Further education payments" do
 
     sign_in_with_one_login
 
+    expect(page).to have_content("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
     expect(page).to have_content("Which academic year did you start teaching in further education in England?")
     choose("September 2023 to August 2024")
     click_button "Continue"

--- a/spec/features/journey_session_expiry_spec.rb
+++ b/spec/features/journey_session_expiry_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "Journey session expiry" do
+  before do
+    create(
+      :journey_configuration,
+      :further_education_payments
+    )
+  end
+
+  scenario "after session expiry starts new session" do
+    visit landing_page_path(Journeys::FurtherEducationPayments::ROUTING_NAME)
+    click_link "Start now"
+
+    expect(page).to have_text "Do you have a GOV.UK One Login account?"
+    choose "Yes"
+    click_button "Continue"
+
+    sign_in_with_one_login
+
+    expect(page).to have_text("Check you’re eligible for a targeted retention incentive payment for further education")
+    click_button "Start eligibility check"
+
+    expect(page).to have_text("Which academic year did you start teaching in further education in England?")
+    choose("September 2023 to August 2024")
+    click_button "Continue"
+
+    expect(page).to have_text("Do you have a teaching qualification?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_text("Are you a member of staff with teaching responsibilities?")
+    choose("Yes")
+    click_button "Continue"
+
+    expect(page).to have_text("Which FE provider directly employs you?")
+    last_path = current_path
+
+    travel(2.days)
+    ExpireJourneySessionsJob.perform_now
+
+    visit last_path
+    expect(page).not_to have_text("Which FE provider directly employs you?")
+    expect(page).to have_link "Start now"
+  end
+end

--- a/spec/jobs/expire_journey_sessions_job_spec.rb
+++ b/spec/jobs/expire_journey_sessions_job_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ExpireJourneySessionsJob do
+  describe "#perform" do
+    let(:over_24_hours_ago) { 24.hours.ago - 1.second }
+    let(:four_hours_ago) { 4.hours.ago }
+
+    it "expires unsubmitted claims not touched for 24 hours" do
+      submitted_journeys = []
+      unsubmitted_fresh_journeys = []
+      unsubmitted_expired_journeys = []
+
+      Journeys::JOURNEYS.each do |journey|
+        submitted_journeys << journey::Session.create!(
+          journey: journey::ROUTING_NAME,
+          claim: create(:claim),
+          updated_at: over_24_hours_ago
+        )
+
+        unsubmitted_fresh_journeys << journey::Session.create!(
+          journey: journey::ROUTING_NAME,
+          updated_at: four_hours_ago
+        )
+
+        unsubmitted_expired_journeys << journey::Session.create!(
+          journey: journey::ROUTING_NAME,
+          updated_at: over_24_hours_ago
+        )
+      end
+
+      subject.perform
+
+      expect(submitted_journeys.each(&:reload)).to all be_not_expired
+      expect(unsubmitted_fresh_journeys.each(&:reload)).to all be_not_expired
+      expect(unsubmitted_expired_journeys.each(&:reload)).to all be_expired
+    end
+  end
+end

--- a/spec/models/journeys/navigator_spec.rb
+++ b/spec/models/journeys/navigator_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Journeys::Navigator do
-  subject { described_class.new(current_slug:, slug_sequence:, params:, session:) }
+  subject do
+    described_class.new(current_slug:, slug_sequence:, params:, session:)
+  end
 
   let(:current_slug) { "have-one-login-account" }
   let(:slug_sequence) { Journeys::FurtherEducationPayments::SlugSequence.new(journey_session) }
@@ -9,6 +11,10 @@ RSpec.describe Journeys::Navigator do
   let(:session) { {} }
   let(:journey_session) do
     create(:further_education_payments_session, answers: answers)
+  end
+
+  before do
+    create(:journey_configuration, :further_education_payments)
   end
 
   describe "#next_slug" do


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2743
- Allow users to resume a previous session based on their OL uid
- We ignore any previous sessions that are in ineligible state

# Other changes

- We now purge FE journey sessions only when the session has not been touched for a year
- Introduced concept of expiring journey sessions. this means journey sessions remain persisted but no longer available for lookup
- These journey remain persisted till they are purged at a later date. this allows users to resume a previous journey session we have persisted
- This is done via an hourly job. This means max theoretical session time is now 25 hours (24.hours - 1.second + 1.hour) down from the current time of 48 hours (24.hours - 1.second + 24.hours)