### PR TITLE
Purge Azure blobs when unsubmitted journey sessions are deleted

### DIFF
--- a/app/jobs/purge_unsubmitted_claims_job.rb
+++ b/app/jobs/purge_unsubmitted_claims_job.rb
@@ -4,8 +4,10 @@
 class PurgeUnsubmittedClaimsJob < ApplicationJob
   def perform
     Journeys::JOURNEYS.each do |journey|
-      Rails.logger.info "Purging #{journey::Session.purgeable.count} old and unsubmitted #{journey::Session} journeys from the database"
-      journey::Session.where(journey: journey.routing_name).purgeable.destroy_all
+      purgeable = journey::Session.where(journey: journey.routing_name).purgeable
+      Rails.logger.info "Purging #{purgeable.count} old and unsubmitted #{journey::Session} journeys from the database"
+
+      purgeable.in_batches(&:destroy_all)
     end
   end
 end

--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/session.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/session.rb
@@ -1,6 +1,8 @@
 module Journeys
   module EarlyYearsTeachersFinancialIncentivePayments
     class Session < Journeys::Session
+      # dependent: :purge_later by default
+      # — blobs are deleted from Azure asynchronously when the session is destroyed
       has_many_attached :employment_proofs
     end
   end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligibility.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligibility.rb
@@ -4,6 +4,9 @@ module Policies
       self.table_name = "early_years_teachers_financial_incentive_payments_eligibilities"
 
       has_one :claim, as: :eligibility, inverse_of: :eligibility
+
+      # dependent: :purge_later by default
+      # — blobs are deleted from Azure asynchronously when the session is destroyed
       has_many_attached :employment_proofs
 
       AMENDABLE_ATTRIBUTES = []

--- a/spec/jobs/purge_unsubmitted_claims_job_spec.rb
+++ b/spec/jobs/purge_unsubmitted_claims_job_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe PurgeUnsubmittedClaimsJob do
       ).to be_empty
     end
 
+    context "when an EYTFI session with file attachments is purgeable" do
+      it "deletes the session and purges its blobs from storage" do
+        session = create(:eytfi_session, :with_employment_proof)
+        session.update_column(:updated_at, over_24_hours_ago)
+
+        expect {
+          perform_enqueued_jobs { PurgeUnsubmittedClaimsJob.new.perform }
+        }.to change(ActiveStorage::Blob, :count).by(-1)
+
+        expect(Journeys::Session.where(id: session.id)).to be_empty
+      end
+    end
+
     context "FE sessions" do
       it "deletes unsubmitted sessions over a year old" do
         Journeys::FurtherEducationPayments::Session.create!(


### PR DESCRIPTION
`PurgeUnsubmittedClaimsJob` used `destroy_all` which bypasses ActiveRecord callbacks, leaving Active Storage blobs orphaned in Azure. Now enqueues `ActiveStorage::PurgeJob` for all attachments before destroying the session records.

