### PR TITLE
update admin filters to show y2 fe claims

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -107,6 +107,12 @@ class Claim < ApplicationRecord
   scope :by_policies, ->(policies) { where(policy: policies) }
   scope :by_policies_for_journey, ->(journey) { by_policies(journey.policies) }
   scope :by_academic_year, ->(academic_year) { where(academic_year: academic_year) }
+  scope :after_academic_year, ->(academic_year) do
+    where(
+      "split_part(academic_year, '/', 1)::integer > ?",
+      academic_year.start_year
+    )
+  end
   scope :assigned_to_team_member, ->(service_operator_id) { where(assigned_to_id: service_operator_id) }
   scope :by_claims_team_member, ->(service_operator_id, status) do
     if %w[approved approved_awaiting_payroll rejected].include?(status)
@@ -136,7 +142,7 @@ class Claim < ApplicationRecord
   scope :awaiting_further_education_provider_verification, -> do
     by_policy(Policies::FurtherEducationPayments)
       .where(
-        eligibility_id: Policies::FurtherEducationPayments::Eligibility.awaiting_provider_verification_year_1.select(:id)
+        eligibility_id: Policies::FurtherEducationPayments::Eligibility.awaiting_provider_verification.select(:id)
       )
   end
   scope :not_awaiting_further_education_provider_verification, -> do

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -108,10 +108,7 @@ class Claim < ApplicationRecord
   scope :by_policies_for_journey, ->(journey) { by_policies(journey.policies) }
   scope :by_academic_year, ->(academic_year) { where(academic_year: academic_year) }
   scope :after_academic_year, ->(academic_year) do
-    where(
-      "split_part(academic_year, '/', 1)::integer > ?",
-      academic_year.start_year
-    )
+    where("academic_year > ?", academic_year.to_s)
   end
   scope :assigned_to_team_member, ->(service_operator_id) { where(assigned_to_id: service_operator_id) }
   scope :by_claims_team_member, ->(service_operator_id, status) do

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -134,12 +134,9 @@ class Claim < ApplicationRecord
   scope :rejected_awaiting_qa, -> { rejected.qa_required.where(qa_completed_at: nil) }
   scope :qa_required, -> { where(qa_required: true) }
   scope :awaiting_further_education_provider_verification, -> do
-    joins("INNER JOIN further_education_payments_eligibilities ON further_education_payments_eligibilities.id = claims.eligibility_id")
-      .left_outer_joins(:notes)
-      .where("further_education_payments_eligibilities.verification = '{}'")
-      .and(
-        Claim.where("further_education_payments_eligibilities.flagged_as_duplicate = FALSE")
-        .or(Claim.where("further_education_payments_eligibilities.flagged_as_duplicate = TRUE").and(Claim.where(notes: {label: "provider_verification"})))
+    by_policy(Policies::FurtherEducationPayments)
+      .where(
+        eligibility_id: Policies::FurtherEducationPayments::Eligibility.awaiting_provider_verification_year_1.select(:id)
       )
   end
   scope :not_awaiting_further_education_provider_verification, -> do

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -31,6 +31,21 @@ module Policies
       scope :provider_verification_email_last_sent_over, ->(older_than) { where("provider_verification_email_last_sent_at < ?", older_than) }
       scope :provider_verification_chase_email_not_sent, -> { where(provider_verification_chase_email_last_sent_at: nil) }
 
+      scope :awaiting_provider_verification_year_1, -> do
+        where(verification: {}, flagged_as_duplicate: false)
+          .or(
+            where(
+              id: left_joins(claim: :notes)
+              .where(
+                verification: {},
+                flagged_as_duplicate: true,
+                notes: {label: "provider_verification"}
+              )
+              .select(:id)
+            )
+          )
+      end
+
       # Claim#school expects this
       alias_method :current_school, :school
 

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -100,14 +100,22 @@ module Policies
       end
 
       def verified?
-        verification.present?
+        if claim.academic_year == AcademicYear.new(2024)
+          verification.present?
+        else
+          provider_verification_completed_at.present?
+        end
       end
 
       def awaiting_provider_verification?
         return false if verified?
 
-        # when a provider verification email is sent by the admin team, a note is created
-        !flagged_as_duplicate? || claim.notes.where(label: "provider_verification").any?
+        if claim.academic_year == AcademicYear.new(2024)
+          # when a provider verification email is sent by the admin team, a note is created
+          !flagged_as_duplicate? || claim.notes.where(label: "provider_verification").any?
+        else
+          !flagged_as_duplicate?
+        end
       end
 
       def provider_and_claimant_details_match?

--- a/spec/features/admin/admin_checks_further_education_payments_claim_spec.rb
+++ b/spec/features/admin/admin_checks_further_education_payments_claim_spec.rb
@@ -4,6 +4,15 @@ RSpec.feature "Admin checks an Further Education Payments claim" do
   it_behaves_like "Admin Checks", Policies::FurtherEducationPayments
 
   describe "further education specific checks" do
+    let(:dfe_sign_in_user) do
+      create(
+        :dfe_signin_user,
+        given_name: "Walter",
+        family_name: "Skinner",
+        email: "w.s.skinner@springfield-elementary.edu"
+      )
+    end
+
     before do
       sign_in_as_service_operator
     end
@@ -19,13 +28,8 @@ RSpec.feature "Admin checks an Further Education Payments claim" do
           email_address: "w.s.skinner@example.com",
           policy: Policies::FurtherEducationPayments,
           eligibility_attributes: {
-            verification: {
-              verifier: {
-                first_name: "Walter",
-                last_name: "Skinner",
-                email: "w.s.skinner@springfield-elementary.edu"
-              }
-            }
+            provider_verification_completed_at: 1.day.ago,
+            provider_verification_verified_by_id: dfe_sign_in_user.id
           }
         )
 
@@ -51,13 +55,8 @@ RSpec.feature "Admin checks an Further Education Payments claim" do
           email_address: "w.s.skinner@springfield-elementary.edu",
           policy: Policies::FurtherEducationPayments,
           eligibility_attributes: {
-            verification: {
-              verifier: {
-                first_name: "Walter",
-                last_name: "Skinner",
-                email: "w.s.skinner@springfield-elementary.edu"
-              }
-            }
+            provider_verification_completed_at: 1.day.ago,
+            provider_verification_verified_by_id: dfe_sign_in_user.id
           }
         )
 
@@ -83,13 +82,8 @@ RSpec.feature "Admin checks an Further Education Payments claim" do
           email_address: "e.krabappel@springfield-elementary.edu",
           policy: Policies::FurtherEducationPayments,
           eligibility_attributes: {
-            verification: {
-              verifier: {
-                first_name: "Walter",
-                last_name: "Skinner",
-                email: "w.s.skinner@springfield-elementary.edu"
-              }
-            }
+            provider_verification_completed_at: 1.day.ago,
+            provider_verification_verified_by_id: dfe_sign_in_user.id
           }
         )
 

--- a/spec/features/admin/admin_claims_filtering_spec.rb
+++ b/spec/features/admin/admin_claims_filtering_spec.rb
@@ -22,8 +22,8 @@ RSpec.feature "Admin claim filtering" do
   let(:rejected_awaiting_qa_claims) { create_list(:claim, 2, :rejected, :flagged_for_qa, policy: Policies::TargetedRetentionIncentivePayments) }
   let(:auto_approved_awaiting_payroll_claims) { create_list(:claim, 2, :auto_approved, policy: Policies::TargetedRetentionIncentivePayments) }
   let(:approved_claim) { create(:claim, :approved, policy: Policies::TargetedRetentionIncentivePayments, assigned_to: mette, decision_creator: mary) }
-  let(:further_education_claims_awaiting_provider_verification) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible, assigned_to: valentino) }
-  let(:further_education_claims_provider_verification_email_not_sent) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate, assigned_to: valentino) }
+  let(:further_education_claims_awaiting_provider_verification) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible, eligibility_attributes: {provider_verification_completed_at: nil}, assigned_to: valentino) }
+  let(:further_education_claims_provider_verified) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: [:eligible, :duplicate], eligibility_attributes: {provider_verification_completed_at: DateTime.now}, assigned_to: valentino) }
   let(:rejected_claim) { create(:claim, :rejected, policy: Policies::TargetedRetentionIncentivePayments, assigned_to: valentino) }
 
   let!(:claims) do
@@ -40,7 +40,7 @@ RSpec.feature "Admin claim filtering" do
       auto_approved_awaiting_payroll_claims,
       approved_claim,
       further_education_claims_awaiting_provider_verification,
-      further_education_claims_provider_verification_email_not_sent,
+      further_education_claims_provider_verified,
       rejected_claim
     ]
   end
@@ -127,7 +127,7 @@ RSpec.feature "Admin claim filtering" do
       early_career_payments_claims_for_mette,
       early_career_payments_claims_failed_bank_validation,
       targeted_retention_incentive_claims_unassigned,
-      further_education_claims_provider_verification_email_not_sent
+      further_education_claims_provider_verified
     )
 
     select "Awaiting provider verification", from: "filter-status-field"

--- a/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
     expect(page).to have_content(claim_with_trn.school.ukprn)
   end
 
-  scenario "Awaiting provider verification claim status" do
+  xscenario "Awaiting provider verification claim status" do
     visit admin_claims_path(filter: {status: "awaiting_provider_verification"})
     find("a[href='#{admin_claim_tasks_path(claim_not_verified)}']").click
     expect(page).to have_content("Awaiting provider verification")

--- a/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
     expect(page).to have_content(claim_with_trn.school.ukprn)
   end
 
-  xscenario "Awaiting provider verification claim status" do
+  scenario "Awaiting provider verification claim status" do
     visit admin_claims_path(filter: {status: "awaiting_provider_verification"})
     find("a[href='#{admin_claim_tasks_path(claim_not_verified)}']").click
     expect(page).to have_content("Awaiting provider verification")

--- a/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
@@ -34,26 +34,17 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
       eligibility_trait: :duplicate
     )
   }
-  let!(:claim_with_duplicates_provider_email_sent) {
-    create(
-      :claim,
-      :submitted,
-      policy: Policies::FurtherEducationPayments,
-      eligibility_trait: :duplicate
-    )
-  }
   let!(:verified_claim) {
     create(
       :claim,
       :submitted,
       policy: Policies::FurtherEducationPayments,
-      eligibility_trait: :verified
+      eligibility_trait: :provider_verification_completed
     )
   }
 
   before do
     sign_in_as_service_operator
-    create(:note, claim: claim_with_duplicates_provider_email_sent, label: "provider_verification")
   end
 
   scenario "view claim summary for claim with no TRN" do
@@ -83,12 +74,7 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
     find("a[href='#{admin_claim_tasks_path(claim_with_duplicates_no_provider_email_sent)}']").click
     expect(page).to have_content("Awaiting decision - not on hold")
 
-    visit admin_claims_path(filter: {status: "awaiting_provider_verification"})
-    find("a[href='#{admin_claim_tasks_path(claim_with_duplicates_provider_email_sent)}']").click
-    expect(page).to have_content("Awaiting provider verification")
-
     visit admin_claims_path
-    click_link "Clear filters"
     find("a[href='#{admin_claim_tasks_path(verified_claim)}']").click
     expect(page).to have_content("Awaiting decision - not on hold")
   end

--- a/spec/features/admin/admin_view_claim_spec.rb
+++ b/spec/features/admin/admin_view_claim_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Admin view claim" do
 
   Policies
     .all
+    .excluding(Policies::FurtherEducationPayments)
     .each { |policy| it_behaves_like "Admin View Claim Feature", policy }
 
   Policies

--- a/spec/features/admin/admin_view_claim_spec.rb
+++ b/spec/features/admin/admin_view_claim_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature "Admin view claim" do
 
   Policies
     .all
-    .excluding(Policies::FurtherEducationPayments)
     .each { |policy| it_behaves_like "Admin View Claim Feature", policy }
 
   Policies

--- a/spec/features/admin/tasks/identity_confirmation_spec.rb
+++ b/spec/features/admin/tasks/identity_confirmation_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Admin performs identity confirmation task" do
       :submitted,
       :with_onelogin_idv_data,
       policy: Policies::FurtherEducationPayments,
-      eligibility_trait: [:eligible, :verified]
+      eligibility_trait: [:eligible, :provider_verification_completed]
     )
   end
 

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -43,32 +43,32 @@ RSpec.feature "Upload SLC data" do
 
   let!(:fe_claim_with_slc_data_no_student_loan_nil_submitted_using_slc_data) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :provider_verification_completed),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
   let!(:fe_claim_with_slc_data_with_student_loan_nil_submitted_using_slc_data) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :provider_verification_completed),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
   let!(:fe_claim_no_slc_data_nil_submitted_using_slc_data) {
     create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :provider_verification_completed),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
   let!(:fe_claim_with_slc_data_no_student_loan) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :provider_verification_completed),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
   let!(:fe_claim_with_slc_data_with_student_loan) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :provider_verification_completed),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
   let!(:fe_claim_no_slc_data) {
     create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :provider_verification_completed),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1490,44 +1490,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "#awaiting_provider_verification?" do
-    subject { claim.awaiting_provider_verification? }
-
-    context "when the eligiblity is not verified" do
-      context "when there are no duplicates" do
-        let(:claim) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
-
-        it { is_expected.to be true }
-      end
-
-      context "when there are duplicates" do
-        let(:claim) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-
-        context "the provider email has not been sent" do
-          it { is_expected.to be false }
-        end
-
-        context "when the provider email has been sent" do
-          before { create(:note, claim: claim, label: "provider_verification") }
-
-          it { is_expected.to be true }
-        end
-      end
-    end
-
-    context "when the eligiblity is verified" do
-      let(:claim) { build(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
-
-      it { is_expected.to be false }
-    end
-
-    context "when the eligiblity is not further education payments" do
-      let(:claim) { build(:claim, policy: Policies::StudentLoans) }
-
-      it { is_expected.to be false }
-    end
-  end
-
   describe "#decision_deadline_date" do
     let(:policy) { Policies.all.sample }
     let(:claim) { create(:claim, :eligible, :early_years_provider_submitted, policy:) }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1011,26 +1011,26 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "awaiting further education provider verification scopes" do
-    let!(:claim_not_verified_provider_email_automatically_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
-    let!(:claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:claim_not_verified_has_duplicates_provider_email_not_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:claim_not_verified_has_duplicates_provider_email_manually_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
+    let!(:year_1_claim_not_verified_provider_email_automatically_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
+    let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
+    let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
+    let!(:year_1_claim_not_verified_has_duplicates_provider_email_manually_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
+    let!(:year_1_claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
     let!(:non_fe_claim) { create(:claim, policy: Policies::StudentLoans) }
 
     before do
-      create(:note, claim: claim_not_verified_has_duplicates_provider_email_manually_sent, label: "provider_verification")
-      create(:note, claim: claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note, label: "student_loan_plan")
+      create(:note, claim: year_1_claim_not_verified_has_duplicates_provider_email_manually_sent, label: "provider_verification")
+      create(:note, claim: year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note, label: "student_loan_plan")
     end
 
     describe ".awaiting_further_education_provider_verification" do
       subject { described_class.awaiting_further_education_provider_verification }
 
-      it "returns claims that have not been verified by the provider, and have had a provider email sent" do
+      it do
         is_expected.to match_array(
           [
-            claim_not_verified_provider_email_automatically_sent,
-            claim_not_verified_has_duplicates_provider_email_manually_sent
+            year_1_claim_not_verified_provider_email_automatically_sent,
+            year_1_claim_not_verified_has_duplicates_provider_email_manually_sent
           ]
         )
       end
@@ -1039,12 +1039,12 @@ RSpec.describe Claim, type: :model do
     describe ".not_awaiting_further_education_provider_verification" do
       subject { described_class.not_awaiting_further_education_provider_verification }
 
-      it "returns claims that have no FE eligiblity, or FE claims that have been verified by the provider, or non-verified claims where a provider email has not been sent" do
+      it do
         is_expected.to match_array(
           [
-            claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note,
-            claim_not_verified_has_duplicates_provider_email_not_sent,
-            claim_with_fe_provider_verification,
+            year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note,
+            year_1_claim_not_verified_has_duplicates_provider_email_not_sent,
+            year_1_claim_with_fe_provider_verification,
             non_fe_claim
           ]
         )

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1011,11 +1011,13 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "awaiting further education provider verification scopes" do
-    let!(:year_1_claim_not_verified_provider_email_automatically_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
-    let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:year_1_claim_not_verified_has_duplicates_provider_email_manually_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:year_1_claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_trait: :verified) }
+    let!(:year_1_claim_not_verified_provider_email_automatically_sent) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
+    let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
+    let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
+    let!(:year_1_claim_not_verified_has_duplicates_provider_email_manually_sent) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
+    let!(:year_1_claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, academic_year: AcademicYear.new(2024), eligibility_trait: :verified) }
+    let!(:year_2_claim_awaiting_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments) }
+    let!(:year_2_claim_with_completed_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_attributes: {provider_verification_completed_at: DateTime.now}) }
     let!(:non_fe_claim) { create(:claim, policy: Policies::StudentLoans) }
 
     before do
@@ -1030,7 +1032,8 @@ RSpec.describe Claim, type: :model do
         is_expected.to match_array(
           [
             year_1_claim_not_verified_provider_email_automatically_sent,
-            year_1_claim_not_verified_has_duplicates_provider_email_manually_sent
+            year_1_claim_not_verified_has_duplicates_provider_email_manually_sent,
+            year_2_claim_awaiting_provider_verification
           ]
         )
       end
@@ -1045,6 +1048,7 @@ RSpec.describe Claim, type: :model do
             year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note,
             year_1_claim_not_verified_has_duplicates_provider_email_not_sent,
             year_1_claim_with_fe_provider_verification,
+            year_2_claim_with_completed_provider_verification,
             non_fe_claim
           ]
         )

--- a/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks, feature_f
     let(:eligibility) do
       build(
         :further_education_payments_eligibility,
+        :provider_verification_completed,
         teacher_reference_number: teacher_reference_number,
-        verification: {
-          verifier: {
-            first_name: "Walter",
-            last_name: "Skinner",
-            email: "w.s.skinner@springfield-elementary.edu"
-          }
-        }
+        verified_by: create(
+          :dfe_signin_user,
+          given_name: "Walter",
+          family_name: "Skinner",
+          email: "w.s.skinner@springfield-elementary.edu"
+        )
       )
     end
 

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
         :with_student_loan,
         :with_onelogin_idv_data,
         policy: policy,
-        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :verified),
+        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :provider_verification_completed),
         onelogin_idv_at: 10.minutes.ago
       )
     else

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -10,7 +10,8 @@ RSpec.shared_examples "Admin Checks" do |policy|
         :with_student_loan,
         :with_onelogin_idv_data,
         policy: policy,
-        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :provider_verification_completed),
+        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :verified),
+        academic_year: AcademicYear.new(2024),
         onelogin_idv_at: 10.minutes.ago
       )
     else

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
 
   let(:eligibility_trait) do
     if policy == Policies::FurtherEducationPayments
-      [:eligible, :with_trn, :verified]
+      [:eligible, :with_trn, :provider_verification_completed]
     else
       :eligible
     end


### PR DESCRIPTION
Update query to work with year 2 fe claims

Year 2 claims have a different provider verification mechanisim so, in
order to get the admin filters to work as expected, we need to update
this query to work with them. We also need the filters to support year 1
claims.

