### PR TITLE
[CAPT-3481] Add teacher auth bypass

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -33,7 +33,7 @@ ONELOGIN_JWKS_URL=https://oidc.integration.account.gov.uk/.well-known/jwks.json
 CANONICAL_HOSTNAME=localhost:3000
 EY_MAGIC_LINK_SECRET=some-secret-for-ey-magic-link
 
-BYPASS_TEACHER_AUTH=false
+BYPASS_TEACHER_AUTH=true
 TEACHER_AUTH_CLIENT_ID=teacher-auth-client-id
 TEACHER_AUTH_SECRET=teacher-auth-secret
 TEACHER_AUTH_ISSUER=https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
@@ -19,24 +19,28 @@ module Journeys
         @omniauth_hash ||= if !TeacherAuth::Config.instance.bypass?
           request.env["omniauth.auth"]
         else
-          form = Debug::TeacherAuth::SignInForm.new(
-            journey_session: nil,
-            journey: nil,
-            params:
-          )
+          omniauth_bypass_hash
+        end
+      end
 
-          OpenStruct.new(
-            extra: OpenStruct.new(
-              raw_info: OpenStruct.new(
-                trn: form.trn,
-                email: form.email,
-                verified_name: form.verified_name.split(" "),
-                verified_date_of_birth: form.verified_date_of_birth.to_s,
-                sub: form.sub
-              )
+      def omniauth_bypass_hash
+        form = Debug::TeacherAuth::SignInForm.new(
+          journey_session: nil,
+          journey: nil,
+          params:
+        )
+
+        OpenStruct.new(
+          extra: OpenStruct.new(
+            raw_info: OpenStruct.new(
+              trn: form.trn,
+              email: form.email,
+              verified_name: form.verified_name.split(" "),
+              verified_date_of_birth: form.verified_date_of_birth.to_s,
+              sub: form.sub
             )
           )
-        end
+        )
       end
 
       def persist_callback_to_session

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
@@ -7,10 +7,36 @@ module Journeys
         redirect_to claim_path(current_journey_routing_name, "trn-found")
       end
 
+      def callback_bypass
+        persist_callback_to_session
+
+        redirect_to claim_path(current_journey_routing_name, "trn-found")
+      end
+
       private
 
       def omniauth_hash
-        @omniauth_hash ||= request.env["omniauth.auth"]
+        @omniauth_hash ||= if !TeacherAuth::Config.instance.bypass?
+          request.env["omniauth.auth"]
+        else
+          form = Debug::TeacherAuth::SignInForm.new(
+            journey_session: nil,
+            journey: nil,
+            params:
+          )
+
+          OpenStruct.new(
+            extra: OpenStruct.new(
+              raw_info: OpenStruct.new(
+                trn: form.trn,
+                email: form.email,
+                verified_name: form.verified_name.split(" "),
+                verified_date_of_birth: form.verified_date_of_birth.to_s,
+                sub: form.sub
+              )
+            )
+          )
+        end
       end
 
       def persist_callback_to_session

--- a/app/forms/debug/teacher_auth/sign_in_form.rb
+++ b/app/forms/debug/teacher_auth/sign_in_form.rb
@@ -1,0 +1,45 @@
+require "faker"
+
+module Debug
+  module TeacherAuth
+    class SignInForm < Form
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveRecord::AttributeAssignment
+
+      attribute :verified_name, :string
+      attribute :verified_date_of_birth, :date
+      attribute :email, :string
+      attribute :trn, :string
+      attribute :sub, :string
+
+      def default_email
+        "#{@default_verified_name.downcase.tr(" ", ".")}@example.com"
+      end
+
+      def default_verified_name
+        @default_verified_name ||= Faker::Name.unique.name
+      end
+
+      def default_verified_date_of_birth
+        rand(50.years.ago..20.years.ago).to_date
+      end
+
+      def default_trn
+        rand(1000000..9999999)
+      end
+
+      def default_sub
+        "urn:fdc:gov.uk:2022:#{SecureRandom.base64(30)}"
+      end
+
+      def journey
+        Journeys::EarlyYearsTeachersFinancialIncentivePayments
+      end
+
+      def load_current_value(attribute)
+        public_send "default_#{attribute}"
+      end
+    end
+  end
+end

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
@@ -4,10 +4,24 @@ module Journeys
     extend self
 
     POLICIES = [Policies::EarlyYearsTeachersFinancialIncentivePayments]
-    FORMS = [
-      SignInForm,
-      TrnFoundForm
-    ]
+
+    def forms
+      return @forms if @forms
+
+      array = []
+
+      array << if TeacherAuth::Config.instance.bypass?
+        Debug::TeacherAuth::SignInForm
+      else
+        SignInForm
+      end
+
+      array += [
+        TrnFoundForm
+      ]
+
+      @forms = array
+    end
 
     def available?
       FeatureFlag.enabled?(:eytfi_journey)

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
@@ -6,8 +6,6 @@ module Journeys
     POLICIES = [Policies::EarlyYearsTeachersFinancialIncentivePayments]
 
     def forms
-      return @forms if @forms
-
       array = []
 
       array << if TeacherAuth::Config.instance.bypass?
@@ -20,7 +18,7 @@ module Journeys
         TrnFoundForm
       ]
 
-      @forms = array
+      array
     end
 
     def available?

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
@@ -1,5 +1,19 @@
 sign in page goes here
 
-<p class="govuk-body">
-  <%= govuk_button_to "/early-years-teachers-financial-incentive-payments/auth/teacher", "/early-years-teachers-financial-incentive-payments/auth/teacher" %>
-</p>
+<% if !TeacherAuth::Config.instance.bypass? %>
+  <p class="govuk-body">
+    <%= govuk_button_to "/early-years-teachers-financial-incentive-payments/auth/teacher", "/early-years-teachers-financial-incentive-payments/auth/teacher" %>
+  </p>
+<% else %>
+  <h2 class="govuk-heading-l">Bypass Teacher Auth</h2>
+
+  <%= form_with model: @form, url: "/early-years-teachers-financial-incentive-payments/auth/teacher", method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= f.govuk_text_field :verified_name, label: { text: "Full name" }, width: 20 %>
+    <%= f.govuk_date_field :verified_date_of_birth, date_of_birth: true, legend: { text: "Date of Birth" } %>
+    <%= f.govuk_text_field :email, width: 20 %>
+    <%= f.govuk_text_field :trn, width: 10, label: { text: "TRN" } %>
+    <%= f.govuk_text_field :sub, label: { text: "One Login UID" } %>
+
+    <%= f.govuk_submit %>
+  <% end %>
+<% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -113,28 +113,32 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     }
   end
 
-  provider :openid_connect, {
-    name: :teacher,
-    discovery: true,
-    response_type: :code,
-    scope: %i[openid email profile offline_access teaching_record],
-    send_scope_to_token_endpoint: false,
-    callback_path: TeacherAuth::Config.instance.callback_path,
-    path_prefix: TeacherAuth::Config.instance.path_prefix,
-    issuer: TeacherAuth::Config.instance.issuer,
-    pkce: true,
-    client_options: {
-      port: 443,
-      scheme: "https",
-      host: TeacherAuth::Config.instance.host,
-      identifier: ENV["TEACHER_AUTH_CLIENT_ID"],
-      secret: ENV["TEACHER_AUTH_SECRET"],
-      redirect_uri: TeacherAuth::Config.instance.redirect_uri,
-      authorization_endpoint: "/oauth2/authorize",
-      end_session_endpoint: "/oauth2/logout",
-      token_endpoint: "/oauth2/token",
-      userinfo_endpoint: "/oauth2/userinfo",
-      jwks_uri: TeacherAuth::Config.instance.jwks_uri
+  if TeacherAuth::Config.instance.bypass?
+    provider :developer
+  else
+    provider :openid_connect, {
+      name: :teacher,
+      discovery: true,
+      response_type: :code,
+      scope: %i[openid email profile offline_access teaching_record],
+      send_scope_to_token_endpoint: false,
+      callback_path: TeacherAuth::Config.instance.callback_path,
+      path_prefix: TeacherAuth::Config.instance.path_prefix,
+      issuer: TeacherAuth::Config.instance.issuer,
+      pkce: true,
+      client_options: {
+        port: 443,
+        scheme: "https",
+        host: TeacherAuth::Config.instance.host,
+        identifier: ENV["TEACHER_AUTH_CLIENT_ID"],
+        secret: ENV["TEACHER_AUTH_SECRET"],
+        redirect_uri: TeacherAuth::Config.instance.redirect_uri,
+        authorization_endpoint: "/oauth2/authorize",
+        end_session_endpoint: "/oauth2/logout",
+        token_endpoint: "/oauth2/token",
+        userinfo_endpoint: "/oauth2/userinfo",
+        jwks_uri: TeacherAuth::Config.instance.jwks_uri
+      }
     }
-  }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,10 @@ Rails.application.routes.draw do
     end
 
     scope constraints: {journey: "early-years-teachers-financial-incentive-payments"} do
+      if TeacherAuth::Config.instance.bypass?
+        post "auth/teacher", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback_bypass"
+      end
+
       get "auth/teacher/callback", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback"
     end
 

--- a/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "EYTFIP with teacher auth bypass", feature_flag: [:eytfi_journey] do
+  before do
+    create(
+      :journey_configuration,
+      :early_years_teachers_financial_incentive_payments
+    )
+
+    allow(TeacherAuth::Config.instance).to receive(:bypass?).and_return(true)
+  end
+
+  scenario "it auto generates dummy data to by pass teacher auth" do
+    visit landing_page_path(Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name)
+    expect(page).to have_text "EYTFI landing page goes here"
+    click_link "Start now"
+
+    expect(page).to have_text "Bypass Teacher Auth"
+    expect(find_field("Full name").value).to be_present
+    expect(find_field("Day").value).to be_present
+    expect(find_field("Month").value).to be_present
+    expect(find_field("Year").value).to be_present
+    expect(find_field("Email").value).to be_present
+    expect(find_field("TRN").value).to be_present
+    expect(find_field("One Login UID").value).to be_present
+    click_button "Continue"
+  end
+end

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -12,7 +12,7 @@ DFE_SIGN_IN_REDIRECT_BASE_URL: https://claim-additional-payments-for-teaching-re
 
 DFE_SIGN_IN_INTERNAL_CLIENT_ID: teacherpaymentsadmin
 
-BYPASS_TEACHER_AUTH: false
+BYPASS_TEACHER_AUTH: true
 TEACHER_AUTH_ISSUER: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/
 TEACHER_AUTH_JWKS_URI: https://preprod.authorise-access-to-a-teaching-record.education.gov.uk/.well-known/jwks
 


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-3481
- Add ability to be able to bypass teacher auth. therefore third party integration not required
- By default bypass teacher auth on local dev environment and review apps

# Screenshots

<img width="904" height="822" alt="Screenshot 2026-04-22 at 12 26 28" src="https://github.com/user-attachments/assets/9c9d4052-6f4f-43fb-9c7d-db2fc635944b" />
