### PR TITLE
Wire up admin task list for EYTFI

### DIFF
--- a/app/helpers/admin/claim_summary_helper.rb
+++ b/app/helpers/admin/claim_summary_helper.rb
@@ -8,6 +8,8 @@ module Admin
         "claim_summary_further_education_payments"
       when Policies::InternationalRelocationPayments
         "claim_summary_international_relocation_payments"
+      when Policies::EarlyYearsTeachersFinancialIncentivePayments
+        "claim_summary_early_years_teachers_financial_incentive_payments"
       else
         "claim_summary"
       end

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -102,6 +102,10 @@ module BasePolicy
     true
   end
 
+  def hidden?
+    false
+  end
+
   def admin_tasks_presenter(claim)
     self::AdminTasksPresenter.new(claim)
   end

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -5,7 +5,8 @@ module Policies
     TargetedRetentionIncentivePayments,
     InternationalRelocationPayments,
     FurtherEducationPayments,
-    EarlyYearsPayments
+    EarlyYearsPayments,
+    EarlyYearsTeachersFinancialIncentivePayments
   ].freeze
 
   AMENDABLE_ELIGIBILITY_ATTRIBUTES = POLICIES.map do |policy|
@@ -13,7 +14,7 @@ module Policies
   end.flatten.uniq.freeze
 
   def self.all
-    POLICIES
+    POLICIES.reject(&:hidden?)
   end
 
   def self.options_for_select

--- a/app/models/policies/early_years_teachers_financial_incentive_payments.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments.rb
@@ -4,5 +4,11 @@ module Policies
     extend self
 
     VERIFIERS = []
+
+    ADMIN_DECISION_REJECTED_REASONS = []
+
+    def hidden?
+      true
+    end
   end
 end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -1,0 +1,19 @@
+module Policies
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class ClaimCheckingTasks < Policies::ClaimCheckingTasks
+      def applicable_task_names
+        tasks = []
+
+        tasks << "identity_confirmation"
+        tasks << "qualifications"
+        tasks << "employment"
+        tasks << "student_loan_plan" if claim.submitted_without_slc_data?
+        tasks << "payroll_details" if claim.must_manually_validate_bank_details?
+        tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
+        tasks << "matching_details" if matching_claims.exists?
+
+        tasks
+      end
+    end
+  end
+end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligibility.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligibility.rb
@@ -1,0 +1,15 @@
+module Policies
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class Eligibility < ApplicationRecord
+      self.table_name = "early_years_teachers_financial_incentive_payments_eligibilities"
+
+      has_one :claim, as: :eligibility, inverse_of: :eligibility
+
+      AMENDABLE_ATTRIBUTES = []
+
+      def policy
+        Policies::EarlyYearsTeachersFinancialIncentivePayments
+      end
+    end
+  end
+end

--- a/app/views/admin/tasks/_claim_summary_early_years_teachers_financial_incentive_payments.html.erb
+++ b/app/views/admin/tasks/_claim_summary_early_years_teachers_financial_incentive_payments.html.erb
@@ -1,0 +1,81 @@
+<div class="govuk-grid-column-full">
+  <span class="govuk-caption-xl"><%= claim.policy.short_name %> (<%= claim.academic_year %>)</span>
+  <h1 class="govuk-heading-xl govuk-heading--navigation">
+    <span id="claim-heading">
+      <%= claim_summary_heading(claim) %>
+    </span>
+    <span class="govuk-body-m">
+      <%= link_to "View tasks", admin_claim_tasks_path(claim), class: "govuk-link" %>
+      <%= link_to "View full claim", admin_claim_path(claim), class: "govuk-link" %>
+      <%= link_to "Amend claim", new_admin_claim_amendment_path(claim), class: "govuk-link" if claim.amendable? %>
+      <%= link_to "Top up claim", new_admin_claim_topup_path(claim), class: "govuk-link" if claim.topupable? %>
+    </span>
+  </h1>
+</div>
+
+<div class="govuk-grid-column-full">
+  <%= render("admin/claims/banner", important_notes: claim.important_notes) if claim.important_notes.any? %>
+</div>
+
+<%= render "shared/assignment_banner", claim: claim %>
+
+<div class="govuk-summary-list govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-one-half">
+    <%= govuk_summary_list(actions: false) do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "NI number" } %>
+        <% row.with_value { personal_data(claim, :national_insurance_number) } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Full name" } %>
+        <% row.with_value { personal_data(claim, :full_name) } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Date of birth" } %>
+        <% row.with_value { personal_data(claim, :date_of_birth) { |date| l(date) } } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Email address" } %>
+        <% row.with_value { claim.email_address } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Mobile number" } %>
+        <% row.with_value { claim.mobile_number } %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <%= govuk_summary_list(actions: false) do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Reference" } %>
+        <% row.with_value { claim.reference } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Submitted" } %>
+        <% row.with_value { l(claim.submitted_at) } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Decision due" } %>
+        <% row.with_value { (l(claim.decision_deadline) + decision_deadline_warning(claim, {na_text: ""})).html_safe } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Status" } %>
+        <% row.with_value { status(claim) } %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Claim amount" } %>
+        <% row.with_value { number_to_currency(claim.award_amount_with_topups)} %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -434,6 +434,11 @@ shared:
     - alternative_idv_claimant_postcode # string, postcode for alt idv
     - alternative_idv_claimant_national_insurance_number # string, national insurance number for alt idv
     - alternative_idv_claimant_email # string, email for alt idv
+  :early_years_teachers_financial_incentive_payments_eligibilities:
+    - id # uuid, identifies the EYTFI eligibility record
+    - created_at # datetime, timestamp when eligibility was created
+    - updated_at # datetime, timestamp when eligibility was last updated
+    - award_amount # decimal, amount being awarded
   :school_workforce_censuses:
     - id # uuid, identifies the school workforce census record
     - teacher_reference_number # string, external identifier for teacher

--- a/config/locales/early_years_teachers_financial_incentive_payments.yml
+++ b/config/locales/early_years_teachers_financial_incentive_payments.yml
@@ -1,5 +1,6 @@
 en:
   early_years_teachers_financial_incentive_payments:
+    policy_short_name: Early Years Teachers Financial Incentive Payments
     journey_name: Early Years Teachers Financial Incentive Payments
     feedback_email: "feedback@example.com"
     support_email_address: "EYTrecognitionpayment@education.gov.uk"

--- a/db/migrate/20260429153731_create_early_years_teachers_financial_incentive_payments_eligibilities.rb
+++ b/db/migrate/20260429153731_create_early_years_teachers_financial_incentive_payments_eligibilities.rb
@@ -1,0 +1,9 @@
+class CreateEarlyYearsTeachersFinancialIncentivePaymentsEligibilities < ActiveRecord::Migration[8.1]
+  def change
+    create_table :early_years_teachers_financial_incentive_payments_eligibilities, id: :uuid do |t|
+      t.timestamps
+
+      t.decimal :award_amount, precision: 7, scale: 2
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_114412) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_153731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -239,6 +239,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_114412) do
     t.index ["alternative_idv_reference"], name: "idx_on_alternative_idv_reference_1053f9bce9", unique: true
     t.index ["practitioner_reminder_email_last_sent_at"], name: "index_ey_eligibilities_on_pract_reminder_last_sent"
     t.index ["practitioner_reminder_email_sent_count"], name: "index_ey_eligibilities_on_pract_reminder_count"
+  end
+
+  create_table "early_years_teachers_financial_incentive_payments_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "award_amount", precision: 7, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "eligible_ey_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/policies/early_years_teachers_financial_incentive_payments/eligibilities.rb
+++ b/spec/factories/policies/early_years_teachers_financial_incentive_payments/eligibilities.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory(
+    :early_years_teachers_financial_incentive_payments_eligibility,
+    class: "Policies::EarlyYearsTeachersFinancialIncentivePayments::Eligibility"
+  ) do
+    trait :eligible do
+    end
+  end
+end

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/claim_tasks_index_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/claim_tasks_index_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Task index page for EYTFI claims" do
+  it "shows the list of tasks" do
+    allow(Policies::EarlyYearsTeachersFinancialIncentivePayments).to(
+      receive(:hidden?) { false }
+    )
+
+    sign_in_as_service_admin
+
+    claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      hmrc_bank_validation_succeeded: false,
+      payroll_gender: "dont_know"
+    )
+
+    _duplicate_claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      email_address: claim.email_address
+    )
+
+    visit admin_claim_tasks_path(claim)
+
+    expect(page).to have_text("1. Identity confirmation")
+    expect(page).to have_text("2. Qualifications")
+    expect(page).to have_text("3. Employment")
+    expect(page).to have_text("4. Student loan plan")
+    expect(page).to have_text("5. Payroll details")
+    expect(page).to have_text("6. Payroll gender")
+    expect(page).to have_text("7. Matching details")
+  end
+end

--- a/spec/helpers/admin/claim_summary_helper_spec.rb
+++ b/spec/helpers/admin/claim_summary_helper_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Admin::ClaimsHelper do
 
     before { assign(:claim, claim) }
 
-    Policies.all.excluding(Policies::FurtherEducationPayments, Policies::InternationalRelocationPayments, Policies::EarlyYearsPayments).each do |policy|
+    Policies.all.excluding(
+      Policies::FurtherEducationPayments,
+      Policies::InternationalRelocationPayments,
+      Policies::EarlyYearsPayments,
+      Policies::EarlyYearsTeachersFinancialIncentivePayments
+    ).each do |policy|
       context "for policy #{policy}" do
         let(:policy) { policy }
 

--- a/spec/models/policies_spec.rb
+++ b/spec/models/policies_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Policies, type: :model do
         Policies::TargetedRetentionIncentivePayments,
         Policies::InternationalRelocationPayments,
         Policies::FurtherEducationPayments,
-        Policies::EarlyYearsPayments
+        Policies::EarlyYearsPayments,
+        Policies::EarlyYearsTeachersFinancialIncentivePayments
       ])
     end
   end
@@ -24,7 +25,9 @@ RSpec.describe Policies, type: :model do
 
   describe "::all" do
     it do
-      expect(described_class.all).to eq(described_class::POLICIES)
+      expect(described_class.all).to eq(described_class::POLICIES.excluding(
+        Policies::EarlyYearsTeachersFinancialIncentivePayments
+      ))
     end
   end
 


### PR DESCRIPTION
Wire up admin task list for EYTFI

Adds the scaffolding for the EYTFI admin claim task list.
Clicking the task links wont work but this gives us a place to drop in
the functionality for each task.

We also introduce `BasePolicy.hidden?` which excludes a policy from
`BasePolicy.all`, allowing us to incrementally work on the admin site
without interrupting the ops team's work.

