### PR TITLE
Handle no search results

### DIFF
--- a/app/views/early_years_teachers_financial_incentive_payments/claims/nursery_select.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/nursery_select.html.erb
@@ -8,21 +8,35 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_radio_buttons(
-        :nursery_id,
-        f.object.radio_options,
-        :id, ->(option) { "#{option.name} #{' (closed)' if option.closed?}" },
-        :address,
-        legend: {
-          text: "Which nursery do you teach in?",
-          tag: "h1",
-          size: "l"
-        },
-        hint: {
-          text: "Select your nursery from the search results."
-        }
-      ) %>
-      <%= f.govuk_submit %>
+      <% if f.object.radio_options.none? %>
+        <h1 class="govuk-heading-l">
+          No results match your search term
+        </h1>
+
+        <p class="govuk-body">
+          No nurseries match your search term, you can try to
+          <%= govuk_link_to(
+            "search again",
+            @backlink_path
+          ) %>
+        </p>
+      <% else %>
+        <%= f.govuk_collection_radio_buttons(
+          :nursery_id,
+          f.object.radio_options,
+          :id, ->(option) { "#{option.name} #{' (closed)' if option.closed?}" },
+          :address,
+          legend: {
+            text: "Which nursery do you teach in?",
+            tag: "h1",
+            size: "l"
+          },
+          hint: {
+            text: "Select your nursery from the search results."
+          }
+        ) %>
+        <%= f.govuk_submit %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/happy_path_spec.rb
@@ -111,4 +111,32 @@ RSpec.feature "EYTFI journey", feature_flag: [:eytfi_journey] do
 
     expect(page).to have_text "Do you hold one of these teaching qualifications?"
   end
+
+  scenario "no nursseries found" do
+    create(
+      :eligible_eytfi_provider,
+      name: "Springfield nursery"
+    )
+
+    visit landing_page_path(
+      Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name
+    )
+
+    click_link "Start now"
+
+    expect(page).to have_text "Which nursery do you teach in?"
+    find_field("claim[nursery_search_query]").set("no results for this search")
+    click_button "Continue"
+
+    expect(page).to have_content("No results match your search term")
+
+    click_link "search again"
+
+    expect(page).to have_text "Which nursery do you teach in?"
+    find_field("claim[nursery_search_query]").set("spring")
+    click_button "Continue"
+
+    expect(page).to have_text "Select your nursery from the search results."
+    expect(page).to have_selector("label", text: "Springfield nursery")
+  end
 end


### PR DESCRIPTION
Previously we showed an empty page. If there's no results inform the
user and give them a link to try searching for something else.
