### PR TITLE
[CAPT-2909] Remove unused govuk verify code

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -48,10 +48,10 @@ module Admin
     def admin_personal_details(claim)
       [
         [translate("admin.teacher_reference_number"), claim.eligibility.teacher_reference_number.presence || "Not provided"],
-        [translate("#{claim.policy.locale_key}.govuk_verify_fields.full_name", default: :"govuk_verify_fields.full_name").capitalize, claim.personal_data_removed? ? personal_data_removed_text : claim.full_name],
-        [translate("govuk_verify_fields.date_of_birth").capitalize, claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth)],
+        ["Full name", claim.personal_data_removed? ? personal_data_removed_text : claim.full_name],
+        ["Date of birth", claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth)],
         [translate("admin.national_insurance_number"), claim.personal_data_removed? ? personal_data_removed_text : claim.national_insurance_number],
-        [translate("govuk_verify_fields.address").capitalize, claim.personal_data_removed? ? personal_data_removed_text : sanitize(claim.address("<br>").html_safe, tags: %w[br])],
+        ["Address", claim.personal_data_removed? ? personal_data_removed_text : sanitize(claim.address("<br>").html_safe, tags: %w[br])],
         [translate("#{claim.policy.locale_key}.admin.email_address", default: :"admin.email_address"), claim.email_address]
       ]
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -332,22 +332,6 @@ class Claim < ApplicationRecord
     govuk_verify_fields.any?
   end
 
-  def name_verified?
-    govuk_verify_fields.include?("first_name")
-  end
-
-  def date_of_birth_verified?
-    govuk_verify_fields.include?("date_of_birth")
-  end
-
-  def payroll_gender_verified?
-    govuk_verify_fields.include?("payroll_gender")
-  end
-
-  def address_from_govuk_verify?
-    (ADDRESS_ATTRIBUTES & govuk_verify_fields).any?
-  end
-
   def personal_data_removed?
     personal_data_removed_at.present?
   end

--- a/app/models/policies/early_years_payments/admin_claim_details_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_claim_details_presenter.rb
@@ -15,10 +15,10 @@ module Policies
 
       def personal_details
         [
-          [translate("#{claim.policy.locale_key}.govuk_verify_fields.full_name").capitalize, personal_data(claim.full_name)],
-          [translate("govuk_verify_fields.date_of_birth").capitalize, personal_data(formatted_date(claim.date_of_birth))],
+          ["Applicant name", personal_data(claim.full_name)],
+          ["Date of birth", personal_data(formatted_date(claim.date_of_birth))],
           [translate("admin.national_insurance_number"), personal_data(claim.national_insurance_number)],
-          [translate("govuk_verify_fields.address").capitalize, personal_data(sanitize(claim.address("<br>").html_safe, tags: %w[br]))],
+          ["Address", personal_data(sanitize(claim.address("<br>").html_safe, tags: %w[br]))],
           [translate("#{claim.policy.locale_key}.admin.email_address"), claim.email_address],
           [translate("#{claim.policy.locale_key}.admin.practitioner_email_address"), claim.practitioner_email_address],
           [translate("admin.mobile_number"), claim.mobile_number],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,14 +272,6 @@ en:
       male: "Male"
       female: "Female"
       dont_know: "Don’t know"
-  govuk_verify_fields:
-    first_name: "first name"
-    middle_name: "middle name"
-    surname: "surname"
-    date_of_birth: "date of birth"
-    payroll_gender: "gender"
-    address: "address"
-    full_name: "Full name"
   forms:
     teacher_reference_number:
       questions:
@@ -1592,8 +1584,6 @@ en:
     policy_full_name: Early years financial incentive payment
     support_email_address: "earlycareerteacherpayments@digital.education.gov.uk"
     claim_description: for an early years financial incentive payment
-    govuk_verify_fields:
-      full_name: Applicant name
     admin:
       email_address: Contact email
       practitioner_email_address: Provider-input contact email

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Admin::ClaimsHelper do
     it "includes an array of questions and answers" do
       expected_answers = [
         [I18n.t("admin.teacher_reference_number"), "1234567"],
-        [I18n.t("govuk_verify_fields.full_name").capitalize, "Bruce Wayne"],
-        [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "1 January 1901"],
+        ["Full name", "Bruce Wayne"],
+        ["Date of birth", "1 January 1901"],
         [I18n.t("admin.national_insurance_number"), "QQ123456C"],
-        [I18n.t("govuk_verify_fields.address").capitalize, "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
+        ["Address", "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
         [I18n.t("admin.email_address"), "test@email.com"]
       ]
 
@@ -40,10 +40,10 @@ RSpec.describe Admin::ClaimsHelper do
       it "returns the expected strings" do
         expected_answers = [
           [I18n.t("admin.teacher_reference_number"), "1234567"],
-          [I18n.t("govuk_verify_fields.full_name").capitalize, helper.personal_data_removed_text],
-          [I18n.t("govuk_verify_fields.date_of_birth").capitalize, helper.personal_data_removed_text],
+          ["Full name", helper.personal_data_removed_text],
+          ["Date of birth", helper.personal_data_removed_text],
           [I18n.t("admin.national_insurance_number"), helper.personal_data_removed_text],
-          [I18n.t("govuk_verify_fields.address").capitalize, helper.personal_data_removed_text],
+          ["Address".capitalize, helper.personal_data_removed_text],
           [I18n.t("admin.email_address"), "test@email.com"]
         ]
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -624,37 +624,6 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "#name_verified?" do
-    it "returns true if the name is present in the list of GOV.UK Verify fields" do
-      expect(Claim.new.name_verified?).to eq false
-      expect(Claim.new(govuk_verify_fields: ["first_name"]).name_verified?).to eq true
-    end
-  end
-
-  describe "#address_from_govuk_verify?" do
-    it "returns true if any address attributes are in the list of GOV.UK Verify fields" do
-      expect(Claim.new.address_from_govuk_verify?).to eq false
-      expect(Claim.new(govuk_verify_fields: ["payroll_gender"]).address_from_govuk_verify?).to eq false
-
-      expect(Claim.new(govuk_verify_fields: ["address_line_1"]).address_from_govuk_verify?).to eq true
-      expect(Claim.new(govuk_verify_fields: ["address_line_1", "postcode"]).address_from_govuk_verify?).to eq true
-    end
-  end
-
-  describe "#date_of_birth_verified?" do
-    it "returns true if date_of_birth is in the list of GOV.UK Verify fields" do
-      expect(Claim.new(govuk_verify_fields: ["date_of_birth"]).date_of_birth_verified?).to eq true
-      expect(Claim.new(govuk_verify_fields: ["address_line_1"]).date_of_birth_verified?).to eq false
-    end
-  end
-
-  describe "#payroll_gender_verified?" do
-    it "returns true if payroll_gender is in the list of GOV.UK Verify fields" do
-      expect(Claim.new(govuk_verify_fields: ["payroll_gender"]).payroll_gender_verified?).to eq true
-      expect(Claim.new(govuk_verify_fields: ["address_line_1"]).payroll_gender_verified?).to eq false
-    end
-  end
-
   describe "#personal_data_removed?" do
     it "returns false if a claim has not had its personal data removed" do
       claim = create(:claim, :approved)

--- a/spec/models/policies/early_years_payments/admin_claim_details_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_claim_details_presenter_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe Policies::EarlyYearsPayments::AdminClaimDetailsPresenter do
 
       it "returns an array of questions and answers" do
         expected_answers = [
-          [I18n.t("early_years_payments.govuk_verify_fields.full_name").capitalize, "Bruce Wayne"],
-          [I18n.t("govuk_verify_fields.date_of_birth").capitalize, nil],
+          ["Applicant name", "Bruce Wayne"],
+          ["Date of birth", nil],
           [I18n.t("admin.national_insurance_number"), nil],
-          [I18n.t("govuk_verify_fields.address").capitalize, ""],
+          ["Address", ""],
           [I18n.t("early_years_payments.admin.email_address"), nil],
           [I18n.t("early_years_payments.admin.practitioner_email_address"), "practitioner@example.com"],
           [I18n.t("admin.mobile_number"), nil],
@@ -91,10 +91,10 @@ RSpec.describe Policies::EarlyYearsPayments::AdminClaimDetailsPresenter do
 
       it "returns an array of questions and answers" do
         expected_answers = [
-          [I18n.t("early_years_payments.govuk_verify_fields.full_name").capitalize, "Bruce Wayne"],
-          [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "1 January 1901"],
+          ["Applicant name", "Bruce Wayne"],
+          ["Date of birth", "1 January 1901"],
           [I18n.t("admin.national_insurance_number"), "QQ123456C"],
-          [I18n.t("govuk_verify_fields.address").capitalize, "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
+          ["Address", "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
           [I18n.t("early_years_payments.admin.email_address"), "test@example.com"],
           [I18n.t("early_years_payments.admin.practitioner_email_address"), "practitioner@example.com"],
           [I18n.t("admin.mobile_number"), "07700900000"],


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2909
- Try to remove `govuk_verify` code
- there still remains the data and one method call which is wired
- the remainder is removal of dead code

