### PR TITLE
Address refactor part 1

### DIFF
--- a/app/forms/postcode_search_form.rb
+++ b/app/forms/postcode_search_form.rb
@@ -14,7 +14,10 @@ class PostcodeSearchForm < Form
     if: -> { postcode.present? }
   )
 
-  validate :postcode_has_address, if: -> { postcode.present? }
+  validate(
+    :postcode_has_address,
+    if: -> { valid_postcode_entered? && !postcode_search.api_error? }
+  )
 
   def save
     if skip_postcode_search?
@@ -38,8 +41,14 @@ class PostcodeSearchForm < Form
       address_line_2: nil,
       address_line_3: nil,
       address_line_4: nil,
-      postcode:
+      postcode: postcode
     )
+
+    if postcode_search.api_error?
+      journey_session.answers.assign_attributes(ordnance_survey_error: true)
+    else
+      journey_session.answers.assign_attributes(ordnance_survey_error: false)
+    end
 
     journey_session.save!
   end
@@ -54,27 +63,17 @@ class PostcodeSearchForm < Form
 
   private
 
-  def address_data
-    return nil if postcode.blank?
+  def valid_postcode_entered?
+    postcode.present? && UKPostcode.parse(postcode).full_valid?
+  end
 
-    @address_data ||= Rails.cache.fetch("address_data/#{postcode}", expires_in: 1.hour) do
-      OrdnanceSurvey::Client.new.api.search_places.index(
-        params: {postcode:}
-      )
-    end
+  def postcode_search
+    @postcode_search ||= PostcodeSearch.new(postcode)
   end
 
   def postcode_has_address
-    return nil unless UKPostcode.parse(postcode).full_valid?
-    return unless address_data.nil?
+    return if postcode_search.addresses.present?
 
-    journey_session.answers.assign_attributes(ordnance_survey_error: false)
     errors.add(:postcode, "Address not found")
-  rescue OrdnanceSurvey::Client::ResponseError => e
-    Sentry.capture_exception(e)
-
-    errors.add(:postcode, "Postcode search is currently unavailable. Please try again or enter your address manually.")
-    journey_session.answers.assign_attributes(ordnance_survey_error: true)
-    journey_session.save!
   end
 end

--- a/app/forms/postcode_search_form.rb
+++ b/app/forms/postcode_search_form.rb
@@ -4,40 +4,42 @@ class PostcodeSearchForm < Form
 
   validates :postcode,
     presence: {message: "Enter a postcode, for example NE1 6EE"},
-    length: {maximum: 11, message: "Postcode must be 11 characters or less"},
-    if: -> { !skip_postcode_search? }
+    length: {maximum: 11, message: "Postcode must be 11 characters or less"}
 
   validates(
     :postcode,
     postcode_format: {
       message: "Enter a postcode in the correct format"
     },
-    if: -> { !skip_postcode_search? && postcode.present? }
+    if: -> { postcode.present? }
   )
 
-  validate :postcode_has_address, if: -> { !skip_postcode_search && postcode.present? }
+  validate :postcode_has_address, if: -> { postcode.present? }
 
   def save
-    return false if invalid?
-
-    if skip_postcode_search
-      journey_session.answers.assign_attributes(
-        skip_postcode_search:,
-        address_line_1: nil,
-        address_line_2: nil,
-        address_line_3: nil,
-        address_line_4: nil
-      )
-    else
-      journey_session.answers.assign_attributes(
-        skip_postcode_search: false,
+    if skip_postcode_search?
+      journey_session.answers.update!(
+        skip_postcode_search: true,
         address_line_1: nil,
         address_line_2: nil,
         address_line_3: nil,
         address_line_4: nil,
-        postcode:
+        postcode: nil
       )
+
+      return true
     end
+
+    return false if invalid?
+
+    journey_session.answers.assign_attributes(
+      skip_postcode_search: false,
+      address_line_1: nil,
+      address_line_2: nil,
+      address_line_3: nil,
+      address_line_4: nil,
+      postcode:
+    )
 
     journey_session.save!
   end

--- a/app/forms/postcode_search_form.rb
+++ b/app/forms/postcode_search_form.rb
@@ -54,7 +54,7 @@ class PostcodeSearchForm < Form
   end
 
   def completed?
-    journey_session.answers.skip_postcode_search || journey_session.answers.ordnance_survey_error || valid?
+    answers.skip_postcode_search? || answers.ordnance_survey_error? || answers.postcode.present?
   end
 
   def skip_postcode_search?

--- a/app/models/postcode_search.rb
+++ b/app/models/postcode_search.rb
@@ -1,0 +1,29 @@
+class PostcodeSearch
+  attr_reader :postcode
+
+  def initialize(postcode)
+    raise ArgumentError if postcode.nil?
+
+    @postcode = postcode
+    @error = false
+  end
+
+  def addresses
+    @addresses ||= Rails.cache.fetch("address_data/#{postcode}", expires_in: 1.hour) do
+      OrdnanceSurvey::Client.new.api.search_places.index(
+        params: {postcode: postcode}
+      )
+    end
+  rescue OrdnanceSurvey::Client::ResponseError => e
+    @error = true
+    Sentry.capture_exception(e)
+  end
+
+  def api_error?
+    return true if @error
+
+    addresses
+
+    @error
+  end
+end

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, page_title(t("forms.address.questions.your_address"), journey: current_journey_routing_name, show_error: @form.errors.any?)) %>
 
 <% if journey_session.answers.ordnance_survey_error %>
-  <%= govuk_notification_banner(title_text: "Notice") { |nb| nb.with_heading(text: "Please enter your address manually") } %>
+  <%= govuk_notification_banner(title_text: "Notice") { |nb| nb.with_heading(text: "Postcode search is currently unavailable. Please enter your address manually") } %>
 <% end %>
 
 <% if !journey_session.answers.postcode %>

--- a/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
+++ b/spec/features/auto_populating_home_address_from_postcode_search_spec.rb
@@ -451,13 +451,8 @@ RSpec.feature "Teacher claiming Early-Career Payments uses the address auto-popu
         fill_in "Postcode", with: "DA1 5FZ"
         click_on "Search"
 
-        # Stays on postcode page and shows availability error
-        expect(page).to have_text("What is your home address?")
-        expect(page).to have_text("Postcode search is currently unavailable. Please try again or enter your address manually.")
-
-        click_button "Enter your address manually"
-
-        # Manual address page is still reachable
+        # Redirects to manual address entry page and shows availability error
+        expect(page).to have_text("Postcode search is currently unavailable. Please enter your address manually")
         expect(page).to have_text("What is your address?")
       end
     end

--- a/spec/features/postcode_journey_changes_spec.rb
+++ b/spec/features/postcode_journey_changes_spec.rb
@@ -106,11 +106,8 @@ RSpec.feature "Postcode journey desired behavior", feature_flag: [:eytfi_journey
     fill_in "Postcode", with: "SO16 9FX"
     click_button "Search"
 
-    expect(page).to have_text("What is your home address?")
     expect(page).to have_text("Postcode search is currently unavailable")
-    expect(page).to have_button("Enter your address manually")
-
-    click_button "Enter your address manually"
+    expect(page).to have_text("Please enter your address manually")
 
     expect(page).to have_text("What is your address?")
   end

--- a/spec/forms/postcode_search_form_spec.rb
+++ b/spec/forms/postcode_search_form_spec.rb
@@ -77,8 +77,6 @@ RSpec.describe PostcodeSearchForm, type: :model do
   end
 
   describe "#save" do
-    subject(:save) { form.save }
-
     let(:answers) do
       attributes_for(
         :targeted_retention_incentive_payments_answers,
@@ -91,7 +89,6 @@ RSpec.describe PostcodeSearchForm, type: :model do
       )
     end
     let(:journey_session) { build(:targeted_retention_incentive_payments_session, answers:) }
-    let(:params) { ActionController::Parameters.new(claim: {skip_postcode_search: true}) }
     let(:form) do
       described_class.new(
         journey: journey,
@@ -100,22 +97,28 @@ RSpec.describe PostcodeSearchForm, type: :model do
       )
     end
 
-    it "clears selected address fields when switching to manual address entry" do
-      expect(save).to be_truthy
+    context "when skipping postcode search" do
+      let(:params) do
+        ActionController::Parameters.new(claim: {skip_postcode_search: true})
+      end
 
-      saved_answers = journey_session.reload.answers
-      expect(saved_answers.skip_postcode_search).to be(true)
-      expect(saved_answers.address_line_1).to be_nil
-      expect(saved_answers.address_line_2).to be_nil
-      expect(saved_answers.address_line_3).to be_nil
-      expect(saved_answers.address_line_4).to be_nil
+      it "clears selected address fields when switching to manual address entry" do
+        expect(form.save).to be_truthy
+
+        saved_answers = journey_session.reload.answers
+        expect(saved_answers.skip_postcode_search).to be(true)
+        expect(saved_answers.address_line_1).to be_nil
+        expect(saved_answers.address_line_2).to be_nil
+        expect(saved_answers.address_line_3).to be_nil
+        expect(saved_answers.address_line_4).to be_nil
+      end
     end
 
     context "when searching with a new postcode" do
       let(:params) { ActionController::Parameters.new(claim: {postcode: "SW1B 1AA", skip_postcode_search: false}) }
 
       it "clears any existing address fields and stores the new postcode" do
-        expect(save).to be_truthy
+        expect(form.save).to be_truthy
 
         saved_answers = journey_session.reload.answers
         expect(saved_answers.skip_postcode_search).to be(false)

--- a/spec/forms/postcode_search_form_spec.rb
+++ b/spec/forms/postcode_search_form_spec.rb
@@ -62,20 +62,6 @@ RSpec.describe PostcodeSearchForm, type: :model do
     end
   end
 
-  context "when the postcode lookup failed" do
-    let(:params) { ActionController::Parameters.new(claim: {postcode: "SW1B 1AA"}) }
-
-    before do
-      allow_any_instance_of(OrdnanceSurvey::Client).to receive_message_chain(:api, :search_places, :index)
-        .and_raise(OrdnanceSurvey::Client::ResponseError)
-    end
-
-    it "stores state to session" do
-      subject.validate
-      expect(journey_session.reload.answers.ordnance_survey_error).to be_truthy
-    end
-  end
-
   describe "#save" do
     let(:answers) do
       attributes_for(
@@ -95,6 +81,20 @@ RSpec.describe PostcodeSearchForm, type: :model do
         params: params,
         journey_session: journey_session
       )
+    end
+
+    context "when the postcode lookup failed" do
+      let(:params) { ActionController::Parameters.new(claim: {postcode: "SW1B 1AA"}) }
+
+      before do
+        allow_any_instance_of(OrdnanceSurvey::Client).to receive_message_chain(:api, :search_places, :index)
+          .and_raise(OrdnanceSurvey::Client::ResponseError)
+      end
+
+      it "stores state to session" do
+        form.save
+        expect(journey_session.reload.answers.ordnance_survey_error).to be_truthy
+      end
     end
 
     context "when skipping postcode search" do


### PR DESCRIPTION
We've been dealing with some issues on the address forms as part of the EYTRP launch and noticed they need a bit of maintenance work.

This is the first PR in a chain, so I'll hold off merging until the others are approved, though this can be merged on it's own.
https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4652
https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4660
(and potentially https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4663 if we want that much coverage!)

## Changes
The UX when the postcode search api is down has changed slightly

### master
<img width="1580" height="1018" alt="master" src="https://github.com/user-attachments/assets/e5787b5e-35bf-4ba8-a405-08febed5270f" />

### this branch
<img width="1580" height="1018" alt="branch" src="https://github.com/user-attachments/assets/840a08f8-baed-48e5-b12e-42ccc9bde49f" />

