### PR TITLE
Remove redundant ECP-related eligibility check

### DIFF
--- a/app/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker.rb
@@ -44,8 +44,6 @@ module Policies
 
         return :insufficient_teaching if insufficient_teaching?
 
-        return :subject_invalid_for_tslr if indicated_ecp_only_itt_subject?
-
         if ineligible_itt_subject_and_no_relevant_degree?
           return :subject_and_degree_ineligible
         end
@@ -90,10 +88,6 @@ module Policies
 
       def insufficient_teaching?
         teaching_subject_now == false
-      end
-
-      def indicated_ecp_only_itt_subject?
-        eligible_itt_subject.present? && (eligible_itt_subject.to_sym == :foreign_languages)
       end
 
       def ineligible_itt_subject_and_no_relevant_degree?

--- a/spec/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker_spec.rb
@@ -122,17 +122,6 @@ RSpec.describe Policies::TargetedRetentionIncentivePayments::PolicyEligibilityCh
       it { is_expected.to eq(:insufficient_teaching) }
     end
 
-    context "when not a tslr subject" do
-      let(:answers) do
-        build(
-          :targeted_retention_incentive_payments_answers,
-          eligible_itt_subject: :foreign_languages
-        )
-      end
-
-      it { is_expected.to eq(:subject_invalid_for_tslr) }
-    end
-
     context "when ineligible subject and no eligible degree subject" do
       let(:answers) do
         build(


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CAPT-2968

Previously the schools Targeted Retention Incentive Payments journey also supported a second policy - Early Career Payments. In this prior version of the journey, an additional ITT subject question radio option was present for foreign languages, as this subject was acceptable for that policy. Since the ECP journey was removed, this radio option will no longer be displayed, so we no longer need this check.

Even if the ECP policy was still active, this code is introducing ECP-specific domain knowledge into the TRI policy models which is brittle and does not maintain a good separation of concerns.

Additionally, the return value `subject_invalid_for_tslr` is incorrect in this context, since TSLR refers to the Teacher Student Loan Repayments policy, which is supported by a separate journey. I assume this was a typo/confusion of acronyms.