### PR TITLE
Fix displaying FE y1 claims

### DIFF
--- a/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_provider_verification_task_presenter.rb
@@ -99,6 +99,9 @@ module Policies
         when "further_education_teaching_start_year"
           "September #{further_education_teaching_start_year.to_i} " \
             "to August #{further_education_teaching_start_year.to_i + 1}"
+        when "teaching_hours_per_week_next_term"
+          # NOTE - this column was erroneously deleted
+          "-"
         else
           I18n.t(
             [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -910,6 +910,11 @@ en:
             claimant_answers:
               true: "Yes"
               false: "No"
+          teaching_hours_per_week_next_term:
+            label: "Timetabled teaching hours next term"
+            claimant_answers:
+              at_least_2_5: "At least 2.5 hours per week"
+              less_than_2_5: "Less than 2.5 hours per week"
         fe_provider_verification_v2:
           name: Alternative verification
           title: Do the details provided by the claimant match the provider’s responses?


### PR DESCRIPTION
The column `teaching_hours_per_week_next_term` was erroneously deleted,
so we just render a place holder to allow admins to view year 1 claims.
