### PR TITLE
Update claim index for eytrp identity task

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -143,7 +143,7 @@ module Admin
 
     def identity_confirmation_task_claim_verifier_match_status_tag(claim)
       case claim.policy
-      when Policies::FurtherEducationPayments
+      when Policies::FurtherEducationPayments, Policies::EarlyYearsTeachersFinancialIncentivePayments
         identity_tasks = []
         identity_tasks << (claim.tasks.detect { |t| t.name == "one_login_identity" } || Task.new)
         identity_tasks << (claim.tasks.detect { |t| t.name == "fe_alternative_verification" } || Task.new)


### PR DESCRIPTION
I was tempted to do

```rb
when Policies::EarlyYearsTeachersFinancialIncentivePayments
 status = "Passed"
 statu_colour = "green"
```

as EYTRP identity task is always passed.

I've decided to tack EYTRP on to the FE case in case the always pass logic changes in future. Both EYTRP and FE use the `one_login_identity` task so makes sense here.

~**I'm working on another commit to clean this helper up** but shipping this one first to complete the ticket.~ Have a PR here to clean up the helper https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4604

