### PR TITLE
CAPT-3575 - Fetch and persist malware scan result for EYTFI employment proofs

### DIFF
--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/information_provided_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/information_provided_form.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Journeys
+  module EarlyYearsTeachersFinancialIncentivePayments
+    class InformationProvidedForm < Form
+      def save
+        # TODO: move job trigger to the check your answers / submission form once built
+        blob_ids = journey_session.answers.confirmed_employment_proof_blob_ids
+
+        blob_ids.each do |blob_id|
+          ::EarlyYearsTeachersFinancialIncentivePayments::FetchEmploymentProofMalwareScanResultJob.perform_later(blob_id)
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/fetch_employment_proof_malware_scan_result_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/fetch_employment_proof_malware_scan_result_job.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module EarlyYearsTeachersFinancialIncentivePayments
+  class FetchEmploymentProofMalwareScanResultJob < ApplicationJob
+    MAX_ATTEMPTS = 10
+
+    DEFENDER_RESULT_KEY = "Malware Scanning scan result"
+    DEFENDER_TIME_KEY = "Malware Scanning scan time UTC"
+
+    DEFENDER_RESULT_MAPPING = {
+      "No threats found" => ActiveStorage::Blob::MALWARE_SCAN_RESULT_PASSED,
+      "Malicious" => ActiveStorage::Blob::MALWARE_SCAN_RESULT_FAILED
+    }.freeze
+
+    def perform(blob_id)
+      blob = ActiveStorage::Blob.find(blob_id)
+
+      if Rails.env.development?
+        blob.update!(
+          malware_scan_result: ActiveStorage::Blob::MALWARE_SCAN_RESULT_PASSED,
+          malware_scanned_at: Time.zone.now
+        )
+
+        return
+      end
+
+      service = ActiveStorage::Blob.service
+      tags = service.client.get_blob_tags(blob.key)
+      defender_result = tags[DEFENDER_RESULT_KEY]
+      scan_time = tags[DEFENDER_TIME_KEY]
+
+      blob.malware_scan_attempts += 1
+
+      if defender_result.present?
+        mapped_result = DEFENDER_RESULT_MAPPING.fetch(defender_result) do
+          Sentry.capture_message(
+            "Unrecognised Azure Defender scan result: #{defender_result.inspect}",
+            level: :error
+          )
+          ActiveStorage::Blob::MALWARE_SCAN_RESULT_UNRECOGNISED
+        end
+
+        blob.update!(
+          malware_scan_result: mapped_result,
+          malware_scanned_at: scan_time
+        )
+      elsif blob.malware_scan_attempts >= MAX_ATTEMPTS
+        Sentry.capture_message(
+          "Malware scan attempts exceeded for blob #{blob.id}",
+          level: :error
+        )
+        blob.update!(
+          malware_scan_result: ActiveStorage::Blob::MALWARE_SCAN_RESULT_SKIPPED,
+          malware_scanned_at: Time.zone.now
+        )
+      else
+        blob.save!
+        self.class.set(wait: 5.minutes).perform_later(blob_id)
+      end
+    end
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -505,6 +505,9 @@ shared:
     - key # string, storage key used to locate the file in the storage backend
     - metadata # jsonb, additional metadata stored alongside the blob
     - service_name # string, which storage service holds this blob (e.g. azure)
+    - malware_scan_result # string, raw Azure Defender scan result tag value
+    - malware_scanned_at # datetime, when the malware scan completed
+    - malware_scan_attempts # integer, number of times the scan result job has been attempted
   :active_storage_attachments:
     - id # uuid, uniquely identifies this attachment record
     - blob_id # uuid, the blob this attachment points to

--- a/config/initializers/active_storage_blob_extensions.rb
+++ b/config/initializers/active_storage_blob_extensions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+ActiveSupport.on_load(:active_storage_blob) do
+  self::MALWARE_SCAN_RESULT_PASSED = "passed"
+  self::MALWARE_SCAN_RESULT_FAILED = "failed"
+  self::MALWARE_SCAN_RESULT_SKIPPED = "skipped"
+  self::MALWARE_SCAN_RESULT_UNRECOGNISED = "defender_result_unrecognised"
+
+  def malware_scan_pending?
+    malware_scan_result.nil?
+  end
+
+  def malware_scan_passed?
+    malware_scan_result == self.class::MALWARE_SCAN_RESULT_PASSED
+  end
+
+  def malware_scan_failed?
+    malware_scan_result == self.class::MALWARE_SCAN_RESULT_FAILED
+  end
+
+  def malware_scan_skipped?
+    malware_scan_result == self.class::MALWARE_SCAN_RESULT_SKIPPED
+  end
+
+  def malware_scan_result_unrecognised?
+    malware_scan_result == self.class::MALWARE_SCAN_RESULT_UNRECOGNISED
+  end
+end

--- a/db/migrate/20260513120000_add_malware_scan_columns_to_active_storage_blobs.rb
+++ b/db/migrate/20260513120000_add_malware_scan_columns_to_active_storage_blobs.rb
@@ -1,0 +1,7 @@
+class AddMalwareScanColumnsToActiveStorageBlobs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :active_storage_blobs, :malware_scan_result, :string
+    add_column :active_storage_blobs, :malware_scanned_at, :datetime
+    add_column :active_storage_blobs, :malware_scan_attempts, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_123642) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -34,6 +34,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_123642) do
     t.datetime "created_at", null: false
     t.string "filename", null: false
     t.string "key", null: false
+    t.integer "malware_scan_attempts", default: 0, null: false
+    t.string "malware_scan_result"
+    t.datetime "malware_scanned_at"
     t.text "metadata"
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/fetch_employment_proof_malware_scan_result_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/fetch_employment_proof_malware_scan_result_job_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::FetchEmploymentProofMalwareScanResultJob do
+  let(:blob) { create(:active_storage_blob) }
+  let(:service_client) { double("AzureBlob::Client") }
+  let(:service) { double("ActiveStorage::Service", client: service_client) }
+  let(:scan_time_tag) { "2026-05-05 19:17:12Z" }
+
+  before do
+    blob
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+    allow(ActiveStorage::Blob).to receive(:service).and_return(service)
+  end
+
+  describe "#perform" do
+    context "when the scan result is passed (no threats found)" do
+      before do
+        allow(service_client).to receive(:get_blob_tags).with(blob.key).and_return(
+          "Malware Scanning scan result" => "No threats found",
+          "Malware Scanning scan time UTC" => scan_time_tag
+        )
+      end
+
+      it "maps the Defender result to the internal value" do
+        subject.perform(blob.id)
+        expect(blob.reload.malware_scan_result).to eq(ActiveStorage::Blob::MALWARE_SCAN_RESULT_PASSED)
+      end
+
+      it "stores the scan time from the Defender tag" do
+        subject.perform(blob.id)
+        expect(blob.reload.malware_scanned_at).to eq(Time.zone.parse(scan_time_tag))
+      end
+
+      it "the blob reports as passed" do
+        subject.perform(blob.id)
+        expect(blob.reload).to be_malware_scan_passed
+      end
+    end
+
+    context "when the scan result is failed (malicious)" do
+      before do
+        allow(service_client).to receive(:get_blob_tags).with(blob.key).and_return(
+          "Malware Scanning scan result" => "Malicious",
+          "Malware Scanning scan time UTC" => scan_time_tag
+        )
+      end
+
+      it "maps the Defender result to the internal value" do
+        subject.perform(blob.id)
+        expect(blob.reload.malware_scan_result).to eq(ActiveStorage::Blob::MALWARE_SCAN_RESULT_FAILED)
+      end
+
+      it "the blob reports as failed" do
+        subject.perform(blob.id)
+        expect(blob.reload).to be_malware_scan_failed
+      end
+    end
+
+    context "when the Defender result is unrecognised" do
+      before do
+        allow(service_client).to receive(:get_blob_tags).with(blob.key).and_return(
+          "Malware Scanning scan result" => "Some new unknown value",
+          "Malware Scanning scan time UTC" => scan_time_tag
+        )
+        allow(Sentry).to receive(:capture_message)
+      end
+
+      it "stores the unrecognised sentinel" do
+        subject.perform(blob.id)
+        expect(blob.reload.malware_scan_result).to eq(ActiveStorage::Blob::MALWARE_SCAN_RESULT_UNRECOGNISED)
+      end
+
+      it "the blob reports as unrecognised" do
+        subject.perform(blob.id)
+        expect(blob.reload).to be_malware_scan_result_unrecognised
+      end
+
+      it "notifies Sentry with the unexpected value" do
+        expect(Sentry).to receive(:capture_message).with(
+          "Unrecognised Azure Defender scan result: \"Some new unknown value\"",
+          level: :error
+        )
+        subject.perform(blob.id)
+      end
+    end
+
+    context "when the scan is still pending (no tags)" do
+      before do
+        allow(service_client).to receive(:get_blob_tags).with(blob.key).and_return({})
+        allow(described_class).to receive_message_chain(:set, :perform_later)
+      end
+
+      it "increments malware_scan_attempts" do
+        expect {
+          subject.perform(blob.id)
+        }.to change { blob.reload.malware_scan_attempts }.by(1)
+      end
+
+      it "re-enqueues the job with a 5 minute wait" do
+        enqueuer = double("enqueuer")
+        allow(described_class).to receive(:set).with(wait: 5.minutes).and_return(enqueuer)
+        expect(enqueuer).to receive(:perform_later).with(blob.id)
+        subject.perform(blob.id)
+      end
+
+      it "does not write a scan result" do
+        subject.perform(blob.id)
+        expect(blob.reload.malware_scan_result).to be_nil
+      end
+    end
+
+    context "when all attempts are exhausted" do
+      before do
+        blob.update!(malware_scan_attempts: 9)
+        allow(service_client).to receive(:get_blob_tags).with(blob.key).and_return({})
+        allow(Sentry).to receive(:capture_message)
+      end
+
+      it "marks the blob as skipped" do
+        subject.perform(blob.id)
+        expect(blob.reload.malware_scan_result).to eq(ActiveStorage::Blob::MALWARE_SCAN_RESULT_SKIPPED)
+      end
+
+      it "sets malware_scanned_at to the current time" do
+        freeze_time do
+          subject.perform(blob.id)
+          expect(blob.reload.malware_scanned_at).to eq(Time.zone.now)
+        end
+      end
+
+      it "the blob reports as skipped" do
+        subject.perform(blob.id)
+        expect(blob.reload).to be_malware_scan_skipped
+      end
+
+      it "does not re-enqueue" do
+        expect(described_class).not_to receive(:set)
+        subject.perform(blob.id)
+      end
+
+      it "notifies Sentry that max attempts were exceeded" do
+        expect(Sentry).to receive(:capture_message).with(
+          "Malware scan attempts exceeded for blob #{blob.id}",
+          level: :error
+        )
+        subject.perform(blob.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
After a claimant completes the EYTFI journey, enqueue a background job for each confirmed employment proof blob that fetches the Azure Defender for Storage scan result and persists it to two new columns on active_storage_blobs: malware_scan_result (passed/failed/skipped) and malware_scanned_at.

Both columns nil means the scan is still pending. The job retries up to 10 times at 5-minute intervals; if all retries are exhausted the blob is marked as skipped with the current timestamp.


