### PR TITLE
CAPT-3011 - Add page position to session for admin claim list navigation and filtering

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -6,11 +6,18 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def index
     @filter_form = Admin::ClaimsFilterForm.new(
       filters: filter_params,
+      selected_page: params[:page],
       session:
     )
+
     @filter_form.save_to_session!
 
-    @pagy, @claims = pagy(@filter_form.claims)
+    if @filter_form.reset?
+      redirect_to admin_claims_path
+      return
+    end
+
+    @pagy, @claims = pagy(@filter_form.claims, page: @filter_form.page)
 
     respond_to do |format|
       format.html

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -238,13 +238,12 @@ module Admin
     end
 
     INDEX_STATUS_FILTER_MESSAGE = {
+      "awaiting_decision" => "awaiting a decision",
       "approved_awaiting_qa" => "approved awaiting QA",
       "rejected_awaiting_qa" => "rejected awaiting QA"
     }
 
     def index_status_filter(status)
-      return "awaiting a decision" unless status.present?
-
       INDEX_STATUS_FILTER_MESSAGE[status] || status.humanize.downcase
     end
 

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -45,12 +45,7 @@
 
         <div>
           <%= f.govuk_submit "Apply filters", secondary: true, class: "admin-filter-group__button" %>
-
-          <% if @filter_form.filters_applied? %>
-            <%= govuk_link_to "Clear filters", admin_claims_path(filter: {reset: true}, anchor: "filter"), class: "button-link admin-filter-group__button" %>
-          <% else %>
-            <%= f.submit "Clear filters", type: "reset", class: "button-link admin-filter-group__button" %>
-          <% end %>
+          <%= govuk_link_to "Clear filters", admin_claims_path(filter: {reset: true}, anchor: "filter"), class: "button-link admin-filter-group__button" %>
         </div>
       </div>
     <% end %>

--- a/spec/forms/admin/claims_filter_form_spec.rb
+++ b/spec/forms/admin/claims_filter_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Admin::ClaimsFilterForm, type: :model do
   describe "#claims" do
     let(:session) { {} }
-    let(:filters) { {} }
+    let(:filters) { {team_member: "all", policy: "all", status: "awaiting_decision"} }
 
     subject { described_class.new(filters:, session:) }
 
@@ -17,7 +17,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         )
       end
 
-      let(:filters) { {status: "awaiting_provider_verification"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "awaiting_provider_verification"} }
 
       it "filtering by status awaiting provider verification excludes them" do
         expect(subject.claims).not_to include(claim)
@@ -81,6 +81,8 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
           form = described_class.new(
             session: {},
             filters: {
+              team_member: "all",
+              policy: "all",
               status: "awaiting_provider_verification"
             }
           )
@@ -162,6 +164,8 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
           form = described_class.new(
             session: {},
             filters: {
+              team_member: "all",
+              policy: "all",
               status: "awaiting_provider_verification"
             }
           )
@@ -195,7 +199,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       let!(:qa_approved_claim) { create(:claim, :approved, :qa_completed, :current_academic_year) }
       let!(:qa_rejected_claim) { create(:claim, :rejected, :qa_completed, :current_academic_year) }
 
-      let(:filters) { {status: "quality_assured"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "quality_assured"} }
 
       it "returns all quality assured claims" do
         expect(subject.claims.size).to eql(2)
@@ -206,7 +210,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       let!(:qa_approved_claim) { create(:claim, :approved, :qa_completed, :current_academic_year) }
       let!(:qa_rejected_claim) { create(:claim, :rejected, :qa_completed, :current_academic_year) }
 
-      let(:filters) { {status: "quality_assured_approved"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "quality_assured_approved"} }
 
       it "returns all approved quality assured claims" do
         expect(subject.claims).to eq([qa_approved_claim])
@@ -217,7 +221,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       let!(:qa_approved_claim) { create(:claim, :approved, :qa_completed, :current_academic_year) }
       let!(:qa_rejected_claim) { create(:claim, :rejected, :qa_completed, :current_academic_year) }
 
-      let(:filters) { {status: "quality_assured_rejected"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "quality_assured_rejected"} }
 
       it "returns all rejected quality assured claims" do
         expect(subject.claims).to eq([qa_rejected_claim])
@@ -236,7 +240,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       end
 
       context "awaiting_claimant_data filter" do
-        let(:filters) { {status: "awaiting_claimant_data"} }
+        let(:filters) { {team_member: "all", policy: "all", status: "awaiting_claimant_data"} }
 
         it "returns claims awaiting claimant data" do
           expect(subject.claims).to eq([claim_awaiting_claimant])
@@ -244,7 +248,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       end
 
       context "awaiting_retention_period_completion filter" do
-        let(:filters) { {status: "awaiting_retention_period_completion"} }
+        let(:filters) { {team_member: "all", policy: "all", status: "awaiting_retention_period_completion"} }
 
         it "returns claims awaiting retention period completion" do
           expect(subject.claims).to eq([claim_within_retention_period])
@@ -252,7 +256,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
       end
 
       context "awaiting_retention_check_data filter" do
-        let(:filters) { {status: "awaiting_retention_check_data"} }
+        let(:filters) { {team_member: "all", policy: "all", status: "awaiting_retention_check_data"} }
 
         it "awaiting_retention_check_data filter" do
           expect(subject.claims).to eq([claim_after_retention_period])
@@ -283,7 +287,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         )
       end
 
-      let(:filters) { {status: "approved_awaiting_qa"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "approved_awaiting_qa"} }
 
       it "filtering by status approved_awaiting_qa includes them" do
         expect(subject.claims).to include(claim)
@@ -314,7 +318,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         )
       end
 
-      let(:filters) { {status: "rejected_awaiting_qa"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "rejected_awaiting_qa"} }
 
       it "filtering by status rejected_awaiting_qa includes them" do
         expect(subject.claims).to include(claim)
@@ -343,7 +347,7 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         )
       end
 
-      let(:filters) { {status: "approved_awaiting_payroll"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "approved_awaiting_payroll"} }
 
       it "filtering by status approved_awaiting_payroll includes them" do
         expect(subject.claims).to include(claim)
@@ -372,11 +376,191 @@ RSpec.describe Admin::ClaimsFilterForm, type: :model do
         )
       end
 
-      let(:filters) { {status: "automatically_approved_awaiting_payroll"} }
+      let(:filters) { {team_member: "all", policy: "all", status: "automatically_approved_awaiting_payroll"} }
 
       it "filtering by status automatically_approved_awaiting_payroll includes them" do
         expect(subject.claims).to include(claim)
         expect(subject.claims).to include(claim_previous_ay)
+      end
+    end
+  end
+
+  describe "#save_to_session!" do
+    let(:session) { {} }
+    let(:filters) { {team_member: "user-123", policy: "further-education-payments", status: "approved"} }
+    subject { described_class.new(filters:, session:) }
+
+    it "saves filters to session with symbol keys" do
+      subject.save_to_session!
+
+      expect(session[:filter]).to eq({
+        "team_member" => "user-123",
+        "policy" => "further-education-payments",
+        "status" => "approved"
+      })
+    end
+
+    it "saves page to session" do
+      subject.save_to_session!
+
+      expect(session[:page]).to eq(1)
+    end
+
+    context "when page is set" do
+      let(:filters) { {team_member: "all", policy: "all", status: "awaiting_decision"} }
+      subject { described_class.new(filters:, session:, selected_page: 3) }
+
+      it "saves the current page" do
+        subject.save_to_session!
+
+        expect(session[:page]).to eq(3)
+      end
+    end
+  end
+
+  describe "#reset?" do
+    let(:session) { {} }
+    subject { described_class.new(filters:, session:) }
+
+    context "when reset filter is present" do
+      let(:filters) { {reset: true} }
+
+      it "returns true" do
+        expect(subject.reset?).to be true
+      end
+    end
+
+    context "when reset filter is not present" do
+      let(:filters) { {} }
+
+      it "returns false" do
+        expect(subject.reset?).to be false
+      end
+    end
+  end
+
+  describe "filter accessors with session fallback" do
+    let(:session) do
+      {
+        filter: {
+          "team_member" => "session-user",
+          "policy" => "early-years",
+          "status" => "rejected"
+        }
+      }
+    end
+    subject { described_class.new(filters:, session:) }
+
+    context "when filters are provided" do
+      let(:filters) { {team_member: "param-user", policy: "further-education-payments"} }
+
+      it "returns the filter values from params" do
+        expect(subject.team_member).to eq("param-user")
+        expect(subject.policy).to eq("further-education-payments")
+      end
+
+      it "falls back to session for filters not in params" do
+        expect(subject.status).to eq("rejected")
+      end
+    end
+
+    context "when filters are not provided" do
+      let(:filters) { {} }
+
+      it "returns values from session" do
+        expect(subject.team_member).to eq("session-user")
+        expect(subject.policy).to eq("early-years")
+        expect(subject.status).to eq("rejected")
+      end
+    end
+
+    context "when reset is applied" do
+      let(:filters) { {reset: true} }
+
+      it "returns defaults" do
+        expect(subject.team_member).to eq("all")
+        expect(subject.policy).to eq("all")
+        expect(subject.status).to eq("awaiting_decision")
+      end
+    end
+  end
+
+  describe "#page with session and filter change detection" do
+    let(:session) { {} }
+    let(:filters) { {} }
+    let(:selected_page) { nil }
+    subject { described_class.new(filters:, session:, selected_page:) }
+
+    context "when selected_page is provided" do
+      let(:selected_page) { 5 }
+
+      it "returns the selected page" do
+        expect(subject.page).to eq(5)
+      end
+    end
+
+    context "when page is in session" do
+      let(:session) { {page: 3} }
+
+      it "returns the page from session" do
+        expect(subject.page).to eq(3)
+      end
+    end
+
+    context "when reset is applied" do
+      let(:filters) { {reset: true} }
+      let(:session) { {page: 5} }
+
+      it "returns 1" do
+        expect(subject.page).to eq(1)
+      end
+    end
+
+    context "when filters change from session" do
+      let(:session) do
+        {
+          filter: {
+            "team_member" => "user-123",
+            "policy" => "further-education-payments",
+            "status" => "awaiting_decision"
+          },
+          page: 5
+        }
+      end
+      let(:filters) { {team_member: "user-456", policy: "further-education-payments", status: "awaiting_decision"} }
+
+      it "returns 1 to reset to first page" do
+        expect(subject.page).to eq(1)
+      end
+    end
+
+    context "when filters do not change from session" do
+      let(:session) do
+        {
+          filter: {
+            "team_member" => "user-123",
+            "policy" => "further-education-payments",
+            "status" => "all"
+          },
+          page: 3
+        }
+      end
+      let(:filters) do
+        {
+          team_member: "user-123",
+          policy: "further-education-payments",
+          status: "all"
+        }
+      end
+
+      it "preserves the page from session" do
+        expect(subject.page).to eq(3)
+      end
+    end
+
+    context "when no page or session data is provided" do
+      it "defaults to 1" do
+        expect(subject.page).to eq(1)
       end
     end
   end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -846,8 +846,8 @@ RSpec.describe Admin::ClaimsHelper do
   describe "#index_status_filter" do
     subject { helper.index_status_filter(status) }
 
-    context "when status is blank" do
-      let(:status) { "" }
+    context "when status is awaiting_decision" do
+      let(:status) { "awaiting_decision" }
 
       it { is_expected.to eq("awaiting a decision") }
     end


### PR DESCRIPTION
* Adds the page in addition to the filters to retain page position
* Changing the filters will clear the page position

