### PR TITLE
Refactor FE factory traits

### DIFF
--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -365,7 +365,7 @@ FactoryBot.define do
     end
 
     trait :awaiting_provider_verification do
-      eligibility_trait { :not_verified }
+      eligibility_trait { :eligible }
 
       after(:create) do |claim, _|
         create(:note, claim:, label: "provider_verification")

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
         create(:journey_configuration, journey::I18N_NAMESPACE)
       end
 
-      claim.eligibility = build(evaluator.eligibility_factory, evaluator.eligibility_trait, **evaluator.eligibility_attributes || {}) unless claim.eligibility
+      claim.eligibility = build(evaluator.eligibility_factory, *Array.wrap(evaluator.eligibility_trait), **evaluator.eligibility_attributes || {}) unless claim.eligibility
       claim.policy = claim.eligibility.policy
 
       raise "Policy of Claim (#{evaluator.policy}) must match Eligibility class (#{claim.eligibility.policy})" if evaluator.policy != claim.eligibility.policy

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -134,7 +134,6 @@ FactoryBot.define do
     end
 
     trait :with_trn do
-      eligible
       teacher_reference_number { generate(:teacher_reference_number) }
     end
 

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -5,7 +5,14 @@ FactoryBot.define do
     trait :eligible do
       eligible_school
       contract_type { "permanent" }
-      verified
+      teaching_responsibilities { true }
+      further_education_teaching_start_year { "2023" }
+      teaching_hours_per_week { "more_than_12" }
+      hours_teaching_eligible_subjects { false }
+      half_teaching_hours { true }
+      subjects_taught { ["maths", "physics"] }
+      maths_courses { ["approved_level_321_maths", "gcse_maths"] }
+      physics_courses { ["gcse_physics"] }
     end
 
     trait :not_verified do
@@ -22,15 +29,6 @@ FactoryBot.define do
     end
 
     trait :verified do
-      contract_type { "permanent" }
-      teaching_responsibilities { true }
-      further_education_teaching_start_year { "2023" }
-      teaching_hours_per_week { "more_than_12" }
-      hours_teaching_eligible_subjects { false }
-      half_teaching_hours { true }
-      subjects_taught { ["maths", "physics"] }
-      maths_courses { ["approved_level_321_maths", "gcse_maths"] }
-      physics_courses { ["gcse_physics"] }
       verification do
         {
           "assertions" => [

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -15,11 +15,6 @@ FactoryBot.define do
       physics_courses { ["gcse_physics"] }
     end
 
-    trait :not_verified do
-      eligible_school
-      contract_type { "permanent" }
-    end
-
     trait :eligible_school do
       association :school, factory: :fe_eligible_school
     end

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature "Admin claim further education payments" do
 
             eligibility = create(
               :further_education_payments_eligibility,
+              :eligible,
               :verified,
               contract_type: "fixed_term",
               school: fe_provider,

--- a/spec/features/admin/admin_claims_filtering_spec.rb
+++ b/spec/features/admin/admin_claims_filtering_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Admin claim filtering" do
   let(:rejected_awaiting_qa_claims) { create_list(:claim, 2, :rejected, :flagged_for_qa, policy: Policies::TargetedRetentionIncentivePayments) }
   let(:auto_approved_awaiting_payroll_claims) { create_list(:claim, 2, :auto_approved, policy: Policies::TargetedRetentionIncentivePayments) }
   let(:approved_claim) { create(:claim, :approved, policy: Policies::TargetedRetentionIncentivePayments, assigned_to: mette, decision_creator: mary) }
-  let(:further_education_claims_awaiting_provider_verification) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :not_verified, assigned_to: valentino) }
+  let(:further_education_claims_awaiting_provider_verification) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible, assigned_to: valentino) }
   let(:further_education_claims_provider_verification_email_not_sent) { create_list(:claim, 2, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate, assigned_to: valentino) }
   let(:rejected_claim) { create(:claim, :rejected, policy: Policies::TargetedRetentionIncentivePayments, assigned_to: valentino) }
 

--- a/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
       :claim,
       :submitted,
       policy: Policies::FurtherEducationPayments,
-      eligibility_trait: :with_trn
+      eligibility_trait: [:eligible, :with_trn]
     )
   }
   let!(:claim_not_verified) {

--- a/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_view_claim_further_education_payments_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Admin view claim for FurtherEducationPayments" do
       :claim,
       :submitted,
       policy: Policies::FurtherEducationPayments,
-      eligibility_trait: :not_verified
+      eligibility_trait: :eligible
     )
   }
   let!(:claim_with_duplicates_no_provider_email_sent) {

--- a/spec/features/admin/tasks/identity_confirmation_spec.rb
+++ b/spec/features/admin/tasks/identity_confirmation_spec.rb
@@ -1,7 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Admin performs identity confirmation task" do
-  let(:claim) { create(:claim, :submitted, :with_onelogin_idv_data, policy: Policies::FurtherEducationPayments) }
+  let(:claim) do
+    create(
+      :claim,
+      :submitted,
+      :with_onelogin_idv_data,
+      policy: Policies::FurtherEducationPayments,
+      eligibility_trait: [:eligible, :verified]
+    )
+  end
 
   before do
     AutomatedChecks::ClaimVerifiers::OneLoginIdentity.new(claim:).perform

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -43,32 +43,32 @@ RSpec.feature "Upload SLC data" do
 
   let!(:fe_claim_with_slc_data_no_student_loan_nil_submitted_using_slc_data) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
   let!(:fe_claim_with_slc_data_with_student_loan_nil_submitted_using_slc_data) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
   let!(:fe_claim_no_slc_data_nil_submitted_using_slc_data) {
     create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: nil) # having nil submitted_using_slc_data won't happen after LUPEYALPHA-1010 merged
   }
   let!(:fe_claim_with_slc_data_no_student_loan) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
   let!(:fe_claim_with_slc_data_with_student_loan) {
     create(:claim, :submitted, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
   let!(:fe_claim_no_slc_data) {
     create(:claim, :submitted, :with_student_loan, policy: Policies::FurtherEducationPayments,
-      eligibility: build(:further_education_payments_eligibility, :eligible),
+      eligibility: build(:further_education_payments_eligibility, :eligible, :verified),
       has_student_loan: nil, student_loan_plan: nil, submitted_using_slc_data: false)
   }
 

--- a/spec/features/further_education_payments/providers/provider_verifying_with_claimant_courses_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_with_claimant_courses_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature "Provider verifying claims" do
       date_of_birth: Date.new(1945, 7, 3),
       reference: "AB123456",
       submitted_at: DateTime.new(2025, 10, 1, 9, 0, 0),
+      eligibility_trait: [:eligible, :verified],
       eligibility_attributes: {
         school: fe_provider,
         teacher_reference_number: "1234567",
@@ -196,6 +197,7 @@ RSpec.feature "Provider verifying claims" do
       date_of_birth: Date.new(1945, 7, 3),
       reference: "AB123456",
       submitted_at: DateTime.new(2025, 10, 1, 9, 0, 0),
+      eligibility_trait: [:eligible, :verified],
       eligibility_attributes: {
         school: fe_provider,
         teacher_reference_number: "1234567",

--- a/spec/features/further_education_payments/viewing_year_1_claims_in_admin_area_spec.rb
+++ b/spec/features/further_education_payments/viewing_year_1_claims_in_admin_area_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Viewing year 1 claims in the admin area" do
   it "shows year 1 verification details" do
     eligibility = create(
       :further_education_payments_eligibility,
+      :eligible,
       :verified,
       :identity_verified_by_provider
     )

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1011,7 +1011,7 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "awaiting further education provider verification scopes" do
-    let!(:claim_not_verified_provider_email_automatically_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :not_verified) }
+    let!(:claim_not_verified_provider_email_automatically_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
     let!(:claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
     let!(:claim_not_verified_has_duplicates_provider_email_not_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
     let!(:claim_not_verified_has_duplicates_provider_email_manually_sent) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
@@ -1491,7 +1491,7 @@ RSpec.describe Claim, type: :model do
 
     context "when the eligiblity is not verified" do
       context "when there are no duplicates" do
-        let(:claim) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :not_verified) }
+        let(:claim) { create(:claim, :submitted, policy: Policies::FurtherEducationPayments, eligibility_trait: :eligible) }
 
         it { is_expected.to be true }
       end

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
         :with_student_loan,
         :with_onelogin_idv_data,
         policy: policy,
-        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible),
+        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :verified),
         onelogin_idv_at: 10.minutes.ago
       )
     else

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
 
   let!(:multiple_claim) {
     eligibility_trait = if policy == Policies::FurtherEducationPayments
-      :with_trn
+      [:eligible, :with_trn]
     else
       :eligible
     end

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -1,6 +1,14 @@
 RSpec.shared_examples "Admin View Claim Feature" do |policy|
   let(:academic_year) { AcademicYear.current }
 
+  let(:eligibility_trait) do
+    if policy == Policies::FurtherEducationPayments
+      [:eligible, :with_trn, :verified]
+    else
+      :eligible
+    end
+  end
+
   let!(:claim) {
     create(
       :claim,
@@ -8,17 +16,11 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       policy: policy,
       first_name: Faker::Name.first_name,
       surname: Faker::Name.last_name,
-      eligibility_trait: :eligible
+      eligibility_trait: eligibility_trait
     )
   }
 
   let!(:multiple_claim) {
-    eligibility_trait = if policy == Policies::FurtherEducationPayments
-      [:eligible, :with_trn]
-    else
-      :eligible
-    end
-
     create(
       :claim,
       :submitted,
@@ -37,7 +39,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       :claim,
       :submitted,
       policy: policy,
-      eligibility_trait: :eligible,
+      eligibility_trait: eligibility_trait,
       eligibility_attributes: duplicate_attribute
     )
   }
@@ -47,7 +49,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       :claim,
       :payrollable,
       policy: policy,
-      eligibility_trait: :eligible
+      eligibility_trait: eligibility_trait
     )
   }
 
@@ -56,7 +58,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       :claim,
       :approved,
       policy: policy,
-      eligibility_trait: :eligible
+      eligibility_trait: eligibility_trait
     )
   }
 
@@ -65,7 +67,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
       :claim,
       :rejected,
       policy: policy,
-      eligibility_trait: :eligible
+      eligibility_trait: eligibility_trait
     )
   }
 
@@ -161,7 +163,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     when Policies::InternationalRelocationPayments
       ["First year application", "Identity confirmation", "Visa", "Employment", "Teaching hours", "Continuous employment", "Decision"]
     when Policies::FurtherEducationPayments
-      ["Identity confirmation", "Provider verification", "Student loan plan", "Decision"]
+      ["Identity confirmation", "Provider verification", "Employment", "Student loan plan", "Decision"]
     when Policies::EarlyYearsPayments
       ["EOI cross reference", "One Login identity check", "Employment", "Student loan plan", "Decision"]
     else


### PR DESCRIPTION
Need to split `verification` out of the `eligible` trait to make migrating specs to use year 2 verification easier.
