### PR TITLE
[CAPT-3606] EYTFI provider upload

### DIFF
--- a/app/controllers/admin/eligible_eytfi_providers_controller.rb
+++ b/app/controllers/admin/eligible_eytfi_providers_controller.rb
@@ -22,7 +22,7 @@ module Admin
       @upload_form = EligibleEytfiProvidersForm.new(upload_params, admin_user)
 
       if @upload_form.valid? && @upload_form.save
-        redirect_to edit_admin_journey_configuration_path(Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name, eligible_fe_providers_upload: {academic_year: @upload_form.academic_year})
+        redirect_to admin_file_upload_path(@upload_form.file_upload)
       else
         render "admin/journey_configurations/edit"
       end

--- a/app/controllers/admin/eligible_eytfi_providers_controller.rb
+++ b/app/controllers/admin/eligible_eytfi_providers_controller.rb
@@ -1,0 +1,43 @@
+module Admin
+  class EligibleEytfiProvidersController < BaseAdminController
+    before_action :ensure_service_operator
+
+    helper_method :journey_configuration
+
+    rate_limit(
+      to: 1,
+      within: 30.seconds,
+      only: :create,
+      with: -> do
+        redirect_to(
+          edit_admin_journey_configuration_path(
+            Journeys::FurtherEducationPayments.routing_name
+          ),
+          alert: "Too many requests"
+        )
+      end
+    )
+
+    def create
+      @upload_form = EligibleEytfiProvidersForm.new(upload_params, admin_user)
+
+      if @upload_form.valid? && @upload_form.save
+        redirect_to edit_admin_journey_configuration_path(Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name, eligible_fe_providers_upload: {academic_year: @upload_form.academic_year})
+      else
+        render "admin/journey_configurations/edit"
+      end
+    end
+
+    private
+
+    def journey_configuration
+      @journey_configuration ||= Journeys::Configuration.find_by(
+        routing_name: Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name
+      )
+    end
+
+    def upload_params
+      params.require(:eligible_eytfi_providers_upload).permit(:academic_year, :file)
+    end
+  end
+end

--- a/app/controllers/admin/file_uploads_controller.rb
+++ b/app/controllers/admin/file_uploads_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def show
       @file_upload = FileUpload.find(params[:id])
 
-      if @file_upload.completed_processing_at.nil?
+      if @file_upload.completed_processing_at.nil? && @file_upload.upload_errors.blank?
         response.headers["Refresh"] = "5"
       end
     end

--- a/app/controllers/admin/file_uploads_controller.rb
+++ b/app/controllers/admin/file_uploads_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class FileUploadsController < BaseAdminController
+    before_action :ensure_service_operator
+
+    def show
+      @file_upload = FileUpload.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/admin/file_uploads_controller.rb
+++ b/app/controllers/admin/file_uploads_controller.rb
@@ -4,6 +4,10 @@ module Admin
 
     def show
       @file_upload = FileUpload.find(params[:id])
+
+      if @file_upload.completed_processing_at.nil?
+        response.headers["Refresh"] = "5"
+      end
     end
   end
 end

--- a/app/forms/admin/eligible_eytfi_providers_form.rb
+++ b/app/forms/admin/eligible_eytfi_providers_form.rb
@@ -33,9 +33,9 @@ class Admin::EligibleEytfiProvidersForm
   end
 
   def save
-    file_upload.save
-  end
-
-  def run_import!
+    ApplicationRecord.transaction do
+      file_upload.save
+      EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfiProvidersJob.perform_later(file_upload)
+    end
   end
 end

--- a/app/forms/admin/eligible_eytfi_providers_form.rb
+++ b/app/forms/admin/eligible_eytfi_providers_form.rb
@@ -34,7 +34,7 @@ class Admin::EligibleEytfiProvidersForm
 
   def save
     ApplicationRecord.transaction do
-      file_upload.save
+      file_upload.save!
       EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfiProvidersJob.perform_later(file_upload)
     end
   end

--- a/app/forms/admin/eligible_eytfi_providers_form.rb
+++ b/app/forms/admin/eligible_eytfi_providers_form.rb
@@ -1,0 +1,41 @@
+class Admin::EligibleEytfiProvidersForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :academic_year, AcademicYear::Type.new
+  attribute :file
+
+  validates :file,
+    presence: {message: "Choose a CSV file of eligible EYTFI providers to upload"}
+
+  attr_reader :admin_user
+
+  def initialize(params, admin_user)
+    super(params)
+
+    @admin_user = admin_user
+  end
+
+  def select_options
+    (0..2).map do |relative_year|
+      academic_year = AcademicYear.current + relative_year
+      OpenStruct.new(id: academic_year.to_s, name: academic_year)
+    end
+  end
+
+  def file_upload
+    @file_upload ||= FileUpload.new(
+      uploaded_by: admin_user,
+      body: File.read(file),
+      target_data_model: Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider.to_s,
+      academic_year: academic_year.to_s
+    )
+  end
+
+  def save
+    file_upload.save
+  end
+
+  def run_import!
+  end
+end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -13,12 +13,39 @@ module EarlyYearsTeachersFinancialIncentivePayments
         @row = row
       end
 
+      def to_provider(file_upload:)
+        Policies::
+          EarlyYearsTeachersFinancialIncentivePayments::
+          EligibleEytfiProvider.new(
+            urn: row["Provider URN"],
+            name: row["Provider name"],
+            address_line_1: row["Provider address line 1"],
+            address_line_2: row["Provider address line 2"],
+            address_line_3: row["Provider address line 3"],
+            town: row["Provider town"],
+            postcode: row["Postcode"],
+            eligible: cast_bool(row["Eligible"]),
+            file_upload:
+          )
+      end
+
       private
 
       def validate_eligible_input
         return if ["TRUE", "FALSE"].include?(row["Eligible"])
 
         errors.add(:eligible, "must be TRUE or FALSE")
+      end
+
+      def cast_bool(value)
+        case value
+        when "TRUE"
+          true
+        when "FALSE"
+          false
+        else
+          raise "#{value} could not be cast to a boolean"
+        end
       end
     end
 
@@ -40,37 +67,12 @@ module EarlyYearsTeachersFinancialIncentivePayments
       end
 
       CSV.foreach(body_io, headers: true) do |row|
-        provider = Policies::
-          EarlyYearsTeachersFinancialIncentivePayments::
-          EligibleEytfiProvider.new(
-            urn: row["Provider URN"],
-            name: row["Provider name"],
-            address_line_1: row["Provider address line 1"],
-            address_line_2: row["Provider address line 2"],
-            address_line_3: row["Provider address line 3"],
-            town: row["Provider town"],
-            postcode: row["Postcode"],
-            eligible: cast_bool(row["Eligible"]),
-            file_upload:
-          )
-
+        parser = RowParser.new(row:)
+        provider = parser.to_provider(file_upload:)
         provider.save!
       end
 
       file_upload.update completed_processing_at: Time.zone.now
-    end
-
-    private
-
-    def cast_bool(value)
-      case value
-      when "TRUE"
-        true
-      when "FALSE"
-        false
-      else
-        raise "#{value} could not be cast to a boolean"
-      end
     end
   end
 end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -81,6 +81,18 @@ module EarlyYearsTeachersFinancialIncentivePayments
       body_io = StringIO.new(file_upload.body)
       errors = []
 
+      headers = CSV.foreach(body_io).first
+
+      if headers != RowParser::HEADERS
+        file_upload.update(
+          upload_errors: [
+            "Headers must be #{RowParser::HEADERS.join(", ")}"
+          ]
+        )
+
+        return
+      end
+
       CSV.foreach(body_io, headers: true).with_index do |row, index|
         row_counter = index + 2
         parser = RowParser.new(row:)

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -69,8 +69,7 @@ module EarlyYearsTeachersFinancialIncentivePayments
 
       if invalid
         file_upload.update(
-          upload_errors: errors,
-          completed_processing_at: Time.zone.now
+          upload_errors: errors
         )
 
         return

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -52,17 +52,27 @@ module EarlyYearsTeachersFinancialIncentivePayments
     def perform(file_upload)
       invalid = false
       body_io = StringIO.new(file_upload.body)
+      errors = []
 
       CSV.foreach(body_io, headers: true).with_index do |row, index|
+        row_counter = index + 2
         parser = RowParser.new(row:)
 
         if parser.invalid?
           invalid = true
+
+          parser.errors.full_messages.each do |message|
+            errors << "Row #{row_counter}: #{message}"
+          end
         end
       end
 
       if invalid
-        file_upload.update completed_processing_at: Time.zone.now
+        file_upload.update(
+          upload_errors: errors,
+          completed_processing_at: Time.zone.now
+        )
+
         return
       end
 

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -76,13 +76,15 @@ module EarlyYearsTeachersFinancialIncentivePayments
         return
       end
 
-      CSV.foreach(body_io, headers: true) do |row|
-        parser = RowParser.new(row:)
-        provider = parser.to_provider(file_upload:)
-        provider.save!
-      end
+      ApplicationRecord.transaction do
+        CSV.foreach(body_io, headers: true) do |row|
+          parser = RowParser.new(row:)
+          provider = parser.to_provider(file_upload:)
+          provider.save!
+        end
 
-      file_upload.update completed_processing_at: Time.zone.now
+        file_upload.update completed_processing_at: Time.zone.now
+      end
     end
   end
 end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -3,11 +3,40 @@ require "csv"
 module EarlyYearsTeachersFinancialIncentivePayments
   class ImportEligibleEytfiProvidersJob < ApplicationJob
     class RowParser
+      HEADERS = [
+        "Provider URN",
+        "Provider name",
+        "Provider address line 1",
+        "Provider address line 2",
+        "Provider address line 3",
+        "Provider town",
+        "Postcode",
+        "Eligible"
+      ]
+
       include ActiveModel::Validations
 
       attr_reader :row
 
-      validate :validate_eligible_input
+      validates "Provider URN",
+        presence: true,
+        length: {in: 6..8}
+
+      validates "Provider name",
+        presence: true
+
+      validates "Provider address line 1",
+        presence: true
+
+      validates "Provider town",
+        presence: true
+
+      validates "Postcode",
+        presence: true
+
+      validates "Eligible",
+        presence: true,
+        inclusion: {in: %w[TRUE FALSE], message: "must be TRUE or FALSE"}
 
       def initialize(row:)
         @row = row
@@ -29,13 +58,11 @@ module EarlyYearsTeachersFinancialIncentivePayments
           )
       end
 
-      private
-
-      def validate_eligible_input
-        return if ["TRUE", "FALSE"].include?(row["Eligible"])
-
-        errors.add(:eligible, "must be TRUE or FALSE")
+      def read_attribute_for_validation(key)
+        row[key]
       end
+
+      private
 
       def cast_bool(value)
         case value

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -1,0 +1,76 @@
+require "csv"
+
+module EarlyYearsTeachersFinancialIncentivePayments
+  class ImportEligibleEytfiProvidersJob < ApplicationJob
+    class RowParser
+      include ActiveModel::Validations
+
+      attr_reader :row
+
+      validate :validate_eligible_input
+
+      def initialize(row:)
+        @row = row
+      end
+
+      private
+
+      def validate_eligible_input
+        return if ["TRUE", "FALSE"].include?(row["Eligible"])
+
+        errors.add(:eligible, "must be TRUE or FALSE")
+      end
+    end
+
+    def perform(file_upload)
+      invalid = false
+      body_io = StringIO.new(file_upload.body)
+
+      CSV.foreach(body_io, headers: true).with_index do |row, index|
+        parser = RowParser.new(row:)
+
+        if parser.invalid?
+          invalid = true
+        end
+      end
+
+      if invalid
+        file_upload.update completed_processing_at: Time.zone.now
+        return
+      end
+
+      CSV.foreach(body_io, headers: true) do |row|
+        provider = Policies::
+          EarlyYearsTeachersFinancialIncentivePayments::
+          EligibleEytfiProvider.new(
+            urn: row["Provider URN"],
+            name: row["Provider name"],
+            address_line_1: row["Provider address line 1"],
+            address_line_2: row["Provider address line 2"],
+            address_line_3: row["Provider address line 3"],
+            town: row["Provider town"],
+            postcode: row["Postcode"],
+            eligible: cast_bool(row["Eligible"]),
+            file_upload:
+          )
+
+        provider.save!
+      end
+
+      file_upload.update completed_processing_at: Time.zone.now
+    end
+
+    private
+
+    def cast_bool(value)
+      case value
+      when "TRUE"
+        true
+      when "FALSE"
+        false
+      else
+        raise "#{value} could not be cast to a boolean"
+      end
+    end
+  end
+end

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -31,4 +31,12 @@ class FileUpload < ApplicationRecord
   def completed_processing!
     update!(completed_processing_at: Time.zone.now)
   end
+
+  def back_link
+    case target_data_model
+    when "Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider"
+      journey = Journeys::EarlyYearsTeachersFinancialIncentivePayments
+      Rails.application.routes.url_helpers.edit_admin_journey_configuration_path(journey.routing_name)
+    end
+  end
 end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
@@ -1,7 +1,6 @@
 module Policies
   module EarlyYearsTeachersFinancialIncentivePayments
     class EligibleEytfiProvider < ApplicationRecord
-      attribute :academic_year, AcademicYear::Type.new
       belongs_to :file_upload
 
       scope :by_academic_year, ->(academic_year) {

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
@@ -1,0 +1,12 @@
+module Policies
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class EligibleEytfiProvider < ApplicationRecord
+      attribute :academic_year, AcademicYear::Type.new
+      belongs_to :file_upload
+
+      scope :by_academic_year, ->(academic_year) {
+        where(file_upload: FileUpload.latest_version_for(EligibleFeProvider, academic_year))
+      }
+    end
+  end
+end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
@@ -3,9 +3,14 @@ module Policies
     class EligibleEytfiProvider < ApplicationRecord
       belongs_to :file_upload
 
-      scope :by_academic_year, ->(academic_year) {
-        where(file_upload: FileUpload.latest_version_for(EligibleFeProvider, academic_year))
-      }
+      scope :by_academic_year, ->(academic_year) do
+        where(
+          file_upload: FileUpload.latest_version_for(
+            EligibleEytfiProvider,
+            academic_year
+          )
+        )
+      end
     end
   end
 end

--- a/app/views/admin/file_uploads/show.html.erb
+++ b/app/views/admin/file_uploads/show.html.erb
@@ -25,7 +25,7 @@
 
   <%= summary_list.with_row do |row| %>
     <%= row.with_key { "Completed processing at" } %>
-    <%= row.with_value { l(@file_upload.completed_processing_at) } %>
+    <%= row.with_value { @file_upload.completed_processing_at.present? ? l(@file_upload.completed_processing_at) : "Not yet processed" } %>
   <% end %>
 <% end %>
 

--- a/app/views/admin/file_uploads/show.html.erb
+++ b/app/views/admin/file_uploads/show.html.erb
@@ -1,0 +1,36 @@
+<h1 class="govuk-heading-l">
+  File upload
+</h1>
+
+<%= govuk_summary_list(actions: false) do |summary_list| %>
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Target" } %>
+    <%= row.with_value { @file_upload.target_data_model.split("::").last } %>
+  <% end %>
+
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Academic year" } %>
+    <%= row.with_value { @file_upload.academic_year } %>
+  <% end %>
+
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Uploaded at" } %>
+    <%= row.with_value { l(@file_upload.created_at) } %>
+  <% end %>
+
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Uploaded by" } %>
+    <%= row.with_value { @file_upload.uploaded_by.full_name } %>
+  <% end %>
+
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Completed processing at" } %>
+    <%= row.with_value { l(@file_upload.completed_processing_at) } %>
+  <% end %>
+<% end %>
+
+<h2 class="govuk-heading-m">
+  Errors
+</h2>
+
+<%= govuk_list @file_upload.upload_errors, type: :bullet %>

--- a/app/views/admin/file_uploads/show.html.erb
+++ b/app/views/admin/file_uploads/show.html.erb
@@ -1,3 +1,9 @@
+<% if @file_upload.back_link %>
+  <% content_for :back_link do %>
+    <%= govuk_back_link href: @file_upload.back_link %>
+  <% end %>
+<% end %>
+
 <h1 class="govuk-heading-l">
   File upload
 </h1>

--- a/app/views/admin/file_uploads/show.html.erb
+++ b/app/views/admin/file_uploads/show.html.erb
@@ -48,7 +48,11 @@
     </p>
   <% end %>
 <% else %>
-  <p class="govuk-body">
-    Please wait for file to finish processing
-  </p>
+  <% if @file_upload.upload_errors.any? %>
+    <%= govuk_list @file_upload.upload_errors, type: :bullet %>
+  <% else %>
+    <p class="govuk-body">
+      Please wait for file to finish processing
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/admin/file_uploads/show.html.erb
+++ b/app/views/admin/file_uploads/show.html.erb
@@ -33,4 +33,16 @@
   Errors
 </h2>
 
-<%= govuk_list @file_upload.upload_errors, type: :bullet %>
+<% if @file_upload.completed_processing_at %>
+  <% if @file_upload.upload_errors.any? %>
+    <%= govuk_list @file_upload.upload_errors, type: :bullet %>
+  <% else %>
+    <p class="govuk-body">
+      No errors found
+    </p>
+  <% end %>
+<% else %>
+  <p class="govuk-body">
+    Please wait for file to finish processing
+  </p>
+<% end %>

--- a/app/views/admin/journey_configurations/_edit_early_years_teachers_financial_incentive_payments.html.erb
+++ b/app/views/admin/journey_configurations/_edit_early_years_teachers_financial_incentive_payments.html.erb
@@ -1,0 +1,19 @@
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h2 class="govuk-heading-m">
+  Upload eligible EYTFI providers
+</h2>
+
+<%= form_with model: @upload_form, scope: :eligible_eytfi_providers_upload, url: admin_eligible_eytfi_providers_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_select :academic_year, f.object.select_options, :id, :name,
+    label: { text: "Academic year" } %>
+
+  <%= f.govuk_file_field :file,
+    label: { text: "Eligible EYTFI providers" },
+    hint: { text: "This file should be a CSV" },
+    javascript: true %>
+
+  <%= f.govuk_submit "Upload CSV" %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -464,24 +464,24 @@ shared:
     - updated_at # datetime, when this datapoint was last updated
     - type # string, type of datapoint
   :events:
-  - id # uuid, identifies this event occurrence
-  - name # string, describes what this event is
-  - claim_id # uuid, references the associated claim
-  - actor_id # uuid, admin that created triggered this event
-  - entity_type # string, used to identify the entity type this event relates to
-  - entity_id # uuid, references associated entity
-  - created_at # datetime, when the event was created
-  - updated_at # datetime, when the event was last updated
+    - id # uuid, identifies this event occurrence
+    - name # string, describes what this event is
+    - claim_id # uuid, references the associated claim
+    - actor_id # uuid, admin that created triggered this event
+    - entity_type # string, used to identify the entity type this event relates to
+    - entity_id # uuid, references associated entity
+    - created_at # datetime, when the event was created
+    - updated_at # datetime, when the event was last updated
   :eligible_eytfi_providers:
-  - id # uuid, identifies the eligible EYTFI provider
-  - urn # string, identifier of the provider
-  - name # string, name of the provider
-  - address_line_1 # string, address line 1 of the provider
-  - address_line_2 # string, address line 2 of the provider
-  - address_line_3 # string, address line 3 of the provider
-  - town # string, town of the provider
-  - postcode # string, postcode of the provider
-  - created_at # datetime, when this provider was uploaded
-  - updated_at # datetime, when this provider was last updated
-  - eligible # boolean, whether or not this provider is eligible for payment
-  - file_upload_id # uuid, associated file upload. use this to work out academic year and latest version as this table is append only
+    - id # uuid, identifies the eligible EYTFI provider
+    - urn # string, identifier of the provider
+    - name # string, name of the provider
+    - address_line_1 # string, address line 1 of the provider
+    - address_line_2 # string, address line 2 of the provider
+    - address_line_3 # string, address line 3 of the provider
+    - town # string, town of the provider
+    - postcode # string, postcode of the provider
+    - created_at # datetime, when this provider was uploaded
+    - updated_at # datetime, when this provider was last updated
+    - eligible # boolean, whether or not this provider is eligible for payment
+    - file_upload_id # uuid, associated file upload. use this to work out academic year and latest version as this table is append only

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -472,3 +472,16 @@ shared:
   - entity_id # uuid, references associated entity
   - created_at # datetime, when the event was created
   - updated_at # datetime, when the event was last updated
+  :eligible_eytfi_providers:
+  - id # uuid, identifies the eligible EYTFI provider
+  - urn # string, identifier of the provider
+  - name # string, name of the provider
+  - address_line_1 # string, address line 1 of the provider
+  - address_line_2 # string, address line 2 of the provider
+  - address_line_3 # string, address line 3 of the provider
+  - town # string, town of the provider
+  - postcode # string, postcode of the provider
+  - created_at # datetime, when this provider was uploaded
+  - updated_at # datetime, when this provider was last updated
+  - eligible # boolean, whether or not this provider is eligible for payment
+  - file_upload_id # uuid, associated file upload. use this to work out academic year and latest version as this table is append only

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -44,6 +44,7 @@
   - target_data_model
   - completed_processing_at
   - academic_year
+  - upload_errors
   :reminders:
   - one_time_password
   :student_loans_data:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
 
     resources :journey_configurations, only: [:index, :edit, :update], path: "journey-configurations"
     resource :feature_flags, only: [:update], path: "feature-flags"
+    resources :file_uploads, only: [:show], path: "file-uploads"
     resources :targeted_retention_incentive_payments_awards, only: [:index, :create]
     resource :eligible_ey_providers, only: [:create, :show], path: "eligible-early-years-providers"
     resource :eligible_fe_providers, only: [:create, :show], path: "eligible-further-education-providers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ Rails.application.routes.draw do
     resources :targeted_retention_incentive_payments_awards, only: [:index, :create]
     resource :eligible_ey_providers, only: [:create, :show], path: "eligible-early-years-providers"
     resource :eligible_fe_providers, only: [:create, :show], path: "eligible-further-education-providers"
+    resource :eligible_eytfi_providers, only: [:create, :show]
     resources :reports, only: [:index, :show]
 
     resources :early_years_providers, only: [:index]

--- a/db/migrate/20260427100232_create_eligible_eytfi_providers.rb
+++ b/db/migrate/20260427100232_create_eligible_eytfi_providers.rb
@@ -1,0 +1,20 @@
+class CreateEligibleEytfiProviders < ActiveRecord::Migration[8.1]
+  def change
+    create_table :eligible_eytfi_providers, id: :uuid do |t|
+      t.uuid "file_upload_id", null: false
+
+      t.text :urn, null: false
+      t.text :name, null: false
+      t.text :address_line_1
+      t.text :address_line_2
+      t.text :address_line_3
+      t.text :town
+      t.text :postcode, null: false
+      t.boolean :eligible, null: false
+
+      t.timestamps
+    end
+
+    add_index :eligible_eytfi_providers, [:urn, :file_upload_id]
+  end
+end

--- a/db/migrate/20260427100232_create_eligible_eytfi_providers.rb
+++ b/db/migrate/20260427100232_create_eligible_eytfi_providers.rb
@@ -15,6 +15,6 @@ class CreateEligibleEytfiProviders < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :eligible_eytfi_providers, [:urn, :file_upload_id]
+    add_index :eligible_eytfi_providers, [:urn, :file_upload_id], unique: true
   end
 end

--- a/db/migrate/20260429114412_add_upload_errors_to_file_uploads.rb
+++ b/db/migrate/20260429114412_add_upload_errors_to_file_uploads.rb
@@ -1,5 +1,5 @@
 class AddUploadErrorsToFileUploads < ActiveRecord::Migration[8.1]
   def change
-    add_column :file_uploads, :upload_errors, :text, array: true, default: []
+    add_column :file_uploads, :upload_errors, :jsonb, default: []
   end
 end

--- a/db/migrate/20260429114412_add_upload_errors_to_file_uploads.rb
+++ b/db/migrate/20260429114412_add_upload_errors_to_file_uploads.rb
@@ -1,0 +1,5 @@
+class AddUploadErrorsToFileUploads < ActiveRecord::Migration[8.1]
+  def change
+    add_column :file_uploads, :upload_errors, :text, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_100232) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_114412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -326,6 +326,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_100232) do
     t.datetime "created_at", null: false
     t.string "target_data_model"
     t.datetime "updated_at", null: false
+    t.text "upload_errors", default: [], array: true
     t.uuid "uploaded_by_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,7 +326,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_114412) do
     t.datetime "created_at", null: false
     t.string "target_data_model"
     t.datetime "updated_at", null: false
-    t.text "upload_errors", default: [], array: true
+    t.jsonb "upload_errors", default: []
     t.uuid "uploaded_by_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -271,7 +271,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_100232) do
     t.text "town"
     t.datetime "updated_at", null: false
     t.text "urn", null: false
-    t.index ["urn", "file_upload_id"], name: "index_eligible_eytfi_providers_on_urn_and_file_upload_id"
+    t.index ["urn", "file_upload_id"], name: "index_eligible_eytfi_providers_on_urn_and_file_upload_id", unique: true
   end
 
   create_table "eligible_fe_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_103432) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_100232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -257,6 +257,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_103432) do
     t.index ["primary_key_contact_email_address"], name: "index_eligible_ey_providers_on_primary_contact_email_address"
     t.index ["secondary_contact_email_address"], name: "index_eligible_ey_providers_on_secondary_contact_email_address"
     t.index ["urn", "file_upload_id"], name: "index_eligible_ey_providers_on_urn_and_file_upload_id", unique: true
+  end
+
+  create_table "eligible_eytfi_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "address_line_1"
+    t.text "address_line_2"
+    t.text "address_line_3"
+    t.datetime "created_at", null: false
+    t.boolean "eligible", null: false
+    t.uuid "file_upload_id", null: false
+    t.text "name", null: false
+    t.text "postcode", null: false
+    t.text "town"
+    t.datetime "updated_at", null: false
+    t.text "urn", null: false
+    t.index ["urn", "file_upload_id"], name: "index_eligible_eytfi_providers_on_urn_and_file_upload_id"
   end
 
   create_table "eligible_fe_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/file_uploads.rb
+++ b/spec/factories/file_uploads.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_current_academic_year do
+      academic_year { AcademicYear.current }
+    end
+
     body do
       string = ""
 

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
@@ -18,5 +18,9 @@ RSpec.feature "Admin of eligible EYTFI providers" do
     expect {
       click_button "Upload CSV"
     }.to change(FileUpload, :count).by(1)
+
+    file_upload = FileUpload.last
+
+    expect(page.current_path).to eql(admin_file_upload_path(file_upload))
   end
 end

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "Admin of eligible EYTFI providers" do
     expect {
       click_button "Upload CSV"
     }.to change(FileUpload, :count).by(1)
+      .and have_enqueued_job(EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfiProvidersJob)
 
     file_upload = FileUpload.last
 

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "Admin of eligible EYTFI providers" do
+  let(:eligible_eytfi_providers_csv_file) do
+    file_fixture("eligible_eytfi_providers.csv")
+  end
+
+  scenario "manage eligible EYTFI providers" do
+    when_eytfi_journey_configuration_exists
+    sign_in_as_service_operator
+
+    click_link "Manage services"
+    click_link "Change Early Years Teachers Financial Incentive Payments"
+
+    select AcademicYear.current.to_s, from: "Academic year"
+    attach_file "eligible-eytfi-providers-upload-file-field", eligible_eytfi_providers_csv_file
+
+    expect {
+      click_button "Upload CSV"
+    }.to change(FileUpload, :count).by(1)
+  end
+end

--- a/spec/features/admin/file_uploads_spec.rb
+++ b/spec/features/admin/file_uploads_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Admin viewing file uploads" do
     sign_in_as_service_operator
   end
 
-  context "when file upload is not yet processed" do
+  context "when file upload is not yet processed without errors" do
     let(:file_upload) do
       create(
         :file_upload,

--- a/spec/features/admin/file_uploads_spec.rb
+++ b/spec/features/admin/file_uploads_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Admin viewing file uploads" do
+  before do
+    sign_in_as_service_operator
+  end
+
+  context "when file upload is not yet processed" do
+    let(:file_upload) do
+      create(
+        :file_upload,
+        :not_completed_processing,
+        :with_current_academic_year,
+        target_data_model: "Foo"
+      )
+    end
+
+    scenario "it refreshes the page every 5 seconds" do
+      visit "/admin/file-uploads/#{file_upload.id}"
+
+      expect(page.response_headers["refresh"]).to eql("5")
+    end
+  end
+
+  context "when file upload has been processed" do
+    let(:file_upload) do
+      create(
+        :file_upload,
+        :with_current_academic_year,
+        target_data_model: "Foo"
+      )
+    end
+
+    scenario "it does not refresh the page" do
+      visit "/admin/file-uploads/#{file_upload.id}"
+
+      expect(page.response_headers["refresh"]).to be_blank
+    end
+  end
+end

--- a/spec/fixtures/files/eligible_eytfi_providers.csv
+++ b/spec/fixtures/files/eligible_eytfi_providers.csv
@@ -1,0 +1,3 @@
+Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible
+123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE

--- a/spec/fixtures/files/eligible_eytfi_providers_with_error.csv
+++ b/spec/fixtures/files/eligible_eytfi_providers_with_error.csv
@@ -1,0 +1,4 @@
+Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible
+123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FOO

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -75,12 +75,6 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
         }.not_to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
       end
 
-      it "touches file upload completed_processing_at" do
-        subject.perform(file_upload)
-
-        expect(file_upload.reload.completed_processing_at).to be_present
-      end
-
       it "saves errors on file upload" do
         subject.perform(file_upload)
 

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -83,3 +83,210 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
     end
   end
 end
+
+RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfiProvidersJob::RowParser, type: :model do
+  let(:file_upload) do
+    create(:file_upload)
+  end
+
+  subject { described_class.new(row:) }
+
+  describe "#validations" do
+    context "urn" do
+      context "when urn missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Provider URN"]).to be_present
+        end
+      end
+
+      context "when urn too short" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "12345"
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Provider URN"]).to be_present
+        end
+      end
+
+      context "when urn too long" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "123456789"
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Provider URN"]).to be_present
+        end
+      end
+    end
+
+    context "name" do
+      context "name missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Provider name"]).to be_present
+        end
+      end
+    end
+
+    context "adress line 1" do
+      context "is missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Provider address line 1"]).to be_present
+        end
+      end
+    end
+
+    context "town" do
+      context "is missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Provider town"]).to be_present
+        end
+      end
+    end
+
+    context "postcode" do
+      context "is missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Postcode"]).to be_present
+        end
+      end
+    end
+
+    context "eligible" do
+      context "is missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Eligible"]).to be_present
+        end
+      end
+
+      context "is malformatted" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "foo"
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Eligible"]).to be_present
+        end
+      end
+    end
+  end
+
+  describe "#to_provider" do
+    it "returns provider object"
+  end
+end

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
           subject.perform(file_upload)
         }.not_to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
       end
+
+      it "touches file upload completed_processing_at" do
+        subject.perform(file_upload)
+
+        expect(file_upload.reload.completed_processing_at).to be_present
+      end
+
+      it "saves errors on file upload" do
+        subject.perform(file_upload)
+
+        expect(file_upload.reload.upload_errors).to eql(["Row 4: Eligible must be TRUE or FALSE"])
+      end
     end
   end
 end

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -311,6 +311,39 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
   end
 
   describe "#to_provider" do
-    it "returns provider object"
+    let(:row) do
+      CSV::Row.new(
+        described_class::HEADERS,
+        [
+          "EY123456",
+          "Some nursery",
+          "Some Road",
+          "Somewhere",
+          "Somewhere Else",
+          "London",
+          "EC1N 2TD",
+          "TRUE"
+        ],
+        true
+      )
+    end
+
+    it "returns provider object" do
+      expected = Policies::
+        EarlyYearsTeachersFinancialIncentivePayments::
+        EligibleEytfiProvider.new(
+          urn: "EY123456",
+          name: "Some nursery",
+          address_line_1: "Some Road",
+          address_line_2: "Somewhere",
+          address_line_3: "Somewhere Else",
+          town: "London",
+          postcode: "EC1N 2TD",
+          eligible: true,
+          file_upload:
+        )
+
+      expect(subject.to_provider(file_upload:).attributes).to eql(expected.attributes)
+    end
   end
 end

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -81,6 +81,30 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
         expect(file_upload.reload.upload_errors).to eql(["Row 4: Eligible must be TRUE or FALSE"])
       end
     end
+
+    context "when incorrect headers" do
+      let(:file_upload) do
+        create(
+          :file_upload,
+          :with_current_academic_year,
+          :not_completed_processing,
+          target_data_model: Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider,
+          body: "wrong,headers,here"
+        )
+      end
+
+      it "does not create any records" do
+        expect {
+          subject.perform(file_upload)
+        }.not_to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
+      end
+
+      it "saves errors on file upload" do
+        subject.perform(file_upload)
+
+        expect(file_upload.reload.upload_errors).to eql(["Headers must be Provider URN, Provider name, Provider address line 1, Provider address line 2, Provider address line 3, Provider town, Postcode, Eligible"])
+      end
+    end
   end
 end
 

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfiProvidersJob do
+  let(:file_upload) do
+    create(
+      :file_upload,
+      :with_current_academic_year,
+      :not_completed_processing,
+      target_data_model: Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider,
+      body: file_fixture("eligible_eytfi_providers.csv").read
+    )
+  end
+
+  describe "#perform" do
+    it "creates eytfi provider" do
+      expect {
+        subject.perform(file_upload)
+      }.to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count).by(2)
+    end
+
+    it "touches file upload completed_processing_at" do
+      subject.perform(file_upload)
+
+      expect(file_upload.reload.completed_processing_at).to be_present
+    end
+
+    context "job runs twice" do
+      it "does not duplicate records" do
+        expect {
+          subject.perform(file_upload)
+        }.to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
+
+        expect {
+          subject.perform(file_upload)
+        }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+
+    context "when uploads twice" do
+      let(:second_file_upload) do
+        create(
+          :file_upload,
+          :with_current_academic_year,
+          :not_completed_processing,
+          target_data_model: Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider,
+          body: file_fixture("eligible_eytfi_providers.csv").read
+        )
+      end
+
+      it "appends records" do
+        expect {
+          subject.perform(file_upload)
+        }.to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
+
+        expect {
+          subject.perform(second_file_upload)
+        }.to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
+      end
+    end
+
+    context "when there is a validation error" do
+      let(:file_upload) do
+        create(
+          :file_upload,
+          :with_current_academic_year,
+          :not_completed_processing,
+          target_data_model: Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider,
+          body: file_fixture("eligible_eytfi_providers_with_error.csv").read
+        )
+      end
+
+      it "does not create any records" do
+        expect {
+          subject.perform(file_upload)
+        }.not_to change(Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider, :count)
+      end
+    end
+  end
+end

--- a/spec/models/file_upload_spec.rb
+++ b/spec/models/file_upload_spec.rb
@@ -46,4 +46,26 @@ RSpec.describe FileUpload, type: :model do
       expect { some_unrelated_file_upload.reload }.not_to raise_error
     end
   end
+
+  describe "#back_link" do
+    context "when EligibleEytfiProvider upload" do
+      before do
+        subject.target_data_model = "Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider"
+      end
+
+      it "returns link to edit journey config" do
+        expect(subject.back_link).to eql("/admin/journey-configurations/early-years-teachers-financial-incentive-payments/edit")
+      end
+    end
+
+    context "when something else" do
+      before do
+        subject.target_data_model = "foo"
+      end
+
+      it "returns nil" do
+        expect(subject.back_link).to be_nil
+      end
+    end
+  end
 end

--- a/spec/support/steps/journey_configuration.rb
+++ b/spec/support/steps/journey_configuration.rb
@@ -13,3 +13,7 @@ end
 def when_early_years_payment_practitioner_journey_configuration_exists
   create(:journey_configuration, :early_years_payment_practitioner)
 end
+
+def when_eytfi_journey_configuration_exists
+  create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
+end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-3606
- Admins can upload CSV of EYTFI providers
- Added a new mechanism/pattern to do file uploads for admins
- Can now view a file upload to view its state
- I have not done so in this PR but we should store some kind of success/fail state against a file upload
- Can now persist errors of a file upload so issues about an upload can be played back to admin
- This upload process is now async so it runs as a background job rather than blocking a web thread 