### PR TITLE
CAPT 3000/update admin view full claim to work with year two claims

### DIFF
--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -209,6 +209,10 @@ module Policies
         employment_check_required?
       end
 
+      def employment_checked?
+        !!provider_verification_claimant_employment_check_declaration?
+      end
+
       def claimant_not_employed_by_college?
         provider_verification_claimant_employed_by_college == false
       end
@@ -293,11 +297,11 @@ module Policies
           )
       end
 
-      private
-
       def year_1_claim?
         claim.academic_year == AcademicYear.new(2024)
       end
+
+      private
 
       def provider_user
         if year_1_claim?

--- a/app/models/policies/further_education_payments/eligibility_admin_answers_presenter.rb
+++ b/app/models/policies/further_education_payments/eligibility_admin_answers_presenter.rb
@@ -16,6 +16,10 @@ module Policies
         end
       end
 
+      def year_1_claim?
+        eligibility.year_1_claim?
+      end
+
       def provider_details
         [
           teaching_responsibilities,

--- a/app/models/policies/further_education_payments/eligibility_admin_provider_answers_presenter.rb
+++ b/app/models/policies/further_education_payments/eligibility_admin_provider_answers_presenter.rb
@@ -1,0 +1,345 @@
+module Policies
+  module FurtherEducationPayments
+    class EligibilityAdminProviderAnswersPresenter
+      def initialize(eligibility)
+        @eligibility = eligibility
+      end
+
+      def provider_employment_check
+        return unless eligibility.provider_verification_completed_at.present?
+        return unless eligibility.employment_checked? || eligibility.claimant_not_employed_by_college?
+
+        [
+          claimant_employed_by_college,
+          claimant_date_of_birth,
+          claimant_national_insurance_number,
+          claimant_bank_details_match,
+          claimant_email
+        ]
+      end
+
+      def provider_details
+        return unless eligibility.provider_verification_completed_at.present?
+        # If the claimant is not employed by the college the wizard exits early
+        return if eligibility.claimant_not_employed_by_college?
+
+        [
+          teaching_responsibilities,
+          in_first_five_years,
+          teaching_qualification,
+          not_started_qualification_reasons,
+          contract_type,
+          contract_covers_full_academic_year,
+          taught_at_least_one_academic_term,
+          performance_measures,
+          disciplinary_measures,
+          teaching_hours_per_week,
+          half_teaching_hours,
+          half_timetabled_teaching_time,
+          continued_employment
+        ]
+      end
+
+      private
+
+      attr_reader :eligibility
+
+      def claimant_employed_by_college
+        [
+          question(
+            :provider_verification_claimant_employed_by_college,
+            provider_name: eligibility.school.name,
+            claimant_name: eligibility.claim.full_name
+          ),
+          I18n.t(
+            eligibility.provider_verification_claimant_employed_by_college,
+            scope: :boolean
+          )
+        ]
+      end
+
+      # If the proivder has flagged the claimant as not employed by the college,
+      # we won't have answered any of the other questions
+      def claimant_date_of_birth
+        answer = if eligibility.provider_verification_claimant_date_of_birth
+          I18n.l(eligibility.provider_verification_claimant_date_of_birth)
+        else
+          "Not answered"
+        end
+        [
+          question(:provider_verification_claimant_date_of_birth),
+          answer
+        ]
+      end
+
+      def claimant_national_insurance_number
+        answer = eligibility.provider_verification_claimant_national_insurance_number || "Not answered"
+
+        [
+          question(:provider_verification_claimant_national_insurance_number),
+          answer
+        ]
+      end
+
+      def claimant_bank_details_match
+        answer = if eligibility.provider_verification_claimant_bank_details_match.nil?
+          "Not answered"
+        else
+          I18n.t(
+            eligibility.provider_verification_claimant_bank_details_match,
+            scope: :boolean
+          )
+        end
+        [
+          question(
+            :provider_verification_claimant_bank_details_match,
+            claimant_name: eligibility.claim.full_name
+          ),
+          answer
+        ]
+      end
+
+      def claimant_email
+        [
+          question(:provider_verification_claimant_email),
+          eligibility.provider_verification_claimant_email.presence || "Not answered"
+        ]
+      end
+
+      def teaching_responsibilities
+        [
+          question(
+            :provider_verification_teaching_responsibilities,
+            claimant_name: eligibility.claim.full_name
+          ),
+          I18n.t(
+            eligibility.provider_verification_teaching_start_year_matches_claim,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def in_first_five_years
+        academic_year = AcademicYear.new(
+          eligibility.further_education_teaching_start_year
+        )
+
+        academic_year_full = I18n.t(
+          "options.between_dates",
+          start_year: academic_year.start_year,
+          end_year: academic_year.end_year,
+          scope: "further_education_payments.forms.further_education_teaching_start_year"
+        )
+
+        [
+          question(
+            :provider_verification_teaching_start_year_matches_claim,
+            claimant_name: eligibility.claim.full_name,
+            claimant_further_education_teaching_start_year: academic_year_full
+          ),
+          I18n.t(
+            eligibility.provider_verification_teaching_start_year_matches_claim,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def teaching_qualification
+        [
+          question(
+            :provider_verification_teaching_qualification,
+            claimant_name: eligibility.claim.full_name
+          ),
+          option(
+            :provider_verification_teaching_qualification,
+            eligibility.provider_verification_teaching_qualification
+          )
+        ]
+      end
+
+      def not_started_qualification_reasons
+        answer = if eligibility.provider_verification_not_started_qualification_reasons.blank?
+          "Not answered"
+        elsif eligibility.provider_verification_not_started_qualification_reasons.include?("other")
+          eligibility.provider_verification_not_started_qualification_reason_other
+        else
+          eligibility.provider_verification_not_started_qualification_reasons.map do |reason|
+            I18n.t(
+              reason,
+              scope: %w[
+                further_education_payments
+                providers
+                claims
+                verification
+                forms
+                not_started_qualification_reason
+                options
+              ].join(".")
+            )
+          end.join(", ")
+        end
+
+        [
+          question(
+            :provider_verification_not_started_qualification_reasons,
+            claimant_name: eligibility.claim.full_name
+          ),
+          answer
+        ]
+      end
+
+      def contract_type
+        [
+          question(
+            :provider_verification_contract_type,
+            claimant_name: eligibility.claim.full_name,
+            provider_name: eligibility.school.name
+          ),
+          option(
+            :provider_verification_contract_type,
+            eligibility.provider_verification_contract_type,
+            provider_name: eligibility.school.name
+          )
+        ]
+      end
+
+      def contract_covers_full_academic_year
+        answer = if eligibility.provider_verification_contract_covers_full_academic_year.nil?
+          "Not answered"
+        else
+          I18n.t(
+            eligibility.provider_verification_contract_covers_full_academic_year,
+            scope: :boolean
+          )
+        end
+
+        [
+          question(
+            :provider_verification_contract_covers_full_academic_year,
+            claimant_name: eligibility.claim.full_name,
+            academic_year: eligibility.claim.academic_year.to_s(:long)
+          ),
+          answer
+        ]
+      end
+
+      def taught_at_least_one_academic_term
+        answer = if eligibility.provider_verification_taught_at_least_one_academic_term.nil?
+          "Not answered"
+        else
+          I18n.t(
+            eligibility.provider_verification_taught_at_least_one_academic_term,
+            scope: :boolean
+          )
+        end
+
+        [
+          question(
+            :provider_verification_taught_at_least_one_academic_term,
+            claimant_name: eligibility.claim.full_name,
+            provider_name: eligibility.school.name
+          ),
+          answer
+        ]
+      end
+
+      def performance_measures
+        [
+          question(
+            :provider_verification_performance_measures,
+            claimant_name: eligibility.claim.full_name
+          ),
+          I18n.t(
+            eligibility.provider_verification_performance_measures,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def disciplinary_measures
+        [
+          question(
+            :provider_verification_disciplinary_action,
+            claimant_name: eligibility.claim.full_name
+          ),
+          I18n.t(
+            eligibility.provider_verification_disciplinary_action,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def teaching_hours_per_week
+        [
+          question(
+            :provider_verification_teaching_hours_per_week,
+            claimant_name: eligibility.claim.full_name,
+            provider_name: eligibility.school.name
+          ),
+          option(
+            :provider_verification_teaching_hours_per_week,
+            eligibility.provider_verification_teaching_hours_per_week
+          )
+        ]
+      end
+
+      def half_teaching_hours
+        [
+          question(
+            :provider_verification_half_teaching_hours,
+            claimant_name: eligibility.claim.full_name
+          ),
+          I18n.t(
+            eligibility.provider_verification_half_teaching_hours,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def half_timetabled_teaching_time
+        [
+          question(
+            :provider_verification_half_timetabled_teaching_time,
+            claimant_name: eligibility.claim.full_name
+          ),
+          I18n.t(
+            eligibility.provider_verification_half_timetabled_teaching_time,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def continued_employment
+        [
+          question(
+            :provider_verification_continued_employment,
+            claimant_name: eligibility.claim.full_name,
+            provider_name: eligibility.school.name
+          ),
+          I18n.t(
+            eligibility.provider_verification_continued_employment,
+            scope: :boolean
+          )
+        ]
+      end
+
+      def question(attr, options = {})
+        I18n.t(
+          form_scope(attr.to_s) + ".question",
+          **options
+        )
+      end
+
+      def option(attr, option_id, options = {})
+        I18n.t(
+          form_scope(attr.to_s) + ".options." + option_id,
+          **options
+        )
+      end
+
+      def form_scope(attr)
+        "further_education_payments_provider.forms.verification.#{attr}"
+      end
+    end
+  end
+end

--- a/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
+++ b/app/views/admin/claims/policies/further_education_payments/_claim.html.erb
@@ -65,14 +65,38 @@
       }
     ) %>
 
-    <% if admin_answers_presenter.provider_verification.present? %>
-      <%= render(
-        "admin/claims/answer_section",
-        {
-          heading: "Provider verification",
-          answers: admin_answers_presenter.provider_verification
-        }
-      ) %>
+    <% if admin_answers_presenter.year_1_claim? %>
+      <% if admin_answers_presenter.provider_verification.present? %>
+        <%= render(
+          "admin/claims/answer_section",
+          {
+            heading: "Provider verification",
+            answers: admin_answers_presenter.provider_verification
+          }
+        ) %>
+      <% end %>
+    <% else %>
+      <% presenter = Policies::FurtherEducationPayments::EligibilityAdminProviderAnswersPresenter.new(@claim.eligibility) %>
+
+      <% if presenter.provider_employment_check.present? %>
+        <%= render(
+          "admin/claims/answer_section",
+          {
+            heading: "Provider employment check",
+            answers: presenter.provider_employment_check
+          }
+        ) %>
+      <% end %>
+
+      <% if presenter.provider_details.present? %>
+        <%= render(
+          "admin/claims/answer_section",
+          {
+            heading: "Provider verification",
+            answers: presenter.provider_details
+          }
+        ) %>
+      <% end %>
     <% end %>
 
     <%= render(

--- a/spec/factories/policies/further_education_payments/eligibilities.rb
+++ b/spec/factories/policies/further_education_payments/eligibilities.rb
@@ -208,5 +208,27 @@ FactoryBot.define do
     trait :with_award_amount do
       award_amount { [2_000, 2_500, 3_000, 4_000, 5_000, 6_000].sample }
     end
+
+    trait :provider_verification_employment_checked do
+      provider_verification_claimant_employed_by_college { true }
+      provider_verification_claimant_date_of_birth { Date.new(1990, 1, 1) }
+      provider_verification_claimant_national_insurance_number { "AB123456C" }
+      provider_verification_claimant_postcode { "TE57 1NG" }
+      provider_verification_claimant_bank_details_match { true }
+      provider_verification_claimant_email { "test@example.com" }
+      provider_verification_claimant_employment_check_declaration { true }
+    end
+
+    trait :provider_verification_employment_checked_claimant_not_employed_by_college do
+      provider_verification_claimant_employed_by_college { false }
+      provider_verification_claimant_date_of_birth { nil }
+      provider_verification_claimant_national_insurance_number { nil }
+      provider_verification_claimant_postcode { nil }
+      provider_verification_claimant_bank_details_match { nil }
+      provider_verification_claimant_email { nil }
+      provider_verification_claimant_employment_check_declaration { nil }
+      provider_verification_completed_at { Time.zone.now }
+      provider_verification_verified_by_id { create(:dfe_signin_user).id }
+    end
   end
 end

--- a/spec/models/policies/further_education_payments/eligibility_admin_provider_answers_presenter_spec.rb
+++ b/spec/models/policies/further_education_payments/eligibility_admin_provider_answers_presenter_spec.rb
@@ -1,0 +1,292 @@
+require "rails_helper"
+
+RSpec.describe Policies::FurtherEducationPayments::EligibilityAdminProviderAnswersPresenter do
+  let(:presenter) { described_class.new(eligibility) }
+
+  let(:school) do
+    create(
+      :school,
+      :further_education,
+      :fe_eligible,
+      name: "Springfield Elementary"
+    )
+  end
+
+  let(:claim) do
+    create(
+      :claim,
+      academic_year: AcademicYear.new(2025),
+      first_name: "Edna",
+      surname: "Krabappel"
+    )
+  end
+
+  describe "#provider_employment_check" do
+    subject { presenter.provider_employment_check }
+
+    context "when provider verification not completed" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :eligible,
+          claim: claim,
+          school: school
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when employment not checked" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_completed,
+          :eligible,
+          claim: claim,
+          school: school
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when claimant is not employed by the college" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_employment_checked_claimant_not_employed_by_college,
+          :eligible,
+          claim: claim,
+          school: school
+        )
+      end
+
+      it do
+        is_expected.to eq([
+          [
+            "Does Springfield Elementary employ Edna Krabappel?",
+            "No"
+          ],
+          [
+            "Enter their date of birth",
+            "Not answered"
+          ],
+          [
+            "Enter their National Insurance number",
+            "Not answered"
+          ],
+          [
+            "Do these bank details match what you have for Edna Krabappel?",
+            "Not answered"
+          ],
+          [
+            "Email address",
+            "Not answered"
+          ]
+        ])
+      end
+    end
+
+    context "when provider verification completed and employment checked" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_completed,
+          :provider_verification_employment_checked,
+          :eligible,
+          claim: claim,
+          school: school,
+          provider_verification_claimant_email: "edna.k@springfield-elementary.edu",
+          provider_verification_claimant_date_of_birth: Date.new(1956, 3, 15)
+        )
+      end
+
+      it do
+        is_expected.to match_array([
+          [
+            "Does Springfield Elementary employ Edna Krabappel?",
+            "Yes"
+          ],
+          [
+            "Enter their date of birth",
+            "15 March 1956"
+          ],
+          [
+            "Enter their National Insurance number",
+            "AB123456C"
+          ],
+          [
+            "Do these bank details match what you have for Edna Krabappel?",
+            "Yes"
+          ],
+          [
+            "Email address",
+            "edna.k@springfield-elementary.edu"
+          ]
+        ])
+      end
+    end
+  end
+
+  describe "#provider_details" do
+    subject { presenter.provider_details }
+
+    context "when provider verification not completed" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :eligible,
+          claim: claim,
+          school: school
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when claimant is not employed by the college" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_employment_checked_claimant_not_employed_by_college,
+          :eligible,
+          claim: claim,
+          school: school
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when provider verification completed" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_completed,
+          :eligible,
+          claim: claim,
+          school: school
+        )
+      end
+
+      it do
+        is_expected.to match_array([
+          [
+            "Is Edna Krabappel a member of staff with the responsibilities of a teacher?",
+            "Yes"
+          ],
+          [
+            "Did Edna Krabappel start their further education (FE) teaching " \
+            "career in England during September 2023 to August 2024?",
+            "Yes"
+          ],
+          [
+            "Does Edna Krabappel have a teaching qualification?",
+            "Yes"
+          ],
+          [
+            "Edna Krabappel said last year that they planned to " \
+            "start a teaching qualification within 12 months. They’ve " \
+            "confirmed the same intention in their application this year. Tell " \
+            "us why they have not yet started or finished a teaching qualification",
+            "Not answered"
+          ],
+          [
+            "What type of contract does Edna Krabappel have directly with Springfield Elementary?",
+            "Fixed-term"
+          ],
+          [
+            "Does Edna Krabappel have a fixed-term contract " \
+            "for the full 2025 to 2026 academic year?",
+            "Yes"
+          ],
+          [
+            "Has Edna Krabappel worked at Springfield Elementary for the full spring term?",
+            "Not answered"
+          ],
+          [
+            "Is Edna Krabappel currently subject to any " \
+            "formal performance measures as a result of continuous poor " \
+            "teaching standards?",
+            "No"
+          ],
+          [
+            "Is Edna Krabappel currently subject to any disciplinary action?",
+            "No"
+          ],
+          [
+            "On average, how many hours per week was Edna Krabappel timetabled to teach at Springfield Elementary during the spring term?",
+            "20 hours or more per week"
+          ],
+          [
+            "Did Edna Krabappel spend at least half of their " \
+            "timetabled teaching hours teaching students on 16 to 19 study " \
+            "programmes, T Levels or 16 to 19 apprenticeships?",
+            "Yes"
+          ],
+          [
+            "During the spring term, did Edna Krabappel spend at least half of their timetabled teaching hours teaching these courses?",
+            "Yes"
+          ],
+          [
+            "Is Edna Krabappel expected to work at Springfield Elementary until the end of the academic year?",
+            "Yes"
+          ]
+        ])
+      end
+    end
+
+    context "when the not started qualification question is answered" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_completed,
+          :eligible,
+          claim: claim,
+          school: school,
+          provider_verification_not_started_qualification_reasons: %w[
+            workload
+            funding_issues
+          ]
+        )
+      end
+
+      it do
+        is_expected.to include([
+          "Edna Krabappel said last year that they planned to " \
+          "start a teaching qualification within 12 months. They’ve " \
+          "confirmed the same intention in their application this year. Tell " \
+          "us why they have not yet started or finished a teaching qualification",
+          "Workload, Funding issues"
+        ])
+      end
+    end
+
+    context "when the not started qualification question is answered with other" do
+      let(:eligibility) do
+        create(
+          :further_education_payments_eligibility,
+          :provider_verification_completed,
+          :eligible,
+          claim: claim,
+          school: school,
+          provider_verification_not_started_qualification_reasons: %w[
+            other
+          ],
+          provider_verification_not_started_qualification_reason_other: "Their dog needed walking"
+        )
+      end
+
+      it do
+        is_expected.to include([
+          "Edna Krabappel said last year that they planned to " \
+          "start a teaching qualification within 12 months. They’ve " \
+          "confirmed the same intention in their application this year. Tell " \
+          "us why they have not yet started or finished a teaching qualification",
+          "Their dog needed walking"
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Display year 2 provider details

Year 2 provider verification is stored and displays different questions
to year 1 provider verification.
As there's quite a lot of information to show we've extracted an "admin
eligibility presenter" just for the provider answers.

