### PR TITLE
[CAPT-3929] Claims without SLC data considers nil or false

### DIFF
--- a/app/models/claim/claims_awaiting_decision_finder.rb
+++ b/app/models/claim/claims_awaiting_decision_finder.rb
@@ -17,19 +17,8 @@ class Claim
           .by_academic_year(journey_configuration.current_academic_year)
           .by_policy(policy)
           .awaiting_decision
-          .where(submitted_using_slc_data: submitted_using_slc_data(policy))
+          .where(submitted_using_slc_data: [nil, false])
       end.compact.reduce(&:or)
-    end
-
-    private
-
-    def submitted_using_slc_data(policy)
-      if policy == Policies::FurtherEducationPayments
-        # For 2024/2025 academic year onwards, only FE claims prior to the deployment of LUPEYALPHA-1010 have submitted_using_slc_data = nil
-        [false, nil]
-      else
-        false
-      end
     end
   end
 end

--- a/spec/models/claim/claims_awaiting_decision_finder_spec.rb
+++ b/spec/models/claim/claims_awaiting_decision_finder_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Claim::ClaimsAwaitingDecisionFinder do
   let!(:claim_tri_not_awaiting_decision) { create(:claim, :approved, policy: Policies::TargetedRetentionIncentivePayments, academic_year: tri_academic_year, submitted_using_slc_data: false) }
   let!(:claim_tri_other_year) { create(:claim, :submitted, policy: Policies::TargetedRetentionIncentivePayments, academic_year: tri_previous_academic_year, submitted_using_slc_data: false) }
   let!(:claim_sl_awaiting_decision_submitted_using_slc_data_false) { create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: fe_academic_year, submitted_using_slc_data: false) }
+
   let(:fe_academic_year) { AcademicYear.new(2024) }
   let(:fe_previous_academic_year) { AcademicYear.new(2023) }
   let(:tri_academic_year) { AcademicYear.new(2023) }
@@ -27,7 +28,8 @@ RSpec.describe Claim::ClaimsAwaitingDecisionFinder do
       expect(subject).to contain_exactly(
         claim_fe_awaiting_decision_submitted_using_slc_data_false,
         claim_fe_awaiting_decision_submitted_using_slc_data_nil,
-        claim_tri_awaiting_decision_submitted_using_slc_data_false
+        claim_tri_awaiting_decision_submitted_using_slc_data_false,
+        claim_tri_awaiting_decision_submitted_using_slc_data_nil
       )
     end
   end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-3929
- Claims with `submitted_using_slc_data` set to either `nil` or `false` are considered as claims submitted without SLC data