### PR TITLE
Employment details missing

### DIFF
--- a/app/models/policies/further_education_payments/admin_tasks_presenter.rb
+++ b/app/models/policies/further_education_payments/admin_tasks_presenter.rb
@@ -1,6 +1,8 @@
 module Policies
   module FurtherEducationPayments
     class AdminTasksPresenter
+      include Admin::PresenterMethods
+
       attr_reader :claim, :eligibility
 
       def initialize(claim)
@@ -61,6 +63,12 @@ module Policies
           ["Provider email", provider_email],
           ["Claimant name", claim.full_name],
           ["Claimant email", claim.email_address]
+        ]
+      end
+
+      def employment
+        [
+          [translate("admin.current_school"), display_school(eligibility.current_school)]
         ]
       end
 

--- a/spec/models/policies/further_education_payments/admin_tasks_presenter_spec.rb
+++ b/spec/models/policies/further_education_payments/admin_tasks_presenter_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 RSpec.describe Policies::FurtherEducationPayments::AdminTasksPresenter do
+  describe "#employment" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::FurtherEducationPayments,
+        eligibility_trait: :eligible
+      )
+    end
+
+    it "displays the current school with a link and DfE number" do
+      row = described_class.new(claim).employment.first
+
+      expect(row[0]).to eql("Current school")
+      expect(row[1]).to include("href")
+      expect(row[1]).to include(claim.school.dfe_number)
+    end
+  end
+
   describe "#provider_verification_rows" do
     context "continued_employment" do
       subject do


### PR DESCRIPTION
2 policies have a TRN and run on V2 eligibility check - fixed the method missing