### PR TITLE
[CAPT-3478] Teacher auth for review apps

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -34,8 +34,8 @@ CANONICAL_HOSTNAME=localhost:3000
 EY_MAGIC_LINK_SECRET=some-secret-for-ey-magic-link
 
 BYPASS_TEACHER_AUTH=false
-TEACHER_AUTH_CLIENT_ID=
-TEACHER_AUTH_SECRET=
+TEACHER_AUTH_CLIENT_ID=teacher-auth-client-id
+TEACHER_AUTH_SECRET=teacher-auth-secret
 TEACHER_AUTH_ISSUER=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
 TEACHER_AUTH_REDIRECT_BASE_URL=http://localhost:3000
 TEACHER_AUTH_JWKS_URI=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks

--- a/.env.development
+++ b/.env.development
@@ -32,3 +32,10 @@ ONELOGIN_JWKS_URL=https://oidc.integration.account.gov.uk/.well-known/jwks.json
 
 CANONICAL_HOSTNAME=localhost:3000
 EY_MAGIC_LINK_SECRET=some-secret-for-ey-magic-link
+
+BYPASS_TEACHER_AUTH=false
+TEACHER_AUTH_CLIENT_ID=
+TEACHER_AUTH_SECRET=
+TEACHER_AUTH_ISSUER=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
+TEACHER_AUTH_REDIRECT_BASE_URL=http://localhost:3000
+TEACHER_AUTH_JWKS_URI=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks

--- a/.env.test
+++ b/.env.test
@@ -50,3 +50,10 @@ ONELOGIN_JWKS_URL=https://oidc.integration.account.gov.uk/.well-known/jwks.json
 CANONICAL_HOSTNAME=www.example.com
 
 EY_MAGIC_LINK_SECRET=some-secret-for-ey-magic-link
+
+BYPASS_TEACHER_AUTH=false
+TEACHER_AUTH_CLIENT_ID=teacher-auth-client-id
+TEACHER_AUTH_SECRET=teacher-auth-secret
+TEACHER_AUTH_ISSUER=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
+TEACHER_AUTH_REDIRECT_BASE_URL=http://localhost:3000
+TEACHER_AUTH_JWKS_URI=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,11 @@ RUN DFE_SIGN_IN_API_CLIENT_ID= \
   GOVUK_APP_DOMAIN= \
   GOVUK_WEBSITE_ROOT= \
   SECRET_KEY_BASE_DUMMY=1 \
+  TEACHER_AUTH_CLIENT_ID="teacher-auth-client-id" \
+  TEACHER_AUTH_SECRET="teacher-auth-secret" \
+  TEACHER_AUTH_ISSUER="https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/" \
+  TEACHER_AUTH_REDIRECT_BASE_URL="http://localhost:3000" \
+  TEACHER_AUTH_JWKS_URI="https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks" \
   bundle exec rake assets:precompile
 
 RUN chown -hR appuser:appgroup ${APP_HOME}

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
@@ -1,0 +1,28 @@
+module Journeys
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class AuthController < BasePublicController
+      def callback
+        persist_callback_to_session
+
+        redirect_to claim_path(current_journey_routing_name, "trn-found")
+      end
+
+      private
+
+      def omniauth_hash
+        @omniauth_hash ||= request.env["omniauth.auth"]
+      end
+
+      def persist_callback_to_session
+        journey_session.answers.assign_attributes(
+          teacher_auth_teacher_reference_number: omniauth_hash.extra.raw_info.trn,
+          teacher_auth_email: omniauth_hash.extra.raw_info.email,
+          teacher_auth_verified_name: omniauth_hash.extra.raw_info.verified_name.join(" "),
+          teacher_auth_verified_date_of_birth: Date.parse(omniauth_hash.extra.raw_info.verified_date_of_birth),
+          teacher_auth_one_login_uid: omniauth_hash.extra.raw_info.sub
+        )
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/trn_found_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/trn_found_form.rb
@@ -1,0 +1,9 @@
+module Journeys
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class TrnFoundForm < Form
+      def save
+        true
+      end
+    end
+  end
+end

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
@@ -5,7 +5,8 @@ module Journeys
 
     POLICIES = [Policies::EarlyYearsTeachersFinancialIncentivePayments]
     FORMS = [
-      SignInForm
+      SignInForm,
+      TrnFoundForm
     ]
 
     def available?

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/session_answers.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/session_answers.rb
@@ -1,6 +1,11 @@
 module Journeys
   module EarlyYearsTeachersFinancialIncentivePayments
     class SessionAnswers < Journeys::SessionAnswers
+      attribute :teacher_auth_teacher_reference_number, :string, pii: true
+      attribute :teacher_auth_email, :string, pii: true
+      attribute :teacher_auth_verified_name, :string, pii: true
+      attribute :teacher_auth_verified_date_of_birth, :date, pii: true
+      attribute :teacher_auth_one_login_uid, :string, pii: true
     end
   end
 end

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/slug_sequence.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/slug_sequence.rb
@@ -3,6 +3,7 @@ module Journeys
     class SlugSequence
       SLUGS = %w[
         sign-in
+        trn-found
       ].freeze
 
       SLUGS_HASH = SLUGS.to_h { |slug| [slug, slug] }.freeze
@@ -31,6 +32,7 @@ module Journeys
         array = []
 
         array << SLUGS_HASH["sign-in"]
+        array << SLUGS_HASH["trn-found"]
 
         array
       end

--- a/app/models/teacher_auth/config.rb
+++ b/app/models/teacher_auth/config.rb
@@ -1,0 +1,47 @@
+module TeacherAuth
+  class Config
+    def self.instance
+      @instance ||= new
+    end
+
+    def bypass?
+      (Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_TEACHER_AUTH"] == "true"
+    end
+
+    def callback_path
+      @callback_path ||= "#{path_prefix}/teacher/callback"
+    end
+
+    def path_prefix
+      @path_prefix ||= "/early-years-teachers-financial-incentive-payments/auth"
+    end
+
+    def issuer
+      @issuer ||= ENV["TEACHER_AUTH_ISSUER"]
+    end
+
+    def host
+      @host ||= URI.parse(issuer).host
+    end
+
+    def redirect_base_url
+      return @redirect_base_url if @redirect_base_url
+
+      @redirect_base_url = URI.parse(ENV["TEACHER_AUTH_REDIRECT_BASE_URL"].presence || "https://www.claim-additional-teaching-payment.service.gov.uk")
+
+      if ENV["ENVIRONMENT_NAME"].start_with?("review")
+        @redirect_base_url.host = ENV["CANONICAL_HOSTNAME"]
+      end
+
+      @redirect_base_url
+    end
+
+    def redirect_uri
+      @redirect_uri ||= "#{redirect_base_url}#{path_prefix}"
+    end
+
+    def jwks_uri
+      @jwks_uri ||= ENV["TEACHER_AUTH_JWKS_URI"]
+    end
+  end
+end

--- a/app/models/teacher_auth/config.rb
+++ b/app/models/teacher_auth/config.rb
@@ -37,7 +37,7 @@ module TeacherAuth
     end
 
     def redirect_uri
-      @redirect_uri ||= "#{redirect_base_url}#{path_prefix}"
+      @redirect_uri ||= "#{redirect_base_url}#{callback_path}"
     end
 
     def jwks_uri

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
@@ -1,1 +1,5 @@
 sign in page goes here
+
+<p class="govuk-body">
+  <%= govuk_button_to "/early-years-teachers-financial-incentive-payments/auth/teacher", "/early-years-teachers-financial-incentive-payments/auth/teacher" %>
+</p>

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/trn_found.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/trn_found.html.erb
@@ -1,0 +1,1 @@
+TRN found

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -112,4 +112,29 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       send_scope_to_token_endpoint: false
     }
   end
+
+  provider :openid_connect, {
+    name: :teacher,
+    discovery: true,
+    response_type: :code,
+    scope: %i[openid email profile offline_access teaching_record],
+    send_scope_to_token_endpoint: false,
+    callback_path: TeacherAuth::Config.instance.callback_path,
+    path_prefix: TeacherAuth::Config.instance.path_prefix,
+    issuer: TeacherAuth::Config.instance.issuer,
+    pkce: true,
+    client_options: {
+      port: 443,
+      scheme: "https",
+      host: TeacherAuth::Config.instance.host,
+      identifier: ENV["TEACHER_AUTH_CLIENT_ID"],
+      secret: ENV["TEACHER_AUTH_SECRET"],
+      redirect_uri: TeacherAuth::Config.instance.redirect_uri,
+      authorization_endpoint: "/oauth2/authorize",
+      end_session_endpoint: "/oauth2/logout",
+      token_endpoint: "/oauth2/token",
+      userinfo_endpoint: "/oauth2/userinfo",
+      jwks_uri: TeacherAuth::Config.instance.jwks_uri
+    }
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,10 @@ Rails.application.routes.draw do
       get "auth/sign-out", to: "omniauth_callbacks#sign_out"
     end
 
+    scope constraints: {journey: "early-years-teachers-financial-incentive-payments"} do
+      get "auth/teacher/callback", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback"
+    end
+
     scope path: "/", constraints: {journey: Regexp.new(Journeys.all_routing_names.join("|"))} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end

--- a/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
@@ -6,6 +6,19 @@ RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
       :journey_configuration,
       :early_years_teachers_financial_incentive_payments
     )
+
+    OmniAuth.config.mock_auth[:teacher] = OmniAuth::AuthHash.new({
+      provider: "teacher",
+      extra: {
+        raw_info: {
+          sub: "urn:fdc:gov.uk:2022:#{SecureRandom.base64(30)}",
+          trn: "1234567",
+          email: "john.doe@example.com",
+          verified_name: ["John", "Doe"],
+          verified_date_of_birth: "1970-12-13"
+        }
+      }
+    })
   end
 
   scenario "happy path" do
@@ -13,5 +26,8 @@ RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
     click_link "Start now"
 
     expect(page).to have_text "sign in page goes here"
+    click_button "/early-years-teachers-financial-incentive-payments/auth/teacher"
+
+    expect(page).to have_text "TRN found"
   end
 end

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -12,6 +12,13 @@ ONELOGIN_REDIRECT_BASE_URL: https://www.claim-additional-teaching-payment.servic
 ONELOGIN_DID_URL: https://identity.account.gov.uk/.well-known/did.json
 ONELOGIN_JWKS_URL: https://oidc.account.gov.uk/.well-known/jwks.json
 
+BYPASS_TEACHER_AUTH: false
+TEACHER_AUTH_ISSUER: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
+TEACHER_AUTH_JWKS_URI: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks
+
+TEACHER_AUTH_CLIENT_ID: teacher-auth-client-id
+TEACHER_AUTH_SECRET: teacher-auth-secret
+
 DQT_API_URL: https://teacher-qualifications-api.education.gov.uk/v3/
 DQT_BASE_URL: https://api-customerengagement.platform.education.gov.uk/dqt-crm/v1/
 

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -12,6 +12,10 @@ DFE_SIGN_IN_REDIRECT_BASE_URL: https://claim-additional-payments-for-teaching-re
 
 DFE_SIGN_IN_INTERNAL_CLIENT_ID: teacherpaymentsadmin
 
+BYPASS_TEACHER_AUTH: false
+TEACHER_AUTH_ISSUER: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
+TEACHER_AUTH_JWKS_URI: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks
+
 DQT_API_URL: https://preprod.teacher-qualifications-api.education.gov.uk/v3/
 DQT_BASE_URL: https://test-api-customerengagement.platform.education.gov.uk/dqt-crm/v1/
 

--- a/terraform/application/config/test_app_env.yml
+++ b/terraform/application/config/test_app_env.yml
@@ -12,6 +12,14 @@ ONELOGIN_REDIRECT_BASE_URL: https://test.claim-additional-teaching-payment.servi
 ONELOGIN_DID_URL: https://identity.integration.account.gov.uk/.well-known/did.json
 ONELOGIN_JWKS_URL: https://oidc.integration.account.gov.uk/.well-known/jwks.json
 
+BYPASS_TEACHER_AUTH: false
+TEACHER_AUTH_ISSUER: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
+TEACHER_AUTH_JWKS_URI: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks
+
+TEACHER_AUTH_CLIENT_ID: teacher-auth-client-id
+TEACHER_AUTH_SECRET: teacher-auth-secret
+TEACHER_AUTH_REDIRECT_BASE_URL: https://test.claim-additional-teaching-payment.service.gov.uk
+
 DQT_API_URL: https://preprod.teacher-qualifications-api.education.gov.uk/v3/
 DQT_BASE_URL: https://test-api-customerengagement.platform.education.gov.uk/dqt-crm/v1/
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-3478
- This change is built atop https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4470 which we may want to review and merge first
- This shows teacher auth working in a review app
- Wildcard redirect on TRS side was not working at the time of this ticket. I believe TRS have now fixed this
- If you need to test you will need to have a teacher auth account. Speak to TRS team to have one created
- Added temporary variables so no issues when deployed to TEST and PROD
- Having said that the journey is behind a feature toggle
- There is no way at the moment to bypass teacher auth, this will be added after this change