### PR TITLE
Strip white space from EY provider csv

### DIFF
--- a/app/models/eligible_ey_providers_importer.rb
+++ b/app/models/eligible_ey_providers_importer.rb
@@ -30,13 +30,13 @@ class EligibleEyProvidersImporter < CsvImporter::Base
 
   def row_to_hash(row)
     {
-      nursery_name: row.fetch("Nursery Name"),
-      urn: row.fetch("EYURN / Ofsted URN"),
-      local_authority_id: LocalAuthority.find_by(code: row.fetch("LA Code")).try(:id),
-      nursery_address: row.fetch("Nursery Address"),
-      primary_key_contact_email_address: row.fetch("Primary Key Contact Email Address"),
-      secondary_contact_email_address: row.fetch("Secondary Contact Email Address (Optional)"),
-      max_claims: Integer(row.fetch("Maximum Number Of Claims")),
+      nursery_name: row.fetch("Nursery Name").strip,
+      urn: row.fetch("EYURN / Ofsted URN").strip,
+      local_authority_id: LocalAuthority.find_by(code: row.fetch("LA Code").strip).try(:id),
+      nursery_address: row.fetch("Nursery Address").strip,
+      primary_key_contact_email_address: row.fetch("Primary Key Contact Email Address").strip,
+      secondary_contact_email_address: row.fetch("Secondary Contact Email Address (Optional)").try(:strip),
+      max_claims: Integer(row.fetch("Maximum Number Of Claims").strip),
       file_upload_id:
     }
   end


### PR DESCRIPTION
We've had some issues on production where the EY provider csv had
trailing spaces in the email address columns
