### PR TITLE
Provider email doesn't include rejected count - CAPT-3698

### DIFF
--- a/app/mailers/further_education_payments_mailer.rb
+++ b/app/mailers/further_education_payments_mailer.rb
@@ -33,10 +33,10 @@ class FurtherEducationPaymentsMailer < ApplicationMailer
       Journeys::FurtherEducationPayments.configuration.current_academic_year
     )
 
-    number_overdue = claims.unverified.verification_overdue.count
-    number_in_progress = claims.unverified.verification_in_progress.count
-    number_not_started = claims.unverified.verification_not_started.count
-    number_overall = claims.unverified.count
+    number_overdue = claims.unverified.not_rejected.verification_overdue.count
+    number_in_progress = claims.unverified.not_rejected.verification_in_progress.count
+    number_not_started = claims.unverified.not_rejected.verification_not_started.count
+    number_overall = claims.unverified.not_rejected.count
 
     return if number_overall.zero?
 

--- a/app/mailers/further_education_payments_mailer.rb
+++ b/app/mailers/further_education_payments_mailer.rb
@@ -29,14 +29,9 @@ class FurtherEducationPaymentsMailer < ApplicationMailer
     provider_email = provider.primary_key_contact_email_address
     provider_name = provider.name
 
-    claims = provider.claims.by_academic_year(
-      Journeys::FurtherEducationPayments.configuration.current_academic_year
-    )
+    stats = FurtherEducationPayments::Providers::Claims::Stats.new(provider: provider)
 
-    number_overdue = claims.unverified.not_rejected.verification_overdue.count
-    number_in_progress = claims.unverified.not_rejected.verification_in_progress.count
-    number_not_started = claims.unverified.not_rejected.verification_not_started.count
-    number_overall = claims.unverified.not_rejected.count
+    number_overall = stats.unverified_overall_count
 
     return if number_overall.zero?
 
@@ -46,9 +41,9 @@ class FurtherEducationPaymentsMailer < ApplicationMailer
       reply_to_id: Policies::FurtherEducationPayments.notify_reply_to_id,
       personalisation: {
         provider_name: provider_name,
-        number_overdue: number_overdue,
-        number_in_progress: number_in_progress,
-        number_not_started: number_not_started,
+        number_overdue: stats.unverified_overdue_count,
+        number_in_progress: stats.unverified_in_progress_count,
+        number_not_started: stats.unverified_not_started_count,
         number_overall: number_overall,
         link_to_provider_dashboard: further_education_payments_providers_claims_url(
           host: ENV.fetch("CANONICAL_HOSTNAME")

--- a/app/models/further_education_payments/providers/claims/stats.rb
+++ b/app/models/further_education_payments/providers/claims/stats.rb
@@ -2,10 +2,11 @@ module FurtherEducationPayments
   module Providers
     module Claims
       class Stats
-        attr_reader :provider
+        attr_reader :provider, :journey_configuration
 
         def initialize(provider:)
           @provider = provider
+          @journey_configuration = Journeys::FurtherEducationPayments.configuration
         end
 
         def rejected_count
@@ -18,6 +19,22 @@ module FurtherEducationPayments
 
         def pending_decision_count
           pending_decision.count
+        end
+
+        def unverified_overdue_count
+          unverified_not_rejected.verification_overdue.count
+        end
+
+        def unverified_in_progress_count
+          unverified_not_rejected.verification_in_progress.count
+        end
+
+        def unverified_not_started_count
+          unverified_not_rejected.verification_not_started.count
+        end
+
+        def unverified_overall_count
+          unverified_not_rejected.count
         end
 
         # this is a fudged number
@@ -40,39 +57,41 @@ module FurtherEducationPayments
         def topups
           Topup
             .joins(:claim)
-            .where(claim: claims)
+            .where(claim: verified_claims)
             .sum(:award_amount)
         end
 
-        def claims
-          @claims ||= provider
+        def verified_claims
+          @verified_claims ||= provider
             .claims.by_academic_year(academic_year)
             .verified
         end
 
+        def unverified_not_rejected
+          @unverified_not_rejected ||= provider
+            .claims.by_academic_year(academic_year)
+            .unverified
+            .not_rejected
+        end
+
         def pending_decision
-          claims - approved - rejected
+          verified_claims - approved - rejected
         end
 
         # approved + does not need QA
         # approved + needs QA and QA passed
         def approved
-          claims.not_awaiting_qa
+          verified_claims.not_awaiting_qa
         end
 
         # rejected + does not need QA
         # rejected + needs QA and QA passed
         def rejected
-          claims.rejected_not_awaiting_qa
+          verified_claims.rejected_not_awaiting_qa
         end
 
         def academic_year
           journey_configuration.current_academic_year
-        end
-
-        def journey_configuration
-          @journey_configuration ||= Journeys::Configuration
-            .find(Journeys::FurtherEducationPayments.routing_name)
         end
       end
     end

--- a/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
+++ b/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
@@ -125,6 +125,40 @@ RSpec.describe FurtherEducationPayments::Providers::WeeklyUpdateEmailJob, type: 
     )
   end
 
+  it "generates the weekly email counts" do
+    [
+      [{}, %i[further_education submitted]],
+      [{provider_verification_started_at: 1.day.ago}, %i[further_education submitted]],
+      [{provider_verification_deadline: 1.day.ago}, %i[further_education submitted]],
+      [{}, %i[further_education rejected]],
+      [{provider_verification_started_at: 1.day.ago}, %i[further_education rejected]],
+      [{provider_verification_deadline: 1.day.ago}, %i[further_education rejected]]
+    ].each do |eligibility_attributes, claim_traits|
+      create(
+        :further_education_payments_eligibility,
+        :eligible,
+        school: provider.school,
+        **eligibility_attributes,
+        claim: create(
+          :claim,
+          *claim_traits
+        )
+      )
+    end
+
+    described_class.new.perform
+
+    expect(provider.primary_key_contact_email_address).to have_received_email(
+      "7e019ad7-f2d8-43fe-8adc-a5c8609926ff",
+      provider_name: provider.name,
+      number_overdue: 1,
+      number_in_progress: 1,
+      number_not_started: 2,
+      number_overall: 3,
+      link_to_provider_dashboard: "http://www.example.com/further-education-payments/providers/claims"
+    )
+  end
+
   it "staggers weekly update emails due to Notify API 3000 per 60 seconds limit" do
     third_provider = create(:eligible_fe_provider, :with_school)
 

--- a/spec/models/further_education_payments/providers/claims/stats_spec.rb
+++ b/spec/models/further_education_payments/providers/claims/stats_spec.rb
@@ -284,6 +284,47 @@ RSpec.describe FurtherEducationPayments::Providers::Claims::Stats do
     end
   end
 
+  describe "weekly email counts" do
+    before do
+      [
+        [{}, %i[further_education submitted]],
+        [{provider_verification_started_at: 1.day.ago}, %i[further_education submitted]],
+        [{provider_verification_deadline: 1.day.ago}, %i[further_education submitted]],
+        [{}, %i[further_education rejected]],
+        [{provider_verification_started_at: 1.day.ago}, %i[further_education rejected]],
+        [{provider_verification_deadline: 1.day.ago}, %i[further_education rejected]]
+      ].each do |eligibility_attributes, claim_traits|
+        create(
+          :further_education_payments_eligibility,
+          :eligible,
+          school: provider.school,
+          **eligibility_attributes,
+          claim: create(
+            :claim,
+            *claim_traits,
+            academic_year: journey_configuration.current_academic_year
+          )
+        )
+      end
+    end
+
+    it "counts overdue unverified, not rejected claims" do
+      expect(subject.unverified_overdue_count).to eq(1)
+    end
+
+    it "counts in progress unverified, not rejected claims" do
+      expect(subject.unverified_in_progress_count).to eq(1)
+    end
+
+    it "counts not started unverified, not rejected claims" do
+      expect(subject.unverified_not_started_count).to eq(2)
+    end
+
+    it "counts all unverified, not rejected claims" do
+      expect(subject.unverified_overall_count).to eq(3)
+    end
+  end
+
   describe "#amount" do
     context "when no claims" do
       it "returns zero" do


### PR DESCRIPTION
The provider email count included the rejected emails