### PR TITLE
CAPT 2921/add herb liniting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,10 @@ jobs:
         run: bundle exec brakeman -c config/brakeman.ignore
       - name: Linting - Standardrb
         run: bin/rails standard
+      - name: Install Herb
+        run: gem install herb
+      - name: Linting - Herb ERB Analysis
+        run: herb analyze ./app
 
   lint-dfe-analytics:
     runs-on: ubuntu-latest

--- a/app/views/early_years_payment/provider/start/consent_form.html.erb
+++ b/app/views/early_years_payment/provider/start/consent_form.html.erb
@@ -40,7 +40,7 @@
     </p>
 
     <p class="govuk-body">
-    <input type="checkbox"></input> I give my employer consent to share the personal details listed with DfE, to apply for an Early Years Financial Incentive Payment (recruitment bonus) on my behalf.
+      <input type="checkbox"> I give my employer consent to share the personal details listed with DfE, to apply for an Early Years Financial Incentive Payment (recruitment bonus) on my behalf.
     </p>
 
     <p class="govuk-body">

--- a/app/views/further_education_payments/claims/teaching_responsibilities.html.erb
+++ b/app/views/further_education_payments/claims/teaching_responsibilities.html.erb
@@ -5,7 +5,7 @@
     <%= form_with model: @form, url: @form.url, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_radio_buttons(
+      <%= f.govuk_collection_radio_buttons \
         :teaching_responsibilities,
         @form.radio_options,
         :id,
@@ -27,7 +27,6 @@
           "assessing learning and reporting on progress for classes of students"
         ], type: :bullet %>
       <% end %>
-      <% ) %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/further_education_payments/providers/claims/verifications/half_timetabled_teaching_time.html.erb
+++ b/app/views/further_education_payments/providers/claims/verifications/half_timetabled_teaching_time.html.erb
@@ -27,7 +27,7 @@
         Subject area
       </h2>
 
-      <%= f.govuk_collection_radio_buttons(
+      <%= f.govuk_collection_radio_buttons \
         :provider_verification_half_timetabled_teaching_time,
         f.object.radio_options,
         :id,
@@ -37,9 +37,8 @@
           size: "s",
         },
         hint: -> do %>
-        <%= govuk_list f.object.course_descriptions, type: :bullet %>
+          <%= govuk_list f.object.course_descriptions, type: :bullet %>
         <% end %>
-      <% ) %>
 
       <%= f.govuk_submit("Continue") %>
 


### PR DESCRIPTION
# Add herb linting to ci pipeline

[Catches invalid HTML / ERB code](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4129)

https://herb-tools.dev

No need to switch ERB parser, though herb is a drop in replacement (and [we're now running it in dev](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4128/files))