### PR TITLE
CAPT-2930 Remove current AY scope on awaiting payroll filters

### DIFF
--- a/app/forms/admin/claims_filter_form.rb
+++ b/app/forms/admin/claims_filter_form.rb
@@ -66,7 +66,7 @@ class Admin::ClaimsFilterForm
           .rejected
       when "automatically_approved_awaiting_payroll"
         Claim
-          .current_academic_year.payrollable.auto_approved
+          .payrollable.auto_approved
       when "rejected"
         Claim
           .current_academic_year.rejected
@@ -192,7 +192,7 @@ class Admin::ClaimsFilterForm
   def approved_awaiting_payroll
     claim_ids_with_payrollable_topups = Topup.payrollable.pluck(:claim_id)
 
-    Claim.current_academic_year.payrollable.or(Claim.current_academic_year.where(id: claim_ids_with_payrollable_topups))
+    Claim.payrollable.or(Claim.where(id: claim_ids_with_payrollable_topups))
   end
 
   def selected_policy

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -169,5 +169,125 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         end
       end
     end
+
+    context "when approved awaiting QA" do
+      let(:current_academic_year) { AcademicYear.current }
+
+      let!(:claim) do
+        create(
+          :claim,
+          :approved,
+          qa_required: true,
+          academic_year: current_academic_year,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      let!(:claim_previous_ay) do
+        create(
+          :claim,
+          :approved,
+          qa_required: true,
+          academic_year: current_academic_year.previous,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      let(:filters) { {status: "approved_awaiting_qa"} }
+
+      it "filtering by status approved_awaiting_qa includes them" do
+        expect(subject.claims).to include(claim)
+        expect(subject.claims).to include(claim_previous_ay)
+      end
+    end
+
+    context "when rejected awaiting QA" do
+      let(:current_academic_year) { AcademicYear.current }
+
+      let!(:claim) do
+        create(
+          :claim,
+          :rejected,
+          qa_required: true,
+          academic_year: current_academic_year,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      let!(:claim_previous_ay) do
+        create(
+          :claim,
+          :rejected,
+          qa_required: true,
+          academic_year: current_academic_year.previous,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      let(:filters) { {status: "rejected_awaiting_qa"} }
+
+      it "filtering by status rejected_awaiting_qa includes them" do
+        expect(subject.claims).to include(claim)
+        expect(subject.claims).to include(claim_previous_ay)
+      end
+    end
+
+    context "when approved awaiting payroll" do
+      let(:current_academic_year) { AcademicYear.current }
+
+      let!(:claim) do
+        create(
+          :claim,
+          :payrollable,
+          academic_year: current_academic_year,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      let!(:claim_previous_ay) do
+        create(
+          :claim,
+          :payrollable,
+          academic_year: current_academic_year.previous,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      let(:filters) { {status: "approved_awaiting_payroll"} }
+
+      it "filtering by status approved_awaiting_payroll includes them" do
+        expect(subject.claims).to include(claim)
+        expect(subject.claims).to include(claim_previous_ay)
+      end
+    end
+
+    context "when automatically approved awaiting payroll" do
+      let(:current_academic_year) { AcademicYear.current }
+
+      let!(:claim) do
+        create(
+          :claim,
+          :auto_approved,
+          academic_year: current_academic_year,
+          policy: Policies::FurtherEducationPayments
+        )
+      end
+
+      let!(:claim_previous_ay) do
+        create(
+          :claim,
+          :auto_approved,
+          academic_year: current_academic_year.previous,
+          policy: Policies::FurtherEducationPayments
+        )
+      end
+
+      let(:filters) { {status: "automatically_approved_awaiting_payroll"} }
+
+      it "filtering by status automatically_approved_awaiting_payroll includes them" do
+        expect(subject.claims).to include(claim)
+        expect(subject.claims).to include(claim_previous_ay)
+      end
+    end
   end
 end


### PR DESCRIPTION
Issue: Currently when a claim is ready for payroll and it's for the previous academic year and we have just started a new academic year the claim isn't visible in admin.

Fix: Relax the current academic year scope on the awaiting payroll listings.