### PR TITLE
Back fill provider verification timestamp

### DIFF
--- a/app/jobs/further_education_payments/back_fill_provider_verification_timestamp_job.rb
+++ b/app/jobs/further_education_payments/back_fill_provider_verification_timestamp_job.rb
@@ -1,0 +1,16 @@
+module FurtherEducationPayments
+  class BackFillProviderVerificationTimestampJob < ApplicationJob
+    def perform
+      scope = Policies::FurtherEducationPayments::Eligibility
+        .joins(:claim)
+        .merge(Claim.by_academic_year(AcademicYear.new(2024)))
+        .where("further_education_payments_eligibilities.verification->>'created_at' IS NOT NULL")
+
+      scope.find_each do |eligibility|
+        eligibility.update!(
+          provider_verification_completed_at: eligibility.verification["created_at"]
+        )
+      end
+    end
+  end
+end

--- a/spec/jobs/further_education_payments/back_fill_provider_verification_timestamp_job_spec.rb
+++ b/spec/jobs/further_education_payments/back_fill_provider_verification_timestamp_job_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe FurtherEducationPayments::BackFillProviderVerificationTimestampJob, type: :job do
+  let(:verification) do
+    {
+      "created_at" => "2024-01-01T12:00:00.000+00:00"
+    }
+  end
+
+  it "does not change the dates for claims in the current academic year" do
+    eligibility = create(
+      :further_education_payments_eligibility,
+      :eligible,
+      verification: verification,
+      provider_verification_completed_at: nil
+    )
+
+    claim = create(
+      :claim,
+      :further_education,
+      academic_year: AcademicYear.current,
+      eligibility: eligibility
+    )
+
+    expect { described_class.new.perform }
+      .not_to change { eligibility.reload.provider_verification_completed_at }
+      .from(nil)
+
+    expect(claim.academic_year).to eq(AcademicYear.current)
+  end
+
+  it "back fills the dates for claims in the 2024/2025 academic year" do
+    eligibility = create(
+      :further_education_payments_eligibility,
+      :eligible,
+      verification: verification,
+      provider_verification_completed_at: nil
+    )
+
+    create(
+      :claim,
+      :further_education,
+      academic_year: AcademicYear.new(2024),
+      eligibility: eligibility
+    )
+
+    expect { described_class.new.perform }
+      .to change { eligibility.reload.provider_verification_completed_at }
+      .from(nil)
+      .to(Time.zone.parse("2024-01-01T12:00:00.000+00:00"))
+  end
+end


### PR DESCRIPTION
Makes some analytics stuff easier if we back fill this for last years
claims.
We need to fire DfE analytics events so we can do the update directly in
SQL as the events are triggered by callbacks.
Takes about a minute to run against a copy of production.
