### PR TITLE
Fix viewing held claims errors

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -98,6 +98,11 @@ module Admin
     end
 
     def decision_deadline_warning(claim, opts = {})
+      if claim.decision_deadline_date.nil?
+        # EY claim where the practitioner journey hasn't been completed
+        return I18n.t("admin.decision_overdue_not_applicable")
+      end
+
       days_until_decision_deadline = days_between(Date.today, claim.decision_deadline_date)
 
       if days_until_decision_deadline.days > Claim::DECISION_DEADLINE_WARNING_POINT

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -170,6 +170,13 @@ RSpec.describe Admin::ClaimsHelper do
 
       it { is_expected.to eq "" }
     end
+
+    context "when an ey claim with no submitted_at" do
+      subject { helper.decision_deadline_warning(claim, {na_text: ""}) }
+      let(:claim) { build(:claim, policy: Policies::EarlyYearsPayments, submitted_at: nil) }
+
+      it { is_expected.to eq "N/A" }
+    end
   end
 
   describe "#identity_confirmation_task_claim_verifier_match_status_tag" do


### PR DESCRIPTION
The admin ui expects all claims to have a non nil submitted_at. EY
claims only get their submitted_at value set when the practitioner has
completed their part of the journey.
