### PR TITLE
Rename trait

### DIFF
--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
       flagged_as_duplicate { true }
     end
 
-    trait :verified do
+    trait :year_one_verified do
       verification do
         {
           "assertions" => [
@@ -68,7 +68,7 @@ FactoryBot.define do
       end
     end
 
-    trait :verified_variable_hours do
+    trait :year_one_verified_variable_hours do
       contract_type { "variable_hours" }
       teaching_responsibilities { true }
       further_education_teaching_start_year { "2023" }

--- a/spec/features/admin/admin_claim_further_education_payments_spec.rb
+++ b/spec/features/admin/admin_claim_further_education_payments_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Admin claim further education payments" do
             eligibility = create(
               :further_education_payments_eligibility,
               :eligible,
-              :verified,
+              :year_one_verified,
               contract_type: "fixed_term",
               school: fe_provider,
               award_amount: 1500
@@ -115,7 +115,7 @@ RSpec.feature "Admin claim further education payments" do
 
             eligibility = create(
               :further_education_payments_eligibility,
-              :verified_variable_hours,
+              :year_one_verified_variable_hours,
               school: fe_provider,
               award_amount: 1500
             )

--- a/spec/features/further_education_payments/providers/provider_verifying_with_claimant_courses_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verifying_with_claimant_courses_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Provider verifying claims" do
       date_of_birth: Date.new(1945, 7, 3),
       reference: "AB123456",
       submitted_at: DateTime.new(2025, 10, 1, 9, 0, 0),
-      eligibility_trait: [:eligible, :verified],
+      eligibility_trait: [:eligible],
       eligibility_attributes: {
         school: fe_provider,
         teacher_reference_number: "1234567",
@@ -205,7 +205,7 @@ RSpec.feature "Provider verifying claims" do
       date_of_birth: Date.new(1945, 7, 3),
       reference: "AB123456",
       submitted_at: DateTime.new(2025, 10, 1, 9, 0, 0),
-      eligibility_trait: [:eligible, :verified],
+      eligibility_trait: [:eligible],
       eligibility_attributes: {
         school: fe_provider,
         teacher_reference_number: "1234567",

--- a/spec/features/further_education_payments/providers/verified_claim_spec.rb
+++ b/spec/features/further_education_payments/providers/verified_claim_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "Provider verified claims dashboard" do
     school = create(:school, :fe_eligible, ukprn: "10000952")
     eligibility = create(
       :further_education_payments_eligibility,
-      :verified,
       :provider_verification_completed,
       school:,
       provider_verification_completed_at: Date.new(2024, 12, 14)

--- a/spec/features/further_education_payments/providers/verified_dashboard_spec.rb
+++ b/spec/features/further_education_payments/providers/verified_dashboard_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Provider verified claims dashboard" do
 
     eligibility1 = create(
       :further_education_payments_eligibility,
-      :verified,
       school:,
       provider_verification_completed_at: Date.new(2024, 12, 14)
     )
@@ -39,7 +38,6 @@ RSpec.describe "Provider verified claims dashboard" do
 
     eligibility2 = create(
       :further_education_payments_eligibility,
-      :verified,
       :provider_verification_completed,
       school:,
       provider_verification_completed_at: Date.new(2024, 12, 14)
@@ -57,7 +55,6 @@ RSpec.describe "Provider verified claims dashboard" do
 
     eligibility3 = create(
       :further_education_payments_eligibility,
-      :verified,
       school: create(:school, :fe_eligible, ukprn: "87654321"),
       provider_verification_completed_at: Date.new(2024, 12, 14)
     )

--- a/spec/features/further_education_payments/viewing_year_1_claims_in_admin_area_spec.rb
+++ b/spec/features/further_education_payments/viewing_year_1_claims_in_admin_area_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Viewing year 1 claims in the admin area" do
     eligibility = create(
       :further_education_payments_eligibility,
       :eligible,
-      :verified,
+      :year_one_verified,
       :identity_verified_by_provider
     )
 

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
 
         create(
           :further_education_payments_eligibility,
-          :verified
+          :provider_verification_completed
         )
 
         form = described_class.new(

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -984,7 +984,7 @@ RSpec.describe Claim, type: :model do
     let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent_has_other_note) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
     let!(:year_1_claim_not_verified_has_duplicates_provider_email_not_sent) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
     let!(:year_1_claim_not_verified_has_duplicates_provider_email_manually_sent) { create(:claim, :submitted, academic_year: AcademicYear.new(2024), policy: Policies::FurtherEducationPayments, eligibility_trait: :duplicate) }
-    let!(:year_1_claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, academic_year: AcademicYear.new(2024), eligibility_trait: :verified) }
+    let!(:year_1_claim_with_fe_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, academic_year: AcademicYear.new(2024), eligibility_trait: :year_one_verified) }
     let!(:year_2_claim_awaiting_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments) }
     let!(:year_2_claim_with_completed_provider_verification) { create(:claim, policy: Policies::FurtherEducationPayments, eligibility_attributes: {provider_verification_completed_at: DateTime.now}) }
     let!(:non_fe_claim) { create(:claim, policy: Policies::StudentLoans) }

--- a/spec/support/admin_checks_feature_shared_examples.rb
+++ b/spec/support/admin_checks_feature_shared_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "Admin Checks" do |policy|
         :with_student_loan,
         :with_onelogin_idv_data,
         policy: policy,
-        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :verified),
+        eligibility: build(:"#{policy.to_s.underscore}_eligibility", :eligible, :year_one_verified),
         academic_year: AcademicYear.new(2024),
         onelogin_idv_at: 10.minutes.ago
       )


### PR DESCRIPTION
Renames the `verified` trait to `year_one_verified` to avoid confusion.
Year one FE claims have a different provider verification mechanism to
year two claims.
We've also removed some unnecessary uses of `:verified`.
