### PR TITLE
Move slug sequence use into navigator

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -55,14 +55,10 @@ class ClaimsController < BasePublicController
     @journey_session = nil
   end
 
-  def slug_sequence
-    @slug_sequence ||= journey::SlugSequence.new(journey_session)
-  end
-
   def navigator
     @navigator ||= Journeys::Navigator.new(
       current_slug: params[:slug],
-      slug_sequence: slug_sequence,
+      journey_session: journey_session,
       params:,
       session:
     )
@@ -82,7 +78,7 @@ class ClaimsController < BasePublicController
 
     temp_navigator = Journeys::Navigator.new(
       current_slug: nil,
-      slug_sequence: new_journey::SlugSequence.new(other_journey_session),
+      journey_session: other_journey_session,
       params:,
       session:
     )
@@ -93,7 +89,7 @@ class ClaimsController < BasePublicController
   def set_backlink_path
     return if navigator.current_slug == "confirmation"
 
-    if navigator.previous_slug.present? && slug_sequence.class::DEAD_END_SLUGS.exclude?(current_slug)
+    if navigator.previous_slug.present?
       @backlink_path = claim_path(current_journey_routing_name, navigator.previous_slug)
     end
   end

--- a/app/models/journeys/navigator.rb
+++ b/app/models/journeys/navigator.rb
@@ -1,10 +1,10 @@
 module Journeys
   class Navigator
-    attr_reader :current_slug, :slug_sequence, :params, :session
+    attr_reader :current_slug, :journey_session, :params, :session
 
-    def initialize(current_slug:, slug_sequence:, params:, session:)
+    def initialize(current_slug:, journey_session:, params:, session:)
       @current_slug = current_slug
-      @slug_sequence = slug_sequence
+      @journey_session = journey_session
       @params = params
       @session = session
     end
@@ -12,6 +12,8 @@ module Journeys
     # when showing a form
     # work out where the backlink should take the user
     def previous_slug
+      return nil if slug_sequence.class::DEAD_END_SLUGS.include?(current_slug)
+
       last_valid_slug = nil
 
       slug_sequence.slugs.each do |slug|
@@ -248,11 +250,7 @@ module Journeys
     end
 
     def journey
-      slug_sequence.journey
-    end
-
-    def journey_session
-      slug_sequence.journey_session
+      journey_session.journey_class
     end
 
     def eligibility_checker
@@ -263,6 +261,10 @@ module Journeys
       params.fetch(form_class.model_name.param_key, {}).slice(
         *form_class.attribute_names.map(&:to_sym)
       )
+    end
+
+    def slug_sequence
+      @slug_sequence ||= journey::SlugSequence.new(journey_session)
     end
 
     def auth_checker

--- a/spec/models/journeys/navigator_spec.rb
+++ b/spec/models/journeys/navigator_spec.rb
@@ -2,11 +2,10 @@ require "rails_helper"
 
 RSpec.describe Journeys::Navigator do
   subject do
-    described_class.new(current_slug:, slug_sequence:, params:, session:)
+    described_class.new(current_slug:, journey_session:, params:, session:)
   end
 
   let(:current_slug) { "have-one-login-account" }
-  let(:slug_sequence) { Journeys::FurtherEducationPayments::SlugSequence.new(journey_session) }
   let(:params) { ActionController::Parameters.new }
   let(:session) { {} }
   let(:journey_session) do


### PR DESCRIPTION
Slug sequence is very closely tied to the navigator. Rather than passing
in an instantiated slug sequence and fetching the journey session from
that, pass in the journey session and build the slug sequence in the
navigator.
Also navigator is now responsible for checking for dead end slugs when
determining if there is a previous slug.
