### PR TITLE
CAPT-2254: Allow sending soft deleted EligibleEyProvider records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.6"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.9"
 
 gem "reactionview", "~> 0.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 14be35cf91c1ca86a18bd87243444cb3e2d9fae2
-  tag: v1.15.6
+  revision: 66887ceeb047568ad4d8a1df7ef1670d13d59a19
+  tag: v1.15.9
   specs:
-    dfe-analytics (1.15.6)
+    dfe-analytics (1.15.9)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.21)
       multi_xml (~> 0.6.0)

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -53,4 +53,7 @@ DfE::Analytics.configure do |config|
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
 
   config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
+
+  # Allow sending soft deleted records - e.g. EligibleEyProvider
+  config.ignore_default_scope = true
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-2254

Implements the change to dfe-analytics discussed in https://github.com/DFE-Digital/dfe-analytics/pull/209 which allows us to send soft-deleted `EligibleEyProvider` records. This allows these to be accessible to the Dataform dashboard.