### PR TITLE
Rename provider verification strings

### DIFF
--- a/app/forms/further_education_payments/providers/claims/verification/teaching_hours_per_week_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/teaching_hours_per_week_form.rb
@@ -5,11 +5,11 @@ module FurtherEducationPayments
         class TeachingHoursPerWeekForm < BaseForm
           TEACHING_HOURS_PER_WEEK_OPTIONS = [
             Form::Option.new(
-              id: "20_or_more_hours_per_week",
+              id: "more_than_20",
               name: "20 hours or more per week"
             ),
             Form::Option.new(
-              id: "12_to_20_hours_per_week",
+              id: "more_than_12",
               name: "12 or more hours per week, but fewer than 20"
             ),
             Form::Option.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1280,8 +1280,8 @@ en:
       forms:
         teaching_hours_per_week:
           options:
-            20_or_more_hours_per_week: "20 hours or more per week"
-            12_to_20_hours_per_week: "12 or more hours per week, but fewer than 20"
+            more_than_20: "20 hours or more per week"
+            more_than_12: "12 or more hours per week, but fewer than 20"
             2_and_a_half_to_12_hours_per_week: "2.5 or more hours per week, but fewer than 12"
             fewer_than_2_and_a_half_hours_per_week: "Fewer than 2.5 hours each week"
       claims:

--- a/db/migrate/20251031133605_update_teaching_hours_strings.rb
+++ b/db/migrate/20251031133605_update_teaching_hours_strings.rb
@@ -1,0 +1,15 @@
+class UpdateTeachingHoursStrings < ActiveRecord::Migration[8.0]
+  def change
+    Policies::FurtherEducationPayments::Eligibility.where(
+      provider_verification_teaching_hours_per_week: "20_or_more_hours_per_week"
+    ).update_all(
+      provider_verification_teaching_hours_per_week: "more_than_20"
+    )
+
+    Policies::FurtherEducationPayments::Eligibility.where(
+      provider_verification_teaching_hours_per_week: "12_to_20_hours_per_week"
+    ).update_all(
+      provider_verification_teaching_hours_per_week: "more_than_12"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_21_132108) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_31_133605) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -146,7 +146,7 @@ FactoryBot.define do
       provider_verification_taught_at_least_one_academic_term { nil }
       provider_verification_performance_measures { false }
       provider_verification_disciplinary_action { false }
-      provider_verification_teaching_hours_per_week { "20_or_more_hours_per_week" }
+      provider_verification_teaching_hours_per_week { "more_than_20" }
       provider_verification_half_teaching_hours { true }
       provider_verification_half_timetabled_teaching_time { true }
       provider_verification_continued_employment { true }

--- a/spec/features/admin/tasks/further_education_payments/fe_provider_verification_v2_spec.rb
+++ b/spec/features/admin/tasks/further_education_payments/fe_provider_verification_v2_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Viewing the FE provider verification year 2 task" do
           further_education_teaching_start_year: "2023",
           provider_verification_teaching_start_year_matches_claim: true,
           teaching_hours_per_week: "more_than_12",
-          provider_verification_teaching_hours_per_week: "12_to_20_hours_per_week",
+          provider_verification_teaching_hours_per_week: "more_than_12",
           half_teaching_hours: true,
           provider_verification_half_teaching_hours: true,
           subjects_taught: %w[maths physics],

--- a/spec/forms/further_education_payments/providers/claims/verification/teaching_hours_per_week_form_spec.rb
+++ b/spec/forms/further_education_payments/providers/claims/verification/teaching_hours_per_week_form_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Teachi
           validate_inclusion_of(:provider_verification_teaching_hours_per_week)
           .in_array(
             %w[
-              20_or_more_hours_per_week
-              12_to_20_hours_per_week
+              more_than_20
+              more_than_12
               2_and_a_half_to_12_hours_per_week
               fewer_than_2_and_a_half_hours_per_week
             ]
@@ -55,8 +55,8 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Teachi
         is_expected.to(
           validate_inclusion_of(:provider_verification_teaching_hours_per_week)
           .in_array([
-            "20_or_more_hours_per_week",
-            "12_to_20_hours_per_week",
+            "more_than_20",
+            "more_than_12",
             "2_and_a_half_to_12_hours_per_week",
             "fewer_than_2_and_a_half_hours_per_week",
             nil
@@ -74,7 +74,7 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Teachi
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_teaching_hours_per_week: "20_or_more_hours_per_week"
+          provider_verification_teaching_hours_per_week: "more_than_20"
         }
       end
 
@@ -96,7 +96,7 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Teachi
     context "when form is valid" do
       let(:params) do
         {
-          provider_verification_teaching_hours_per_week: "20_or_more_hours_per_week"
+          provider_verification_teaching_hours_per_week: "more_than_20"
         }
       end
 
@@ -107,7 +107,7 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Verification::Teachi
 
         expect(
           claim.eligibility.provider_verification_teaching_hours_per_week
-        ).to eq("20_or_more_hours_per_week")
+        ).to eq("more_than_20")
       end
     end
 


### PR DESCRIPTION
We want the strings that back the provider options to match the strings
that back the claimant options to make comparison easier.
There's no entries in `provider_verification_teaching_hours_per_week` on
production but we've added the migration to not break any review apps
that are still in use.
