### PR TITLE
CAPT-3564 - On admin errors log the user

### DIFF
--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -9,6 +9,7 @@ module Admin
     before_action :end_expired_admin_sessions
     before_action :ensure_authenticated_user
     before_action :set_cache_headers
+    before_action :set_sentry_user_context
     after_action :update_last_seen_at
     helper_method :admin_signed_in?, :admin_timeout_in_minutes, :service_operator_signed_in?
 
@@ -71,6 +72,10 @@ module Admin
         clear_session
         flash[:notice] = "Your session has timed out due to inactivity, please sign-in again"
       end
+    end
+
+    def set_sentry_user_context
+      Sentry.set_user(id: session[:user_id])
     end
 
     def admin_signed_in?

--- a/spec/requests/admin/admin_sentry_context_spec.rb
+++ b/spec/requests/admin/admin_sentry_context_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Admin Sentry context", type: :request do
+  describe "when signed in" do
+    it "sets the Sentry user context to the signed-in admin's id" do
+      user = sign_in_as_service_operator
+
+      expect(Sentry).to receive(:set_user).with(id: user.id).at_least(:once)
+
+      get admin_claims_path
+    end
+  end
+
+  describe "when not signed in" do
+    it "redirects before setting Sentry user context" do
+      expect(Sentry).not_to receive(:set_user)
+
+      get admin_claims_path
+
+      expect(response).to redirect_to(admin_sign_in_path)
+    end
+  end
+end


### PR DESCRIPTION
CAPT-3564 - On admin errors log the user
- This doesn't address the error, but log the admin causing it to help debug