### PR TITLE
CAPT 2957/magic link mayhem

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -12,7 +12,7 @@ class ClaimsController < BasePublicController
   before_action :check_page_is_permissible, only: [:show]
   before_action :set_backlink_path, only: [:show, :update]
   before_action :check_claim_not_in_progress, only: [:new]
-  before_action :clear_claim_session, only: [:new], unless: -> { journey.start_with_magic_link? }
+  before_action :clear_claim_session, only: [:new]
   before_action :prepend_view_path_for_journey
   before_action :persist_claim, only: [:new, :create]
   before_action :handle_magic_link, only: [:new], if: -> { journey.start_with_magic_link? }


### PR DESCRIPTION
Fix revisiting magic link

Visiting the magic link twice would show providers an empty list of
nurseries.

On the first visit to the magic link a new journey session is created
by the `persist_claim` callback and the `handle_magic_link` callback
assigns the provider email address from the params to this session.

On the second visit to the magic link one of the callbacks in the
ClaimsController runs (`check_whether_closed_for_submissions`) which
calls `JourneyConcern#journey_session` loading the session from the db
and, importantly, memoising it for this request. The code then hits
`persist_claim` which creates a new journey session, however as
`JourneyConcern#journey_session` has already loaded the old session the
email address from the params is re-written to the old session rather
than the new session. On subsequent requests the new session is loaded
(find_by sorts by created_at), however it lacks a provider email
address, so when `Journeys::EarlyYearsPayment::Provider::Authenticated`
tries to load the EY providers with this email the list is empty.

There's quite a lot of issues here! I think the main one is that the EY
provider journey should be a single journey rather than two separate
journeys so we don't have to worry about creating a new session and
setting the provider email from the url params.

As a quick fix we're making sure we clear out any existing sessions for
a given journey when we create a new session.

