### PR TITLE
Check SLC plan for EYTRP claim on upload

### DIFF
--- a/app/jobs/student_loan_plan_check_job.rb
+++ b/app/jobs/student_loan_plan_check_job.rb
@@ -1,10 +1,4 @@
 class StudentLoanPlanCheckJob < ApplicationJob
-  APPLICABLE_POLICIES = [
-    Policies::TargetedRetentionIncentivePayments,
-    Policies::FurtherEducationPayments,
-    Policies::EarlyYearsPayments
-  ].freeze
-
   def perform(admin)
     delete_no_data_student_loan_plan_tasks
     claims = current_year_claims_awaiting_decision.awaiting_task("student_loan_plan")
@@ -31,7 +25,11 @@ class StudentLoanPlanCheckJob < ApplicationJob
     current_year_claims_awaiting_decision.joins(:tasks).where(tasks: {name: "student_loan_plan", claim_verifier_match: nil, manual: false})
   end
 
+  def applicable_policies
+    Policies.all.select(&:auto_check_student_loan_plan_task?)
+  end
+
   def current_year_claims_awaiting_decision
-    Claim::ClaimsAwaitingDecisionFinder.new(policies: APPLICABLE_POLICIES).claims_submitted_without_slc_data
+    Claim::ClaimsAwaitingDecisionFinder.new(policies: applicable_policies).claims_submitted_without_slc_data
   end
 end

--- a/app/models/claim/claims_awaiting_decision_finder.rb
+++ b/app/models/claim/claims_awaiting_decision_finder.rb
@@ -8,13 +8,17 @@ class Claim
 
     def claims_submitted_without_slc_data
       policies.map do |policy|
-        journey_configuration = Journeys.for_policy(policy).configuration
+        journey = Journeys.for_policy(policy)
+
+        next if journey.nil? # ECP
+
+        journey_configuration = journey.configuration
         Claim
           .by_academic_year(journey_configuration.current_academic_year)
           .by_policy(policy)
           .awaiting_decision
           .where(submitted_using_slc_data: submitted_using_slc_data(policy))
-      end.reduce(&:or)
+      end.compact.reduce(&:or)
     end
 
     private

--- a/spec/features/admin/upload_slc_data_spec.rb
+++ b/spec/features/admin/upload_slc_data_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Upload SLC data" do
     create(:journey_configuration, :targeted_retention_incentive_payments)
     create(:journey_configuration, :further_education_payments)
     create(:journey_configuration, :early_years_payment_provider_start)
+    create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
     sign_in_as_service_operator
   end
 

--- a/spec/jobs/student_loan_plan_check_job_spec.rb
+++ b/spec/jobs/student_loan_plan_check_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe StudentLoanPlanCheckJob do
   before do
     create(:journey_configuration, :further_education_payments)
     create(:journey_configuration, :early_years_payment_provider_start)
+    create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
   end
 
   let!(:claim) { create(:claim, claim_status, academic_year:, policy: Policies::TargetedRetentionIncentivePayments) }
@@ -23,14 +24,6 @@ RSpec.describe StudentLoanPlanCheckJob do
         expect(AutomatedChecks::ClaimVerifiers::StudentLoanPlan).not_to receive(:new)
         perform_job
       end
-    end
-
-    it "includes all applicable policies" do
-      expect(StudentLoanPlanCheckJob::APPLICABLE_POLICIES).to eq [
-        Policies::TargetedRetentionIncentivePayments,
-        Policies::FurtherEducationPayments,
-        Policies::EarlyYearsPayments
-      ]
     end
 
     context "when the previous student loan plan check was run manually" do # not sure it's possible to do this any more

--- a/spec/requests/admin/admin_student_loans_data_upload_spec.rb
+++ b/spec/requests/admin/admin_student_loans_data_upload_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "SLC (Student Loans Company) data upload " do
   let!(:journey_configuration_targeted_retention_incentive) { create(:journey_configuration, :targeted_retention_incentive_payments) }
   let!(:journey_configuration_fe) { create(:journey_configuration, :further_education_payments) }
   let!(:journey_configuration_ey) { create(:journey_configuration, :early_years_payment_provider_start) }
+  let!(:journey_configuration_eytrp) { create(:journey_configuration, :early_years_teachers_financial_incentive_payments) }
 
   before { @signed_in_user = sign_in_as_service_operator }
 


### PR DESCRIPTION
SLC uploads weren't checking EYTRP claims.
We had two different implementations of which policies to check
`Policy.auto_check_student_loan_plan_task?`
and the hard coded list of policies in this job.
Switch to just one implementation so we don't miss policies.
