### PR TITLE
Add employment date check to admin view

### DIFF
--- a/app/models/policies/early_years_payments/eligibility.rb
+++ b/app/models/policies/early_years_payments/eligibility.rb
@@ -33,6 +33,8 @@ module Policies
         start_date + RETENTION_PERIOD
       end
 
+      alias_method :employment_check_date, :employment_task_available_at
+
       def employment_task_available?
         Date.today >= employment_task_available_at
       end

--- a/app/views/admin/tasks/_claim_summary_early_years_payments.html.erb
+++ b/app/views/admin/tasks/_claim_summary_early_years_payments.html.erb
@@ -110,6 +110,20 @@
 
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
+        Employment check
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if claim.eligibility.employment_check_date %>
+          <%= l(claim.eligibility.employment_check_date) %>
+          <%= decision_deadline_warning_lozenge(
+            days_between(claim.eligibility.employment_check_date, Date.today)
+          ) %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
         Decision due
       </dt>
       <dd class="govuk-summary-list__value">

--- a/spec/features/admin/admin_view_claim_early_years_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_early_years_payments_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature "Admin view claim for EarlyYearsPayments" do
     expect(page).to have_summary_item(key: "Mobile number", value: practitioner_claim.mobile_number)
     expect(page).to have_summary_item(key: "Reference", value: practitioner_claim.reference)
     expect(page).to have_summary_item(key: "Submitted", value: practitioner_claim.submitted_at.strftime(I18n.t("time.formats.default")))
+    expect(page).to have_summary_item(key: "Employment check", value: practitioner_claim.eligibility.employment_check_date.strftime(I18n.t("date.formats.default")), exact_text: false)
     expect(page).to have_summary_item(key: "Decision due", value: practitioner_claim.decision_deadline_date.strftime(I18n.t("date.formats.default")), exact_text: false)
     expect(page).to have_summary_item(key: "Status", value: "Awaiting decision - not on hold")
     expect(page).to have_summary_item(key: "Claim amount", value: "£0.00")


### PR DESCRIPTION
For EY claims we want to highlight when the employment check is due.
