### PR TITLE
CAPT-3831 - Add claim_mail_to helper with screen reader context for EYTFI email links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,17 @@ module ApplicationHelper
     number_to_currency(value, delimiter: "", unit: "")
   end
 
+  # Wraps govuk_mail_to with visually-hidden spans so screen readers announce context
+  # when tabbing to an email link and handle all mail links in one place
+  # TODO: all govuk_mail_to should use claim_mail_to as it delegates to govuk_mail_to
+  #       if screen_reader params is not used
+  def claim_mail_to(email, text = nil, screen_reader: {}, **options)
+    screen_reader = {before: "email", after: "if you need support"} if screen_reader == :default
+    before = screen_reader[:before] ? content_tag(:span, "#{screen_reader[:before]} ", class: "govuk-visually-hidden") : ""
+    after = screen_reader[:after] ? content_tag(:span, " #{screen_reader[:after]}", class: "govuk-visually-hidden") : ""
+    govuk_mail_to(email, "#{before}#{text || email}#{after}".html_safe, **options)
+  end
+
   def support_email_address(routing_name = nil)
     return t("support_email_address") unless routing_name
 

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_check_eligibility_not_confirmed_content.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_check_eligibility_not_confirmed_content.html.erb
@@ -9,7 +9,10 @@
     </p>
 
     <p class="govuk-body">
-      If you think this is a mistake, please check your answers or contact us at <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      If you think this is a mistake, please check your answers or contact us at
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        screen_reader: :default %>.
     </p>
   </div>
 </div>

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_ineligible_provider.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_ineligible_provider.html.erb
@@ -14,8 +14,9 @@
 
     <p class="govuk-body">
       If you think this is a mistake, check that you have selected the correct nursery or email us at
-      <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        screen_reader: :default %>.
     </p>
   </div>
 </div>
-

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_teaching_qualification_not_confirmed.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/_ineligible_teaching_qualification_not_confirmed.html.erb
@@ -9,7 +9,10 @@
     </p>
 
     <p class="govuk-body">
-      If you think this is a mistake, please check your answers or contact us at <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      If you think this is a mistake, please check your answers or contact us at
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        screen_reader: :default %>.
     </p>
   </div>
 </div>

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/nursery_search.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/nursery_search.html.erb
@@ -12,7 +12,12 @@
       </p>
 
       <p class="govuk-body">
-        If you think you might be classed as working as part of <%= govuk_link_to "childcare on domestic premises", t("early_years_teachers_financial_incentive_payments.codp_url") %>, email <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+        If you think you might be classed as working as part of
+        <%= govuk_link_to "childcare on domestic premises", t("early_years_teachers_financial_incentive_payments.codp_url") %>,
+        email
+        <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+          t("early_years_teachers_financial_incentive_payments.support_email_address"),
+          screen_reader: :default %>.
       </p>
 
       <%= f.govuk_school_search(

--- a/app/views/early_years_teachers_financial_incentive_payments/claims/nursery_select.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/claims/nursery_select.html.erb
@@ -32,9 +32,14 @@
             size: "l"
           },
           hint: {
-            text: "<p>Select your nursery from the search results.</p>
-            <p>If you teach at a #{govuk_link_to "provider of childcare on domestic premises (CoDP)", t("early_years_teachers_financial_incentive_payments.codp_url")} 
-            and cannot find it in the search, email #{govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") }.</p>".html_safe
+            text: "
+            <p>Select your nursery from the search results.</p>
+            <p>
+              If you teach at a
+              #{govuk_link_to "provider of childcare on domestic premises (CoDP)", t("early_years_teachers_financial_incentive_payments.codp_url")}
+              and cannot find it in the search, email
+              #{claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"), t("early_years_teachers_financial_incentive_payments.support_email_address"), screen_reader: :default }.
+            </p>".html_safe
           }
         ) %>
         <%= f.govuk_submit %>

--- a/app/views/early_years_teachers_financial_incentive_payments/guidance.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/guidance.html.erb
@@ -85,12 +85,12 @@
 
     <%= govuk_list [
       "hold qualified teacher status (QTS), early years teacher status (EYTS) or early years professional status (EYPS), and",
-      "be directly employed to work in an eligible early years group-based settings that offers the #{govuk_link_to "early years entitlements", "https://www.gov.uk/government/publications/early-years-funding-2024-to-2025/early-years-entitlements-local-authority-funding-operational-guide-2024-to-2025"}. 
+      "be directly employed to work in an eligible early years group-based settings that offers the #{govuk_link_to "early years entitlements", "https://www.gov.uk/government/publications/early-years-funding-2024-to-2025/early-years-entitlements-local-authority-funding-operational-guide-2024-to-2025"}.
       Eligible providers include only registered group based settings (GBS) delivering early years entitlements. Childminders and teachers working in school based settings are not eligible.".html_safe
     ], type: :bullet %>
 
     <p class="govuk-body">
-      <%= govuk_link_to "Early years teacher recognition payment: methodology", "https://draft-origin.publishing.service.gov.uk/government/publications/early-years-teacher-recognition-payment-methodology?token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmYmFmYjA0Ny0wNzMxLTRlYzUtODE3MS1lZDU2MjhkOWFlMWEiLCJjb250ZW50X2lkIjoiNDlhZjMwNWItMmUwZi00N2IzLTk0MDItMzE0MDUxOTIzZWMzIiwiaWF0IjoxNzc4NTg2ODEzLCJleHAiOjE3ODEyNjUyMTN9.s8bwl8Vsf2I7XoLIpZ1t7_x4pXODT7AzmeQk_yfiDbs&utm_campaign=govuk_publishing&utm_medium=preview&utm_source=share" %> gives 
+      <%= govuk_link_to "Early years teacher recognition payment: methodology", "https://draft-origin.publishing.service.gov.uk/government/publications/early-years-teacher-recognition-payment-methodology?token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmYmFmYjA0Ny0wNzMxLTRlYzUtODE3MS1lZDU2MjhkOWFlMWEiLCJjb250ZW50X2lkIjoiNDlhZjMwNWItMmUwZi00N2IzLTk0MDItMzE0MDUxOTIzZWMzIiwiaWF0IjoxNzc4NTg2ODEzLCJleHAiOjE3ODEyNjUyMTN9.s8bwl8Vsf2I7XoLIpZ1t7_x4pXODT7AzmeQk_yfiDbs&utm_campaign=govuk_publishing&utm_medium=preview&utm_source=share" %> gives
       further information on how local authority areas and early years group-based settings were selected.
     </p>
 
@@ -215,7 +215,9 @@
 
     <p class="govuk-body">
       If you have any questions, email
-      <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"), t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+          t("early_years_teachers_financial_incentive_payments.support_email_address"),
+          screen_reader: :default %>.
     </p>
   </div>
 </div>

--- a/app/views/early_years_teachers_financial_incentive_payments/landing_page.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/landing_page.html.erb
@@ -49,7 +49,10 @@
     <h2 class="govuk-heading-m">Contact us</h2>
 
     <p class="govuk-body">
-      If you have any questions, email <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"), t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      If you have any questions, email
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        screen_reader: :default %>.
     </p>
 
     <%= govuk_start_button(text: "Start now", href: claim_path(current_journey_routing_name, "claim", answers: { service_access_code: params[:service_access_code] })) %>

--- a/app/views/early_years_teachers_financial_incentive_payments/methodology.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/methodology.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">Methodology</span>
     <h1 class="govuk-heading-l">
-      Early Years Teacher Recognition Payment 
+      Early Years Teacher Recognition Payment
     </h1>
 
     <h2 class="govuk-heading-m">
@@ -10,19 +10,19 @@
     </h2>
 
     <p class="govuk-body">
-      To be eligible for a recognition payment, teachers must be working in an eligible early years (EY) setting. 
+      To be eligible for a recognition payment, teachers must be working in an eligible early years (EY) setting.
       This document outlines our methodology for the eligibility of early years settings.
     </p>
 
     <p class="govuk-body">
-      In addition to working in an eligible setting, teachers must meet the eligibility criteria as outlined on the main guidance page 
+      In addition to working in an eligible setting, teachers must meet the eligibility criteria as outlined on the main guidance page
       <%= govuk_link_to "Claim an early years teacher recognition payment", eytfi_guidance_path %>.
     </p>
 
     <h2 id="eligibility" class="govuk-heading-m">Local Authority (LA) area:</h2>
 
     <p class="govuk-body">
-      Eligible settings must be within one of the following 10 LA areas: 
+      Eligible settings must be within one of the following 10 LA areas:
     </p>
 
     <%= govuk_list [
@@ -55,13 +55,13 @@
     ], type: :bullet %>
 
     <p class="govuk-body">
-      This criteria reflects evidence that group‑based settings face greater workforce challenges than school‑based settings and we 
-      are prioritising the recognition payments for settings where there is greatest needed. We know that staff in group‑based settings are paid less on average, 
-      staff turnover is higher and fewer staff in group-based settings hold Level 6 qualifications.  
+      This criteria reflects evidence that group‑based settings face greater workforce challenges than school‑based settings and we
+      are prioritising the recognition payments for settings where there is greatest needed. We know that staff in group‑based settings are paid less on average,
+      staff turnover is higher and fewer staff in group-based settings hold Level 6 qualifications.
     </p>
 
     <p class="govuk-body">
-      A list of all eligible GBS in phase one is available here: 
+      A list of all eligible GBS in phase one is available here:
     </p>
 
     <h2 id="updates-eligibility" class="govuk-heading-m">Updates to the eligibility criteria</h2>
@@ -75,8 +75,11 @@
     </p>
 
     <p class="govuk-body">
-      GBS that have recently opened may not be included on our list but will still be eligible. If a teacher believes they work in an eligible GBS but it is not included on the list linked above, 
-      they should contact the department at: <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      GBS that have recently opened may not be included on our list but will still be eligible. If a teacher believes they work in an eligible GBS but it is not included on the list linked above,
+      they should contact the department at:
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        screen_reader: :default %>.
     </p>
   </div>
 </div>

--- a/app/views/feedback/confirmation.html.erb
+++ b/app/views/feedback/confirmation.html.erb
@@ -5,7 +5,10 @@
     ) %>
 
     <p class="govuk-body">
-      If you need more help, email us at <%= govuk_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address") %>.
+      If you need more help, email us at
+      <%= claim_mail_to t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        t("early_years_teachers_financial_incentive_payments.support_email_address"),
+        screen_reader: :default %>.
     </p>
   </div>
 </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -74,6 +74,64 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#claim_mail_to" do
+    let(:email) { "support@example.gov.uk" }
+    let(:text) { "support@example.gov.uk" }
+
+    it "renders a govuk mailto link with the given text" do
+      result = helper.claim_mail_to(email, text)
+      expect(result).to include('href="mailto:support@example.gov.uk"')
+      expect(result).to include("support@example.gov.uk")
+    end
+
+    context "when text is omitted" do
+      it "falls back to the email address as the link text" do
+        result = helper.claim_mail_to(email)
+        expect(result).to include('href="mailto:support@example.gov.uk"')
+        expect(result).to include(">support@example.gov.uk<")
+      end
+    end
+
+    context "with screen_reader: :default" do
+      it "wraps text with visually hidden 'email' before and 'if you need support' after" do
+        result = helper.claim_mail_to(email, text, screen_reader: :default)
+        expect(result).to include('<span class="govuk-visually-hidden">email </span>')
+        expect(result).to include('<span class="govuk-visually-hidden"> if you need support</span>')
+      end
+    end
+
+    context "with explicit hidden before and after" do
+      it "wraps text with the given visually hidden strings" do
+        result = helper.claim_mail_to(email, text, screen_reader: {before: "Email us at", after: "for help"})
+        expect(result).to include('<span class="govuk-visually-hidden">Email us at </span>')
+        expect(result).to include('<span class="govuk-visually-hidden"> for help</span>')
+      end
+    end
+
+    context "with only hidden before" do
+      it "adds a visually hidden span before but not after" do
+        result = helper.claim_mail_to(email, text, screen_reader: {before: "Email"})
+        expect(result).to include('<span class="govuk-visually-hidden">Email </span>')
+        expect(result).not_to include('govuk-visually-hidden"> ')
+      end
+    end
+
+    context "with only hidden after" do
+      it "adds a visually hidden span after but not before" do
+        result = helper.claim_mail_to(email, text, screen_reader: {after: "for queries"})
+        expect(result).to include('<span class="govuk-visually-hidden"> for queries</span>')
+        expect(result).not_to match(/<span class="govuk-visually-hidden">[^ ]/)
+      end
+    end
+
+    context "with no hidden option" do
+      it "renders the link without any visually hidden spans" do
+        result = helper.claim_mail_to(email, text)
+        expect(result).not_to include("govuk-visually-hidden")
+      end
+    end
+  end
+
   describe "#one_login_home_url" do
     context "when ONELOGIN_DID_URL env var not present" do
       it "defaults to production url" do


### PR DESCRIPTION
Introduces a claim_mail_to helper that wraps govuk_mail_to with visually-hidden spans so screen readers announce context (e.g. "email ... if you need support") when tabbing to an email link. Replaces all govuk_mail_to calls across the EYTFI journey with the new helper using screen_reader: :default.

