### PR TITLE
Only run employment verifier if used by policy

### DIFF
--- a/app/jobs/employment_check_job.rb
+++ b/app/jobs/employment_check_job.rb
@@ -2,6 +2,7 @@ class EmploymentCheckJob < ApplicationJob
   def perform
     delete_employment_tasks
     claims = claims_awaiting_decision
+      .with_verifier(AutomatedChecks::ClaimVerifiers::Employment)
       .awaiting_task("employment")
       .includes(eligibility: [:current_school, :claim_school])
 

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -105,4 +105,8 @@ module BasePolicy
   def admin_tasks_presenter(claim)
     self::AdminTasksPresenter.new(claim)
   end
+
+  def has_verifier?(verifier)
+    self::VERIFIERS.include?(verifier)
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -177,6 +177,10 @@ class Claim < ApplicationRecord
     by_policies(Policies.all.select { |p| p.require_in_progress_update_emails? })
   }
 
+  scope :with_verifier, ->(verifier) do
+    by_policies(Policies.all.select { it.has_verifier?(verifier) })
+  end
+
   def hold!(reason:, user:)
     if holdable? && !held?
       self.class.transaction do

--- a/spec/jobs/employment_check_job_spec.rb
+++ b/spec/jobs/employment_check_job_spec.rb
@@ -61,5 +61,23 @@ RSpec.describe EmploymentCheckJob do
         expect(AutomatedChecks::ClaimVerifiers::Employment).not_to have_received(:new)
       end
     end
+
+    context "when the claim is for a policy that doesn't use employment verifier" do
+      it "doesn't run the employment verifier" do
+        eytrp_claim = create(
+          :claim,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+          eligibility_attributes: {
+            teacher_reference_number: "1234567"
+          }
+        )
+
+        job.perform
+
+        expect(AutomatedChecks::ClaimVerifiers::Employment).not_to(
+          have_received(:new).with(claim: eytrp_claim)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Had an error in monitoring where we tried to update the employment check
for an EYTRP claim. Usually if claims don't implement the employment
verifier they won't have a TRN and this check will skip the claim.
However EYTRP claims have a TRN and so blow up further down the verifier
where we're checking if they worked at an eligible school during the
claim month.
This commit changes to only attempting to run the verifier if the policy
uses it.
