### PR TITLE
Fix weekly provider email

### DIFF
--- a/app/jobs/further_education_payments/providers/weekly_update_email_job.rb
+++ b/app/jobs/further_education_payments/providers/weekly_update_email_job.rb
@@ -20,7 +20,7 @@ module FurtherEducationPayments
             ).merge(
               Policies::FurtherEducationPayments::Eligibility
                 .awaiting_provider_verification_year_2
-            )
+            ).distinct
 
         providers_with_unverified_claims.each_with_index do |provider, index|
           ApplicationMailer.deliver_later_with_throttling(

--- a/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
+++ b/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
@@ -94,6 +94,13 @@ RSpec.describe FurtherEducationPayments::Providers::WeeklyUpdateEmailJob, type: 
       number_overall: 15,
       link_to_provider_dashboard: "http://www.example.com/further-education-payments/providers/claims"
     )
+
+    # expect the provider to have only received one email
+    provider_email_count = ActionMailer::Base.deliveries.count do |email|
+      email.to.include?(provider.primary_key_contact_email_address)
+    end
+
+    expect(provider_email_count).to eq(1)
   end
 
   it "doesn't send an email if there are no unverified claims" do


### PR DESCRIPTION
Adds back the distinct clause otherwise we send an email for each row in
the result set which means some providers get over 100 emails!
