### PR TITLE
Update template to generate based on payment tax year automatically

### DIFF
--- a/app/helpers/payment_mailer_helper.rb
+++ b/app/helpers/payment_mailer_helper.rb
@@ -1,4 +1,9 @@
 module PaymentMailerHelper
+  def tax_year_for(date)
+    year = (date.month < 4 || (date.month == 4 && date.day < 6)) ? date.year - 1 : date.year
+    "#{year} to #{year + 1}"
+  end
+
   def breakdown_of_payment_bullets(payment)
     bullets = []
 

--- a/app/views/payment_mailer/confirmation.text.erb
+++ b/app/views/payment_mailer/confirmation.text.erb
@@ -10,7 +10,7 @@ This payment is treated as pay and is therefore subject to a student loan contri
 * <%= bullet %>
 <% end %>
 
-Your payment is also subject to Income Tax and National Insurance (NI) contributions, which we pay to HMRC on your behalf. This does not affect the amount you receive and we only share this with you in case you need the information in the future. Please note that this payment forms part of your income in the current 2025 to 2026 tax year.
+Your payment is also subject to Income Tax and National Insurance (NI) contributions, which we pay to HMRC on your behalf. This does not affect the amount you receive and we only share this with you in case you need the information in the future. Please note that this payment forms part of your income in the current <%= tax_year_for(@payment_date) %> tax year.
 
 * Income Tax: <%= number_to_currency(@payment.tax) %>
 * Employee NI: <%= number_to_currency(@payment.national_insurance) %>

--- a/spec/helpers/payment_mailer_helper_spec.rb
+++ b/spec/helpers/payment_mailer_helper_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe PaymentMailerHelper do
+  describe "#tax_year_for" do
+    it "returns the tax year spanning the given date" do
+      expect(tax_year_for(Date.parse("2019-01-01"))).to eq("2018 to 2019")
+    end
+
+    context "when date is nil" do
+      it "raises a NoMethodError" do
+        expect { tax_year_for(nil) }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe PaymentMailer, type: :mailer do
           expect(mail.body).to include("You will receive £500.00 on Tuesday 1st January 2019")
         end
 
+        it "includes the tax year derived from the payment date" do
+          expect(mail.body).to include("current 2018 to 2019 tax year")
+        end
+
         it "creates an event" do
           expect { mail.body }.to change {
             Event.where(claim:, name: "email_confirmation_single_sent").count
@@ -145,6 +149,10 @@ RSpec.describe PaymentMailer, type: :mailer do
 
         it "includes the NET pay amount and payment date in the body" do
           expect(mail.body).to include("You will receive £2,500.00 on Tuesday 1st January 2019")
+        end
+
+        it "includes the tax year derived from the payment date" do
+          expect(mail.body).to include("current 2018 to 2019 tax year")
         end
 
         it "mentions the type of claim in the body" do


### PR DESCRIPTION
The template needs updating manually currently, this will general the correct year range based on the payment tax year.
