### PR TITLE
Allow approval if fe_repeat_applicant_check

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -45,7 +45,7 @@ class Task < ApplicationRecord
 
   NAMES.each { |name| scope name.to_sym, -> { where(name: name) } }
 
-  BLOCKS_APPROAVAL = %w[claimant_check fe_provider_check fe_repeat_applicant_check].freeze
+  BLOCKS_APPROAVAL = %w[claimant_check fe_provider_check].freeze
 
   belongs_to :claim
   belongs_to :created_by, class_name: "DfeSignIn::User", optional: true


### PR DESCRIPTION
Request from Dan. The ops team may reach out to claimants if this check
has failed, receive more evidence, and be happy to approve the claim.
