### PR TITLE
Fix claim cancelled

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -60,6 +60,20 @@ class StaticPagesController < BasePublicController
     end
   end
 
+  def claim_cancelled
+    claim_cancelled_page = "#{journey.view_path}/claims/claim_cancelled"
+
+    if lookup_context.template_exists?(claim_cancelled_page, [], false)
+      render claim_cancelled_page
+    else
+      render(
+        file: Rails.root.join("public", "404.html"),
+        status: :not_found,
+        layout: false
+      )
+    end
+  end
+
   private
 
   def journey_available?

--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/claim_cancelled_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/claim_cancelled_form.rb
@@ -1,9 +1,5 @@
 module Journeys
   module EarlyYearsTeachersFinancialIncentivePayments
-    class ClaimCancelledForm < Form
-      def save
-        session.clear
-      end
-    end
+    class ClaimCancelledForm < Form; end
   end
 end

--- a/app/forms/journeys/early_years_teachers_financial_incentive_payments/continue_claim_form.rb
+++ b/app/forms/journeys/early_years_teachers_financial_incentive_payments/continue_claim_form.rb
@@ -14,6 +14,10 @@ module Journeys
 
         journey_session.answers.update!(continue_claim:)
 
+        if claim_cancelled?
+          session.clear
+        end
+
         true
       end
 
@@ -28,6 +32,12 @@ module Journeys
             name: t("options.false")
           )
         ]
+      end
+
+      private
+
+      def claim_cancelled?
+        continue_claim == false
       end
     end
   end

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/claim_cancelled.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/claim_cancelled.html.erb
@@ -10,8 +10,6 @@
       If you change your mind, you can start a new claim.
     </div>
 
-    <%= form_with model: @form, url: @form.url, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_submit "Start a new claim" %>
-    <% end %>
+    <%= govuk_button_link_to("Start a new claim", landing_page_path) %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,12 @@ Rails.application.routes.draw do
     end
   }
 
+  scope path: ":journey", constraints: {journey: "early-years-teachers-recognition-payments"} do
+    get "guidance", to: "static_pages#guidance_page", as: :eytfi_guidance
+    get "methodology", to: "static_pages#methodology_page", as: :eytfi_methodology
+    get "claim-cancelled", to: "static_pages#claim_cancelled", as: :claim_cancelled
+  end
+
   # Define routes that are specific to each journey's page sequence
   Journeys.all.each do |journey|
     constraints(restrict_to_sequence_slugs.new(journey)) do
@@ -98,11 +104,6 @@ Rails.application.routes.draw do
       end
 
       get "auth/teacher/callback", to: "journeys/early_years_teachers_financial_incentive_payments/auth#callback"
-    end
-
-    scope constraints: {journey: "early-years-teachers-recognition-payments"} do
-      get "guidance", to: "static_pages#guidance_page", as: :eytfi_guidance
-      get "methodology", to: "static_pages#methodology_page", as: :eytfi_methodology
     end
 
     scope path: "/", constraints: {journey: Regexp.new(Journeys.all_routing_names.join("|"))} do

--- a/spec/features/early_years_teachers_financial_incentive_payments/claim_cancelled_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/claim_cancelled_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "EYTFI - Claim cancelled", feature_flag: [:eytfi_journey] do
+  let(:mock_teacher) do
+    instance_double(
+      "Dqt::Teacher",
+      has_eligible_eytfi_qualification?: true
+    )
+  end
+
+  let(:mock_teacher_resource) do
+    instance_double(
+      "Dqt::TeacherResource",
+      find: mock_teacher
+    )
+  end
+
+  let(:mock_client) do
+    instance_double(
+      "Dqt::Client",
+      teacher: mock_teacher_resource
+    )
+  end
+
+  before do
+    create(
+      :journey_configuration,
+      :early_years_teachers_financial_incentive_payments
+    )
+
+    OmniAuth.config.mock_auth[:teacher] = OmniAuth::AuthHash.new({
+      provider: "teacher",
+      extra: {
+        raw_info: {
+          sub: "urn:fdc:gov.uk:2022:#{SecureRandom.base64(30)}",
+          trn: "1234567",
+          email: "john.doe@example.com",
+          verified_name: ["John", "Doe"],
+          verified_date_of_birth: "1970-12-13"
+        }
+      }
+    })
+
+    allow(Dqt::Client).to receive(:new).and_return(mock_client)
+  end
+
+  it "allows the claimant to cancel their claim" do
+    create(
+      :eligible_eytfi_provider,
+      name: "Springfield nursery"
+    )
+
+    visit landing_page_path(
+      Journeys::EarlyYearsTeachersFinancialIncentivePayments.routing_name
+    )
+
+    click_link "Start now"
+
+    expect(page).to have_text "Which nursery do you teach in?"
+    find_field("claim[nursery_search_query]").set("Springfield nursery")
+    click_button "Continue"
+
+    expect(page).to have_text "Which nursery do you teach in?"
+    choose "Springfield nursery"
+    click_button "Continue"
+
+    expect(page).to have_text "Do you hold one of these teaching qualifications?"
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_text("Check that you are eligible")
+    check "I spend at least 50%"
+    check "I am not currently subject"
+    click_button "Confirm and continue"
+
+    expect(page).to have_text "You are eligible to apply"
+    click_button "Continue"
+
+    expect(page).to have_text "Sign in with GOV.UK One Login"
+
+    perform_enqueued_jobs do
+      click_button "Continue"
+    end
+
+    expect(page).to have_text "You may be eligible for a recognition payment"
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_content "Your claim has been cancelled"
+
+    click_on "Start a new claim"
+
+    click_on "Start now"
+
+    # As we've cleared the session expect not to see the claim in progress
+    # warning
+    expect(page).not_to have_content(
+      "You have already started an eligibility check"
+    )
+  end
+end

--- a/spec/features/early_years_teachers_financial_incentive_payments/ineligible_spec.rb
+++ b/spec/features/early_years_teachers_financial_incentive_payments/ineligible_spec.rb
@@ -175,9 +175,8 @@ RSpec.feature "EYTFI journey ineligible paths", feature_flag: [:eytfi_journey] d
       choose "No"
       click_button "Continue"
 
-      expect(page).to have_link "Back"
       expect(page).to have_text "Claim cancelled"
-      click_button "Start a new claim"
+      click_on "Start a new claim"
 
       expect(page).to have_text "Start now"
     end


### PR DESCRIPTION
This was a tricky one.
When the claimant chooses "No" on the continue claim screen we need to
clear their session and show them the claim cancelled page. This is
tricky as once their session is cleared the claims controller kicks the
claimant back to the landing page before the navigator can determine the
slug to use. To work round this we've added a new route to the static
pages controller and moved the EYTRP static pages to come before the
journey route definitions, that way requests for `claim-cancelled` will
be picked up by the statis pages controller, which doesn't check for
active sessions.
This seemed to be the lightest touch approach as we keep the
claim-cancelled slug in the slug sequence and the navigator remains
responsible for picking the next slug. Though it feels like a bit of a
hack.

Now that we need a page that sits outside the claim controller's
control, along with forms specifying their own redirects makes me think
we need to think a bit more about we handle redirects in the app.
Ideally we'd specify all redirection rules in the slug sequence, and the
navigator would look only at that to decide what to do.
