### PR TITLE
Use value object rather than string comp

### DIFF
--- a/app/forms/further_education_payments/providers/claims/verification/teaching_hours_per_week_form.rb
+++ b/app/forms/further_education_payments/providers/claims/verification/teaching_hours_per_week_form.rb
@@ -5,7 +5,7 @@ module FurtherEducationPayments
         class TeachingHoursPerWeekForm < BaseForm
           TEACHING_HOURS_PER_WEEK_OPTIONS = [
             Form::Option.new(
-              id: "more_than_20",
+              id: TeachingHours.more_than_20,
               name: I18n.t(
                 %w[
                   further_education_payments_provider
@@ -18,7 +18,7 @@ module FurtherEducationPayments
               )
             ),
             Form::Option.new(
-              id: "more_than_12",
+              id: TeachingHours.more_than_12,
               name: I18n.t(
                 %w[
                   further_education_payments_provider
@@ -31,7 +31,7 @@ module FurtherEducationPayments
               )
             ),
             Form::Option.new(
-              id: "between_2_5_and_12",
+              id: TeachingHours.between_2_5_and_12,
               name: I18n.t(
                 %w[
                   further_education_payments_provider
@@ -44,7 +44,7 @@ module FurtherEducationPayments
               )
             ),
             Form::Option.new(
-              id: "less_than_2_5",
+              id: TeachingHours.less_than_2_5,
               name: I18n.t(
                 %w[
                   further_education_payments_provider

--- a/app/forms/journeys/further_education_payments/teaching_hours_per_week_form.rb
+++ b/app/forms/journeys/further_education_payments/teaching_hours_per_week_form.rb
@@ -12,19 +12,19 @@ module Journeys
       def radio_options
         @radio_options ||= [
           Option.new(
-            id: "more_than_20",
+            id: ::FurtherEducationPayments::TeachingHours.more_than_20,
             name: t("options.more_than_20")
           ),
           Option.new(
-            id: "more_than_12",
+            id: ::FurtherEducationPayments::TeachingHours.more_than_12,
             name: t("options.more_than_12")
           ),
           Option.new(
-            id: "between_2_5_and_12",
+            id: ::FurtherEducationPayments::TeachingHours.between_2_5_and_12,
             name: t("options.between_2_5_and_12")
           ),
           Option.new(
-            id: "less_than_2_5",
+            id: ::FurtherEducationPayments::TeachingHours.less_than_2_5,
             name: t("options.less_than_2_5")
           )
         ]

--- a/app/models/further_education_payments/teaching_hours.rb
+++ b/app/models/further_education_payments/teaching_hours.rb
@@ -1,0 +1,50 @@
+module FurtherEducationPayments
+  class TeachingHours
+    VALUES = [
+      "more_than_20",
+      "more_than_12",
+      "between_2_5_and_12",
+      "less_than_2_5"
+    ]
+
+    VALUES.each do |supported_value|
+      define_singleton_method(supported_value) do
+        supported_value
+      end
+
+      define_method "#{supported_value}?" do
+        @value == supported_value
+      end
+    end
+
+    def initialize(value)
+      if value.is_a?(self.class)
+        value = value.instance_variable_get(:@value)
+      end
+
+      raise ArgumentError unless value.in?(VALUES)
+
+      @value = value
+    end
+
+    def __value
+      @value
+    end
+
+    def ==(other)
+      unless other.is_a?(self.class)
+        raise ArgumentError, "`#{other}` is not a `#{self.class}`"
+      end
+
+      other.__value == @value
+    end
+
+    def upperband?
+      more_than_20? || more_than_12?
+    end
+
+    def to_s
+      @value
+    end
+  end
+end

--- a/app/models/journeys/further_education_payments/session_answers.rb
+++ b/app/models/journeys/further_education_payments/session_answers.rb
@@ -57,8 +57,14 @@ module Journeys
         !further_education_teaching_start_year&.start_with?("pre-")
       end
 
+      def teaching_hours_per_week
+        return unless super
+
+        ::FurtherEducationPayments::TeachingHours.new(super)
+      end
+
       def teaching_less_than_2_5_hours_per_week?
-        teaching_hours_per_week == "less_than_2_5"
+        teaching_hours_per_week&.less_than_2_5?
       end
 
       def teaching_less_than_2_5_hours_per_week_next_term?
@@ -113,10 +119,9 @@ module Journeys
       end
 
       def calculate_award_amount
-        case teaching_hours_per_week
-        when "more_than_12", "more_than_20"
+        if teaching_hours_per_week.upperband?
           school.eligible_fe_provider.max_award_amount
-        when "between_2_5_and_12"
+        elsif teaching_hours_per_week.between_2_5_and_12?
           school.eligible_fe_provider.lower_award_amount
         else
           0

--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -161,16 +161,18 @@ module Policies
       def timetabled_teaching_hours
         # The max we want to show admins is "12 or more hours"
         provider_teaching_hours_per_week =
-          case eligibility.provider_verification_teaching_hours_per_week
-          when "more_than_20" then "more_than_12"
-          else eligibility.provider_verification_teaching_hours_per_week
+          if eligibility.provider_verification_teaching_hours_per_week.more_than_20?
+            "more_than_12"
+          else
+            eligibility.provider_verification_teaching_hours_per_week.to_s
           end
 
         # The max we want to show admins is "12 or more hours"
         claimant_teaching_hours_per_week =
-          case eligibility.teaching_hours_per_week
-          when "more_than_20" then "more_than_12"
-          else eligibility.teaching_hours_per_week
+          if eligibility.teaching_hours_per_week.more_than_20?
+            "more_than_12"
+          else
+            eligibility.teaching_hours_per_week.to_s
           end
 
         locale_scope = %w[

--- a/app/models/policies/further_education_payments/eligibility.rb
+++ b/app/models/policies/further_education_payments/eligibility.rb
@@ -76,6 +76,26 @@ module Policies
       # Claim#school expects this
       alias_method :current_school, :school
 
+      composed_of(
+        :teaching_hours_per_week,
+        class_name: "::FurtherEducationPayments::TeachingHours",
+        mapping: {
+          teaching_hours_per_week: :__value
+        },
+        converter: proc { |value| ::FurtherEducationPayments::TeachingHours.new(value) },
+        allow_nil: true
+      )
+
+      composed_of(
+        :provider_verification_teaching_hours_per_week,
+        class_name: "::FurtherEducationPayments::TeachingHours",
+        mapping: {
+          provider_verification_teaching_hours_per_week: :__value
+        },
+        converter: proc { |value| ::FurtherEducationPayments::TeachingHours.new(value) },
+        allow_nil: true
+      )
+
       def policy
         Policies::FurtherEducationPayments
       end
@@ -232,18 +252,23 @@ module Policies
       end
 
       def insufficient_teaching_hours_per_week?
-        provider_verification_teaching_hours_per_week == "less_than_2_5"
+        provider_verification_teaching_hours_per_week&.less_than_2_5?
       end
 
       def teaching_hours_mismatch?
-        (
-          provider_verification_teaching_hours_per_week == "between_2_5_and_12" &&
-          teaching_hours_per_week.in?(%w[more_than_20 more_than_12])
-        ) ||
-          (
-            teaching_hours_per_week == "between_2_5_and_12" &&
-            provider_verification_teaching_hours_per_week.in?(%w[more_than_12 more_than_20])
-          )
+        return unless provider_verification_teaching_hours_per_week && teaching_hours_per_week
+
+        claimant_hours_more_than_provider_hours? || provider_hours_more_than_claimant_hours?
+      end
+
+      def provider_hours_more_than_claimant_hours?
+        provider_verification_teaching_hours_per_week.upperband? &&
+          teaching_hours_per_week.between_2_5_and_12?
+      end
+
+      def claimant_hours_more_than_provider_hours?
+        provider_verification_teaching_hours_per_week.between_2_5_and_12? &&
+          teaching_hours_per_week.upperband?
       end
 
       def previous_approved_claim


### PR DESCRIPTION
Speculative approach, happy to go a completely different route!
Tried out constants but was too unreadable. Not 100% so on using
`composed_of` over just creating the `TeachingHours` where we 
need them.


We had a bug where we updated a string and neglected to update one of
the sites where the string value was compared.
This commit replaces use of the fe teaching hours strings with a value
object `FurtherEducationPayments::TeachingHours`.

We use `composed_of` to wrap the `teaching_hours_per_week` and
`provider_verification_teaching_hours_per_week` columns with a
`TeachingHours` object and update any string comparisons to use methods
on the object.

The `TeachingHours` object defines `__value` to return the string value
as that's required to work with `composed_of`, however we want to
discourage checking the value directly (hence the __ prefix), any checks
for the value should use the predicate methods. A nice feature from
using a value object is we can clean up some of the code by defining
`upperband?` on the `TeachingHours`.

If we decide on this approach we can extract a `ValueObject` sub class
to handle the generic setup and replace `TeachingHours` with something
like

```
class FurtherEducationPayments::TeachingHours < ValueObject
  self.values = %w(
    more_than_20
    more_than_12
    between_2_5_and_12
    less_than_2_5
  )

  def upperband?
    more_than_20? || more_than_12
  end
end
```

We decided against using a `Data` object as they don't offer predicate
methods and encourage checking string values.


If we decide on this approach we'll want to open a ticket to replace all string
comparisons in the app with value objects to keep things consistent. Maybe a
good task for AI?
