### PR TITLE
CAPT-3571 - Restrict EYTFI employment proof uploads to PDF, JPG, PNG and HEIC under 20 MB

### DIFF
--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/upload_employment_proof_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/upload_employment_proof_form.rb
@@ -3,9 +3,21 @@
 module Journeys
   module EarlyYearsTeachersFinancialIncentivePayments
     class UploadEmploymentProofForm < Form
+      ALLOWED_CONTENT_TYPES = %w[
+        application/pdf
+        image/jpeg
+        image/png
+        image/heic
+        image/heif
+      ].freeze
+
+      MAX_FILE_SIZE = 20.megabytes
+
       attribute :file
 
       validates :file, presence: {message: "Select a file to upload"}
+      validate :file_type_allowed
+      validate :file_size_within_limit
 
       def save
         return false if invalid?
@@ -26,6 +38,24 @@ module Journeys
 
       def has_confirmed_blobs?
         journey_session.answers.confirmed_employment_proof_blob_ids.any?
+      end
+
+      private
+
+      def file_type_allowed
+        return unless file.present?
+
+        unless ALLOWED_CONTENT_TYPES.include?(file.content_type)
+          errors.add(:file, "The selected file must be a PDF, JPG, PNG or HEIC")
+        end
+      end
+
+      def file_size_within_limit
+        return unless file.present?
+
+        if file.size > MAX_FILE_SIZE
+          errors.add(:file, "The selected file must be smaller than 20MB")
+        end
       end
     end
   end

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/upload_employment_proof.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/upload_employment_proof.html.erb
@@ -29,7 +29,8 @@
 
       <p class="govuk-body">You upload a clear photo or a scanned copy of the document.</p>
 
-      <%= f.govuk_file_field :file, label: { hidden: true } %>
+      <%= f.govuk_file_field :file, label: { hidden: true },
+            accept: f.object.class::ALLOWED_CONTENT_TYPES.join(",") %>
 
       <%= f.govuk_submit "Upload" %>
 

--- a/spec/features/early_years_teachers_financial_incentive_payments/upload_employment_proof_validation_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/upload_employment_proof_validation_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "EYTFI employment proof upload validation", feature_flag: [:eytfi_journey] do
+  let(:mock_teacher) do
+    instance_double("Dqt::Teacher", has_eligible_eytfi_qualification?: true)
+  end
+
+  let(:mock_teacher_resource) do
+    instance_double("Dqt::TeacherResource", find: mock_teacher)
+  end
+
+  let(:mock_client) do
+    instance_double("Dqt::Client", teacher: mock_teacher_resource)
+  end
+
+  before do
+    create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
+    create(:eligible_eytfi_provider, name: "Springfield nursery")
+
+    OmniAuth.config.mock_auth[:teacher] = OmniAuth::AuthHash.new({
+      provider: "teacher",
+      extra: {
+        raw_info: {
+          sub: "urn:fdc:gov.uk:2022:#{SecureRandom.base64(30)}",
+          trn: "1234567",
+          email: "john.doe@example.com",
+          verified_name: ["John", "Doe"],
+          verified_date_of_birth: "1970-12-13"
+        }
+      }
+    })
+
+    allow(Dqt::Client).to receive(:new).and_return(mock_client)
+
+    navigate_to_upload_page
+  end
+
+  scenario "shows an error when the file type is not allowed" do
+    Tempfile.create(["employment_proof", ".txt"]) do |file|
+      file.write("test content")
+      file.flush
+
+      attach_file "File", file.path
+      click_on "Upload"
+    end
+
+    expect(page).to have_text("The selected file must be a PDF, JPG, PNG or HEIC")
+  end
+
+  scenario "shows an error when the file is too large" do
+    stub_const(
+      "Journeys::EarlyYearsTeachersFinancialIncentivePayments::UploadEmploymentProofForm::MAX_FILE_SIZE",
+      1.kilobyte
+    )
+
+    Tempfile.create(["employment_proof", ".pdf"]) do |file|
+      file.write("x" * 2.kilobytes)
+      file.flush
+
+      attach_file "File", file.path
+      click_on "Upload"
+    end
+
+    expect(page).to have_text("The selected file must be smaller than 20MB")
+  end
+
+  def navigate_to_upload_page
+    visit landing_page_path(Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name)
+    click_link "Start now"
+
+    find_field("claim[nursery_search_query]").set("Springfield nursery")
+    click_button "Continue"
+
+    choose "Springfield nursery"
+    click_button "Continue"
+
+    choose "Yes"
+    click_button "Continue"
+
+    click_button "Continue"
+
+    perform_enqueued_jobs { click_button "Continue" }
+
+    choose "Yes"
+    click_button "Continue"
+  end
+end

--- a/spec/forms/journeys/early_years_teachers_financial_incentive_payments/upload_employment_proof_form_spec.rb
+++ b/spec/forms/journeys/early_years_teachers_financial_incentive_payments/upload_employment_proof_form_spec.rb
@@ -31,6 +31,54 @@ RSpec.describe Journeys::EarlyYearsTeachersFinancialIncentivePayments::UploadEmp
         expect(form.errors[:file]).to include("Select a file to upload")
       end
     end
+
+    context "when the file type is not allowed" do
+      let(:file) { Rack::Test::UploadedFile.new(StringIO.new("test content"), "text/plain", original_filename: "document.txt") }
+
+      it { is_expected.not_to be_valid }
+
+      it "has an appropriate error message" do
+        form.valid?
+        expect(form.errors[:file]).to include("The selected file must be a PDF, JPG, PNG or HEIC")
+      end
+    end
+
+    context "when the file is too large" do
+      let(:file) do
+        Rack::Test::UploadedFile.new(
+          StringIO.new("x" * (20.megabytes + 1)),
+          "application/pdf",
+          original_filename: "document.pdf"
+        )
+      end
+
+      it { is_expected.not_to be_valid }
+
+      it "has an appropriate error message" do
+        form.valid?
+        expect(form.errors[:file]).to include("The selected file must be smaller than 20MB")
+      end
+    end
+
+    context "when the file is exactly 20MB" do
+      let(:file) do
+        Rack::Test::UploadedFile.new(
+          StringIO.new("x" * 20.megabytes),
+          "application/pdf",
+          original_filename: "document.pdf"
+        )
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    %w[application/pdf image/jpeg image/png image/heic image/heif].each do |content_type|
+      context "when the file type is #{content_type}" do
+        let(:file) { Rack::Test::UploadedFile.new(StringIO.new("test content"), content_type, original_filename: "document") }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
Adds server-side content type and file size validations to the upload form, with an accept attribute on the file input as a browser-level hint. Covers both validations with unit and feature specs.

