### PR TITLE
Record steps on session

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -155,12 +155,19 @@ class ClaimsController < BasePublicController
   def add_answers_to_rollbar_context
     return unless journey_session
 
-    Rollbar.scope!(answers: journey_session.answers.attributes_with_pii_redacted)
+    Rollbar.scope!(
+      answers: journey_session.answers.attributes_with_pii_redacted,
+      steps: journey_session.steps
+    )
 
     Sentry.configure_scope do |scope|
       scope.set_context(
         "Journey session anwers",
         journey_session.answers.attributes_with_pii_redacted
+      )
+
+      scope.set_context(
+        "Journey session steps", steps: journey_session.steps
       )
     end
   end

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -72,6 +72,9 @@ module FormSubmittable
           navigator.clear_impermissible_answers
           navigator.clear_furthest_ineligible_answer
 
+          @form.journey_session.steps << @navigator.current_slug
+          @form.journey_session.save!
+
           redirect_to_next_slug
         else
           render_template_for_current_slug

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -293,6 +293,7 @@ shared:
     - created_at # datetime, timestamp when journey session was created
     - updated_at # datetime, timestamp when journey session was last updated
     - expired # boolean, has this session expired
+    - steps # jsonb, array of steps taken in the journey
   :further_education_payments_eligibilities:
     - id # uuid, that identifies the eligibility
     - created_at # datetime, timestamp when eligibility was created

--- a/db/migrate/20251021132108_add_steps_to_journeys_sessions.rb
+++ b/db/migrate/20251021132108_add_steps_to_journeys_sessions.rb
@@ -1,0 +1,5 @@
+class AddStepsToJourneysSessions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :journeys_sessions, :steps, :jsonb, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_25_112536) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_21_132108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -409,6 +409,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_112536) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "expired", default: false, null: false
+    t.jsonb "steps", default: []
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/happy_path_spec.rb
@@ -91,6 +91,7 @@ RSpec.feature "Early years payment provider" do
     expect(page.current_path).to eq claim_path(Journeys::EarlyYearsPayment::Provider::Authenticated::ROUTING_NAME, slug: "confirmation")
 
     claim = Claim.last
+
     expect(claim.provider_contact_name).to eq "John Doe"
     expect(page).to have_content(claim.reference)
     expect(claim.submitted_at).to be_nil
@@ -98,6 +99,24 @@ RSpec.feature "Early years payment provider" do
     expect(claim.eligibility.provider_email_address).to eq email_address
     expect(claim.eligibility.award_amount).to eq 1000
     expect(claim.eligibility.provider_entered_contract_type).to eq "permanent"
+
+    # Note the spec revisits some steps
+    expect(claim.journey_session.steps).to eq %w[
+      consent
+      current-nursery
+      paye-reference
+      claimant-name
+      start-date
+      contract-type
+      child-facing
+      returner
+      returner
+      returner-worked-with-children
+      returner-worked-with-children
+      returner-contract-type
+      employee-email
+      check-your-answers
+    ]
   end
 
   scenario "using magic link after having completed some of the journey" do


### PR DESCRIPTION
When debugging errors it's useful to see the path through the wizard the
claimant has taken. We've added a new column to journey sessions to
track the steps completed, and we've updated our monitoring to include
this information.

We may want to consider introducing a report showing the number of
sessions stopped at each step to highlight any service issues.

On rollbar steps show up in the json version of the error (truncated on the over view page)
This is the FE claimant journey erroring on sending email
<img width="367" height="525" alt="Screenshot 2025-10-21 at 16 25 20" src="https://github.com/user-attachments/assets/f4dee5a6-90fb-4277-b327-e23ff590a6b8" />