### PR TITLE
Make herb optional in dev

### DIFF
--- a/config/initializers/reactionview.rb
+++ b/config/initializers/reactionview.rb
@@ -2,7 +2,7 @@
 
 ReActionView.configure do |config|
   # Intercept .html.erb templates and process them with `Herb::Engine` for enhanced features
-  config.intercept_erb = Rails.env.development?
+  config.intercept_erb = Rails.env.development? && ENV.fetch("DEBUG_VIEW", false)
 
   # Enable debug mode in development (adds debug attributes to HTML)
   config.debug_mode = Rails.env.development?


### PR DESCRIPTION
Herb overlay changes the spacing on checkboxes.
We'll default the overlay to off for the time being.
Enable it by setting the DEBUG_VIEW variable when booting the app.
