### PR TITLE
Enable EYTRP in admin site

### DIFF
--- a/app/models/admin/task_list_form.rb
+++ b/app/models/admin/task_list_form.rb
@@ -140,6 +140,16 @@ module Admin
         payroll_details
         matching_details
         payroll_gender
+      ],
+      Policies::EarlyYearsTeachersFinancialIncentivePayments => %w[
+        provider_claim_count
+        one_login_identity
+        qualifications
+        employment
+        student_loan_plan
+        payroll_details
+        payroll_gender
+        matching_details
       ]
     }
 

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -102,10 +102,6 @@ module BasePolicy
     true
   end
 
-  def hidden?
-    false
-  end
-
   def admin_tasks_presenter(claim)
     self::AdminTasksPresenter.new(claim)
   end

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -14,7 +14,7 @@ module Policies
   end.flatten.uniq.freeze
 
   def self.all
-    POLICIES.reject(&:hidden?)
+    POLICIES
   end
 
   def self.options_for_select

--- a/app/models/policies/early_years_teachers_financial_incentive_payments.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments.rb
@@ -22,10 +22,6 @@ module Policies
       :other_reason_only_used_in_exceptional_circumstances
     ]
 
-    def hidden?
-      Rails.env.production? && !ENV["ENVIRONMENT_NAME"].start_with?("review")
-    end
-
     def notify_reply_to_id
       "f7ad7769-b521-4b30-bd60-9779cfe12c63".freeze
     end

--- a/spec/models/policies/early_years_teachers_financial_incentive_payments_spec.rb
+++ b/spec/models/policies/early_years_teachers_financial_incentive_payments_spec.rb
@@ -40,34 +40,4 @@ RSpec.describe Policies::EarlyYearsTeachersFinancialIncentivePayments do
       expect(described_class.decision_deadline_in_weeks).to eq(10.weeks)
     end
   end
-
-  describe "#hidden?" do
-    subject(:hidden?) { described_class.hidden? }
-
-    context "when in review environment" do
-      before do
-        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
-        allow(ENV).to receive(:[]).with("ENVIRONMENT_NAME").and_return("review-123")
-      end
-
-      it { is_expected.to be(false) }
-    end
-
-    context "when in production but not review" do
-      before do
-        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
-        allow(ENV).to receive(:[]).with("ENVIRONMENT_NAME").and_return("production")
-      end
-
-      it { is_expected.to be(true) }
-    end
-
-    context "when not in production" do
-      before do
-        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
-      end
-
-      it { is_expected.to be(false) }
-    end
-  end
 end


### PR DESCRIPTION
Removes the `hidden?` method on policy as we no longer need it.
