### PR TITLE
Always show banking name

### DIFF
--- a/app/forms/admin/amendment_form.rb
+++ b/app/forms/admin/amendment_form.rb
@@ -175,10 +175,6 @@ class Admin::AmendmentForm
     !admin_user.is_service_admin?
   end
 
-  def show_banking_name?
-    !claim.hmrc_bank_validation_succeeded?
-  end
-
   private
 
   def nilify_student_loan_repayment_plan

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -101,21 +101,19 @@
     </div>
   </div>
 
-  <% if @form.show_banking_name? %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <div class="govuk-body">
-          <%= label_tag "amendment-banking-name-field", "Banking name" %>
-        </div>
-      </div>
-      <div class="govuk-grid-column-two-thirds">
-        <%= f.govuk_text_field :banking_name,
-          label: nil,
-          width: 10,
-          disabled: @form.banking_name_disabled? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <div class="govuk-body">
+        <%= label_tag "amendment-banking-name-field", "Banking name" %>
       </div>
     </div>
-  <% end %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_text_field :banking_name,
+        label: nil,
+        width: 10,
+        disabled: @form.banking_name_disabled? %>
+    </div>
+  </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">

--- a/spec/features/admin/admin_amend_claim_spec.rb
+++ b/spec/features/admin/admin_amend_claim_spec.rb
@@ -327,11 +327,15 @@ RSpec.feature "Admin amends a claim" do
         sign_in_as_service_admin
       end
 
-      scenario "admin cannot view or edit account name" do
+      scenario "admin can view or edit account name" do
         visit admin_claim_url(claim)
         click_link "Amend claim"
 
-        expect(page).not_to have_field("Banking name", with: claim.banking_name)
+        expect(page).to have_field(
+          "Banking name",
+          with: claim.banking_name,
+          disabled: false
+        )
       end
     end
 
@@ -344,7 +348,11 @@ RSpec.feature "Admin amends a claim" do
         visit admin_claim_url(claim)
         click_link "Amend claim"
 
-        expect(page).not_to have_field("Banking name", with: claim.banking_name)
+        expect(page).to have_field(
+          "Banking name",
+          with: claim.banking_name,
+          disabled: true
+        )
       end
     end
   end


### PR DESCRIPTION
Previously we only showed the banking name field if the hmrc validation
failed. Ops have requested to always show this field.
