### PR TITLE
CAPT 2904/remove in progess session warning between journeys

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -35,7 +35,9 @@ class ClaimsController < BasePublicController
       clear_claim_session
       redirect_to(new_claim_path(current_journey_routing_name))
     else
-      redirect_to_existing_claim_journey
+      redirect_to(
+        claim_path(current_journey_routing_name, navigator.furthest_permissible_slug)
+      )
     end
   end
 
@@ -69,23 +71,6 @@ class ClaimsController < BasePublicController
 
   def current_slug
     params[:slug]
-  end
-
-  def redirect_to_existing_claim_journey
-    # If other journey sessions is empty, then the claimant has hit the landing
-    # page for the journey they're already on, so we need to look at the
-    # existing session.
-    other_journey_session = other_journey_sessions.first || journey_session
-    new_journey = Journeys.for_routing_name(other_journey_session.journey)
-
-    temp_navigator = Journeys::Navigator.new(
-      current_slug: nil,
-      journey_session: other_journey_session,
-      params:,
-      session:
-    )
-
-    redirect_to(claim_path(new_journey::ROUTING_NAME, slug: temp_navigator.furthest_permissible_slug)) && return
   end
 
   def set_backlink_path

--- a/app/controllers/concerns/journey_concern.rb
+++ b/app/controllers/concerns/journey_concern.rb
@@ -26,12 +26,7 @@ module JourneyConcern
   end
 
   def eligible_claim_in_progress?
-    journey_sessions.any? && journey_sessions.none? { |js| claim_ineligible?(js) }
-  end
-
-  def claim_ineligible?(journey_session)
-    journey = Journeys.for_routing_name(journey_session.journey)
-    journey::EligibilityChecker.new(journey_session: journey_session).ineligible?
+    journey_session.present? && !journey::EligibilityChecker.new(journey_session: journey_session).ineligible?
   end
 
   def clear_journey_sessions!

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -9,92 +9,21 @@ RSpec.feature "Switching policies" do
     create(:journey_configuration, :get_a_teacher_relocation_payment)
   end
 
-  context "swtiching from student loans to targeted retention incentive payments" do
-    before do
+  context "swtiching to a different journey" do
+    scenario "a user doesn't need to confirm they want to change journey" do
       start_student_loans_claim
       visit new_claim_path("targeted-retention-incentive-payments")
-    end
 
-    scenario "a user can switch to a different policy after starting a claim on another" do
       expect(page.title).to have_text(I18n.t("targeted_retention_incentive_payments.journey_name"))
       expect(page.find(".govuk-service-navigation")).to have_text(I18n.t("targeted_retention_incentive_payments.journey_name"))
 
-      choose "Start a new eligibility check"
-      click_on "Continue"
-
-      # - Check eligibility intro
-      expect(page).to have_text("Check you’re eligible for a targeted retention incentive payment")
-      click_on "Start eligibility check"
-
-      expect(page).to have_text("You can sign in or set up a DfE Identity account to make it easier to claim additional payments.")
-    end
-
-    scenario "a user can choose to continue their claim" do
-      choose "Continue with the eligibility check that you have already started"
-      click_on "Continue"
-
-      expect(page).to have_text(claim_school_question)
-    end
-  end
-
-  context "switching from targeted retention incentive payments to get a teacher relocation payment" do
-    before do
-      school = create(:school, :targeted_retention_incentive_payments_eligible)
-
-      visit new_claim_path("targeted-retention-incentive-payments")
-
-      skip_tid
-
-      choose_school school
-
-      visit new_claim_path("get-a-teacher-relocation-payment")
-    end
-
-    scenario "a user can switch to a different policy after starting a claim on another" do
-      expect(page.title).to have_text(
-        I18n.t("get_a_teacher_relocation_payment.journey_name")
+      expect(page).not_to have_text(
+        "You have already started an eligibility check"
       )
 
-      expect(page.find(".govuk-service-navigation")).to(
-        have_text(I18n.t("get_a_teacher_relocation_payment.journey_name"))
+      expect(page).not_to have_text(
+        "You can only have one eligibility check in progress at any time."
       )
-
-      choose "Start a new eligibility check"
-      click_on "Continue"
-
-      expect(page.title).to include(
-        "Have you previously received an international relocation payment? — Get a teacher relocation payment"
-      )
-    end
-
-    scenario "a user can choose to continue their claim" do
-      choose "Continue with the eligibility check that you have already started"
-      click_on "Continue"
-
-      expect(page.title).to include("Claim a targeted retention incentive payment")
-    end
-  end
-
-  context "Switching from teacher relocation to additional payments" do
-    before do
-      visit new_claim_path("get-a-teacher-relocation-payment")
-
-      # FIXME RL as of writing this test, the journey only has one page "check
-      # your answers", once the real first page of the journey is added this
-      # test will need to be updated to select an option on that page
-      click_on "Continue"
-
-      visit new_claim_path("targeted-retention-incentive-payments")
-    end
-
-    scenario "a user can switch to a different policy after starting a claim on another" do
-      expect(page).to have_content "You have already started an eligibility check"
-
-      expect(page).to have_content "You can only have one eligibility check in progress at any time."
-
-      choose "Start a new eligibility check"
-
-      click_on "Continue"
     end
   end
 
@@ -130,7 +59,8 @@ RSpec.feature "Switching policies" do
 
   scenario "a user does not select an option" do
     start_student_loans_claim
-    visit new_claim_path("targeted-retention-incentive-payments")
+
+    visit new_claim_path("student-loans")
 
     click_on "Continue"
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe "Claims", type: :request do
     context "switching claim policies" do
       before { create(:journey_configuration, :targeted_retention_incentive_payments) }
 
-      it "redirects to the existing claim interruption page if a claim for another policy is already in progress" do
+      it "doesn't redirects to the existing claim interruption page if a claim for another policy is already in progress" do
         start_student_loans_claim
         get new_claim_path(Journeys::TargetedRetentionIncentivePayments::ROUTING_NAME)
 
-        expect(response).to redirect_to(existing_session_path(Journeys::TargetedRetentionIncentivePayments::ROUTING_NAME))
+        expect(response).not_to redirect_to(existing_session_path(Journeys::TargetedRetentionIncentivePayments::ROUTING_NAME))
       end
     end
   end


### PR DESCRIPTION
Don't show warning when switching journey

We no longer need to show the inprogress session warning when a user
switches journey as sessions are namespaced by journey name.


https://github.com/user-attachments/assets/a237321c-b09d-48d1-81c8-2d0585e953c0

