### PR TITLE
[CAPT-3512] Async EYTFI TRS api call for qualifications

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -105,7 +105,7 @@ module FormSubmittable
       return if @form.blank?
       return if @form.auto_refresh.blank?
 
-      response.headers["Refresh"] = "5"
+      response.headers["Refresh"] = @form.auto_refresh
     end
   end
 end

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -3,6 +3,7 @@ module FormSubmittable
 
   included do
     before_action :load_form_if_exists, only: [:show, :update, :create]
+    before_action :set_auto_refresh_headers
 
     def new
       redirect_to_next_slug
@@ -99,5 +100,12 @@ module FormSubmittable
       DfeSignIn::NullUser.new
     end
     helper_method :current_user
+
+    def set_auto_refresh_headers
+      return if @form.blank?
+      return if @form.auto_refresh.blank?
+
+      response.headers["Refresh"] = "5"
+    end
   end
 end

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
@@ -7,40 +7,10 @@ module Journeys
         redirect_to claim_path(current_journey_routing_name, "eligible-qualification-confirmed")
       end
 
-      def callback_bypass
-        persist_callback_to_session
-
-        redirect_to claim_path(current_journey_routing_name, "eligible-qualification-confirmed")
-      end
-
       private
 
       def omniauth_hash
-        @omniauth_hash ||= if !TeacherAuth::Config.instance.bypass?
-          request.env["omniauth.auth"]
-        else
-          omniauth_bypass_hash
-        end
-      end
-
-      def omniauth_bypass_hash
-        form = Debug::TeacherAuth::SignInForm.new(
-          journey_session: nil,
-          journey: nil,
-          params:
-        )
-
-        OpenStruct.new(
-          extra: OpenStruct.new(
-            raw_info: OpenStruct.new(
-              trn: form.trn,
-              email: form.email,
-              verified_name: form.verified_name.split(" "),
-              verified_date_of_birth: form.verified_date_of_birth.to_s,
-              sub: form.sub
-            )
-          )
-        )
+        @omniauth_hash ||= request.env["omniauth.auth"]
       end
 
       def persist_callback_to_session

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
@@ -21,7 +21,8 @@ module Journeys
           teacher_auth_email: omniauth_hash.extra.raw_info.email,
           teacher_auth_verified_name: omniauth_hash.extra.raw_info.verified_name.join(" "),
           teacher_auth_verified_date_of_birth: Date.parse(omniauth_hash.extra.raw_info.verified_date_of_birth),
-          teacher_auth_one_login_uid: omniauth_hash.extra.raw_info.sub
+          teacher_auth_one_login_uid: omniauth_hash.extra.raw_info.sub,
+          teacher_auth_completed_at: Time.zone.now
         )
         journey_session.save!
       end

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/auth_controller.rb
@@ -4,7 +4,9 @@ module Journeys
       def callback
         persist_callback_to_session
 
-        redirect_to claim_path(current_journey_routing_name, "eligible-qualification-confirmed")
+        ::EarlyYearsTeachersFinancialIncentivePayments::FetchQualificationsJob.perform_later(journey_session)
+
+        redirect_to claim_path(current_journey_routing_name, "qualifications-check")
       end
 
       private

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
@@ -26,6 +26,7 @@ module Journeys
           teacher_auth_verified_name: form.verified_name,
           teacher_auth_verified_date_of_birth: form.verified_date_of_birth,
           teacher_auth_one_login_uid: form.sub,
+          teacher_auth_completed_at: Time.zone.now,
           trs_data: {},
           trs_data_fetched_at: Time.zone.now,
           has_eligible_qualification: form.has_eligible_qualification

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
@@ -4,7 +4,9 @@ module Journeys
       def callback
         persist_callback_to_session
 
-        ::EarlyYearsTeachersFinancialIncentivePayments::FetchQualificationsJob.perform_later(journey_session)
+        ::EarlyYearsTeachersFinancialIncentivePayments::FetchQualificationsBypassJob
+          .set(wait: 2.seconds)
+          .perform_later(journey_session)
 
         redirect_to claim_path(current_journey_routing_name, "qualifications-check")
       end
@@ -27,8 +29,6 @@ module Journeys
           teacher_auth_verified_date_of_birth: form.verified_date_of_birth,
           teacher_auth_one_login_uid: form.sub,
           teacher_auth_completed_at: Time.zone.now,
-          trs_data: {},
-          trs_data_fetched_at: Time.zone.now,
           has_eligible_qualification: form.has_eligible_qualification
         )
         journey_session.save!

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
@@ -4,7 +4,9 @@ module Journeys
       def callback
         persist_callback_to_session
 
-        redirect_to claim_path(current_journey_routing_name, "eligible-qualification-confirmed")
+        ::EarlyYearsTeachersFinancialIncentivePayments::FetchQualificationsJob.perform_later(journey_session)
+
+        redirect_to claim_path(current_journey_routing_name, "qualifications-check")
       end
 
       private

--- a/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
+++ b/app/controllers/journeys/early_years_teachers_financial_incentive_payments/bypass_auth_controller.rb
@@ -1,0 +1,35 @@
+module Journeys
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class BypassAuthController < BasePublicController
+      def callback
+        persist_callback_to_session
+
+        redirect_to claim_path(current_journey_routing_name, "eligible-qualification-confirmed")
+      end
+
+      private
+
+      def form
+        @form ||= Debug::TeacherAuth::SignInForm.new(
+          journey_session: nil,
+          journey: nil,
+          params:
+        )
+      end
+
+      def persist_callback_to_session
+        journey_session.answers.assign_attributes(
+          teacher_auth_teacher_reference_number: form.trn,
+          teacher_auth_email: form.email,
+          teacher_auth_verified_name: form.verified_name,
+          teacher_auth_verified_date_of_birth: form.verified_date_of_birth,
+          teacher_auth_one_login_uid: form.sub,
+          trs_data: {},
+          trs_data_fetched_at: Time.zone.now,
+          has_eligible_qualification: form.has_eligible_qualification
+        )
+        journey_session.save!
+      end
+    end
+  end
+end

--- a/app/forms/debug/teacher_auth/sign_in_form.rb
+++ b/app/forms/debug/teacher_auth/sign_in_form.rb
@@ -12,6 +12,7 @@ module Debug
       attribute :email, :string
       attribute :trn, :string
       attribute :sub, :string
+      attribute :has_eligible_qualification, :boolean
 
       def default_email
         "#{@default_verified_name.downcase.tr(" ", ".")}@example.com"
@@ -31,6 +32,10 @@ module Debug
 
       def default_sub
         "urn:fdc:gov.uk:2022:#{SecureRandom.base64(30)}"
+      end
+
+      def default_has_eligible_qualification
+        true
       end
 
       def journey

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -106,6 +106,12 @@ class Form
     nil
   end
 
+  # returns an integer which represents number of seconds for browser refresh
+  # can return falsey if feature not enabled
+  def auto_refresh
+    false
+  end
+
   private
 
   def permitted_attributes

--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/qualifications_check_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/qualifications_check_form.rb
@@ -10,7 +10,7 @@ module Journeys
       end
 
       def auto_refresh
-        5
+        1
       end
     end
   end

--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/qualifications_check_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/qualifications_check_form.rb
@@ -1,0 +1,17 @@
+module Journeys
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class QualificationsCheckForm < Form
+      def save
+        true
+      end
+
+      def redirect_to_next_slug?
+        journey_session.answers.trs_data_fetched_at.present?
+      end
+
+      def auto_refresh
+        5
+      end
+    end
+  end
+end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_bypass_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_bypass_job.rb
@@ -1,0 +1,16 @@
+require "csv"
+
+module EarlyYearsTeachersFinancialIncentivePayments
+  class FetchQualificationsBypassJob < ApplicationJob
+    def perform(journey_session)
+      return if journey_session.answers.trs_data_fetched_at.present?
+
+      journey_session.answers.assign_attributes(
+        trs_data: {},
+        trs_data_fetched_at: Time.zone.now
+      )
+
+      journey_session.save!
+    end
+  end
+end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_job.rb
@@ -1,0 +1,23 @@
+require "csv"
+
+module EarlyYearsTeachersFinancialIncentivePayments
+  class FetchQualificationsJob < ApplicationJob
+    def perform(journey_session)
+      return if journey_session.answers.trs_data_fetched_at.present?
+
+      client = Dqt::Client.new
+      trs_data = client
+        .teacher
+        .find(journey_session.answers.teacher_auth_teacher_reference_number)
+
+      has_eligible_qualification = trs_data.has_valid_qts? || trs_data.has_valid_eyts? || trs_data.has_valid_eyps?
+
+      journey_session.answers.assign_attributes(
+        trs_data: trs_data.as_json(without_table: true),
+        trs_data_fetched_at: Time.zone.now,
+        has_eligible_qualification:
+      )
+      journey_session.save!
+    end
+  end
+end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_job.rb
@@ -10,13 +10,12 @@ module EarlyYearsTeachersFinancialIncentivePayments
         .teacher
         .find(journey_session.answers.teacher_auth_teacher_reference_number)
 
-      has_eligible_qualification = trs_data.has_valid_qts? || trs_data.has_valid_eyts? || trs_data.has_valid_eyps?
-
       journey_session.answers.assign_attributes(
         trs_data: trs_data.as_json(without_table: true),
         trs_data_fetched_at: Time.zone.now,
-        has_eligible_qualification:
+        has_eligible_qualification: trs_data.has_eligible_eytfi_qualification?
       )
+
       journey_session.save!
     end
   end

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments.rb
@@ -23,6 +23,7 @@ module Journeys
       end
 
       array += [
+        QualificationsCheckForm,
         EligibleQualificationConfirmedForm,
         UploadEmploymentProofForm,
         ReviewEmploymentProofForm,

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/session_answers.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/session_answers.rb
@@ -12,6 +12,10 @@ module Journeys
       attribute :teaching_qualification_confirmation, :boolean, pii: false
       attribute :confirmed_employment_proof_blob_ids, default: [], pii: true
 
+      attribute :trs_data, pii: true
+      attribute :trs_data_fetched_at, :datetime, pii: false
+      attribute :has_eligible_qualification, :boolean, pii: false
+
       def nursery
         @nursery ||= Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider.find_by(
           id: nursery_id

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/session_answers.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/session_answers.rb
@@ -6,6 +6,7 @@ module Journeys
       attribute :teacher_auth_verified_name, :string, pii: true
       attribute :teacher_auth_verified_date_of_birth, :date, pii: true
       attribute :teacher_auth_one_login_uid, :string, pii: true
+      attribute :teacher_auth_completed_at, :datetime, pii: false
 
       attribute :nursery_search_query, :string, pii: false
       attribute :nursery_id, :string, pii: false

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/slug_sequence.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/slug_sequence.rb
@@ -7,6 +7,7 @@ module Journeys
         teaching-qualification-confirmation
         eligible-teaching-qualification-held
         sign-in
+        qualifications-check
         eligible-qualification-confirmed
         upload-employment-proof
         review-employment-proof
@@ -57,6 +58,7 @@ module Journeys
         array << SLUGS_HASH["teaching-qualification-confirmation"]
         array << SLUGS_HASH["eligible-teaching-qualification-held"]
         array << SLUGS_HASH["sign-in"]
+        array << SLUGS_HASH["qualifications-check"]
         array << SLUGS_HASH["eligible-qualification-confirmed"]
         array << SLUGS_HASH["upload-employment-proof"]
         array << SLUGS_HASH["review-employment-proof"]

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/policy_eligibility_checker.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/policy_eligibility_checker.rb
@@ -18,6 +18,8 @@ module Policies
           :ineligible_provider
         elsif answers.teaching_qualification_confirmation == false
           :teaching_qualification_not_confirmed
+        elsif answers.has_eligible_qualification == false
+          :teaching_qualification_ineligible
         end
       end
     end

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_teaching_qualification_ineligible.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_teaching_qualification_ineligible.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= @form.t([@form.ineligibility_reason, "heading"]) %>
+    </h1>
+
+    <p class="govuk-body">
+      We’ve checked your details and you do not hold one of the following teaching qualifications:
+    </p>
+
+    <%= govuk_list [
+      "Qualified Teacher Status (QTS)",
+      "Early Years Teacher Status (EYTS)",
+      "Early Years Professional Status (EYPS)"
+    ], type: :bullet %>
+
+    <p class="govuk-body">
+      Unfortunately, this means you’re not eligible for an early years teacher recognition payment. You may be eligible in the future if your circumstances change. Check the guidance again if you gain one of these qualifications.
+    </p>
+
+    <p class="govuk-body">
+      If you think this is a mistake, please check your answers or contact us at
+      <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+    </p>
+  </div>
+</div>

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/qualifications_check.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/qualifications_check.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Checking qualifications
+    </h1>
+
+    <p class="govuk-body">
+      We are checking your qualifications and will update shortly.
+    </p>
+  </div>
+</div>

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
@@ -37,6 +37,17 @@
         <%= f.govuk_text_field :trn, width: 10, label: { text: "TRN" } %>
         <%= f.govuk_text_field :sub, label: { text: "One Login UID" } %>
 
+        <%= f.govuk_check_boxes_fieldset :has_eligible_qualification, multiple: false, legend: nil do %>
+          <%= f.govuk_check_box :has_eligible_qualification,
+            true,
+            false,
+            multiple: false,
+            link_errors: true,
+            label: {
+              text: "Has eligible qualification?"
+            } %>
+        <% end %>
+
         <%= f.govuk_submit %>
       <% end %>
     <% end %>

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/sign_in.html.erb
@@ -30,7 +30,7 @@
     <% else %>
       <h2 class="govuk-heading-l">Bypass Teacher Auth</h2>
 
-      <%= form_with model: @form, url: "/early-years-teachers-financial-incentive-payments/auth/teacher", method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= form_with model: @form, url: "/early-years-teachers-financial-incentive-payments/bypass-auth/teacher", method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <%= f.govuk_text_field :verified_name, label: { text: "Full name" }, width: 20 %>
         <%= f.govuk_date_field :verified_date_of_birth, date_of_birth: true, legend: { text: "Date of Birth" } %>
         <%= f.govuk_text_field :email, width: 20 %>
@@ -39,8 +39,8 @@
 
         <%= f.govuk_check_boxes_fieldset :has_eligible_qualification, multiple: false, legend: nil do %>
           <%= f.govuk_check_box :has_eligible_qualification,
-            true,
-            false,
+            1,
+            0,
             multiple: false,
             link_errors: true,
             label: {

--- a/config/initializers/core_ext.rb
+++ b/config/initializers/core_ext.rb
@@ -1,1 +1,2 @@
 require "core_ext/date"
+require "core_ext/open_struct"

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -10,6 +10,10 @@ OmniAuth.config.on_failure = proc { |env|
 }
 
 Rails.application.config.middleware.use OmniAuth::Builder do
+  if Rails.env.test?
+    provider :developer
+  end
+
   if DfeSignIn::Config.instance.bypass?
     provider :developer
   else

--- a/config/locales/early_years_teachers_financial_incentive_payments.yml
+++ b/config/locales/early_years_teachers_financial_incentive_payments.yml
@@ -26,3 +26,5 @@ en:
           heading: You are not eligible for this payment
         ineligible_provider:
           heading: You are not eligible for this payment
+        teaching_qualification_ineligible:
+          heading: You’re not eligible based on your qualification

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
 
     scope constraints: {journey: "early-years-teachers-financial-incentive-payments"} do
       if TeacherAuth::Config.instance.bypass? || Rails.env.test?
-        post "auth/teacher", to: "journeys/early_years_teachers_financial_incentive_payments/bypass_auth#callback"
+        post "bypass-auth/teacher", to: "journeys/early_years_teachers_financial_incentive_payments/bypass_auth#callback"
       end
 
       get "auth/teacher/callback", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
 
     scope constraints: {journey: "early-years-teachers-financial-incentive-payments"} do
       if TeacherAuth::Config.instance.bypass?
-        post "auth/teacher", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback_bypass"
+        post "auth/teacher", to: "journeys/early_years_teachers_financial_incentive_payments/bypass_auth#callback"
       end
 
       get "auth/teacher/callback", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,7 @@ Rails.application.routes.draw do
     end
 
     scope constraints: {journey: "early-years-teachers-financial-incentive-payments"} do
-      if TeacherAuth::Config.instance.bypass?
+      if TeacherAuth::Config.instance.bypass? || Rails.env.test?
         post "auth/teacher", to: "journeys/early_years_teachers_financial_incentive_payments/bypass_auth#callback"
       end
 

--- a/lib/core_ext/open_struct.rb
+++ b/lib/core_ext/open_struct.rb
@@ -1,0 +1,15 @@
+require "ostruct"
+
+module CoreExt
+  module OpenStruct
+    def as_json(options = nil)
+      if (options || {})[:without_table]
+        @table.as_json(options)
+      else
+        super
+      end
+    end
+  end
+end
+
+OpenStruct.include CoreExt::OpenStruct

--- a/lib/dqt/objects/teacher.rb
+++ b/lib/dqt/objects/teacher.rb
@@ -129,5 +129,9 @@ module Dqt
 
       qts.routes.any? { |route| route.routeToProfessionalStatusType.professionalStatusType == "QualifiedTeacherStatus" }
     end
+
+    def has_eligible_eytfi_qualification?
+      has_valid_qts? || has_valid_eyts? || has_valid_eyps?
+    end
   end
 end

--- a/lib/dqt/objects/teacher.rb
+++ b/lib/dqt/objects/teacher.rb
@@ -108,5 +108,26 @@ module Dqt
         .reject { |a| a.endDate.present? }
         .any?
     end
+
+    def has_valid_eyts?
+      return false if eyts.blank?
+      return false if date_reader(eyts.holdsFrom) > Date.today
+
+      eyts.routes.any? { |route| route.routeToProfessionalStatusType.professionalStatusType == "EarlyYearsTeacherStatus" }
+    end
+
+    def has_valid_eyps?
+      return false if eyts.blank?
+      return false if date_reader(eyts.holdsFrom) > Date.today
+
+      eyts.routes.any? { |route| route.routeToProfessionalStatusType.professionalStatusType == "EarlyYearsProfessionalStatus" }
+    end
+
+    def has_valid_qts?
+      return false if qts.blank?
+      return false if date_reader(qts.holdsFrom) > Date.today
+
+      qts.routes.any? { |route| route.routeToProfessionalStatusType.professionalStatusType == "QualifiedTeacherStatus" }
+    end
   end
 end

--- a/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
@@ -1,6 +1,27 @@
 require "rails_helper"
 
 RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
+  let(:mock_teacher) do
+    instance_double(
+      "Dqt::Teacher",
+      has_eligible_eytfi_qualification?: true
+    )
+  end
+
+  let(:mock_teacher_resource) do
+    instance_double(
+      "Dqt::TeacherResource",
+      find: mock_teacher
+    )
+  end
+
+  let(:mock_client) do
+    instance_double(
+      "Dqt::Client",
+      teacher: mock_teacher_resource
+    )
+  end
+
   before do
     create(
       :journey_configuration,
@@ -19,6 +40,8 @@ RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
         }
       }
     })
+
+    allow(Dqt::Client).to receive(:new).and_return(mock_client)
   end
 
   scenario "happy path" do
@@ -49,7 +72,9 @@ RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
     click_button "Continue"
 
     expect(page).to have_text "Sign in with GOV.UK One Login"
-    click_button "Continue"
+    perform_enqueued_jobs do
+      click_button "Continue"
+    end
 
     expect(page).to have_text "You hold an eligible qualification"
     click_button "Continue"

--- a/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
@@ -76,6 +76,19 @@ RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
       click_button "Continue"
     end
 
+    journey_session = Journeys::EarlyYearsTeachersFinancialIncentivePayments::Session.last
+
+    expect(journey_session.answers.teacher_auth_teacher_reference_number).to eql("1234567")
+    expect(journey_session.answers.teacher_auth_email).to eql("john.doe@example.com")
+    expect(journey_session.answers.teacher_auth_verified_name).to eql("John Doe")
+    expect(journey_session.answers.teacher_auth_verified_date_of_birth).to eql(Date.new(1970, 12, 13))
+    expect(journey_session.answers.teacher_auth_one_login_uid).to be_present
+    expect(journey_session.answers.teacher_auth_completed_at).to be_within(1.minute).of(Time.zone.now)
+
+    expect(journey_session.answers.trs_data).to be_present
+    expect(journey_session.answers.trs_data_fetched_at).to be_within(1.minute).of(Time.zone.now)
+    expect(journey_session.answers.has_eligible_qualification).to be_truthy
+
     expect(page).to have_text "You hold an eligible qualification"
     click_button "Continue"
 

--- a/spec/features/early_years_teachers_financial_incentive_payments/ineligible_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/ineligible_spec.rb
@@ -72,4 +72,63 @@ RSpec.feature "EYTFI journey ineligible paths", feature_flag: [:eytfi_journey] d
 
     expect(page).to have_text "You are not eligible for this payment"
   end
+
+  context do
+    let(:mock_teacher) do
+      instance_double(
+        "Dqt::Teacher",
+        has_eligible_eytfi_qualification?: false
+      )
+    end
+
+    let(:mock_teacher_resource) do
+      instance_double(
+        "Dqt::TeacherResource",
+        find: mock_teacher
+      )
+    end
+
+    let(:mock_client) do
+      instance_double(
+        "Dqt::Client",
+        teacher: mock_teacher_resource
+      )
+    end
+
+    before do
+      allow(Dqt::Client).to receive(:new).and_return(mock_client)
+    end
+
+    scenario "claimant does not have eligible qualification from TRS lookup" do
+      create(
+        :eligible_eytfi_provider,
+        name: "Springfield nursery"
+      )
+
+      visit landing_page_path(Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name)
+      click_link "Start now"
+
+      expect(page).to have_text "Which nursery do you teach in?"
+      find_field("claim[nursery_search_query]").set("Springfield nursery")
+      click_button "Continue"
+
+      expect(page).to have_text "Which nursery do you teach in?"
+      choose "Springfield nursery"
+      click_button "Continue"
+
+      expect(page).to have_text "Do you hold one of these teaching qualifications?"
+      choose "Yes"
+      click_button "Continue"
+
+      expect(page).to have_text "You are eligible to apply"
+      click_button "Continue"
+
+      expect(page).to have_text "Sign in with GOV.UK One Login"
+      perform_enqueued_jobs do
+        click_button "Continue"
+      end
+
+      expect(page).to have_text "not eligible"
+    end
+  end
 end

--- a/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
@@ -42,6 +42,5 @@ RSpec.describe "EYTFIP with teacher auth bypass", feature_flag: [:eytfi_journey]
     expect(find_field("Email").value).to be_present
     expect(find_field("TRN").value).to be_present
     expect(find_field("One Login UID").value).to be_present
-    click_button "Continue"
   end
 end

--- a/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe "EYTFIP with teacher auth bypass", feature_flag: [:eytfi_journey]
 
     expect(page).to have_text "Bypass Teacher Auth"
     uncheck "Has eligible qualification?"
-    click_button "Continue"
+    perform_enqueued_jobs do
+      click_button "Continue"
+    end
 
     expect(page).to have_text "not eligible"
   end

--- a/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/teacher_auth_bypass_spec.rb
@@ -42,5 +42,32 @@ RSpec.describe "EYTFIP with teacher auth bypass", feature_flag: [:eytfi_journey]
     expect(find_field("Email").value).to be_present
     expect(find_field("TRN").value).to be_present
     expect(find_field("One Login UID").value).to be_present
+    click_button "Continue"
+  end
+
+  scenario "can emulate no eligible qualification pathway" do
+    visit landing_page_path(Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name)
+    expect(page).to have_text "Claim an early years teacher recognition payment"
+    click_link "Start now"
+
+    find_field("claim[nursery_search_query]").set("Springfield nursery")
+    click_button "Continue"
+
+    expect(page).to have_text "Which nursery do you teach in?"
+    choose "Springfield nursery"
+    click_button "Continue"
+
+    expect(page).to have_text "Do you hold one of these teaching qualifications?"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_text "You are eligible to apply"
+    click_button "Continue"
+
+    expect(page).to have_text "Bypass Teacher Auth"
+    uncheck "Has eligible qualification?"
+    click_button "Continue"
+
+    expect(page).to have_text "not eligible"
   end
 end

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/fetch_qualifications_job_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::FetchQualificationsJob do
+  let(:journey_session) do
+    create(
+      :eytfi_session
+    )
+  end
+
+  let(:response_hash) do
+    {
+      trn: "3013822",
+      firstName: "Newell",
+      middleName: "",
+      lastName: "Ondricka",
+      dateOfBirth: "1960-01-01",
+      nationalInsuranceNumber: "LC882331C",
+      emailAddress: nil,
+      qts: nil,
+      eyts: {
+        holdsFrom: "2026-01-01",
+        routes: [
+          {
+            routeToProfessionalStatusType: {
+              routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+              name: "Early Years Teacher Degree Apprenticeship",
+              professionalStatusType: "EarlyYearsTeacherStatus"
+            }
+          }
+        ]
+      },
+      qtlsStatus: "None"
+    }
+  end
+
+  let(:mock_teacher) do
+    Dqt::Teacher.new(
+      response_hash
+    )
+  end
+
+  let(:mock_teacher_resource) do
+    instance_double(
+      "Dqt::TeacherResource",
+      find: -> { mock_teacher }.call
+    )
+  end
+
+  let(:mock_client) do
+    instance_double(
+      "Dqt::Client",
+      teacher: mock_teacher_resource
+    )
+  end
+
+  before do
+    allow(Dqt::Client).to receive(:new).and_return(mock_client)
+  end
+
+  describe "#perform" do
+    it "persists api call" do
+      subject.perform(journey_session)
+
+      expect(journey_session.reload.answers.trs_data).to eql(response_hash.deep_stringify_keys)
+    end
+
+    it "touches trs_data_fetched_at" do
+      expect {
+        subject.perform(journey_session)
+      }.to change { journey_session.reload.answers.trs_data_fetched_at }
+    end
+
+    it "calculates and persists has_eligible_qualification" do
+      expect {
+        subject.perform(journey_session)
+      }.to change { journey_session.reload.answers.has_eligible_qualification }.from(nil).to(true)
+    end
+
+    context "when user for api call does not have eligible qualifications" do
+      let(:response_hash) do
+        {
+          trn: "3013822",
+          firstName: "Newell",
+          middleName: "",
+          lastName: "Ondricka",
+          dateOfBirth: "1960-01-01",
+          nationalInsuranceNumber: "LC882331C",
+          emailAddress: nil,
+          qts: nil,
+          eyts: nil,
+          qtlsStatus: "None"
+        }
+      end
+
+      it "persists has_eligible_qualification to false" do
+        expect {
+          subject.perform(journey_session)
+        }.to change { journey_session.reload.answers.has_eligible_qualification }.from(nil).to(false)
+      end
+    end
+
+    context "when trs_data_fetched_at is set" do
+      it "does not make an api call again" do
+        subject.perform(journey_session)
+        subject.perform(journey_session)
+
+        expect(Dqt::Client).to have_received(:new).once
+      end
+    end
+  end
+end

--- a/spec/lib/dqt/objects/teacher_spec.rb
+++ b/spec/lib/dqt/objects/teacher_spec.rb
@@ -480,4 +480,244 @@ RSpec.describe Dqt::Teacher do
 
     specify { expect(degree_names).to contain_exactly("mathematics", "accounting") }
   end
+
+  describe "#has_valid_eyts?" do
+    subject { described_class.new(response) }
+
+    context "when valid eyts present?" do
+      let(:response) do
+        {
+          eyts: {
+            holdsFrom: "2020-04-03",
+            routes: [
+              {
+                routeToProfessionalStatusType: {
+                  routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+                  name: "Early Years Teacher Degree Apprenticeship",
+                  professionalStatusType: "EarlyYearsTeacherStatus"
+                }
+              }
+            ]
+          },
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns true" do
+        expect(subject).to have_valid_eyts
+      end
+    end
+
+    context "when eyts missing" do
+      let(:response) do
+        {
+          eyts: nil,
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns false" do
+        expect(subject).not_to have_valid_eyts
+      end
+    end
+
+    context "when eyts in the future" do
+      let(:response) do
+        {
+          eyts: {
+            holdsFrom: "3000-04-03",
+            routes: [
+              {
+                routeToProfessionalStatusType: {
+                  routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+                  name: "Early Years Teacher Degree Apprenticeship",
+                  professionalStatusType: "EarlyYearsTeacherStatus"
+                }
+              }
+            ]
+          },
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns false" do
+        expect(subject).not_to have_valid_eyts
+      end
+    end
+  end
+
+  describe "#has_valid_eyps?" do
+    subject { described_class.new(response) }
+
+    context "when valid eyps present?" do
+      let(:response) do
+        {
+          eyts: {
+            holdsFrom: "2020-04-03",
+            routes: [
+              {
+                routeToProfessionalStatusType: {
+                  routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+                  name: "Early Years Teacher Degree Apprenticeship",
+                  professionalStatusType: "EarlyYearsProfessionalStatus"
+                }
+              }
+            ]
+          },
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns true" do
+        expect(subject).to have_valid_eyps
+      end
+    end
+
+    context "when eyps missing" do
+      let(:response) do
+        {
+          eyts: nil,
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns false" do
+        expect(subject).not_to have_valid_eyps
+      end
+    end
+
+    context "when eyps in the future" do
+      let(:response) do
+        {
+          eyts: {
+            holdsFrom: "3000-04-03",
+            routes: [
+              {
+                routeToProfessionalStatusType: {
+                  routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+                  name: "Early Years Teacher Degree Apprenticeship",
+                  professionalStatusType: "EarlyYearsTeacherStatus"
+                }
+              }
+            ]
+          },
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns false" do
+        expect(subject).not_to have_valid_eyps
+      end
+    end
+  end
+
+  describe "#has_valid_qts?" do
+    subject { described_class.new(response) }
+
+    context "when valid qts present?" do
+      let(:response) do
+        {
+          qts: {
+            holdsFrom: "2020-04-03",
+            routes: [
+              {
+                routeToProfessionalStatusType: {
+                  routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+                  name: "Early Years Teacher Degree Apprenticeship",
+                  professionalStatusType: "QualifiedTeacherStatus"
+                }
+              }
+            ]
+          },
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns true" do
+        expect(subject).to have_valid_qts
+      end
+    end
+
+    context "when qts missing" do
+      let(:response) do
+        {
+          qts: nil,
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns false" do
+        expect(subject).not_to have_valid_qts
+      end
+    end
+
+    context "when qts in the future" do
+      let(:response) do
+        {
+          qts: {
+            holdsFrom: "3000-04-03",
+            routes: [
+              {
+                routeToProfessionalStatusType: {
+                  routeToProfessionalStatusTypeId: "11b66de5-4670-4c82-86aa-20e42df723b7",
+                  name: "Early Years Teacher Degree Apprenticeship",
+                  professionalStatusType: "QualifiedTeacherStatus"
+                }
+              }
+            ]
+          },
+          trn: teacher_reference_number_str,
+          alerts: [],
+          lastName: "Doe",
+          firstName: "John",
+          dateOfBirth: date_of_birth_str,
+          nationalInsuranceNumber: "JR501209A"
+        }
+      end
+
+      it "returns false" do
+        expect(subject).not_to have_valid_qts
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-3512
- Adds API call to TRS to fetch qualifications
- This is done async so there is a holding page added
- This is bypass-able when setting auth bypass is enabled