### PR TITLE
CAPT-3055 / Early years providers search

### DIFF
--- a/app/controllers/admin/early_years_providers_controller.rb
+++ b/app/controllers/admin/early_years_providers_controller.rb
@@ -1,0 +1,50 @@
+module Admin
+  class EarlyYearsProvidersController < Admin::BaseAdminController
+    before_action :ensure_service_operator
+
+    def index
+      scope = Policies::EarlyYearsPayments::EligibleEyProvider
+        .joins(
+          <<~SQL
+            LEFT JOIN early_years_payment_eligibilities
+              ON early_years_payment_eligibilities.nursery_urn = eligible_ey_providers.urn
+            LEFT JOIN claims
+              ON claims.eligibility_id = early_years_payment_eligibilities.id
+              AND claims.eligibility_type = 'Policies::EarlyYearsPayments::Eligibility'
+          SQL
+        )
+        .where(
+          "claims.academic_year = :academic_year OR claims.id IS NULL",
+          academic_year: Journeys::EarlyYearsPayment::Provider::Authenticated.configuration.current_academic_year.to_s
+
+        )
+        .group(
+          "eligible_ey_providers.nursery_name",
+          "eligible_ey_providers.primary_key_contact_email_address",
+          "eligible_ey_providers.max_claims"
+        )
+        .select(
+          "eligible_ey_providers.nursery_name",
+          "eligible_ey_providers.primary_key_contact_email_address",
+          "eligible_ey_providers.max_claims",
+          "COUNT(claims.id) AS claims_submitted",
+          "JSON_AGG(JSON_BUILD_OBJECT('reference', claims.reference, 'id', claims.id)) AS claims_data"
+        )
+
+      if params[:query]
+        scope = scope.where(
+          <<~SQL,
+            eligible_ey_providers.nursery_name ILIKE :query
+            OR
+            eligible_ey_providers.primary_key_contact_email_address ILIKE :query
+          SQL
+          query: "%#{params[:query]}%"
+        )
+      end
+
+      scope = scope.order("eligible_ey_providers.nursery_name ASC")
+
+      @provider_results = scope
+    end
+  end
+end

--- a/app/views/admin/early_years_providers/index.html.erb
+++ b/app/views/admin/early_years_providers/index.html.erb
@@ -1,0 +1,63 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Early years providers</h1>
+
+    <%= form_with(
+      url: admin_early_years_providers_path,
+      method: :get,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <%= f.govuk_text_field(
+        :query,
+        label: {
+          text: "Search by nursery name or primary contact email address"
+        },
+        value: params[:query],
+      ) %>
+
+      <%= f.govuk_submit "Search" %>
+      <% if params[:query].present? %>
+        <%= govuk_button_link_to(
+          "Clear search",
+          admin_early_years_providers_path,
+          secondary: true
+        ) %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_table do |table| %>
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: "Nursery name", width: "one-third") %>
+          <%= row.with_cell(text: "Primary contact email address", width: "one-third") %>
+          <%= row.with_cell(text: "Claim allowance") %>
+          <%= row.with_cell(text: "Claims submitted") %>
+          <%= row.with_cell(text: "Claims") %>
+        <% end %>
+      <% end %>
+
+      <%= table.with_body do |body| %>
+        <% @provider_results.each do |provider| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(text: provider.nursery_name) %>
+            <%= row.with_cell(text: provider.primary_key_contact_email_address) %>
+            <%= row.with_cell(text: provider.max_claims) %>
+            <%= row.with_cell(text: provider.claims_submitted) %>
+            <%= row.with_cell do %>
+              <ul class="govuk-list govuk-!-margin-bottom-0">
+                <% provider.claims_data.select { it["id"].present? }.each do |data| %>
+                  <li>
+                    <%= govuk_link_to(
+                      data["reference"],
+                      admin_claim_tasks_path(data["id"])
+                    ) %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/journey_configurations/_edit_early_years_payment_provider.html.erb
+++ b/app/views/admin/journey_configurations/_edit_early_years_payment_provider.html.erb
@@ -1,6 +1,14 @@
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
 <h2 class="govuk-heading-m">
+  Early years providers overview
+</h2>
+
+<%= govuk_link_to("View providers", admin_early_years_providers_path) %>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h2 class="govuk-heading-m">
   Download eligible EY providers
 </h2>
 

--- a/app/views/further_education_payments/providers/sessions/_dfe_sign_in_by_pass.html.erb
+++ b/app/views/further_education_payments/providers/sessions/_dfe_sign_in_by_pass.html.erb
@@ -75,5 +75,5 @@
     ) %>
   </div>
 
-  <%= f.govuk_submit("Start now")%>
+  <%= f.govuk_submit("Start now") %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,8 @@ Rails.application.routes.draw do
     resource :eligible_fe_providers, only: [:create, :show], path: "eligible-further-education-providers"
     resources :reports, only: [:index, :show]
 
+    resources :early_years_providers, only: [:index]
+
     get "refresh-session", to: "sessions#refresh", as: :refresh_session
 
     patch "allocate/:id", to: "allocations#allocate", as: :allocate

--- a/spec/features/admin/early_years/providers_search_spec.rb
+++ b/spec/features/admin/early_years/providers_search_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "Providers Search" do
+  before do
+    journey_config = create(
+      :journey_configuration,
+      :early_years_payment_provider_authenticated
+    )
+
+    provider_1 = create(
+      :eligible_ey_provider,
+      nursery_name: "Happy Kids Nursery",
+      primary_key_contact_email_address: "hkn@example.com",
+      max_claims: 5
+    )
+
+    2.times do
+      create(
+        :claim,
+        policy: Policies::EarlyYearsPayments,
+        eligibility_attributes: {
+          nursery_urn: provider_1.urn
+        },
+        academic_year: journey_config.current_academic_year
+      )
+    end
+
+    _provider_2 = create(
+      :eligible_ey_provider,
+      nursery_name: "Sunny Days Nursery",
+      primary_key_contact_email_address: "sdn@example.com",
+      max_claims: 10
+    )
+  end
+
+  it "requires admin authentication" do
+    visit admin_early_years_providers_path
+
+    expect(page).to have_current_path("/admin/auth/sign-in")
+  end
+
+  it "shows provider claims" do
+    sign_in_as_service_operator
+
+    visit admin_early_years_providers_path
+
+    within("tbody tr:first-of-type") do
+      expect(page).to have_content("Happy Kids Nursery")
+      expect(page).to have_content("hkn@example.com")
+      expect(page).to have_content("5")
+      expect(page).to have_content("2") # claims made
+    end
+
+    within("tbody tr:last-of-type") do
+      expect(page).to have_content("Sunny Days Nursery")
+      expect(page).to have_content("sdn@example.com")
+      expect(page).to have_content("10")
+      expect(page).to have_content("0") # claims made
+    end
+  end
+
+  it "allows searching for providers by name or email" do
+    sign_in_as_service_operator
+
+    visit admin_early_years_providers_path
+
+    fill_in(
+      "Search by nursery name or primary contact email address",
+      with: "Happy"
+    )
+
+    click_button "Search"
+
+    expect(page).to have_content("Happy Kids Nursery")
+    expect(page).not_to have_content("Sunny Days Nursery")
+
+    fill_in(
+      "Search by nursery name or primary contact email address",
+      with: "sdn@example.com"
+    )
+
+    click_button "Search"
+
+    expect(page).to have_content("Sunny Days Nursery")
+    expect(page).not_to have_content("Happy Kids Nursery")
+  end
+end


### PR DESCRIPTION
The ops team currently maintain a spreadsheet of claims submitted by
provider. We have this information in the system. This commit adds a
simple searchable dashboard for ops to check the number of claims
submitted by a given provider against their claim allowance.
Theres ~450 providers on production. We're only returning a
handful of attributes from the DB, and this page isn't likely to be
frequently visited so we can trade off pagination for ability to scan
the whole data set.
