### PR TITLE
[CAPT-2088] Able to strip whitespace from string attributes

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -24,6 +24,7 @@ class Form
   include ActiveModel::Validations::Callbacks
   include FormHelpers
   include Rails.application.routes.url_helpers
+  include WhitespaceAttributes
 
   attr_accessor :journey
   attr_accessor :journey_session

--- a/app/models/concerns/whitespace_attributes.rb
+++ b/app/models/concerns/whitespace_attributes.rb
@@ -1,0 +1,46 @@
+module WhitespaceAttributes
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :strip_whitespace_attributes,
+      default: [],
+      instance_writer: false,
+      instance_predicate: false
+
+    class_attribute :strip_all_whitespace_attributes,
+      default: [],
+      instance_writer: false,
+      instance_predicate: false
+
+    before_validation do
+      strip_whitespace_attributes.each do |attr|
+        if attribute_names.include?(attr.to_s) && public_send(attr)
+          public_send("#{attr}=", public_send(attr).strip)
+        end
+      end
+
+      strip_all_whitespace_attributes.each do |attr|
+        if attribute_names.include?(attr.to_s) && public_send(attr)
+          public_send("#{attr}=", public_send(attr).gsub(/\s/, ""))
+        end
+      end
+    end
+  end
+
+  class_methods do
+    def attribute(name, type = nil, **options)
+      strip_all_whitespace_flag = options.delete(:strip_all_whitespace)
+      keep_whitespace_flag = options.delete(:keep_whitespace)
+
+      if type == :string && keep_whitespace_flag
+        # noop
+      elsif type == :string && strip_all_whitespace_flag
+        strip_all_whitespace_attributes << name
+      elsif type == :string
+        strip_whitespace_attributes << name
+      end
+
+      super
+    end
+  end
+end

--- a/spec/models/concerns/whitespace_attributes_spec.rb
+++ b/spec/models/concerns/whitespace_attributes_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe WhitespaceAttributes do
+  let(:dummy_class) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+      include ActiveModel::Validations::Callbacks
+      include WhitespaceAttributes
+
+      attribute :email, :string
+      attribute :ni, :string, strip_all_whitespace: true
+      attribute :keep_space, :string, keep_whitespace: true
+    end
+  end
+
+  subject do
+    dummy_class.new(
+      email: " bob@example.com ",
+      ni: " AB 12 34 56 C ",
+      keep_space: " A B C "
+    )
+  end
+
+  it "strips whitespace accordingly" do
+    subject.valid?
+
+    expect(subject.email).to eql("bob@example.com")
+    expect(subject.ni).to eql("AB123456C")
+    expect(subject.keep_space).to eql(" A B C ")
+  end
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-2088
- including the module `WhitespaceAttributes` by default will remove leading and trailing whitespace from `string` attributes
- This module has been included into `Form`
- Can opt out of default with `keep_whitespace` option
- Can change to remove all whitespace in string with `strip_all_whitespace` option