### PR TITLE
Move claims to controller load rather than inpage

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -21,8 +21,11 @@ module Admin
     end
 
     def create
-      claims = Claim.where(id: params[:claim_ids])
-      topups = Topup.where(id: params[:topup_ids])
+      claims = Claim
+        .payrollable
+        .order(submitted_at: :asc)
+
+      topups = Topup.payrollable
 
       if claims.empty? && topups.empty?
         redirect_to new_admin_payroll_run_path, alert: "Payroll not run, no claims or top ups"

--- a/app/views/admin/payroll_runs/new.html.erb
+++ b/app/views/admin/payroll_runs/new.html.erb
@@ -46,11 +46,5 @@
 </div>
 
 <%= form_with url: admin_payroll_runs_path do |form| %>
-  <% @claims.each do |claim| %>
-    <%= hidden_field_tag "claim_ids[]", claim.id %>
-  <% end %>
-  <% @topups.each do |topup| %>
-    <%= hidden_field_tag "topup_ids[]", topup.id %>
-  <% end %>
   <%= form.submit "Confirm and submit", class: "govuk-button", data: {module: "govuk-button"} %>
 <% end %>

--- a/spec/features/admin/admin_payroll_runs_spec.rb
+++ b/spec/features/admin/admin_payroll_runs_spec.rb
@@ -64,15 +64,15 @@ RSpec.feature "Payroll" do
     end
   end
 
-  scenario "Any claims approved in the meantime are not included" do
+  scenario "All claims approved are included" do
     click_on "Payroll"
 
-    expected_claims = create_list(:claim, 3, :approved)
+    initial_claims = create_list(:claim, 3, :approved)
 
     month_name = Date.today.strftime("%B")
     click_on "Run #{month_name} payroll"
 
-    create_list(:claim, 3, :approved)
+    additional_claims = create_list(:claim, 3, :approved)
 
     click_on "Confirm and submit"
 
@@ -80,10 +80,10 @@ RSpec.feature "Payroll" do
 
     click_on "Refresh"
 
-    expect(page).to have_content("Approved claims 3")
+    expect(page).to have_content("Approved claims 6")
 
     payroll_run = PayrollRun.order(:created_at).last
-    expect(payroll_run.claims).to match_array(expected_claims)
+    expect(payroll_run.claims).to match_array(initial_claims + additional_claims)
   end
 
   scenario "Service admin can view a list of previous payroll runs" do

--- a/spec/requests/admin/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin/admin_payroll_runs_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Admin payroll runs" do
         claims = create_list(:claim, 2, :approved)
 
         perform_enqueued_jobs do
-          expect { post admin_payroll_runs_path(claim_ids: claims.map(&:id)) }.to change { PayrollRun.count }.by(1)
+          expect { post admin_payroll_runs_path }.to change { PayrollRun.count }.by(1)
         end
 
         payroll_run = PayrollRun.order(:created_at).last


### PR DESCRIPTION
This page hit “If you are using more than 4096 parameters, you need to configure a higher limit. the easiest way to do so is by setting the RACK_QUERY_PARSER_PARAMS_LIMIT environment variable to a higher value before loading Rack.”

Moving the claims to load ID's in the controller logic rather than browser passing the ID's