### PR TITLE
Handle file upload scoped records

### DIFF
--- a/app/models/policies/early_years_teachers_financial_incentive_payments/eligibility.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/eligibility.rb
@@ -14,8 +14,9 @@ module Policies
 
       def eligible_eytfi_provider
         @eligible_eytfi_provider ||= EligibleEytfiProvider
-          .by_academic_year(claim.academic_year)
-          .find_by!(urn: eligible_eytfi_provider_urn)
+          .where(urn: eligible_eytfi_provider_urn)
+          .order(created_at: :desc) # Handle EytfiProviders being backed by file uploads
+          .first!
       end
 
       def ey_qualification

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
@@ -24,4 +24,35 @@ RSpec.feature "Admin of eligible EYTFI providers" do
 
     expect(page.current_path).to eql(admin_file_upload_path(file_upload))
   end
+
+  scenario "re-uploading the file doesn't lose existing claims" do
+    academic_year = AcademicYear.current
+
+    claim = create(
+      :claim,
+      :submitted,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      academic_year: academic_year
+    )
+
+    sign_in_as_service_operator
+
+    visit admin_claim_tasks_path(claim)
+
+    expect(page).to have_content(claim.reference)
+
+    click_link "Manage services"
+    click_link "Change Early Years Teachers Recognition Payments"
+
+    select academic_year.to_s, from: "Academic year"
+    attach_file "eligible-eytfi-providers-upload-file-field", eligible_eytfi_providers_csv_file
+
+    perform_enqueued_jobs do
+      click_button "Upload CSV"
+    end
+
+    visit admin_claim_tasks_path(claim)
+
+    expect(page).to have_content(claim.reference)
+  end
 end


### PR DESCRIPTION
Previously when uploading a new provider file existing claims were
404ing as finding the provider was throwing active record record not
found.
