### PR TITLE
Revert incorrect analytics blocking of payroll National Insurance contributions

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -126,6 +126,8 @@ shared:
     - gross_value # decimal, gross value of payment
     - student_loan_repayment # decimal, ???
     - tax # decimal, the amount of tax that was paid on the payment
+    - national_insurance # decimal, the amount of employee national insurance paid
+    - employers_national_insurance # decimal, the amount of employer's national insurance paid
     - net_pay # decimal, amount paid after deductions
     - gross_pay # decimal, amount paid before deductions
     - postgraduate_loan_repayment # decimal, amount paid towards postgrad loan

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -233,6 +233,3 @@
   - description
   - created_at
   - updated_at
-  :payments:
-  - national_insurance
-  - employers_national_insurance


### PR DESCRIPTION
These fields were blocked in https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/0ab34fecf32d8f09c18a0ccea6b226424c095829 incorrectly, as they are not PII

