### PR TITLE
Move notify stagger to common method

### DIFF
--- a/app/jobs/further_education_payments/providers/weekly_update_email_job.rb
+++ b/app/jobs/further_education_payments/providers/weekly_update_email_job.rb
@@ -22,11 +22,13 @@ module FurtherEducationPayments
                 .awaiting_provider_verification_year_2
             )
 
-        providers_with_unverified_claims.each do |provider|
-          FurtherEducationPaymentsMailer
-            .with(provider: provider)
-            .provider_weekly_update_email
-            .deliver_later
+        providers_with_unverified_claims.each_with_index do |provider, index|
+          ApplicationMailer.deliver_later_with_throttling(
+            FurtherEducationPaymentsMailer
+              .with(provider: provider)
+              .provider_weekly_update_email,
+            index:
+          )
         end
       end
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -58,4 +58,9 @@ class ApplicationMailer < Mail::Notify::Mailer
     PROVIDER_SIX_MONTH_EMPLOYMENT_REMINDER_TEMPLATE_ID: "bc7faa96-8a19-4765-9d7a-6a6fd02aee9e".freeze,
     PRACTITIONER_CLAIM_REMINDER_TEMPLATE_ID: "cf03a3c7-587a-48c4-83b9-0cd762d103f6".freeze
   }
+
+  def self.deliver_later_with_throttling(mail_delivery, index:, **options)
+    options[:wait] ||= (index / 10.0).seconds
+    mail_delivery.deliver_later(**options)
+  end
 end

--- a/app/models/payment_confirmation_upload.rb
+++ b/app/models/payment_confirmation_upload.rb
@@ -43,7 +43,10 @@ class PaymentConfirmationUpload
       raise ActiveRecord::Rollback if errors.any?
 
       payments.each_with_index do |payment, index|
-        PaymentMailer.confirmation(payment).deliver_later(wait: (index / 10.0).seconds)
+        ApplicationMailer.deliver_later_with_throttling(
+          PaymentMailer.confirmation(payment),
+          index:
+        )
       end
     end
   end

--- a/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
+++ b/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
@@ -118,6 +118,41 @@ RSpec.describe FurtherEducationPayments::Providers::WeeklyUpdateEmailJob, type: 
     )
   end
 
+  it "staggers weekly update emails due to Notify API 3000 per 60 seconds limit" do
+    third_provider = create(:eligible_fe_provider, :with_school)
+
+    [provider, other_provider, third_provider].each do |fe_provider|
+      create(
+        :further_education_payments_eligibility,
+        :eligible,
+        school: fe_provider.school,
+        claim: create(
+          :claim,
+          :further_education,
+          :submitted
+        )
+      )
+    end
+
+    deliver_later_calls = []
+    mail_double = double("mail")
+    mailer_scope_double = double("mailer scope", provider_weekly_update_email: mail_double)
+
+    allow(mail_double).to receive(:deliver_later) do |wait: nil|
+      deliver_later_calls << wait
+    end
+
+    allow(FurtherEducationPaymentsMailer).to receive(:with).and_return(mailer_scope_double)
+
+    described_class.new.perform
+
+    expect(deliver_later_calls).to eq([
+      0.seconds,
+      0.1.seconds,
+      0.2.seconds
+    ])
+  end
+
   context "when there are versioned eligible FE providers" do
     let(:provider) { create(:eligible_fe_provider, :with_school) }
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  describe ".deliver_later_with_throttling" do
+    let(:mail_delivery) { instance_double(ActionMailer::MessageDelivery) }
+
+    it "delivers later with a throttled wait based on the index" do
+      allow(mail_delivery).to receive(:deliver_later)
+
+      described_class.deliver_later_with_throttling(mail_delivery, index: 2)
+
+      expect(mail_delivery).to have_received(:deliver_later).with(wait: 0.2.seconds)
+    end
+
+    it "preserves an explicitly provided wait" do
+      allow(mail_delivery).to receive(:deliver_later)
+
+      described_class.deliver_later_with_throttling(mail_delivery, index: 2, wait: 5.seconds)
+
+      expect(mail_delivery).to have_received(:deliver_later).with(wait: 5.seconds)
+    end
+  end
+end


### PR DESCRIPTION
There is likely to be more areas the deliver_later has to be removed in favour of a custom staggered release, as there is already 2 I've moved it to a shared method 