### PR TITLE
CAPT-2934 - Redirect to start_page_url instead of using landing_page

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -15,7 +15,7 @@ module FormSubmittable
       render_template_for_current_slug
     rescue ActionView::Template::Error => e
       if e.cause.is_a?(Journeys::ConfirmationForm::SubmittedClaimNotFound)
-        redirect_to landing_page_path(current_journey_routing_name)
+        redirect_to journey.start_page_url
       else
         raise e
       end

--- a/app/forms/journeys/early_years_payment/provider/authenticated/check_your_answers_form.rb
+++ b/app/forms/journeys/early_years_payment/provider/authenticated/check_your_answers_form.rb
@@ -42,7 +42,7 @@ module Journeys
           private
 
           def clear_claim_session
-            key = "#{Journeys::EarlyYearsPayment::Provider::Authenticated}_journeys_session_id"
+            key = "#{Journeys::EarlyYearsPayment::Provider::Authenticated.routing_name}_journeys_session_id"
             session.delete(key)
           end
 

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -75,7 +75,7 @@ module Journeys
         if Rails.env.production?
           "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
         else
-          "/student-loans/claim"
+          Rails.application.routes.url_helpers.landing_page_path("student-loans")
         end
       end
 

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -26,6 +26,6 @@ RSpec.feature "Claim journey does not get cached" do
     )
 
     expect(page).to_not have_text(journey_session.answers.first_name)
-    expect(page).to have_text("Use DfE Identity to sign in")
+    expect(page).to have_text("Claim back student loan repayments if you’re a teacher")
   end
 end

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -187,7 +187,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     # Check we can't skip to pages in middle of page sequence after claim is submitted
     visit claim_path(Journeys::TeacherStudentLoanReimbursement.routing_name, "still-teaching")
-    expect(page).to have_current_path("/#{Journeys::TeacherStudentLoanReimbursement.routing_name}/sign-in-or-continue")
+    expect(page).to have_current_path("/#{Journeys::TeacherStudentLoanReimbursement.routing_name}/landing-page")
   end
 
   [

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,6 +1,7 @@
 module FeatureHelpers
   def start_student_loans_claim
-    visit new_claim_path(Journeys::TeacherStudentLoanReimbursement.routing_name)
+    visit Journeys::TeacherStudentLoanReimbursement.start_page_url
+    click_on "Start now"
     skip_tid
     choose_qts_year
     Claim.by_policy(Policies::StudentLoans).order(:created_at).last


### PR DESCRIPTION
Tweak this https://github.com/DFE-Digital/claim-additional-payments-for-teaching/commit/6bc5a42fba3220aea515a20c4bab1b1a5be79aaa update so it redirects to the start page url as the EY provider journey doesn't have a landing page, when we really want the start page.

This fixes the error when a provider refreshes the confirmation page and the session has gone.

This gives a list of the landing page vs start page from the journeys:
```
Journeys.all_routing_names.map {|r| Rails.application.routes.url_helpers.landing_page_path(r)} 
=> 
["/targeted-retention-incentive-payments/landing-page",
 "/student-loans/landing-page",
 "/get-a-teacher-relocation-payment/landing-page",
 "/further-education-payments/landing-page",
 "/early-years-payment/landing-page",
 "/early-years-payment-provider/landing-page", # CAUSES THE ERROR
 "/early-years-payment-provider-alternative-idv/landing-page",
 "/early-years-payment-practitioner/landing-page"]
> Journeys.all.map {|j| j.start_page_url}
=> 
["/targeted-retention-incentive-payments/landing-page",
 "/student-loans/landing-page",
 "/get-a-teacher-relocation-payment/landing-page",
 "/further-education-payments/landing-page",
 "/early-years-payment/landing-page",
 "/early-years-payment/landing-page", # Already configured as a start_page
 "/early-years-payment-provider-alternative-idv/landing-page",
 "/early-years-payment-practitioner/landing-page"]
```