### PR TITLE
clean update task status helper

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -142,62 +142,16 @@ module Admin
     end
 
     def identity_confirmation_task_claim_verifier_match_status_tag(claim)
-      case claim.policy
-      when Policies::FurtherEducationPayments, Policies::EarlyYearsTeachersFinancialIncentivePayments
-        identity_tasks = []
-        identity_tasks << (claim.tasks.detect { |t| t.name == "one_login_identity" } || Task.new)
-        identity_tasks << (claim.tasks.detect { |t| t.name == "fe_alternative_verification" } || Task.new)
+      status = claim.policy::ClaimCheckingTasks.new(claim).identity_status
 
-        if identity_tasks.any? { |t| t.passed? }
-          status = "Passed"
-          status_colour = "green"
-        elsif identity_tasks.all? { |t| t.failed? }
-          status = "Failed"
-          status_colour = "red"
-        else
-          status = "Unverified"
-          status_colour = "grey"
-        end
-      when Policies::EarlyYearsPayments
-        identity_tasks = Policies::EarlyYearsPayments::ClaimCheckingTasks.new(claim).identity_tasks.map do |name|
-          claim.tasks.detect { |t| t.name == name } || Task.new
-        end
-
-        if !claim.eligibility.practitioner_journey_completed?
-          status = "Incomplete"
-          status_colour = "grey"
-        elsif identity_tasks.any? { |t| t.passed? }
-          status = "Passed"
-          status_colour = "green"
-        elsif identity_tasks.all? { |t| t.failed? }
-          status = "Failed"
-          status_colour = "red"
-        else
-          status = "Unverified"
-          status_colour = "grey"
-        end
-      else
-        task = claim.tasks.detect { |t| t.name == "identity_confirmation" }
-
-        if task.nil?
-          status = "Unverified"
-          status_colour = "grey"
-        elsif task.passed?
-          status = "Passed"
-          status_colour = "green"
-        elsif task.passed == false
-          status = "Failed"
-          status_colour = "red"
-        elsif task.claim_verifier_match_all?
-          status = "Full match"
-          status_colour = "green"
-        elsif task.claim_verifier_match_any?
-          status = "Partial match"
-          status_colour = "yellow"
-        elsif task.claim_verifier_match_none?
-          status = "No match"
-          status_colour = "red"
-        end
+      status_colour = case status
+      when "Passed" then "green"
+      when "Full match" then "green"
+      when "Partial match" then "yellow"
+      when "Failed" then "red"
+      when "No match" then "red"
+      when "Unverified" then "grey"
+      when "Incomplete" then "grey"
       end
 
       tag_classes = "govuk-tag app-task-list__task-completed govuk-tag--#{status_colour}"

--- a/app/models/policies/claim_checking_tasks.rb
+++ b/app/models/policies/claim_checking_tasks.rb
@@ -21,6 +21,24 @@ module Policies
         .select(&:not_passed?)
     end
 
+    def identity_status
+      task = claim.tasks.detect { |t| t.name == "identity_confirmation" }
+
+      if task.nil?
+        "Unverified"
+      elsif task.passed?
+        "Passed"
+      elsif task.passed == false
+        "Failed"
+      elsif task.claim_verifier_match_all?
+        "Full match"
+      elsif task.claim_verifier_match_any?
+        "Partial match"
+      elsif task.claim_verifier_match_none?
+        "No match"
+      end
+    end
+
     private
 
     def all_tasks

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -6,7 +6,7 @@ module Policies
       def applicable_task_names
         tasks = []
         tasks << "ey_eoi_cross_reference" unless year_1_of_ey?
-        tasks += identity_tasks
+        tasks += identity_task_names
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
@@ -16,7 +16,25 @@ module Policies
         tasks
       end
 
-      def identity_tasks
+      def identity_status
+        if !claim.eligibility.practitioner_journey_completed?
+          "Incomplete"
+        elsif identity_tasks.any? { |t| t.passed? }
+          "Passed"
+        elsif identity_tasks.all? { |t| t.failed? }
+          "Failed"
+        else
+          "Unverified"
+        end
+      end
+
+      private
+
+      def year_1_of_ey?
+        claim.academic_year == AcademicYear.new("2024/2025")
+      end
+
+      def identity_task_names
         tasks = []
 
         if year_1_of_ey?
@@ -36,10 +54,10 @@ module Policies
         tasks
       end
 
-      private
-
-      def year_1_of_ey?
-        claim.academic_year == AcademicYear.new("2024/2025")
+      def identity_tasks
+        identity_task_names.map do |task_name|
+          claim.tasks.detect { |t| t.name == task_name } || Task.new
+        end
       end
     end
   end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -24,6 +24,18 @@ module Policies
         end
       end
 
+      def identity_status
+        task = claim.tasks.detect { |t| t.name == "one_login_identity" } || Task.new
+
+        if task.passed?
+          "Passed"
+        elsif task.failed?
+          "Failed"
+        else
+          "Unverified"
+        end
+      end
+
       private
 
       def add_provider_claim_count_task?

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -39,6 +39,20 @@ module Policies
         applicable_task_names - task_names_for_claim
       end
 
+      def identity_status
+        identity_tasks = []
+        identity_tasks << (claim.tasks.detect { |t| t.name == "one_login_identity" } || Task.new)
+        identity_tasks << (claim.tasks.detect { |t| t.name == "fe_alternative_verification" } || Task.new)
+
+        if identity_tasks.any? { |t| t.passed? }
+          "Passed"
+        elsif identity_tasks.all? { |t| t.failed? }
+          "Failed"
+        else
+          "Unverified"
+        end
+      end
+
       private
 
       def y1_fe_claim?

--- a/spec/models/policies/early_career_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/early_career_payments/claim_checking_tasks_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::EarlyCareerPayments::ClaimCheckingTasks do
+  subject(:identity_status) { described_class.new(claim).identity_status }
+
+  describe "#identity_status" do
+    let(:claim) do
+      build(
+        :claim,
+        policy: Policies::EarlyCareerPayments,
+        tasks: claim_tasks
+      )
+    end
+
+    context "when there is no identity_confirmation task" do
+      let(:claim_tasks) { [] }
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when the task passed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: true
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when the task failed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: false
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+
+    context "when the task is incomplete with a full claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :all,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Full match") }
+    end
+
+    context "when the task is incomplete with a partial claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :any,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Partial match") }
+    end
+
+    context "when the task is incomplete with no claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :none,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("No match") }
+    end
+  end
+end

--- a/spec/models/policies/early_years_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/early_years_payments/claim_checking_tasks_spec.rb
@@ -110,4 +110,102 @@ RSpec.describe Policies::EarlyYearsPayments::ClaimCheckingTasks do
       end
     end
   end
+
+  describe "#identity_status" do
+    subject(:identity_status) { described_class.new(claim).identity_status }
+
+    context "when the practitioner has not completed their part of the claim" do
+      let(:claim) do
+        create(
+          :claim,
+          :awaiting_practitioner,
+          policy: Policies::EarlyYearsPayments
+        )
+      end
+
+      it { is_expected.to eq("Incomplete") }
+    end
+
+    context "when the one login identity task passed" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          tasks: [
+            build(:task, name: "one_login_identity", passed: true)
+          ]
+        )
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when one login idv failed but alternative verification is pending" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          onelogin_idv_at: DateTime.current,
+          identity_confirmed_with_onelogin: false,
+          tasks: [
+            build(:task, name: "one_login_identity", passed: false)
+          ]
+        )
+      end
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when one login idv failed and alternative verification failed" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          tasks: [
+            build(:task, name: "one_login_identity", passed: false),
+            build(:task, name: "ey_alternative_verification", passed: false)
+          ]
+        )
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+
+    context "when one login idv failed and alternative verification passed" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          onelogin_idv_at: DateTime.current,
+          identity_confirmed_with_onelogin: false,
+          tasks: [
+            build(:task, name: "one_login_identity", passed: false),
+            build(:task, name: "ey_alternative_verification", passed: true)
+          ]
+        )
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "with a year 1 claim that passed identity confirmation" do
+      let(:claim) do
+        create(
+          :claim,
+          :submitted,
+          policy: Policies::EarlyYearsPayments,
+          academic_year: AcademicYear.new("2024/2025"),
+          tasks: [
+            build(:task, name: "identity_confirmation", passed: true)
+          ]
+        )
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+  end
 end

--- a/spec/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks_spec.rb
@@ -112,4 +112,52 @@ RSpec.describe Policies::EarlyYearsTeachersFinancialIncentivePayments::ClaimChec
       end
     end
   end
+
+  describe "#identity_status" do
+    subject(:identity_status) { described_class.new(claim).identity_status }
+
+    let(:claim) do
+      build(
+        :claim,
+        policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+        tasks: claim_tasks
+      )
+    end
+
+    context "when there is no identity_confirmation task" do
+      let(:claim_tasks) { [] }
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when the task passed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "one_login_identity",
+            passed: true
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when the task failed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "one_login_identity",
+            passed: false
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+  end
 end

--- a/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/further_education_payments/claim_checking_tasks_spec.rb
@@ -176,4 +176,64 @@ RSpec.describe Policies::FurtherEducationPayments::ClaimCheckingTasks, feature_f
       end
     end
   end
+
+  describe "#identity_status" do
+    subject(:identity_status) { described_class.new(claim).identity_status }
+
+    let(:claim) do
+      create(
+        :claim,
+        policy: Policies::FurtherEducationPayments,
+        tasks: claim_tasks
+      )
+    end
+
+    context "when there are no identity tasks" do
+      let(:claim_tasks) { [] }
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when the one login identity task passed" do
+      let(:claim_tasks) do
+        [
+          create(:task, name: "one_login_identity", passed: true)
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when one login idv failed but alternative verification is pending" do
+      let(:claim_tasks) do
+        [
+          create(:task, name: "one_login_identity", passed: false)
+        ]
+      end
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when one login idv failed and alternative verification passed" do
+      let(:claim_tasks) do
+        [
+          create(:task, name: "one_login_identity", passed: false),
+          create(:task, name: "fe_alternative_verification", passed: true)
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when one login idv failed and alternative verification failed" do
+      let(:claim_tasks) do
+        [
+          create(:task, name: "one_login_identity", passed: false),
+          create(:task, name: "fe_alternative_verification", passed: false)
+        ]
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+  end
 end

--- a/spec/models/policies/international_relocation_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/international_relocation_payments/claim_checking_tasks_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::InternationalRelocationPayments::ClaimCheckingTasks do
+  subject(:identity_status) { described_class.new(claim).identity_status }
+
+  describe "#identity_status" do
+    let(:claim) do
+      build(
+        :claim,
+        policy: Policies::InternationalRelocationPayments,
+        tasks: claim_tasks
+      )
+    end
+
+    context "when there is no identity_confirmation task" do
+      let(:claim_tasks) { [] }
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when the task passed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: true
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when the task failed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: false
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+
+    context "when the task is incomplete with a full claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :all,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Full match") }
+    end
+
+    context "when the task is incomplete with a partial claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :any,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Partial match") }
+    end
+
+    context "when the task is incomplete with no claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :none,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("No match") }
+    end
+  end
+end

--- a/spec/models/policies/student_loans/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/student_loans/claim_checking_tasks_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::StudentLoans::ClaimCheckingTasks do
+  subject(:identity_status) { described_class.new(claim).identity_status }
+
+  describe "#identity_status" do
+    let(:claim) do
+      build(
+        :claim,
+        policy: Policies::StudentLoans,
+        tasks: claim_tasks
+      )
+    end
+
+    context "when there is no identity_confirmation task" do
+      let(:claim_tasks) { [] }
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when the task passed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: true
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when the task failed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: false
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+
+    context "when the task is incomplete with a full claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :all,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Full match") }
+    end
+
+    context "when the task is incomplete with a partial claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :any,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Partial match") }
+    end
+
+    context "when the task is incomplete with no claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :none,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("No match") }
+    end
+  end
+end

--- a/spec/models/policies/targeted_retention_incentive_payments/claim_checking_tasks_spec.rb
+++ b/spec/models/policies/targeted_retention_incentive_payments/claim_checking_tasks_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::TargetedRetentionIncentivePayments::ClaimCheckingTasks do
+  subject(:identity_status) { described_class.new(claim).identity_status }
+
+  describe "#identity_status" do
+    let(:claim) do
+      build(
+        :claim,
+        policy: Policies::TargetedRetentionIncentivePayments,
+        tasks: claim_tasks
+      )
+    end
+
+    context "when there is no identity_confirmation task" do
+      let(:claim_tasks) { [] }
+
+      it { is_expected.to eq("Unverified") }
+    end
+
+    context "when the task passed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: true
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Passed") }
+    end
+
+    context "when the task failed" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: nil,
+            name: "identity_confirmation",
+            passed: false
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Failed") }
+    end
+
+    context "when the task is incomplete with a full claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :all,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Full match") }
+    end
+
+    context "when the task is incomplete with a partial claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :any,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("Partial match") }
+    end
+
+    context "when the task is incomplete with no claim verifier match" do
+      let(:claim_tasks) do
+        [
+          build(
+            :task,
+            claim_verifier_match: :none,
+            name: "identity_confirmation",
+            passed: nil
+          )
+        ]
+      end
+
+      it { is_expected.to eq("No match") }
+    end
+  end
+end


### PR DESCRIPTION
Refactor admin helper

This helper was doing a lot of work.
I've moved returning the status for a claim into claim checking tasks.
Mostly it's a copy paste of what the helper was doing and could be
cleaned up further but moving it into an object is enough for now.

What colour the ui should be seems like a decent responsibility for a
helper so have left that there.

