### PR TITLE
Use school search form

### DIFF
--- a/app/forms/journeys/further_education_payments/further_education_provision_search_form.rb
+++ b/app/forms/journeys/further_education_payments/further_education_provision_search_form.rb
@@ -16,17 +16,17 @@ module Journeys
       def save
         return if invalid? || no_results?
 
-        if possible_school_id.present? && changed_possible_school?
-          journey_session.answers.assign_attributes(
-            possible_school_id:
-          )
-          reset_dependent_answers
-        end
-
         if changed_query?
           journey_session.answers.assign_attributes(
             possible_school_id: nil,
             provision_search:
+          )
+          reset_dependent_answers
+        end
+
+        if possible_school_id.present? && changed_possible_school?
+          journey_session.answers.assign_attributes(
+            possible_school_id:
           )
           reset_dependent_answers
         end

--- a/app/views/further_education_payments/claims/further_education_provision_search.html.erb
+++ b/app/views/further_education_payments/claims/further_education_provision_search.html.erb
@@ -6,25 +6,21 @@
       url: @form.url,
       method: :patch,
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-      id: "further-education-provision-search-form",
-      data: { "fe-only" => true },
       html: { novalidate: false } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.hidden_field :possible_school_id %>
-
-      <h1 class="govuk-heading-l">
-        <%= @form.t(:question) %>
-      </h1>
-
-      <div id="autocomplete-container" class="govuk-!-margin-bottom-9">
-        <%= f.govuk_text_field :provision_search,
-          class: "js-remove",
-          label: nil,
-          hint: -> do %>
-            Enter the name or postcode using at least 3 characters.
-          <% end %>
-      </div>
+      <%= f.govuk_school_search(
+        :provision_search,
+        search_path: school_search_index_path(fe_only: true),
+        result_attribute: :possible_school_id,
+        label: {
+          text: @form.t(:question),
+          size: "l"
+        },
+        hint: {
+          text: "Enter the name or postcode using at least 3 characters."
+        }
+      ) %>
 
       <p class="govuk-body">
         You can find 


### PR DESCRIPTION
Update FE to use `school_search_field` for accessible auto complete.
Also fixes an issue with the select school page not preselecting the chosen school.

Will merge this after Sunday when the journeys close.