### PR TITLE
Address refactor part 2

### DIFF
--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -1,24 +1,20 @@
 class SelectHomeAddressForm < Form
   attribute :address, :string
-  attribute :address_line_1, :string
-  attribute :postcode, :string
   attribute :skip_postcode_search, :boolean
 
-  validate :validate_address_selected, unless: -> { skip_postcode_search? }
-  validate :validate_address_entered, if: -> { skip_postcode_search? }
+  validates(
+    :address,
+    inclusion: {
+      in: ->(form) { form.radio_options.map(&:id) },
+      message: "Select an address"
+    },
+    unless: :skip_postcode_search
+  )
 
   def radio_options
     address_data.map do |option|
-      id = [
-        option[:address],
-        option[:address_line_1],
-        option[:address_line_2],
-        option[:address_line_3],
-        option[:postcode]
-      ].join(":")
-
       Option.new(
-        id:,
+        id: option[:address],
         name: option[:address]
       )
     end
@@ -37,15 +33,15 @@ class SelectHomeAddressForm < Form
         postcode:
       )
     else
-      address_parts = address.split(":")
+      selected_address = address_data.detect { it[:address] == address }
 
       journey_session.answers.assign_attributes({
         skip_postcode_search: false,
-        address_line_1: address_parts[1].titleize,
-        address_line_2: address_parts[2].titleize,
-        address_line_3: address_parts[3].titleize,
+        address_line_1: selected_address[:address_line_1].titleize,
+        address_line_2: selected_address[:address_line_2].titleize,
+        address_line_3: selected_address[:address_line_3].titleize,
         address_line_4: nil,
-        postcode: address_parts[4]
+        postcode: selected_address[:postcode]
       })
     end
 
@@ -53,40 +49,36 @@ class SelectHomeAddressForm < Form
   end
 
   def completed?
-    skip_postcode_search? || address_selected_in_answers? || valid?
+    skip_postcode_search? || answers.address_present? || valid?
   end
 
   private
 
-  def address_data
-    return [] if postcode.blank?
+  def load_current_value(attribute)
+    if attribute.to_s == "address"
+      [
+        answers.address_line_1,
+        answers.address_line_2,
+        answers.address_line_3,
+        answers.address_line_4,
+        answers.postcode
+      ].compact.join(", ")
+    else
+      super
+    end
+  end
 
-    @address_data ||= Rails.cache.fetch("address_data/#{postcode}", expires_in: 1.hour) do
+  def address_data
+    return [] if answers.postcode.blank?
+
+    @address_data ||= Rails.cache.fetch("address_data/#{answers.postcode}", expires_in: 1.hour) do
       OrdnanceSurvey::Client.new.api.search_places.index(
-        params: {postcode:}
+        params: {postcode: answers.postcode}
       )
     end
   end
 
   def skip_postcode_search?
     journey_session.answers.skip_postcode_search || skip_postcode_search
-  end
-
-  def validate_address_selected
-    if address.present?
-      return
-    end
-
-    errors.add(:address, "Select an address")
-  end
-
-  def validate_address_entered
-    if journey_session.answers.address_line_1.blank? && journey_session.answers.postcode.blank?
-      errors.add(:address, "Enter an address") if journey_session.answers.address_line_1.blank?
-    end
-  end
-
-  def address_selected_in_answers?
-    journey_session.answers.address_line_1.present? && journey_session.answers.postcode.present?
   end
 end

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -7,8 +7,7 @@ class SelectHomeAddressForm < Form
     inclusion: {
       in: ->(form) { form.radio_options.map(&:id) },
       message: "Select an address"
-    },
-    unless: :skip_postcode_search
+    }
   )
 
   def radio_options
@@ -21,35 +20,37 @@ class SelectHomeAddressForm < Form
   end
 
   def save
-    return false unless valid?
-
-    if skip_postcode_search?
-      journey_session.answers.assign_attributes(
+    if skip_postcode_search
+      journey_session.answers.update!(
         skip_postcode_search: true,
         address_line_1: nil,
         address_line_2: nil,
         address_line_3: nil,
         address_line_4: nil,
-        postcode:
+        postcode: nil
       )
-    else
-      selected_address = address_data.detect { it[:address] == address }
 
-      journey_session.answers.assign_attributes({
-        skip_postcode_search: false,
-        address_line_1: selected_address[:address_line_1].titleize,
-        address_line_2: selected_address[:address_line_2].titleize,
-        address_line_3: selected_address[:address_line_3].titleize,
-        address_line_4: nil,
-        postcode: selected_address[:postcode]
-      })
+      return true
     end
+
+    return false unless valid?
+
+    selected_address = address_data.detect { it[:address] == address }
+
+    journey_session.answers.assign_attributes({
+      skip_postcode_search: false,
+      address_line_1: selected_address[:address_line_1].titleize,
+      address_line_2: selected_address[:address_line_2].titleize,
+      address_line_3: selected_address[:address_line_3].titleize,
+      address_line_4: nil,
+      postcode: selected_address[:postcode]
+    })
 
     journey_session.save!
   end
 
   def completed?
-    skip_postcode_search? || answers.address_present? || valid?
+    skip_postcode_search || answers.address_present? || valid?
   end
 
   private
@@ -76,9 +77,5 @@ class SelectHomeAddressForm < Form
         params: {postcode: answers.postcode}
       )
     end
-  end
-
-  def skip_postcode_search?
-    journey_session.answers.skip_postcode_search || skip_postcode_search
   end
 end

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -50,7 +50,7 @@ class SelectHomeAddressForm < Form
   end
 
   def completed?
-    skip_postcode_search || answers.address_present? || valid?
+    skip_postcode_search || answers.address_present?
   end
 
   private

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -11,7 +11,7 @@ class SelectHomeAddressForm < Form
   )
 
   def radio_options
-    address_data.map do |option|
+    postcode_search.addresses.map do |option|
       Option.new(
         id: option[:address],
         name: option[:address]
@@ -35,7 +35,7 @@ class SelectHomeAddressForm < Form
 
     return false unless valid?
 
-    selected_address = address_data.detect { it[:address] == address }
+    selected_address = postcode_search.addresses.detect { it[:address] == address }
 
     journey_session.answers.assign_attributes({
       skip_postcode_search: false,
@@ -69,13 +69,7 @@ class SelectHomeAddressForm < Form
     end
   end
 
-  def address_data
-    return [] if answers.postcode.blank?
-
-    @address_data ||= Rails.cache.fetch("address_data/#{answers.postcode}", expires_in: 1.hour) do
-      OrdnanceSurvey::Client.new.api.search_places.index(
-        params: {postcode: answers.postcode}
-      )
-    end
+  def postcode_search
+    @postcode_search ||= PostcodeSearch.new(answers.postcode)
   end
 end

--- a/app/forms/select_home_address_form.rb
+++ b/app/forms/select_home_address_form.rb
@@ -39,9 +39,9 @@ class SelectHomeAddressForm < Form
 
     journey_session.answers.assign_attributes({
       skip_postcode_search: false,
-      address_line_1: selected_address[:address_line_1].titleize,
-      address_line_2: selected_address[:address_line_2].titleize,
-      address_line_3: selected_address[:address_line_3].titleize,
+      address_line_1: selected_address[:address_line_1]&.titleize,
+      address_line_2: selected_address[:address_line_2]&.titleize,
+      address_line_3: selected_address[:address_line_3]&.titleize,
       address_line_4: nil,
       postcode: selected_address[:postcode]
     })

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -132,5 +132,9 @@ module Journeys
         teacher_reference_number: teacher_id_user_info["trn"]
       )
     end
+
+    def address_present?
+      address_line_1.present? && postcode.present?
+    end
   end
 end

--- a/app/views/claims/select_home_address.html.erb
+++ b/app/views/claims/select_home_address.html.erb
@@ -9,9 +9,9 @@
         <h1 class="govuk-heading-xl"><%= t("questions.address.home.title") %></h1>
         <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Postcode</h2>
         <p class="govuk-body">
-          <%= @form.postcode %>
+          <%= @form.answers.postcode %>
           <%= govuk_link_to claim_path(current_journey_routing_name, "postcode-search"), class: "govuk-!-margin-left-3" do %>
-            Change <span class="govuk-visually-hidden">postcode <%= @form.postcode %></span>
+            Change <span class="govuk-visually-hidden">postcode <%= @form.answers.postcode %></span>
           <% end %>
         </p>
 

--- a/spec/forms/select_home_address_form_spec.rb
+++ b/spec/forms/select_home_address_form_spec.rb
@@ -1,10 +1,47 @@
 require "rails_helper"
 
 RSpec.describe SelectHomeAddressForm, type: :model do
-  describe "#save" do
-    subject(:save) { form.save }
+  before do
+    stub_address_search(
+      postcode: "TE57 1NG",
+      results: [
+        {
+          address: "123, Main Street, Springfield, TE57 1NG",
+          address_line_1: "123",
+          address_line_2: "Main Street",
+          address_line_3: "Springfield",
+          postcode: "TE57 1NG"
+        }
+      ]
+    )
+  end
 
-    let(:address) { "The full address:123:Main Street:Springfield:12345" }
+  describe "#initialize" do
+    context "when the address step is completed" do
+      it "is valid" do
+        session = create(
+          :targeted_retention_incentive_payments_session,
+          answers: {
+            address_line_1: "123",
+            address_line_2: "Main Street",
+            address_line_3: "Springfield",
+            postcode: "TE57 1NG"
+          }
+        )
+
+        form = described_class.new(
+          journey: Journeys::TargetedRetentionIncentivePayments,
+          journey_session: session,
+          params: ActionController::Parameters.new(claim: {})
+        )
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:address) { "123, Main Street, Springfield, TE57 1NG" }
     let(:form) do
       described_class.new(
         journey: journey,
@@ -17,26 +54,27 @@ RSpec.describe SelectHomeAddressForm, type: :model do
     let(:answers) do
       attributes_for(
         :"#{journey.i18n_namespace}_answers",
-        skip_postcode_search: false
+        skip_postcode_search: false,
+        postcode: "TE57 1NG"
       )
     end
     let(:params) { ActionController::Parameters.new(claim: {address:}) }
 
-    it { is_expected.to be_truthy }
-
-    it "splits the address and assigns it to the current claim" do
-      save
+    it "sets the address" do
+      expect(form.save).to be true
       answers = journey_session.reload.answers
       expect(answers.address_line_1).to eq("123")
       expect(answers.address_line_2).to eq("Main Street")
       expect(answers.address_line_3).to eq("Springfield")
-      expect(answers.postcode).to eq("12345")
+      expect(answers.postcode).to eq("TE57 1NG")
     end
 
     context "when the form is invalid" do
       let(:address) { nil }
 
-      it { is_expected.to be_falsey }
+      it "returns false" do
+        expect(form.save).to be false
+      end
     end
 
     context "when an address is already selected and no new selection is submitted" do
@@ -44,17 +82,16 @@ RSpec.describe SelectHomeAddressForm, type: :model do
         attributes_for(
           :"#{journey.i18n_namespace}_answers",
           skip_postcode_search: false,
-          address_line_1: "1 High Street",
-          address_line_2: "Town Centre",
+          address_line_1: "123",
+          address_line_2: "Main Street",
           address_line_3: "Springfield",
-          postcode: "NE1 6EE"
+          postcode: "TE57 1NG"
         )
       end
       let(:params) { ActionController::Parameters.new(claim: {}) }
 
-      it "is invalid and requires selecting an address" do
-        expect(save).to be_falsey
-        expect(form.errors[:address]).to include("Select an address")
+      it "is valid as the address is preselected in the ui" do
+        expect(form.save).to be true
       end
     end
   end

--- a/spec/support/ordnance_survey_helpers.rb
+++ b/spec/support/ordnance_survey_helpers.rb
@@ -324,6 +324,58 @@ module OrdnanceSurveyHelpers
       )
   end
 
+  # Stubs the API call to OS
+  #
+  # usage:
+  # ```
+  # stub_address_search(
+  #   postcode: "TE57 1NG",
+  #   results: [
+  #     {
+  #       address: "123, Main Street, Springfield, TE57 1NG",
+  #       address_line_1: "123",
+  #       address_line_2: "Main Street",
+  #       address_line_3: "Springfield",
+  #       postcode: "TE57 1NG"
+  #     }
+  #   ]
+  # )
+  # ```
+  def stub_address_search(postcode:, results:)
+    allow(OrdnanceSurvey).to receive(:configuration).and_return(
+      double(
+        client: double(
+          base_url: "https://api.os.uk",
+          params: {"key" => "ABC123"}
+        )
+      )
+    )
+
+    results_in_os_response_format = results.map do |result|
+      {
+        DPA: {
+          ADDRESS: result[:address],
+          BUILDING_NUMBER: result[:address_line_1],
+          THOROUGHFARE_NAME: result[:address_line_2],
+          POST_TOWN: result[:address_line_3],
+          POSTCODE: result[:postcode]
+        }
+      }
+    end
+
+    stub_request(
+      :get,
+      "https://api.os.uk/search/places/v1/postcode?key=ABC123&postcode=#{postcode.remove(" ")}"
+    )
+      .to_return(
+        status: 200,
+        body: {
+          results: results_in_os_response_format
+        }.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+  end
+
   private
 
   def merge_recursively(a, b)


### PR DESCRIPTION
Couple of simplifications to the select home address form.
We've moved skip postcode search handling to before the validations run to reduce the conditionals.
We've changed how we load the address from the answers into the form so we can drop the address_line_1 and postcode attributes that this form doesn't really care about. We've also changed how we find the address from the selected option to allow us to drop those attributes.
We've switched to using `PostcodeSearch` to hide the caching implementation from the form.

We're still needing to check `skip_postcode_search` in the `completed?` method. Once we've cleaned up the slug sequence we'll be able to drop this check.