### PR TITLE
[CAPT-3558] user_type required for DfE sign in

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -13,7 +13,7 @@ module Admin
     end
 
     def callback
-      dfe_sign_in_user = DfeSignIn::User.admin.from_session(admin_session)
+      dfe_sign_in_user = DfeSignIn::User.admin.from_session(session: admin_session, user_type: "admin")
 
       if dfe_sign_in_user&.has_admin_access?
         dfe_sign_in_user.regenerate_session_token

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -220,7 +220,7 @@ class OmniauthCallbacksController < ApplicationController
       dfe_sign_in_session = DfeSignIn::AuthenticatedSession.from_auth_hash(auth, user_type: "provider")
     end
 
-    dfe_sign_in_user = DfeSignIn::User.from_session(dfe_sign_in_session)
+    dfe_sign_in_user = DfeSignIn::User.from_session(session: dfe_sign_in_session, user_type: "provider")
 
     # If from_session returns nil, it means the user is deleted
     unless dfe_sign_in_user.present?

--- a/app/models/dfe_sign_in/user.rb
+++ b/app/models/dfe_sign_in/user.rb
@@ -24,8 +24,8 @@ module DfeSignIn
       inverse_of: :assigned_to,
       dependent: :nullify
 
-    def self.from_session(session)
-      user = where(dfe_sign_in_id: session.user_id, user_type: "admin").first_or_initialize
+    def self.from_session(session:, user_type:)
+      user = where(dfe_sign_in_id: session.user_id, user_type:).first_or_initialize
 
       return if user.deleted?
 

--- a/spec/features/further_education_payments/providers/provider_verification_access_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verification_access_spec.rb
@@ -280,7 +280,8 @@ RSpec.feature "Provider verification access control", feature_flag: [:fe_provide
       create(
         :dfe_signin_user,
         dfe_sign_in_id: "11111",
-        deleted_at: Time.zone.now
+        deleted_at: Time.zone.now,
+        user_type: "provider"
       )
 
       mock_dfe_sign_in_auth_session(

--- a/spec/models/dfe_sign_in/user_spec.rb
+++ b/spec/models/dfe_sign_in/user_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe DfeSignIn::User, type: :model do
   let(:user) { build(:dfe_signin_user) }
+  let(:user_type) { "admin" }
 
   describe ".from_session" do
     let(:session) do
@@ -12,11 +13,9 @@ RSpec.describe DfeSignIn::User, type: :model do
         role_codes: ["some-role"]
       )
     end
-    let(:user) { DfeSignIn::User.from_session(session) }
+    let(:user) { DfeSignIn::User.from_session(session:, user_type:) }
 
     it "initializes a user when the user does not exist" do
-      user = DfeSignIn::User.from_session(session)
-
       expect(user.id).to be_nil
       expect(user.dfe_sign_in_id).to eq("123")
       expect(user.role_codes).to eq(["some-role"])


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-3558
- `user_type` is now required as part of DfE sign in flow