### PR TITLE
[CAPT-2906] Admins see FE continued employment

### DIFF
--- a/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/check_answers_form.rb
@@ -160,6 +160,8 @@ module FurtherEducationPayments
               Policies::FurtherEducationPayments.alternative_idv_completed!(claim)
             end
 
+            Policies::FurtherEducationPayments.provider_verification_completed!(claim)
+
             true
           end
 

--- a/app/jobs/tasks/fe_provider_verification_v2_job.rb
+++ b/app/jobs/tasks/fe_provider_verification_v2_job.rb
@@ -1,0 +1,10 @@
+module Tasks
+  class FeProviderVerificationV2Job < ApplicationJob
+    def perform(claim)
+      task = AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2
+        .new(claim)
+
+      task.perform
+    end
+  end
+end

--- a/app/models/automated_checks/claim_verifiers/fe_provider_verification_v2.rb
+++ b/app/models/automated_checks/claim_verifiers/fe_provider_verification_v2.rb
@@ -1,0 +1,42 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    class FeProviderVerificationV2
+      TASK_NAME = "fe_provider_verification_v2".freeze
+
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      def perform
+        return if task_already_persisted?
+
+        if claim.eligibility.provider_verification_continued_employment == false
+          create_task
+        end
+      end
+
+      private
+
+      def create_task
+        task = claim.tasks.build(
+          {
+            name: TASK_NAME,
+            claim_verifier_match: nil,
+            passed: false,
+            manual: false
+          }
+        )
+
+        task.save!(context: :claim_verifier)
+
+        task
+      end
+
+      def task_already_persisted?
+        claim.tasks.any? { |task| task.name == TASK_NAME }
+      end
+    end
+  end
+end

--- a/app/models/policies/further_education_payments.rb
+++ b/app/models/policies/further_education_payments.rb
@@ -80,6 +80,10 @@ module Policies
       Tasks::FeAlternativeVerificationJob.perform_later(claim)
     end
 
+    def provider_verification_completed!(claim)
+      Tasks::FeProviderVerificationV2Job.perform_later(claim)
+    end
+
     def notify_reply_to_id
       "89939786-7078-4267-b197-ee505dfad8ae"
     end

--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -32,7 +32,8 @@ module Policies
           subject,
           course,
           performance_measure,
-          disciplinary_action
+          disciplinary_action,
+          continued_employment
         ]
       end
 
@@ -149,6 +150,14 @@ module Policies
           "Disciplinary action",
           I18n.t(eligibility.subject_to_disciplinary_action, scope: :boolean),
           provider_answers.disciplinary_action
+        ]
+      end
+
+      def continued_employment
+        [
+          "Continued employment",
+          "N/A",
+          provider_answers.continued_employment
         ]
       end
     end

--- a/app/views/admin/tasks/fe_provider_verification_v2.html.erb
+++ b/app/views/admin/tasks/fe_provider_verification_v2.html.erb
@@ -73,4 +73,3 @@
     <%= render partial: "admin/task_pagination", locals: { task_pagination: @task_pagination } %>
   </div>
 </div>
-

--- a/spec/jobs/tasks/fe_provider_verification_v2_job_spec.rb
+++ b/spec/jobs/tasks/fe_provider_verification_v2_job_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Tasks::FeProviderVerificationV2Job do
+  let(:claim) { create(:claim) }
+
+  describe "#perform" do
+    let(:mock_task) { instance_double(AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2, perform: true) }
+
+    it "calls perform on the task" do
+      allow(AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2).to receive(:new).with(claim).and_return(mock_task)
+
+      subject.perform(claim)
+
+      expect(mock_task).to have_received(:perform)
+    end
+  end
+end

--- a/spec/models/automated_checks/claim_verifiers/fe_provider_verification_v2_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/fe_provider_verification_v2_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
+  subject { described_class.new(claim) }
+
+  describe "#perform" do
+    let(:claim) do
+      create(
+        :claim,
+        :further_education,
+        eligibility:
+      )
+    end
+
+    context "when provider declares no for claimant continued employment" do
+      let(:eligibility) do
+        build(
+          :further_education_payments_eligibility,
+          provider_verification_continued_employment: false
+        )
+      end
+
+      it "persists task as failed" do
+        expect {
+          subject.perform
+        }.to change(Task, :count).by(1)
+
+        expect(Task.last.passed?).to be_falsey
+      end
+
+      context "when task already persisted" do
+        before do
+          Task.create!(
+            name: described_class::TASK_NAME,
+            claim:,
+            passed: true
+          )
+        end
+
+        it "not create another task" do
+          expect {
+            subject.perform
+          }.to not_change(Task, :count)
+        end
+      end
+    end
+
+    context "when provider declares yes for claimant continued employment" do
+      let(:eligibility) do
+        build(
+          :further_education_payments_eligibility,
+          provider_verification_continued_employment: true
+        )
+      end
+
+      it "does not persist a task" do
+        expect {
+          subject.perform
+        }.to not_change(Task, :count)
+      end
+    end
+  end
+end

--- a/spec/models/policies/further_education_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/further_education_payments/admin_tasks_presenter_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Policies::FurtherEducationPayments::AdminTasksPresenter do
+  subject do
+    described_class.new(claim)
+  end
+
+  let(:claim) do
+    build(
+      :claim,
+      :further_education,
+      eligibility:
+    )
+  end
+
+  describe "#provider_verification_rows" do
+    context "continued_employment" do
+      context "when provider answers claimant is" do
+        let(:eligibility) do
+          build(
+            :further_education_payments_eligibility,
+            :provider_verification_completed
+          )
+        end
+
+        it "returns Yes" do
+          expect(subject.provider_verification_rows[9][0]).to eql("Continued employment")
+          expect(subject.provider_verification_rows[9][1]).to eql("N/A")
+          expect(subject.provider_verification_rows[9][2]).to eql("Yes")
+        end
+      end
+
+      context "when provider answers claimant is not" do
+        let(:eligibility) do
+          build(
+            :further_education_payments_eligibility,
+            :provider_verification_completed,
+            provider_verification_continued_employment: false
+          )
+        end
+
+        it "returns No" do
+          expect(subject.provider_verification_rows[9][0]).to eql("Continued employment")
+          expect(subject.provider_verification_rows[9][1]).to eql("N/A")
+          expect(subject.provider_verification_rows[9][2]).to eql("No")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/policies/further_education_payments_spec.rb
+++ b/spec/models/policies/further_education_payments_spec.rb
@@ -70,4 +70,14 @@ RSpec.describe Policies::FurtherEducationPayments do
       expect(subject.decision_deadline_date(claim)).to eql(Date.new(2025, 12, 2))
     end
   end
+
+  describe "#provider_verification_completed!" do
+    let(:claim) { create(:claim) }
+
+    it "invokes Tasks::FeProviderVerificationV2Job" do
+      expect(Tasks::FeProviderVerificationV2Job).to receive(:perform_later)
+
+      subject.provider_verification_completed!(claim)
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2906
- Admins can see FE continued employment within provider verification task
- task is also auto failed if provider declares `no` for continued employment

