### PR TITLE
Allow indexing some pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -168,4 +168,19 @@ module ApplicationHelper
       ]
     end
   end
+
+  INDEXABLE_PATHS = %w[
+    /early-years-teachers-recognition-payments/landing-page
+    /early-years-teachers-recognition-payments/guidance
+  ]
+
+  def current_path_indexable?
+    return false if review_app?
+
+    INDEXABLE_PATHS.any? { |path| current_page?(path) }
+  end
+
+  def review_app?
+    ENV["ENVIRONMENT_NAME"].start_with?("review")
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#1d70b8">
-    <meta name="robots" content="noindex,nofollow">
+    <meta name="robots" content="<%= current_path_indexable? ? "index" : "noindex" %>,nofollow">
 
     <%= favicon_link_tag asset_path("favicon.ico") %>
     <%= favicon_link_tag asset_path("govuk-icon-mask.svg"), rel: "mask-icon", type: "image/svg", color: "#0b1c0c" %>

--- a/spec/features/robots_spec.rb
+++ b/spec/features/robots_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.feature "Robots", feature_flag: [:eytfi_journey] do
+  before do
+    create(
+      :journey_configuration,
+      :early_years_teachers_financial_incentive_payments
+    )
+
+    create(:journey_configuration, :further_education_payments)
+  end
+
+  describe "metatag" do
+    context "when on an indexable page" do
+      it "excludes noindex from the robots meta tag" do
+        visit "/early-years-teachers-recognition-payments/landing-page"
+
+        expect(page).to(
+          have_selector(
+            "meta[name='robots'][content='index,nofollow']",
+            visible: false
+          )
+        )
+
+        visit "/early-years-teachers-recognition-payments/guidance"
+
+        expect(page).to(
+          have_selector(
+            "meta[name='robots'][content='index,nofollow']",
+            visible: false
+          )
+        )
+      end
+    end
+
+    context "when not on an indexable page" do
+      it "includes noindex in the robots meta tag" do
+        visit "/further-education-payments/landing-page"
+
+        expect(page).to(
+          have_selector(
+            "meta[name='robots'][content='noindex,nofollow']",
+            visible: false
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "layouts/application.html.erb" do
   before do
     allow(ENV).to receive(:[]).with("GOOGLE_ANALYTICS_ID").and_return("foo")
     allow(ENV).to receive(:[]).with("GTM_ANALYTICS").and_return("foo")
+    allow(ENV).to receive(:[]).with("ENVIRONMENT_NAME").and_return("foo")
 
     without_partial_double_verification do
       allow(view).to receive(:current_journey_routing_name).and_return("further-education-payments")


### PR DESCRIPTION
For EYTRP private beta we don't have a link on the main govuk content
pages. We want claimants to be able to find our service via google.
