### PR TITLE
Handle year 1 ey claims

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -149,9 +149,9 @@ module Admin
           status_colour = "grey"
         end
       when Policies::EarlyYearsPayments
-        identity_tasks = []
-        identity_tasks << (claim.tasks.detect { |t| t.name == "one_login_identity" } || Task.new)
-        identity_tasks << (claim.tasks.detect { |t| t.name == "ey_alternative_verification" } || Task.new)
+        identity_tasks = Policies::EarlyYearsPayments::ClaimCheckingTasks.new(claim).identity_tasks.map do |name|
+          claim.tasks.detect { |t| t.name == name } || Task.new
+        end
 
         if !claim.eligibility.practitioner_journey_completed?
           status = "Incomplete"

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -13,20 +13,27 @@ module Policies
 
       def applicable_task_names
         tasks = []
-
-        if year_1_of_ey?
-          tasks << "identity_confirmation"
-          tasks << "ey_alternative_verification" if claim.tasks.exists?(name: "ey_alternative_verification")
-        else
-          tasks << "ey_eoi_cross_reference"
-          tasks << "one_login_identity"
-          tasks << "ey_alternative_verification" if claim.failed_one_login_idv?
-        end
+        tasks << "ey_eoi_cross_reference" unless year_1_of_ey?
+        tasks += identity_tasks
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "payroll_gender" if claim.payroll_gender_missing? || claim.tasks.exists?(name: "payroll_gender")
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
         tasks << "matching_details" if matching_claims.exists?
+
+        tasks
+      end
+
+      def identity_tasks
+        tasks = []
+
+        if year_1_of_ey?
+          tasks << "identity_confirmation"
+          tasks << "ey_alternative_verification" if task_exists?("ey_alternative_verification")
+        else
+          tasks << "one_login_identity"
+          tasks << "ey_alternative_verification" if claim.failed_one_login_idv?
+        end
 
         tasks
       end
@@ -45,6 +52,14 @@ module Policies
 
       def matching_claims
         @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims
+      end
+
+      def task_exists?(name)
+        if claim.tasks.loaded?
+          claim.tasks.any? { |task| task.name == name }
+        else
+          claim.tasks.exists?(name: name)
+        end
       end
     end
   end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -350,6 +350,13 @@ RSpec.describe Admin::ClaimsHelper do
           ]
         end
 
+        before do
+          claim.update!(
+            onelogin_idv_at: DateTime.current,
+            identity_confirmed_with_onelogin: false
+          )
+        end
+
         it "return unverified grey tag" do
           expect(subject).to match("Unverified")
           expect(subject).to match("grey")
@@ -394,7 +401,35 @@ RSpec.describe Admin::ClaimsHelper do
           ]
         end
 
+        before do
+          claim.update!(
+            onelogin_idv_at: DateTime.current,
+            identity_confirmed_with_onelogin: false
+          )
+        end
+
         it "return passed green tag" do
+          expect(subject).to match("Passed")
+          expect(subject).to match("green")
+        end
+      end
+
+      context "with a year 1 claim that passsed idv" do
+        let(:claim_tasks) do
+          [
+            create(
+              :task,
+              name: "identity_confirmation",
+              passed: true
+            )
+          ]
+        end
+
+        before do
+          claim.update!(academic_year: AcademicYear.new("2024/2025"))
+        end
+
+        it "returns passed green tag" do
           expect(subject).to match("Passed")
           expect(subject).to match("green")
         end


### PR DESCRIPTION
We need to check the `identity_confirmation` task for year 1 ey claims
