### PR TITLE
Fix resend email link

### DIFF
--- a/app/views/early_years_payment/provider/authenticated/claims/expired_link.html.erb
+++ b/app/views/early_years_payment/provider/authenticated/claims/expired_link.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= govuk_link_to "Resend email", claim_path(Journeys::EarlyYearsPayment::Provider::Start.routing_name, "email-address") %>
+      <%= govuk_link_to "Resend email", claim_path(Journeys::EarlyYearsPayment::Provider::Start.routing_name, "email-address", skip_landing_page: true) %>
     </p>
   </div>
 </div>

--- a/spec/features/early_years_payment/provider/authenticated/expired_magic_link_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/expired_magic_link_spec.rb
@@ -20,5 +20,33 @@ RSpec.feature "Early years payment provider" do
 
     expect(page).to have_content("This link has expired")
     expect(page.current_path).to eq "/early-years-payment-provider/expired-link"
+
+    click_link "Resend email"
+
+    fill_in "Enter your email address", with: email_address
+    click_button "Submit"
+
+    expect(email_address).to have_received_email(
+      ApplicationMailer::EARLY_YEARS_PAYMENTS[:CLAIM_PROVIDER_EMAIL_TEMPLATE_ID]
+    )
+  end
+
+  scenario "attempting to resend expired magic link in different browser" do
+    when_early_years_payment_provider_start_journey_configuration_exists
+    when_early_years_payment_provider_authenticated_journey_configuration_exists
+
+    # If the code isn't expected we show the expired link page.
+    visit "/early-years-payment-provider/claim?code=383323&email=test@example.com"
+
+    expect(page).to have_content("This link has expired")
+
+    click_link "Resend email"
+
+    fill_in "Enter your email address", with: email_address
+    click_button "Submit"
+
+    expect(email_address).to have_received_email(
+      ApplicationMailer::EARLY_YEARS_PAYMENTS[:CLAIM_PROVIDER_EMAIL_TEMPLATE_ID]
+    )
   end
 end


### PR DESCRIPTION
If a user visits an expired verification link in a different browser (or
after their session is purged) the resend link throws a 500 error.
The error occurs as there is no journey session for EY PV Start journey,
so when the navigator attempts to check if the "email-address" slug is
in sequence it calling methods on `nil`.
The core of the issue is the "Resend email" link takes the user to a
different journey (EY PV Start) from the expired link page (EY PV
Authenticated). These journeys have different routing names and so
create different journey sessions.
To fix this issue we rely on how the claim's controller handles the skip
landing page param. If the skip landing page param is present the claims
controller will create a new journey session if one doesn't exist.

We may want to consider combining the start and authenticated journeys
into a single provider journey.
