### PR TITLE
CAPT 3658/claims per setting

### DIFF
--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -41,7 +41,7 @@ module EarlyYearsTeachersFinancialIncentivePayments
 
       validates "Max claims",
         presence: true,
-        numericality: {only_integer: true, greater_than: 0}
+        numericality: {only_integer: true, greater_than_or_equal_to: 0}
 
       def initialize(row:)
         @row = row

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -40,8 +40,8 @@ module EarlyYearsTeachersFinancialIncentivePayments
         inclusion: {in: %w[TRUE FALSE], message: "must be TRUE or FALSE"}
 
       validates "Max claims",
-        presence: true,
-        numericality: {only_integer: true, greater_than_or_equal_to: 0}
+        numericality: {only_integer: true, greater_than_or_equal_to: 0},
+        if: -> { row["Max claims"].present? }
 
       def initialize(row:)
         @row = row
@@ -59,7 +59,7 @@ module EarlyYearsTeachersFinancialIncentivePayments
             town: row["Provider town"],
             postcode: row["Postcode"],
             eligible: cast_bool(row["Eligible"]),
-            max_claims: row["Max claims"],
+            max_claims: row["Max claims"].presence || 5,
             file_upload:
           )
       end

--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -11,7 +11,8 @@ module EarlyYearsTeachersFinancialIncentivePayments
         "Provider address line 3",
         "Provider town",
         "Postcode",
-        "Eligible"
+        "Eligible",
+        "Max claims"
       ]
 
       include ActiveModel::Validations
@@ -38,6 +39,10 @@ module EarlyYearsTeachersFinancialIncentivePayments
         presence: true,
         inclusion: {in: %w[TRUE FALSE], message: "must be TRUE or FALSE"}
 
+      validates "Max claims",
+        presence: true,
+        numericality: {only_integer: true, greater_than: 0}
+
       def initialize(row:)
         @row = row
       end
@@ -54,6 +59,7 @@ module EarlyYearsTeachersFinancialIncentivePayments
             town: row["Provider town"],
             postcode: row["Postcode"],
             eligible: cast_bool(row["Eligible"]),
+            max_claims: row["Max claims"],
             file_upload:
           )
       end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -4,6 +4,7 @@ module Policies
       def applicable_task_names
         tasks = []
 
+        tasks << "provider_claim_count" if add_provider_claim_count_task? || task_exists?("provider_claim_count")
         tasks << "one_login_identity"
         tasks << "qualifications"
         tasks << "employment"
@@ -21,6 +22,28 @@ module Policies
           locale_key = (name == "one_login_identity") ? "identity_confirmation" : name
           OpenStruct.new(name:, locale_key:)
         end
+      end
+
+      private
+
+      def add_provider_claim_count_task?
+        # Don't add the task to already decided claims
+        provider_claim_limit_exceeded? && !claim.decision_made?
+      end
+
+      def provider_claim_count
+        @provider_claim_count ||= claim
+          .eligibility
+          .eligible_eytfi_provider
+          .claims
+          .not_rejected
+          .count
+      end
+
+      def provider_claim_limit_exceeded?
+        return false if claim.eligibility.eligible_eytfi_provider_urn.blank?
+
+        provider_claim_count > claim.eligibility.eligible_eytfi_provider.max_claims
       end
     end
   end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_provider.rb
@@ -32,6 +32,16 @@ module Policies
           .limit(School::SEARCH_RESULTS_LIMIT)
       end
 
+      def claims
+        Claim
+          .where(
+            eligibility_type: Eligibility.name,
+            eligibility_id: Eligibility
+              .where(eligible_eytfi_provider_urn: urn)
+              .select(:id)
+          )
+      end
+
       def address
         [
           address_line_1,

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,6 +40,7 @@ class Task < ApplicationRecord
     fe_repeat_applicant_check
     fe_provider_check
     claimant_check
+    provider_claim_count
   ].freeze
 
   NAMES.each { |name| scope name.to_sym, -> { where(name: name) } }

--- a/app/views/admin/tasks/early_years_teachers_financial_incentive_payments/provider_claim_count.html.erb
+++ b/app/views/admin/tasks/early_years_teachers_financial_incentive_payments/provider_claim_count.html.erb
@@ -1,0 +1,80 @@
+<% content_for(:page_title) {
+  page_title(
+    "Claim #{@claim.reference} provider claim count check for #{@claim.policy.short_name}"
+  )
+} %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
+<%= form_with(
+  model: @form,
+  scope: :form,
+  url: root_path,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
+  <%= f.govuk_error_summary %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <%= render claim_summary_view, claim: @claim, heading: "Claims at nursery" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @form.task.name.humanize %></h2>
+
+    <h3 class="govuk-heading-m">
+      Claims for <%= @form.task.claim.eligibility.eligible_eytfi_provider.name %>
+    </h3>
+
+    <ul class="govuk-list govuk-!-margin-bottom-8">
+      <% @claim.eligibility.eligible_eytfi_provider.claims.excluding(@claim).each do |provider_claim| %>
+        <li>
+          <%= link_to(
+            provider_claim.reference,
+            admin_claim_tasks_path(provider_claim),
+            class: "govuk-link"
+          ) %>
+          <% if provider_claim.approved? %>
+            (approved)
+          <% elsif provider_claim.rejected? %>
+            (rejected)
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+
+    <% if @form.task.persisted? %>
+      <%= render "task_outcome", task: @form.task %>
+    <% else %>
+      <%= form_with(
+        model: @form,
+        scope: :form,
+        url: admin_claim_tasks_path(@claim),
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |f| %>
+        <%= f.hidden_field :name, value: @form.task.name %>
+
+        <%= f.govuk_collection_radio_buttons :passed,
+          @form.radio_options,
+          :id,
+          :name,
+          inline: true,
+          legend: {
+            text: I18n.t(
+              "#{@form.translation}.title",
+              count: @form.task.claim.eligibility.eligible_eytfi_provider.claims.not_rejected.count - 1,
+            ),
+            tag: "h3",
+            size: "m"
+          } %>
+
+        <%= f.govuk_submit "Save and continue" %>
+      <% end %>
+    <% end %>
+
+    <%= render "task_notes_section" %>
+
+    <%= render partial: "admin/task_pagination", locals: { task_pagination: @task_pagination } %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -506,6 +506,7 @@ shared:
     - eligible # boolean, whether or not this provider is eligible for payment
     - file_upload_id # uuid, associated file upload. use this to work out academic year and latest version as this table is append only
     - sanitised_postcode # string, postcode of the provider normalised
+    - max_claims # integer, max number of claims permitted for this nursery
   :active_storage_variant_records:
     - id # uuid, uniquely identifies this variant record
     - blob_id # uuid, the blob this variant was derived from

--- a/config/locales/admin.yml
+++ b/config/locales/admin.yml
@@ -81,6 +81,9 @@ en:
       matching_details:
         name: Matching details
         title: "Review matching details from other claims"
+      provider_claim_count:
+        name: Provider claim count
+        title: "Review claims at nursery"
       identity_confirmation:
         name: Identity confirmation
         title: "Confirm the claimant made the claim"
@@ -517,3 +520,5 @@ en:
           title: "The claimant’s personal bank account details have not been automatically validated. Has the claimant confirmed their personal bank account details?"
         matching_details:
           title: "Is this claim still valid despite having matching details with other claims?"
+        provider_claim_count:
+          title: "Is this claim still valid given there are %{count} other claims for this provider?"

--- a/db/migrate/20260520120000_add_max_claims_to_eligible_eytfi_providers.rb
+++ b/db/migrate/20260520120000_add_max_claims_to_eligible_eytfi_providers.rb
@@ -1,0 +1,5 @@
+class AddMaxClaimsToEligibleEytfiProviders < ActiveRecord::Migration[8.1]
+  def change
+    add_column :eligible_eytfi_providers, :max_claims, :integer, null: false
+  end
+end

--- a/db/migrate/20260520120000_add_max_claims_to_eligible_eytfi_providers.rb
+++ b/db/migrate/20260520120000_add_max_claims_to_eligible_eytfi_providers.rb
@@ -1,5 +1,11 @@
 class AddMaxClaimsToEligibleEytfiProviders < ActiveRecord::Migration[8.1]
   def change
-    add_column :eligible_eytfi_providers, :max_claims, :integer, null: false
+    add_column(
+      :eligible_eytfi_providers,
+      :max_claims,
+      :integer,
+      null: false,
+      default: 5
+    )
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_143355) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -318,6 +318,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_143355) do
     t.datetime "created_at", null: false
     t.boolean "eligible", null: false
     t.uuid "file_upload_id", null: false
+    t.integer "max_claims", null: false
     t.text "name", null: false
     t.text "postcode", null: false
     t.text "sanitised_postcode"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -318,7 +318,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_20_120000) do
     t.datetime "created_at", null: false
     t.boolean "eligible", null: false
     t.uuid "file_upload_id", null: false
-    t.integer "max_claims", null: false
+    t.integer "max_claims", default: 5, null: false
     t.text "name", null: false
     t.text "postcode", null: false
     t.text "sanitised_postcode"

--- a/spec/factories/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers.rb
+++ b/spec/factories/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers.rb
@@ -20,5 +20,6 @@ FactoryBot.define do
     town { Faker::Address.city }
     postcode { "EC1N 2TD" }
     eligible { true }
+    max_claims { 5 }
   end
 end

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/claim_tasks_index_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/claim_tasks_index_spec.rb
@@ -365,6 +365,79 @@ RSpec.describe "Task index page for EYTFI claims" do
     expect(page).to have_no_link("employment_proof2.pdf")
   end
 
+  it "shows the provider claim count task when number claims exceed the limit" do
+    eligible_eytfi_provider = create(
+      :eligible_eytfi_provider,
+      urn: "EY123456",
+      name: "Sunny Days Nursery",
+      max_claims: 5
+    )
+
+    claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      eligibility_attributes: {
+        eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+      }
+    )
+
+    5.times do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+        eligibility_attributes: {
+          eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+        }
+      )
+    end
+
+    # A rejected claim at the same provider — doesn't count toward the limit
+    rejected_claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      eligibility_attributes: {
+        eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+      }
+    )
+    create(:decision, :rejected, claim: rejected_claim)
+
+    approved_claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      eligibility_attributes: {
+        eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+      }
+    )
+    create(:decision, :approved, claim: approved_claim)
+
+    Claim.where(
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments
+    ).where.not(id: [claim.id, rejected_claim.id, approved_claim.id]).first
+
+    sign_in_as_service_admin
+
+    visit admin_claim_tasks_path(claim)
+
+    click_on "Review claims at nursery"
+
+    expect(page).to have_text(
+      "Is this claim still valid given there are 6 other claims for this provider?"
+    )
+
+    choose "Yes"
+
+    click_on "Save and continue"
+
+    visit admin_claim_task_path(claim, "provider_claim_count")
+
+    expect(page).to have_text("Passed")
+    expect(page).to have_text("This task was performed by Aaron Admin")
+  end
+
   it "shows the matching details" do
     eligible_eytfi_provider = create(
       :eligible_eytfi_provider,

--- a/spec/fixtures/files/eligible_eytfi_providers.csv
+++ b/spec/fixtures/files/eligible_eytfi_providers.csv
@@ -1,3 +1,3 @@
-Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible
-123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE
-EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE
+Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible,Max claims
+123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE,5
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE,10

--- a/spec/fixtures/files/eligible_eytfi_providers_with_error.csv
+++ b/spec/fixtures/files/eligible_eytfi_providers_with_error.csv
@@ -1,4 +1,4 @@
-Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible
-123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE
-EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE
-EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FOO
+Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible,Max claims
+123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE,5
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE,10
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FOO,10

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
       it "saves errors on file upload" do
         subject.perform(file_upload)
 
-        expect(file_upload.reload.upload_errors).to eql(["Headers must be Provider URN, Provider name, Provider address line 1, Provider address line 2, Provider address line 3, Provider town, Postcode, Eligible"])
+        expect(file_upload.reload.upload_errors).to eql(["Headers must be Provider URN, Provider name, Provider address line 1, Provider address line 2, Provider address line 3, Provider town, Postcode, Eligible, Max claims"])
       end
     end
   end
@@ -308,6 +308,83 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
         end
       end
     end
+
+    context "max claims" do
+      context "is missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Max claims"]).to be_present
+        end
+      end
+
+      context "is not a positive integer" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "0"
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Max claims"]).to be_present
+        end
+      end
+
+      context "is not an integer" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "foo"
+            ],
+            true
+          )
+        end
+
+        it "is not valid" do
+          subject.valid?
+          expect(subject.errors["Max claims"]).to be_present
+        end
+      end
+    end
   end
 
   describe "#to_provider" do
@@ -322,7 +399,8 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
           "Somewhere Else",
           "London",
           "EC1N 2TD",
-          "TRUE"
+          "TRUE",
+          "5"
         ],
         true
       )
@@ -340,6 +418,7 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
           town: "London",
           postcode: "EC1N 2TD",
           eligible: true,
+          max_claims: 5,
           file_upload:
         )
 

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
               "",
               "",
               "",
-              "0"
+              "-1"
             ],
             true
           )

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -315,23 +315,23 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
           CSV::Row.new(
             described_class::HEADERS,
             [
-              "",
-              "",
-              "",
-              "",
-              "",
-              "",
-              "",
-              "",
+              "123456",
+              "Some nursery",
+              "Some Road",
+              "Somewhere",
+              "Somewhere Else",
+              "Some Town",
+              "TE57 1NG",
+              "TRUE",
               ""
             ],
             true
           )
         end
 
-        it "is not valid" do
-          subject.valid?
-          expect(subject.errors["Max claims"]).to be_present
+        it "defaults to 5" do
+          provider = subject.to_provider(file_upload:)
+          expect(provider.max_claims).to eql(5)
         end
       end
 

--- a/spec/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe Policies::EarlyYearsTeachersFinancialIncentivePayments::ClaimCheckingTasks do
+  subject(:checking_tasks) { described_class.new(claim) }
+
+  describe "#provider_claim_count" do
+    context "when the claim limit is not exceeded" do
+      it "doesn't include the provider claim count task" do
+        eligible_eytfi_provider = create(
+          :eligible_eytfi_provider,
+          max_claims: 2
+        )
+
+        create(
+          :claim,
+          :submitted,
+          :approved,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+          }
+        )
+
+        # Rejected claim, not counted
+        create(
+          :claim,
+          :submitted,
+          :rejected,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+          }
+        )
+
+        # claim at other provider, not counted
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: create(:eligible_eytfi_provider)
+          }
+        )
+
+        claim = create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+          }
+        )
+
+        expect(described_class.new(claim).applicable_task_names).not_to include(
+          "provider_claim_count"
+        )
+      end
+    end
+
+    context "when the claim limit is exceeded" do
+      it "includes the provider claim count task" do
+        eligible_eytfi_provider = create(
+          :eligible_eytfi_provider,
+          max_claims: 2
+        )
+
+        2.times do
+          create(
+            :claim,
+            :submitted,
+            :approved,
+            policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+            eligibility_attributes: {
+              eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+            }
+          )
+        end
+
+        # Rejected claim, not counted
+        create(
+          :claim,
+          :submitted,
+          :rejected,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+          }
+        )
+
+        # claim at other provider, not counted
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: create(:eligible_eytfi_provider)
+          }
+        )
+
+        claim = create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            eligible_eytfi_provider_urn: eligible_eytfi_provider.urn
+          }
+        )
+
+        expect(described_class.new(claim).applicable_task_names).to include(
+          "provider_claim_count"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add claim limit check task

If there are more than <some number> of claims at a provider we want to
add a task to any undecided claims for that provider for the ops team to
review. The limit will be set as a column in the eytfi provider csv
that's uploaded to the admin site.

