### PR TITLE
Fix EY claim identity task

### DIFF
--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -28,7 +28,13 @@ module Policies
         tasks = []
 
         if year_1_of_ey?
-          tasks << "identity_confirmation"
+          tasks << if task_exists?("one_login_identity")
+            # Handle Y1 claims where practitioner submitted their part after we
+            # replaced the Identity claim verifier with the OneLogin verifier.
+            "one_login_identity"
+          else
+            "identity_confirmation"
+          end
           tasks << "ey_alternative_verification" if task_exists?("ey_alternative_verification")
         else
           tasks << "one_login_identity"

--- a/spec/models/policies/early_years_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/early_years_payments/claim_checking_tasks_spec.rb
@@ -17,6 +17,52 @@ RSpec.describe Policies::EarlyYearsPayments::ClaimCheckingTasks do
       end
     end
 
+    describe "one_login_identity" do
+      context "with a year 1 claim" do
+        context "when the claim was submitted before we switched to one login" do
+          # It doesn't have the one login task as the OL claim verifier didn't
+          # run
+          let(:claim) do
+            create(
+              :claim,
+              policy: Policies::EarlyYearsPayments,
+              academic_year: AcademicYear.new(2024)
+            )
+          end
+
+          it "includes identity_confirmation task" do
+            expect(subject.applicable_task_names).to include("identity_confirmation")
+          end
+
+          it "does not include one_login_identity task" do
+            expect(subject.applicable_task_names).not_to include("one_login_identity")
+          end
+        end
+
+        context "when the claim was submitted after we switched to one login" do
+          let(:claim) do
+            create(
+              :claim,
+              policy: Policies::EarlyYearsPayments,
+              academic_year: AcademicYear.new(2024)
+            )
+          end
+
+          before do
+            create(:task, name: "one_login_identity", claim: claim)
+          end
+
+          it "includes one_login_identity task" do
+            expect(subject.applicable_task_names).to include("one_login_identity")
+          end
+
+          it "does not include identity_confirmation task" do
+            expect(subject.applicable_task_names).not_to include("identity_confirmation")
+          end
+        end
+      end
+    end
+
     describe "ey_alternative_verification task" do
       let(:claim) do
         build(


### PR DESCRIPTION
For some EY year 1 claims the practitioner journey was completed after
we removed the Identity claim verifier from EY. There for the identity
task wasn't passed, nor was `claim_verifier_match` set on the task, this
caused the identity task on these claims to be rendered in as incomplete
and the form to complete them was not shown. These claims did have the
one_login_identity (OLIdentity verifier replaced Identity verifier) so
we want to render the `one_login_identity` task rather than the
`identity_confirmation` task if it's present.
