### PR TITLE
CAPT-3865 - Fix flaky LogoutToken expiry spec by checking exp claim early

### DIFF
--- a/app/models/one_login/logout_token.rb
+++ b/app/models/one_login/logout_token.rb
@@ -13,7 +13,8 @@ class OneLogin::LogoutToken
     encoded_token.verify_claims!(
       iss:,
       aud:,
-      iat: true
+      iat: true,
+      exp: {}
     )
 
     encoded_token.verify!(

--- a/spec/models/one_login/logout_token_spec.rb
+++ b/spec/models/one_login/logout_token_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe OneLogin::LogoutToken do
   end
 
   describe "#valid?" do
+    context "when all claims are valid" do
+      it "returns true" do
+        expect(subject.valid?).to be_truthy
+      end
+    end
+
     context "when iss claim is invalid" do
       let(:payload) do
         {


### PR DESCRIPTION
An expired token was only rejected after a JWKS network fetch, which happens during signature verification. If the fetch failed the test would error rather than cleanly return false.

Explicitly passing exp to verify_claims! checks expiry before any network call is made. Without it, exp is only checked as a side effect of verify!, which runs after the JWKS fetch.

