### PR TITLE
CAPT-3799 - Add extra fields to EYTRP check your answers page

### DIFF
--- a/app/models/journeys/early_years_teachers_financial_incentive_payments/answers_presenter.rb
+++ b/app/models/journeys/early_years_teachers_financial_incentive_payments/answers_presenter.rb
@@ -10,12 +10,22 @@ module Journeys
 
       def nursery_answers
         [].tap do |a|
-          a << ["Nursery selected", nursery.name, "nursery-search"]
+          a << ["Nursery", nursery_with_address, "nursery-search"]
+          uploaded_documents.each do |blob|
+            a << [
+              "Uploaded payslip",
+              "#{govuk_link_to(blob.filename.to_s, rails_storage_proxy_path(blob, only_path: true), new_tab: true)}, #{number_to_human_size(blob.byte_size)}",
+              "review-employment-proof"
+            ]
+          end
+          a << ["Qualification", ey_qualification, nil] if ey_qualification.present?
         end
       end
 
       def identity_answers
         [].tap do |a|
+          a << ["Name", answers.teacher_auth_verified_name, nil]
+          a << ["Email address", answers.teacher_auth_email, nil]
           a << ["Home address", address, "address"]
           a << gender
           a << ["National Insurance number", answers.national_insurance_number, "national-insurance-number"]
@@ -24,20 +34,9 @@ module Journeys
 
       def banking_answers
         [].tap do |a|
-          a << ["Name on bank account", answers.banking_name, "personal-bank-account"]
-          a << ["Bank sort code", answers.bank_sort_code, "personal-bank-account"]
-          a << ["Bank account number", answers.bank_account_number, "personal-bank-account"]
-        end
-      end
-
-      def upload_answers
-        # Should only be ONE
-        uploaded_documents.map do |blob|
-          [
-            "Payslip",
-            "#{govuk_link_to(blob.filename.to_s, rails_storage_proxy_path(blob, only_path: true), new_tab: true)}, #{number_to_human_size(blob.byte_size)}",
-            "review-employment-proof"
-          ]
+          a << ["Name on your account", answers.banking_name, "personal-bank-account"]
+          a << ["Sort code", answers.bank_sort_code, "personal-bank-account"]
+          a << ["Account number", answers.bank_account_number, "personal-bank-account"]
         end
       end
 
@@ -45,6 +44,17 @@ module Journeys
 
       def nursery
         Policies::EarlyYearsTeachersFinancialIncentivePayments::EligibleEytfiProvider.find(answers.nursery_id)
+      end
+
+      def nursery_with_address
+        [
+          nursery.name,
+          nursery.address_line_1,
+          nursery.address_line_2,
+          nursery.address_line_3,
+          nursery.town,
+          nursery.postcode
+        ].reject(&:blank?).join(", ")
       end
 
       def address
@@ -68,6 +78,19 @@ module Journeys
       def uploaded_documents
         confirmed_ids = answers.confirmed_employment_proof_blob_ids
         ActiveStorage::Blob.where(id: confirmed_ids).order(created_at: :asc)
+      end
+
+      def ey_qualification
+        return if answers.trs_data.blank?
+
+        teacher = Dqt::Teacher.new(answers.trs_data)
+        if teacher.has_valid_qts?
+          "Qualified Teacher Status (QTS)"
+        elsif teacher.has_valid_eyts?
+          "Early Years Teacher Status (EYTS)"
+        elsif teacher.has_valid_eyps?
+          "Early Years Professional Status (EYPS)"
+        end
       end
     end
   end

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/check_your_answers.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/check_your_answers.html.erb
@@ -18,7 +18,7 @@
 
       <%= render partial: "claims/check_your_answers_section",
         locals: {
-          heading: "Nursery",
+          heading: "Employment details",
           answers: journey.answers_for_claim(@form.journey_session).nursery_answers
         } %>
 
@@ -32,12 +32,6 @@
         locals: {
           heading: "Bank details",
           answers: journey.answers_for_claim(@form.journey_session).banking_answers
-        } %>
-
-      <%= render partial: "claims/check_your_answers_section",
-        locals: {
-          heading: "Uploaded document",
-          answers: journey.answers_for_claim(@form.journey_session).upload_answers
         } %>
 
       <%= f.govuk_check_boxes_fieldset :claimant_declaration, multiple: false, legend: { text: "Confirm you are eligible" } do %>

--- a/spec/models/journeys/early_years_teachers_financial_incentive_payments/answers_presenter_spec.rb
+++ b/spec/models/journeys/early_years_teachers_financial_incentive_payments/answers_presenter_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe Journeys::EarlyYearsTeachersFinancialIncentivePayments::AnswersPresenter, type: :model do
+  let(:nursery) { create(:eligible_eytfi_provider, name: "Springfield nursery") }
+
+  let(:base_answers) do
+    {
+      nursery_id: nursery.id,
+      teacher_auth_verified_name: "John Doe",
+      teacher_auth_email: "john@example.com"
+    }
+  end
+
+  let(:journey_session) do
+    create(:eytfi_session, answers: base_answers.merge(extra_answers))
+  end
+
+  let(:extra_answers) { {} }
+
+  subject(:presenter) { described_class.new(journey_session) }
+
+  describe "#identity_answers" do
+    subject { presenter.identity_answers }
+
+    it "has name as the first row" do
+      expect(subject.first).to eq(["Name", "John Doe", nil])
+    end
+
+    it "has email address as the second row" do
+      expect(subject.second).to eq(["Email address", "john@example.com", nil])
+    end
+  end
+
+  describe "#nursery_answers" do
+    subject { presenter.nursery_answers }
+
+    context "when trs_data is blank" do
+      let(:extra_answers) { {trs_data: nil} }
+
+      it "does not include a qualification row" do
+        expect(subject.map(&:first)).not_to include("Qualification")
+      end
+    end
+
+    context "when teacher has valid QTS" do
+      let(:extra_answers) do
+        {
+          trs_data: {
+            "qts" => {
+              "holdsFrom" => "2020-01-01",
+              "routes" => [{"routeToProfessionalStatusType" => {"professionalStatusType" => "QualifiedTeacherStatus"}}]
+            }
+          }
+        }
+      end
+
+      it "shows Qualified Teacher Status (QTS) as the last row" do
+        expect(subject.last).to eq(["Qualification", "Qualified Teacher Status (QTS)", nil])
+      end
+    end
+
+    context "when teacher has valid EYTS" do
+      let(:extra_answers) do
+        {
+          trs_data: {
+            "eyts" => {
+              "holdsFrom" => "2020-01-01",
+              "routes" => [{"routeToProfessionalStatusType" => {"professionalStatusType" => "EarlyYearsTeacherStatus"}}]
+            }
+          }
+        }
+      end
+
+      it "shows Early Years Teacher Status (EYTS) as the last row" do
+        expect(subject.last).to eq(["Qualification", "Early Years Teacher Status (EYTS)", nil])
+      end
+    end
+
+    context "when teacher has valid EYPS" do
+      let(:extra_answers) do
+        {
+          trs_data: {
+            "eyts" => {
+              "holdsFrom" => "2020-01-01",
+              "routes" => [{"routeToProfessionalStatusType" => {"professionalStatusType" => "EarlyYearsProfessionalStatus"}}]
+            }
+          }
+        }
+      end
+
+      it "shows Early Years Professional Status (EYPS) as the last row" do
+        expect(subject.last).to eq(["Qualification", "Early Years Professional Status (EYPS)", nil])
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add name and email address as the first two rows of the personal details section, sourced from OneLogin auth data. Consolidate the nursery and uploaded document sections into a single "Employment details" section containing nursery (with address), uploaded payslip, and qualification (derived from TRS data).
- Add answers presenter spec.

<img width="389" height="727" alt="Screenshot 2026-06-02 at 13 09 16" src="https://github.com/user-attachments/assets/2413886b-c162-4401-8b51-dc9a98476981" />

<img width="387" height="870" alt="Screenshot 2026-06-02 at 13 09 23" src="https://github.com/user-attachments/assets/831b31c9-9661-4df7-9f69-d598fa7690f8" />
