### PR TITLE
CAPT 2961/tid by pass

### DIFF
--- a/app/forms/sign_in_or_continue_form.rb
+++ b/app/forms/sign_in_or_continue_form.rb
@@ -65,7 +65,7 @@ class SignInOrContinueForm < Form
   end
 
   def tid_bypassable?
-    Rails.env.development? || Rails.env["BYPASS_DFE_SIGN_IN"]
+    false
   end
 
   def radio_options
@@ -100,7 +100,7 @@ class SignInOrContinueForm < Form
 
         journey_session.save!
 
-        Dqt::RetrieveClaimQualificationsData.call(journey_session)
+        retrieve_qualifications_data!
       else
         journey_session.answers.assign_attributes(
           logged_in_with_tid: true,
@@ -140,5 +140,9 @@ class SignInOrContinueForm < Form
     )
 
     journey_session.save!
+  end
+
+  def retrieve_qualifications_data!
+    Dqt::RetrieveClaimQualificationsData.call(journey_session)
   end
 end

--- a/app/forms/sign_in_or_continue_testing_form.rb
+++ b/app/forms/sign_in_or_continue_testing_form.rb
@@ -1,0 +1,92 @@
+class SignInOrContinueTestingForm < SignInOrContinueForm
+  attribute :dqt_active_alert, :boolean
+  attribute :dqt_qts_name, :string
+  attribute :dqt_qts_date, :date
+  attribute :dqt_induction_start_date, :date
+  attribute :dqt_induction_completion_date, :date
+  attribute :dqt_induction_status, :string
+  attribute :dqt_itt_programme_start_date, :date
+  attribute :dqt_itt_programme_end_date, :date
+  attribute :dqt_itt_programme_type, :string
+  attribute :dqt_itt_result, :string
+  attribute :dqt_qualification, :string
+  attribute :dqt_itt_subject_1_name, :string
+  attribute :dqt_itt_subject_1_code, :string
+  attribute :dqt_itt_subject_2_name, :string
+  attribute :dqt_itt_subject_2_code, :string
+  attribute :dqt_itt_subject_3_name, :string
+  attribute :dqt_itt_subject_3_code, :string
+
+  def tid_bypassable?
+    true
+  end
+
+  def dqt_induction_status_options
+    [
+      Form::Option.new(id: "Pass", name: "Pass"),
+      Form::Option.new(id: "Fail", name: "Fail")
+    ]
+  end
+
+  def dqt_itt_result_options
+    [
+      Form::Option.new(id: "Pass", name: "Pass"),
+      Form::Option.new(id: "Fail", name: "Fail")
+    ]
+  end
+
+  def dqt_grouped_qualification_options
+    Dqt::Matchers::General::QUALIFICATION_MATCHING_TYPE
+  end
+
+  def dqt_grouped_itt_subject_name_options
+    Dqt::Matchers::TargetedRetentionIncentivePayments::ELIGIBLE_ITT_SUBJECTS.merge(
+      foreign_languages: [
+        "German"
+      ]
+    )
+  end
+
+  def dqt_itt_subject_code_options
+    Policies::TargetedRetentionIncentivePayments::DqtRecord::ELIGIBLE_CODES
+  end
+
+  private
+
+  def retrieve_qualifications_data!
+    journey_session.answers.dqt_teacher_status = {
+      trn: teacher_id_user_info.trn,
+      ni_number: teacher_id_user_info.ni_number,
+      name: "#{teacher_id_user_info.given_name} #{teacher_id_user_info.family_name}",
+      dob: teacher_id_user_info.birthdate,
+      active_alert: dqt_active_alert,
+      qualified_teacher_status: {
+        name: dqt_qts_name,
+        qts_date: dqt_qts_date&.iso8601
+      },
+      induction: {
+        start_date: dqt_induction_start_date&.iso8601,
+        completion_date: dqt_induction_completion_date&.iso8601,
+        status: dqt_induction_status
+      },
+      initial_teacher_training: {
+        programme_start_date: dqt_itt_programme_start_date&.iso8601,
+        programme_end_date: dqt_itt_programme_end_date&.iso8601,
+        result: dqt_itt_result,
+        qualification: dqt_qualification,
+        subject1_name: dqt_itt_subject_1_name,
+        subject1_code: dqt_itt_subject_1_code,
+        subject2_name: dqt_itt_subject_2_name,
+        subject2_code: dqt_itt_subject_2_code,
+        subject3_name: dqt_itt_subject_3_name,
+        subject3_code: dqt_itt_subject_3_code
+      }
+    }
+
+    journey_session.save!
+  end
+
+  def i18n_form_namespace
+    self.class.superclass.name.demodulize.gsub("Form", "").underscore
+  end
+end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -2,7 +2,7 @@ module Journeys
   module Base
     SHARED_FORMS = {
       "claims" => {
-        "sign-in-or-continue" => SignInOrContinueForm,
+        "sign-in-or-continue" => TeacherId.bypass? ? SignInOrContinueTestingForm : SignInOrContinueForm,
         "current-school" => CurrentSchoolForm,
         "select-current-school" => SelectCurrentSchoolForm,
         "information-provided" => InformationProvidedForm,

--- a/app/views/claims/_confirmation_form.html.erb
+++ b/app/views/claims/_confirmation_form.html.erb
@@ -30,5 +30,11 @@
     details above are correct.
   </p>
 
+  <% if f.object.tid_bypassable? %>
+    <%= govuk_details(summary_text: "Developer bypass - DQT payload data") do %>
+      <%= render(partial: "dqt_bypass", locals: { f: f }) %>
+    <% end %>
+  <% end %>
+
   <%= f.govuk_submit("Continue") %>
 <% end %>

--- a/app/views/claims/_dqt_bypass.html.erb
+++ b/app/views/claims/_dqt_bypass.html.erb
@@ -1,0 +1,157 @@
+<p class="govuk-body govuk-!-margin-bottom-6">
+  In testing environments these fields allow setting the payload returned from
+  the DQT api.
+</p>
+
+<%= f.govuk_check_boxes_fieldset(
+  :dqt_active_alert,
+  multiple: false,
+  legend: {
+    text: "DQT active alert",
+    size: "s",
+  }
+) do %>
+  <%= f.govuk_check_box(
+    :dqt_active_alert,
+    true,
+    false,
+    label: {
+      text: "Active alert",
+    },
+    multiple: false,
+  ) %>
+<% end %>
+
+<%= f.govuk_text_field(
+  :dqt_qts_name,
+  value: "Qualified teacher (trained)",
+  label: {
+    text: "QTS name",
+    size: "s"
+  },
+) %>
+
+<%= f.govuk_text_field(
+  :dqt_qts_date,
+  label: {
+    text: "QTS date",
+    size: "s",
+  },
+  hint: { text: "yyyy-mm-dd" }
+) %>
+
+<%= f.govuk_text_field(
+  :dqt_induction_start_date,
+  label: {
+    text: "Induction start date",
+    size: "s",
+  },
+  hint: { text: "yyyy-mm-dd" }
+) %>
+
+<%= f.govuk_text_field(
+  :dqt_induction_completion_date,
+  label: {
+    text: "Induction completion date",
+    size: "s",
+  },
+  hint: { text: "yyyy-mm-dd" }
+) %>
+
+<%= f.govuk_collection_radio_buttons(
+  :dqt_induction_status,
+  f.object.dqt_induction_status_options,
+  :id,
+  :name,
+  legend: {
+    text: "Inducation status",
+    size: "s",
+  },
+  inline: true,
+) %>
+
+<%= f.govuk_text_field(
+  :dqt_itt_programme_start_date,
+  label: {
+    text: "ITT programme start date",
+    size: "s",
+  },
+  hint: { text: "yyyy-mm-dd" }
+) %>
+
+<%= f.govuk_text_field(
+  :dqt_itt_programme_end_date,
+  label: {
+    text: "ITT programme end date",
+    size: "s",
+  },
+  hint: { text: "yyyy-mm-dd" }
+) %>
+
+<%= f.govuk_collection_radio_buttons(
+  :dqt_itt_result,
+  f.object.dqt_itt_result_options,
+  :id,
+  :name,
+  legend: {
+    text: "ITT result",
+    size: "s",
+  },
+  inline: true,
+) %>
+
+<%= f.govuk_select(
+  :dqt_qualification,
+  label: {
+    text: "Qualification",
+    size: "s",
+  },
+  options: {
+    include_blank: true,
+  },
+) do %>
+  <% f.object.dqt_grouped_qualification_options.each do |group_name, options| %>
+    <optgroup label="<%= group_name.to_s.humanize %>">
+      <% options.each do |option| %>
+        <option value="<%= option %>" <%= 'selected="selected"' if option == f.object.dqt_qualification %>>
+          <%= option %>
+        </option>
+      <% end %>
+    </optgroup>
+  <% end %>
+<% end %>
+
+<% [1, 2, 3].each do |n| %>
+  <%= f.govuk_select(
+    :"dqt_itt_subject_#{n}_name",
+    label: {
+      text: "ITT subject #{n} name",
+      size: "s",
+    },
+    options: {
+      include_blank: true,
+    },
+  ) do %>
+    <% f.object.dqt_grouped_itt_subject_name_options.each do |group_name, options| %>
+      <optgroup label="<%= group_name.to_s.humanize %>">
+        <% options.each do |option| %>
+          <option value="<%= option %>" <%= 'selected="selected"' if option == f.object.send(:"dqt_itt_subject_#{n}_name") %>>
+            <%= option %>
+          </option>
+        <% end %>
+      </optgroup>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_select(
+    :"dqt_itt_subject_#{n}_code",
+    options_for_select(f.object.dqt_itt_subject_code_options),
+    label: {
+      text: "ITT subject #{n} code",
+      size: "s",
+    },
+    options: {
+      include_blank: true,
+    },
+  ) %>
+<% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -49,6 +49,12 @@ module ::OneLoginSignIn
   end
 end
 
+module ::TeacherId
+  def self.bypass?
+    (Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_DFE_SIGN_IN"] == "true"
+  end
+end
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   if DfESignIn.bypass?
     provider :developer


### PR DESCRIPTION
Adds form for setting DQT payload

In test environments we want to allow stubbing the response from the DQT
API.

For student loans the only field that affects eligibility is the
`dqt_qts_date`

For TRI `dqt_qts_date` (undergrads) and `dqt_itt_programme_start_date`
(postgrads) affect eligibility. So if the qualification is an undergraduate one we use the `dqt_qts_date` to determine eligibility, if the qualification is a postgraduate one we use the `dqt_itt_programme_start_date` to determine eligibility.
`dqt_itt_subject_*` would also affect eligibility, however the form only
returns eligible options as they're the only values stored in the code
base and we don't know what the other options stored in dqt look like.

