### PR TITLE
Fix employment check

### DIFF
--- a/app/models/automated_checks/claim_verifiers/employment.rb
+++ b/app/models/automated_checks/claim_verifiers/employment.rb
@@ -7,11 +7,9 @@ module AutomatedChecks
       def initialize(claim:, admin_user: nil)
         self.admin_user = admin_user
         self.claim = claim
-        self.teachers_pensions_service = TeachersPensionsService.by_teacher_reference_number(claim.eligibility.teacher_reference_number)
       end
 
       def perform
-        return if claim.policy == Policies::StudentLoans # disabled as algorithm has errors and should be redesigned and mapped to current service logic
         return unless required?
         return unless awaiting_task?
 
@@ -24,38 +22,10 @@ module AutomatedChecks
         claim.eligibility.teacher_reference_number.present?
       end
 
-      attr_accessor :admin_user, :claim, :teachers_pensions_service
+      attr_accessor :admin_user, :claim
 
       def awaiting_task?
         claim.tasks.where(name: TASK_NAME).count.zero?
-      end
-
-      def teachers_pensions_service_schools
-        return [] if teachers_pensions_service.empty?
-
-        @teachers_pensions_service_schools ||= begin
-          from = claim.submitted_at.beginning_of_month.prev_month
-          to = claim.submitted_at.end_of_month
-
-          teachers_pensions_service
-            .between_claim_dates(from, to)
-            .map { |r| [r.la_urn, r.school_urn] }
-            .uniq
-        end
-      end
-
-      def teachers_pensions_service_claim_schools
-        return [] unless teachers_pensions_service.any? && claim.policy == Policies::StudentLoans
-
-        @teachers_pensions_service_claim_schools ||= begin
-          latest_start_date = end_of_previous_financial_year - 1.month
-          earliest_end_date = start_of_previous_financial_year + 1.month
-
-          teachers_pensions_service
-            .claim_dates_interval(latest_start_date, earliest_end_date)
-            .map { |r| [r.la_urn, r.school_urn] }
-            .uniq
-        end
       end
 
       def start_of_previous_financial_year
@@ -68,13 +38,13 @@ module AutomatedChecks
       end
 
       def no_data
-        return unless teachers_pensions_service.empty?
+        return unless claimant_tps_records.empty?
 
         create_task(match: nil)
       end
 
       def no_match
-        return unless teachers_pensions_service.empty? || !eligible?
+        return unless claimant_tps_records.empty? || !eligible?
 
         create_task(match: :none)
       end
@@ -86,17 +56,48 @@ module AutomatedChecks
       end
 
       def eligible?
-        eligible_current_school = eligible_school?(teachers_pensions_service_schools, claim.eligibility.current_school)
-
-        return eligible_current_school unless claim.policy == Policies::StudentLoans && eligible_current_school
-
-        eligible_school?(teachers_pensions_service_claim_schools, claim.eligibility.claim_school)
+        if claim.policy == Policies::StudentLoans
+          worked_at_eligible_school_during_month_of_making_claim? &&
+            worked_at_eligible_school_during_previous_financial_year?
+        else
+          worked_at_eligible_school_during_month_of_making_claim?
+        end
       end
 
-      def eligible_school?(tps_schools, school)
-        tps_schools.select do |code, establishment_number|
-          school.local_authority.code == code && school.establishment_number == establishment_number
-        end.any?
+      def worked_at_eligible_school_during_month_of_making_claim?
+        school_during_claim_month = claim.eligibility.current_school
+
+        tps_records_during_month_of_claim.any? do |tps_record|
+          tps_record.for_school?(school_during_claim_month)
+        end
+      end
+
+      def tps_records_during_month_of_claim
+        previous_month_start = claim.submitted_at.beginning_of_month.prev_month
+        end_of_month = claim.submitted_at.end_of_month
+
+        claimant_tps_records.covering_dates(previous_month_start, end_of_month)
+      end
+
+      def worked_at_eligible_school_during_previous_financial_year?
+        school_during_previous_financial_year = claim.eligibility.claim_school
+
+        tps_records_during_previous_financial_year.any? do |tps_record|
+          tps_record.for_school?(school_during_previous_financial_year)
+        end
+      end
+
+      def tps_records_during_previous_financial_year
+        claimant_tps_records.covering_dates(
+          start_of_previous_financial_year,
+          end_of_previous_financial_year
+        )
+      end
+
+      def claimant_tps_records
+        TeachersPensionsService.where(
+          teacher_reference_number: claim.eligibility.teacher_reference_number
+        )
       end
 
       def create_task(match:, passed: nil)
@@ -113,28 +114,44 @@ module AutomatedChecks
         task
       end
 
-      def create_note(match:)
-        body = if teachers_pensions_service.empty?
-          "[Employment] - No data"
-        else
-          schools_details = ""
-          teachers_pensions_service_schools.each do |school|
-            schools_details += "Current school: LA Code: #{school[0]} / Establishment Number: #{school[1]}\n"
-          end
+      def note_body(match:)
+        return "[Employment] - No data" if claimant_tps_records.empty?
+        notes = []
 
-          teachers_pensions_service_claim_schools.each do |school|
-            schools_details += "Claim school: LA Code: #{school[0]} / Establishment Number: #{school[1]}\n"
-          end
+        uniq_tps_schools_in_month_of_claim = tps_records_during_month_of_claim
+          .map { |tps_record| [tps_record.la_urn, tps_record.school_urn] }
+          .uniq
 
-          <<~HTML
-            [Employment] - #{(match == :none) ? "Ine" : "E"}ligible:
-            <pre>#{schools_details}</pre>
-          HTML
+        uniq_tps_schools_in_month_of_claim.each do |la_urn, school_urn|
+          notes << "Current school: LA Code: #{la_urn} / Establishment Number: #{school_urn}"
         end
 
+        if claim.policy == Policies::StudentLoans
+          uniq_tps_schools_in_previous_financial_year = tps_records_during_previous_financial_year
+            .map { |tps_record| [tps_record.la_urn, tps_record.school_urn] }
+            .uniq
+
+          uniq_tps_schools_in_previous_financial_year.each do |la_urn, school_urn|
+            notes << "Claim school: LA Code: #{la_urn} / Establishment Number: #{school_urn}"
+          end
+        end
+
+        eligible_state = ((match == :all) ? "Eligible" : "Ineligible")
+
+        prefix = "[Employment] - #{eligible_state}:"
+
+        schools_details = notes.join("\n")
+
+        <<~HTML
+          #{prefix}
+          <pre>#{schools_details}\n</pre>
+        HTML
+      end
+
+      def create_note(match:)
         claim.notes.create!(
           {
-            body: body,
+            body: note_body(match: match),
             label: TASK_NAME,
             created_by: admin_user
           }

--- a/app/models/automated_checks/claim_verifiers/employment.rb
+++ b/app/models/automated_checks/claim_verifiers/employment.rb
@@ -44,13 +44,21 @@ module AutomatedChecks
       end
 
       def no_match
-        return unless claimant_tps_records.empty? || !eligible?
+        if claimant_tps_records.empty?
+          # call no_data first
+          raise "Attempting to create a no match when no tps records exist"
+        end
+
+        return if eligible?
 
         create_task(match: :none)
       end
 
       def matched
-        return unless eligible?
+        unless eligible?
+          # call no_match first
+          raise "Attempting to create a match when the claim is not eligible"
+        end
 
         create_task(match: :all, passed: true)
       end
@@ -115,7 +123,8 @@ module AutomatedChecks
       end
 
       def note_body(match:)
-        return "[Employment] - No data" if claimant_tps_records.empty?
+        return "[Employment] - No data" if match.nil?
+
         notes = []
 
         uniq_tps_schools_in_month_of_claim = tps_records_during_month_of_claim

--- a/app/models/teachers_pensions_service.rb
+++ b/app/models/teachers_pensions_service.rb
@@ -11,10 +11,17 @@ class TeachersPensionsService < ApplicationRecord
   # Be careful with boundary comparisons and time zones.
 
   scope :by_teacher_reference_number, ->(teacher_reference_number) { where(teacher_reference_number: teacher_reference_number) }
-  scope :between_claim_dates, ->(start_date, end_date) { where(start_date: start_date..end_date) }
-  scope :claim_dates_interval, ->(latest_start_date, earliest_end_date) { where(start_date: ..latest_start_date).or(where(end_date: earliest_end_date..)) }
   scope :ended_on_or_after, ->(earliest_end_date) { where(end_date: earliest_end_date..) }
   scope :employed_between, ->(start_date, end_date) { where(end_date: start_date..).and(where(start_date: ..end_date)) }
+
+  scope :covering_dates, ->(first_date, last_date) do
+    where(
+      <<~SQL, last_date: last_date, first_date: first_date
+        start_date < :last_date
+        AND (end_date >= :first_date OR end_date IS NULL)
+      SQL
+    )
+  end
 
   def self.recent_tps_school(claim_date:, teacher_reference_number:)
     earliest_end_date = (claim_date - RECENT_TPS_FULL_MONTHS).beginning_of_month
@@ -55,5 +62,10 @@ class TeachersPensionsService < ApplicationRecord
   def self.school_for_tps_record(tps_record)
     # The TPS data is labelled 'URN' but is actually the DfE establishment number
     School.open.joins(:local_authority).find_by(establishment_number: tps_record.school_urn, local_authority: {code: tps_record.la_urn})
+  end
+
+  def for_school?(school)
+    school_urn == school.establishment_number &&
+      la_urn == school.local_authority.code
   end
 end

--- a/spec/models/automated_checks/claim_verifiers/employment_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/employment_spec.rb
@@ -389,6 +389,90 @@ module AutomatedChecks
             expect(task.claim_verifier_match).to eq("none")
             expect(task.passed).to be_nil
           end
+
+          it "passes when claim school employment starts exactly on 6 April (previous FY start boundary)" do
+            create(:journey_configuration, :student_loans, current_academic_year: "2025/2026")
+
+            current_school = create(:school, :student_loans_eligible,
+              establishment_number: 1234,
+              local_authority: local_authority_camden)
+
+            claim_school = create(:school, :student_loans_eligible,
+              establishment_number: 5678,
+              local_authority: local_authority_barnsley)
+
+            claim = create(:claim, :submitted,
+              policy: Policies::StudentLoans,
+              submitted_at: DateTime.new(2025, 1, 12, 13, 0, 0))
+
+            claim.eligibility.update!(
+              attributes_for(:student_loans_eligibility, :eligible,
+                current_school_id: current_school.id,
+                teacher_reference_number: 1334426)
+            )
+            claim.eligibility.update!(claim_school: claim_school)
+
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 202,
+              school_urn: 1234,
+              start_date: DateTime.new(2025, 1, 1, 16, 0, 0))
+
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 370,
+              school_urn: 5678,
+              start_date: DateTime.new(2024, 4, 6, 0, 0, 0),
+              end_date: DateTime.new(2024, 6, 1, 16, 0, 0))
+
+            described_class.new(claim: claim).perform
+            task = claim.tasks.find_by(name: "employment")
+
+            expect(task.claim_verifier_match).to eq("all")
+            expect(task.passed).to eq(true)
+          end
+
+          it "passes when claim school employment ends exactly on 5 April (previous FY end boundary)" do
+            create(:journey_configuration, :student_loans, current_academic_year: "2025/2026")
+
+            current_school = create(:school, :student_loans_eligible,
+              establishment_number: 1234,
+              local_authority: local_authority_camden)
+
+            claim_school = create(:school, :student_loans_eligible,
+              establishment_number: 5678,
+              local_authority: local_authority_barnsley)
+
+            claim = create(:claim, :submitted,
+              policy: Policies::StudentLoans,
+              submitted_at: DateTime.new(2025, 1, 12, 13, 0, 0))
+
+            claim.eligibility.update!(
+              attributes_for(:student_loans_eligibility, :eligible,
+                current_school_id: current_school.id,
+                teacher_reference_number: 1334426)
+            )
+            claim.eligibility.update!(claim_school: claim_school)
+
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 202,
+              school_urn: 1234,
+              start_date: DateTime.new(2025, 1, 1, 16, 0, 0))
+
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 370,
+              school_urn: 5678,
+              start_date: DateTime.new(2025, 3, 1, 16, 0, 0),
+              end_date: DateTime.new(2025, 4, 5, 0, 0, 0))
+
+            described_class.new(claim: claim).perform
+            task = claim.tasks.find_by(name: "employment")
+
+            expect(task.claim_verifier_match).to eq("all")
+            expect(task.passed).to eq(true)
+          end
         end
       end
     end

--- a/spec/models/automated_checks/claim_verifiers/employment_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/employment_spec.rb
@@ -120,30 +120,6 @@ module AutomatedChecks
               it { is_expected.to eq(nil) }
             end
           end
-
-          context "when the claim is TSLR" do
-            subject(:perform) { employment.perform }
-
-            let(:teacher_reference_number) { 1334426 }
-            let!(:school) do
-              create(:school,
-                :student_loans_eligible,
-                establishment_number: 8091,
-                local_authority: local_authority_camden)
-            end
-
-            let(:policy) { Policies::StudentLoans }
-
-            before { claim_arg.eligibility.update!(claim_school: school) }
-
-            it "returns early and does not create an employment task or note" do
-              verifier = described_class.new(claim: claim_arg)
-
-              expect { verifier.perform }
-                .to not_change { claim_arg.tasks.where(name: "employment").count }
-                .and not_change { claim_arg.notes.where(label: "employment").count }
-            end
-          end
         end
 
         context "with no matching Employment record" do
@@ -276,6 +252,142 @@ module AutomatedChecks
 
           it "does not create duplicate tasks or notes" do
             expect { perform }.not_to change { [claim_arg.reload.notes.count, claim_arg.tasks.count] }
+          end
+        end
+
+        # With current_academic_year "2025/2026":
+        # Previous financial year: Apr 6 2024 to Apr 5 2025
+        context "when checking Student Loans claim school employment in previous financial year" do
+          it "passes when the claimant was employed at the claim school during the previous financial year" do
+            create(:journey_configuration, :student_loans, current_academic_year: "2025/2026")
+
+            current_school = create(:school, :student_loans_eligible,
+              establishment_number: 1234,
+              local_authority: local_authority_camden)
+
+            claim_school = create(:school, :student_loans_eligible,
+              establishment_number: 5678,
+              local_authority: local_authority_barnsley)
+
+            claim = create(:claim, :submitted,
+              policy: Policies::StudentLoans,
+              submitted_at: DateTime.new(2025, 1, 12, 13, 0, 0))
+
+            claim.eligibility.update!(
+              attributes_for(:student_loans_eligibility, :eligible,
+                current_school_id: current_school.id,
+                teacher_reference_number: 1334426)
+            )
+            claim.eligibility.update!(claim_school: claim_school)
+
+            # TPS record at current school within submission month window (Dec 2024 - Jan 2025)
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 202,
+              school_urn: 1234,
+              start_date: DateTime.new(2025, 1, 1, 16, 0, 0))
+
+            # TPS record at claim school during the previous financial year
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 370,
+              school_urn: 5678,
+              start_date: DateTime.new(2024, 9, 1, 16, 0, 0),
+              end_date: DateTime.new(2025, 2, 1, 16, 0, 0))
+
+            described_class.new(claim: claim).perform
+            task = claim.tasks.find_by(name: "employment")
+
+            expect(task.claim_verifier_match).to eq("all")
+            expect(task.passed).to eq(true)
+          end
+
+          it "does not pass when the claimant's employment at the claim school ended before the previous financial year" do
+            create(:journey_configuration, :student_loans, current_academic_year: "2025/2026")
+
+            current_school = create(:school, :student_loans_eligible,
+              establishment_number: 1234,
+              local_authority: local_authority_camden)
+
+            claim_school = create(:school, :student_loans_eligible,
+              establishment_number: 5678,
+              local_authority: local_authority_barnsley)
+
+            claim = create(:claim, :submitted,
+              policy: Policies::StudentLoans,
+              submitted_at: DateTime.new(2025, 1, 12, 13, 0, 0))
+
+            claim.eligibility.update!(
+              attributes_for(:student_loans_eligibility, :eligible,
+                current_school_id: current_school.id,
+                teacher_reference_number: 1334426)
+            )
+            claim.eligibility.update!(claim_school: claim_school)
+
+            # TPS record at current school within submission month window (Dec 2024 - Jan 2025)
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 202,
+              school_urn: 1234,
+              start_date: DateTime.new(2025, 1, 1, 16, 0, 0))
+
+            # TPS record at claim school that ENDED BEFORE the previous financial year (before Apr 6 2024)
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 370,
+              school_urn: 5678,
+              start_date: DateTime.new(2023, 6, 1, 16, 0, 0),
+              end_date: DateTime.new(2024, 3, 1, 16, 0, 0))
+
+            described_class.new(claim: claim).perform
+            task = claim.tasks.find_by(name: "employment")
+
+            expect(task.claim_verifier_match).to eq("none")
+            expect(task.passed).to be_nil
+          end
+
+          it "does not pass when the claimant's employment at the claim school started after the previous financial year" do
+            create(:journey_configuration, :student_loans, current_academic_year: "2025/2026")
+
+            current_school = create(:school, :student_loans_eligible,
+              establishment_number: 1234,
+              local_authority: local_authority_camden)
+
+            claim_school = create(:school, :student_loans_eligible,
+              establishment_number: 5678,
+              local_authority: local_authority_barnsley)
+
+            claim = create(:claim, :submitted,
+              policy: Policies::StudentLoans,
+              submitted_at: DateTime.new(2025, 1, 12, 13, 0, 0))
+
+            claim.eligibility.update!(
+              attributes_for(:student_loans_eligibility, :eligible,
+                current_school_id: current_school.id,
+                teacher_reference_number: 1334426)
+            )
+            claim.eligibility.update!(claim_school: claim_school)
+
+            # TPS record at current school within submission month window (Dec 2024 - Jan 2025)
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 202,
+              school_urn: 1234,
+              start_date: DateTime.new(2025, 1, 1, 16, 0, 0))
+
+            # TPS record at claim school that STARTED AFTER the previous financial year (after Apr 5 2025)
+            create(:teachers_pensions_service,
+              teacher_reference_number: 1334426,
+              la_urn: 370,
+              school_urn: 5678,
+              start_date: DateTime.new(2025, 5, 1, 16, 0, 0),
+              end_date: DateTime.new(2025, 8, 1, 16, 0, 0))
+
+            described_class.new(claim: claim).perform
+            task = claim.tasks.find_by(name: "employment")
+
+            expect(task.claim_verifier_match).to eq("none")
+            expect(task.passed).to be_nil
           end
         end
       end

--- a/spec/models/teachers_pensions_service_spec.rb
+++ b/spec/models/teachers_pensions_service_spec.rb
@@ -120,4 +120,166 @@ RSpec.describe TeachersPensionsService do
       end
     end
   end
+
+  describe ".covering_dates" do
+    it "includes a record fully within the date range" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2023, 3, 1),
+        end_date: Date.new(2023, 3, 31)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).to include(record)
+    end
+
+    it "includes a record that starts before and ends within the date range" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2022, 11, 1),
+        end_date: Date.new(2023, 2, 15)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).to include(record)
+    end
+
+    it "includes a record that starts within and ends after the date range" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2023, 5, 1),
+        end_date: Date.new(2023, 8, 31)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).to include(record)
+    end
+
+    it "includes a record that completely spans the date range" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2022, 6, 1),
+        end_date: Date.new(2023, 12, 31)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).to include(record)
+    end
+
+    it "includes a record with a nil end_date when start_date is before last_date" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2023, 3, 1),
+        end_date: nil
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).to include(record)
+    end
+
+    it "excludes a record that ends before the date range starts" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2022, 6, 1),
+        end_date: Date.new(2022, 12, 31)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).not_to include(record)
+    end
+
+    it "excludes a record that starts on or after the last_date" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2023, 7, 1),
+        end_date: Date.new(2023, 8, 31)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).not_to include(record)
+    end
+
+    it "includes a record whose end_date equals the first_date exactly" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2022, 11, 1),
+        end_date: Date.new(2023, 1, 1)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).to include(record)
+    end
+
+    it "excludes a record whose end_date is one day before the first_date" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2022, 11, 1),
+        end_date: Date.new(2022, 12, 31)
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).not_to include(record)
+    end
+
+    it "excludes a record with a nil end_date when start_date is on or after last_date" do
+      record = create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: Date.new(2023, 7, 1),
+        end_date: nil
+      )
+
+      result = described_class.covering_dates(
+        Date.new(2023, 1, 1),
+        Date.new(2023, 6, 1)
+      )
+
+      expect(result).not_to include(record)
+    end
+  end
 end

--- a/spec/requests/admin/admin_tps_data_upload_spec.rb
+++ b/spec/requests/admin/admin_tps_data_upload_spec.rb
@@ -171,9 +171,9 @@ RSpec.describe "TPS data upload" do
         let(:csv) do
           <<~CSV
             Teacher reference number,NINO,Start Date,End Date,LA URN,School URN,Employer ID
-            1000106,ZX043155C,01/07/2022,30/09/2022,#{school.local_authority.code},#{school.establishment_number},1122
+            1000106,ZX043155C,01/07/2022,30/09/2022,371,111123,1122
             1000107,ZX043155C,01/07/2022,30/09/2022,111,2222,1122
-            1000106,ZX043155C,01/07/2021,30/03/2022,#{school.local_authority.code},#{school.establishment_number},1122
+            1000106,ZX043155C,01/04/2021,30/03/2022,371,111123,1122
           CSV
         end
 
@@ -229,9 +229,27 @@ RSpec.describe "TPS data upload" do
             expect(claim_matched.tasks.last.claim_verifier_match).to eq "all"
             expect(claim_no_match.tasks.last.claim_verifier_match).to eq "none"
             expect(claim_no_data.tasks.last.claim_verifier_match).to be_nil
-            expect(claim_matched.notes.last[:body]).to eq "[Employment] - Eligible:\n<pre>Current school: LA Code: #{school.local_authority.code} / Establishment Number: #{school.establishment_number}\nClaim school: LA Code: #{school.local_authority.code} / Establishment Number: #{school.establishment_number}\n</pre>\n"
-            expect(claim_no_match.notes.last[:body]).to eq "[Employment] - Ineligible:\n<pre>Current school: LA Code: 111 / Establishment Number: 2222\nClaim school: LA Code: 111 / Establishment Number: 2222\n</pre>\n"
-            expect(claim_no_data.notes.last[:body]).to eq "[Employment] - No data"
+
+            expect(claim_matched.notes.last[:body]).to eq(
+              <<~TEXT
+                [Employment] - Eligible:
+                <pre>Current school: LA Code: 371 / Establishment Number: 111123
+                Claim school: LA Code: 371 / Establishment Number: 111123
+                </pre>
+              TEXT
+            )
+
+            expect(claim_no_match.notes.last[:body]).to eq(
+              <<~TEXT
+                [Employment] - Ineligible:
+                <pre>Current school: LA Code: 111 / Establishment Number: 2222
+                </pre>
+              TEXT
+            )
+
+            expect(claim_no_data.notes.last[:body]).to eq(
+              "[Employment] - No data"
+            )
 
             expect(response).to redirect_to(admin_claims_path)
           end

--- a/spec/requests/admin/admin_tps_data_upload_spec.rb
+++ b/spec/requests/admin/admin_tps_data_upload_spec.rb
@@ -156,7 +156,15 @@ RSpec.describe "TPS data upload" do
       context "when the claim is TSLR" do
         before { create(:journey_configuration, :student_loans, current_academic_year: "2021/2022") }
 
-        let(:school) { create(:school, :student_loans_eligible) }
+        let(:local_authority) { create(:local_authority, code: "371") }
+        let(:school) do
+          create(
+            :school,
+            :student_loans_eligible,
+            establishment_number: "111123",
+            local_authority: local_authority
+          )
+        end
         let(:claim_school) { school }
         let(:current_school) { claim_school }
 
@@ -203,18 +211,27 @@ RSpec.describe "TPS data upload" do
           )
         end
 
-        it "does not create employment tasks or notes and redirects to the right page" do
-          aggregate_failures "no tasks or notes created for TSLR" do
-            expect { upload_tps_data_csm_file(file) }.to not_change {
-              [
-                claim_matched.reload.tasks.size,
-                claim_no_match.reload.tasks.size,
-                claim_no_data.reload.tasks.size,
-                claim_matched.reload.notes.size,
-                claim_no_match.reload.notes.size,
-                claim_no_data.reload.notes.size
-              ]
-            }
+        it "runs the tasks, adds notes and redirects to the right page" do
+          aggregate_failures "testing tasks and notes" do
+            expect { upload_tps_data_csm_file(file) }.to(
+              change do
+                [
+                  claim_matched.reload.tasks.size,
+                  claim_no_match.reload.tasks.size,
+                  claim_no_data.reload.tasks.size,
+                  claim_matched.reload.notes.size,
+                  claim_no_match.reload.notes.size,
+                  claim_no_data.reload.notes.size
+                ]
+              end
+            )
+
+            expect(claim_matched.tasks.last.claim_verifier_match).to eq "all"
+            expect(claim_no_match.tasks.last.claim_verifier_match).to eq "none"
+            expect(claim_no_data.tasks.last.claim_verifier_match).to be_nil
+            expect(claim_matched.notes.last[:body]).to eq "[Employment] - Eligible:\n<pre>Current school: LA Code: #{school.local_authority.code} / Establishment Number: #{school.establishment_number}\nClaim school: LA Code: #{school.local_authority.code} / Establishment Number: #{school.establishment_number}\n</pre>\n"
+            expect(claim_no_match.notes.last[:body]).to eq "[Employment] - Ineligible:\n<pre>Current school: LA Code: 111 / Establishment Number: 2222\nClaim school: LA Code: 111 / Establishment Number: 2222\n</pre>\n"
+            expect(claim_no_data.notes.last[:body]).to eq "[Employment] - No data"
 
             expect(response).to redirect_to(admin_claims_path)
           end
@@ -224,19 +241,100 @@ RSpec.describe "TPS data upload" do
           let(:csv) do
             <<~CSV
               Teacher reference number,NINO,Start Date,End Date,LA URN,School URN,Employer ID
-              1000106,ZX043155C,01/07/2022,30/09/2022,371,#{school.establishment_number},1122
-              1000106,ZX043155C,01/07/2021,30/03/2022,#{school.local_authority.code},#{school.establishment_number},1122
+              1000106,ZX043155C,01/07/2021,30/09/2021,371,111123,1122
+              1000106,ZX043155C,01/07/2020,01/01/2022,371,111123,1122
             CSV
           end
 
-          it "does not create employment tasks or notes and redirects to the right page", flaky: true do
-            aggregate_failures "no tasks or notes created for TSLR" do
-              expect { upload_tps_data_csm_file(file) }.to not_change {
-                [
-                  claim_matched.reload.tasks.size,
-                  claim_matched.reload.notes.size
-                ]
-              }
+          it "runs the tasks, adds notes and redirects to the right page", flaky: true do
+            aggregate_failures "testing tasks and notes" do
+              expect { upload_tps_data_csm_file(file) }.to(
+                change do
+                  [
+                    claim_matched.reload.tasks.size,
+                    claim_matched.reload.notes.size
+                  ]
+                end
+              )
+
+              expect(claim_matched.tasks.last.claim_verifier_match).to eq "none"
+              expect(claim_matched.notes.last[:body]).to eq(
+                <<~TEXT
+                  [Employment] - Ineligible:
+                  <pre>Claim school: LA Code: 371 / Establishment Number: 111123
+                  </pre>
+                TEXT
+              )
+
+              expect(response).to redirect_to(admin_claims_path)
+            end
+          end
+        end
+
+        context "when a current school is eligible and the claim school is ineligible" do
+          let(:csv) do
+            <<~CSV
+              Teacher reference number,NINO,Start Date,End Date,LA URN,School URN,Employer ID
+              1000106,ZX043155C,01/07/2022,30/09/2022,371,111123,1122
+              1000106,ZX043155C,01/07/2021,30/03/2022,371,111123,1122
+            CSV
+          end
+
+          it "runs the tasks, adds notes and redirects to the right page", flaky: true do
+            aggregate_failures "testing tasks and notes" do
+              expect { upload_tps_data_csm_file(file) }.to(
+                change do
+                  [
+                    claim_matched.reload.tasks.size,
+                    claim_matched.reload.notes.size
+                  ]
+                end
+              )
+
+              expect(claim_matched.tasks.last.claim_verifier_match).to eq "none"
+              expect(claim_matched.notes.last[:body]).to eq(
+                <<~TEXT
+                  [Employment] - Ineligible:
+                  <pre>Current school: LA Code: 371 / Establishment Number: 111123
+                  </pre>
+                TEXT
+              )
+
+              expect(response).to redirect_to(admin_claims_path)
+            end
+          end
+        end
+
+        context "when a current school is eligible and the claim school is eligible" do
+          let(:csv) do
+            <<~CSV
+              Teacher reference number,NINO,Start Date,End Date,LA URN,School URN,Employer ID
+              1000106,ZX043155C,01/07/2022,30/09/2022,371,111123,1122
+              1000106,ZX043155C,01/07/2021,30/03/2022,371,111123,1122
+              1000106,ZX043155C,01/07/2020,30/08/2020,371,111123,1122
+            CSV
+          end
+
+          it "runs the tasks, adds notes and redirects to the right page", flaky: true do
+            aggregate_failures "testing tasks and notes" do
+              expect { upload_tps_data_csm_file(file) }.to(
+                change do
+                  [
+                    claim_matched.reload.tasks.size,
+                    claim_matched.reload.notes.size
+                  ]
+                end
+              )
+
+              expect(claim_matched.tasks.last.claim_verifier_match).to eq "all"
+              expect(claim_matched.notes.last[:body]).to eq(
+                <<~TEXT
+                  [Employment] - Eligible:
+                  <pre>Current school: LA Code: 371 / Establishment Number: 111123
+                  Claim school: LA Code: 371 / Establishment Number: 111123
+                  </pre>
+                TEXT
+              )
 
               expect(response).to redirect_to(admin_claims_path)
             end


### PR DESCRIPTION
Fix employment check

The employment check wasn't scoping TPS records correctly, it was
checking if the claimant had an employment start date before the end of
the previous financial year OR they had an employment end date after the
end of the previous financial year, not that they were employed during
the previous financial year.

The tests in `spec/requests/admin/admin_tps_data_upload_spec.rb` were
incorrectly passing and have been updated. Previously the specs set up a note
which was `Ineligibile` and had both a "Current school" and two "Claim school"
rows. If there is a "Current school" and a "Claim school" in the notes then the
note should not be "Ineligibile", to create an "Ineligibile" note for TSLR there
should be either only a claim school or a current school. Also the notes in the
specs had a "Current school" row and _two_ "Claim school" rows, as due to the
scoping bug, where any TPS entry with an end date after the previous financial
year was returned, the "Current school" was being counted as one of the "Claim
schools".
