### PR TITLE
Improve the ability to delete claims and add missing logic into specs

### DIFF
--- a/app/jobs/destroy_claim_job.rb
+++ b/app/jobs/destroy_claim_job.rb
@@ -1,0 +1,8 @@
+# Destroys a single claim and all its dependent records.
+# Enqueue via: DestroyClaimJob.perform_later(claim.id)
+class DestroyClaimJob < ApplicationJob
+  def perform(claim_id)
+    claim = Claim.find(claim_id)
+    claim.destroy!
+  end
+end

--- a/spec/jobs/destroy_claim_job_spec.rb
+++ b/spec/jobs/destroy_claim_job_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe DestroyClaimJob do
+  subject(:destroy_claim_job) { described_class.new }
+
+  it { expect(destroy_claim_job).to be_an(ApplicationJob) }
+
+  describe "#perform" do
+    let!(:claim) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments) }
+
+    it "destroys the claim" do
+      expect { destroy_claim_job.perform(claim.id) }.to change(Claim, :count).by(-1)
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1237,22 +1237,40 @@ RSpec.describe Claim, type: :model do
   end
 
   describe "#destroy" do
-    let(:claim) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments) }
+    let(:journey_session) { create(:targeted_retention_incentive_payments_session) }
+    let(:claim) { create(:claim, :submitted, policy: Policies::EarlyCareerPayments, journey_session: journey_session) }
+    let(:payment) { create(:payment, claim_policies: []) }
 
     before do
       create(:note, claim: claim)
       create(:task, claim: claim)
       create(:amendment, claim: claim)
       create(:decision, :approved, claim: claim)
+      create(:topup, claim: claim)
+      Event.create!(claim: claim, name: "claim_submitted")
+      ClaimPayment.create!(claim: claim, payment: payment)
     end
 
     it "destroys associated records" do
+      claim_id = claim.id
+      eligibility_id = claim.eligibility_id
+      journey_session_id = journey_session.id
+      payment_id = payment.id
+
       claim.reload.destroy!
-      expect(Policies::EarlyCareerPayments::Eligibility.count).to be_zero
-      expect(Note.count).to be_zero
-      expect(Task.count).to be_zero
-      expect(Amendment.count).to be_zero
-      expect(Decision.count).to be_zero
+
+      aggregate_failures do
+        expect(Policies::EarlyCareerPayments::Eligibility.where(id: eligibility_id)).to be_empty
+        expect(Note.where(claim_id: claim_id)).to be_empty
+        expect(Task.where(claim_id: claim_id)).to be_empty
+        expect(Amendment.where(claim_id: claim_id)).to be_empty
+        expect(Decision.where(claim_id: claim_id)).to be_empty
+        expect(Event.where(claim_id: claim_id)).to be_empty
+        expect(Topup.where(claim_id: claim_id)).to be_empty
+        expect(ClaimPayment.where(claim_id: claim_id)).to be_empty
+        expect(Payment.where(id: payment_id)).to exist
+        expect(Journeys::TargetedRetentionIncentivePayments::Session.where(id: journey_session_id)).to exist
+      end
     end
   end
 

--- a/spec/models/journeys/session_spec.rb
+++ b/spec/models/journeys/session_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.shared_examples_for "a journey session" do |journey|
   let(:factory_name) { :"#{journey.i18n_namespace}_session" }
+  let(:policy) { journey.policies.first }
 
   describe "validations" do
     describe "journey" do
@@ -57,6 +58,21 @@ RSpec.shared_examples_for "a journey session" do |journey|
         expect(session.answers.surname).to eq("Thompson")
         expect(session.answers.address_line_1).to eq("742")
         expect(session.answers.address_line_2).to eq("Terror Lake")
+      end
+    end
+  end
+
+  describe "when a linked claim is destroyed" do
+    let(:session) { create(factory_name) }
+    let!(:claim) { create(:claim, :submitted, policy: policy, journey_session: session) }
+
+    it "keeps the session and nullifies the claim association" do
+      claim.destroy!
+
+      aggregate_failures do
+        expect(described_class.where(id: session.id)).to exist
+        expect(session.reload.claim).to be_nil
+        expect(session).not_to be_submitted
       end
     end
   end


### PR DESCRIPTION
We need to delete a claim however reviewing the codebase we have some missing test coverage.

I've also added a job to delete the claim. Rather than calling destroy manually. 