### PR TITLE
Centralise awaiting task

### DIFF
--- a/app/models/automated_checks/claim_verifiers/census_subjects_taught.rb
+++ b/app/models/automated_checks/claim_verifiers/census_subjects_taught.rb
@@ -15,7 +15,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless awaiting_task?(TASK_NAME)
+        return unless claim.awaiting_task?(TASK_NAME)
 
         no_data || no_match || any_match
       end
@@ -24,10 +24,6 @@ module AutomatedChecks
 
       attr_accessor :admin_user, :claim, :school_workforce_census
       attr_reader :school_workforce_census_subjects
-
-      def awaiting_task?(task_name)
-        claim.tasks.none? { |task| task.name == task_name }
-      end
 
       def school_workforce_census_subjects=(school_workforce_census)
         return if school_workforce_census.empty?

--- a/app/models/automated_checks/claim_verifiers/employment.rb
+++ b/app/models/automated_checks/claim_verifiers/employment.rb
@@ -11,7 +11,7 @@ module AutomatedChecks
 
       def perform
         return unless required?
-        return unless awaiting_task?
+        return unless claim.awaiting_task?(TASK_NAME)
 
         no_data || no_match || matched
       end
@@ -23,10 +23,6 @@ module AutomatedChecks
       end
 
       attr_accessor :admin_user, :claim
-
-      def awaiting_task?
-        claim.tasks.where(name: TASK_NAME).count.zero?
-      end
 
       def start_of_previous_financial_year
         previous_academic_year = Policies::StudentLoans.current_academic_year - 1

--- a/app/models/automated_checks/claim_verifiers/employment.rb
+++ b/app/models/automated_checks/claim_verifiers/employment.rb
@@ -10,17 +10,12 @@ module AutomatedChecks
       end
 
       def perform
-        return unless required?
         return unless claim.awaiting_task?(TASK_NAME)
 
         no_data || no_match || matched
       end
 
       private
-
-      def required?
-        claim.eligibility.teacher_reference_number.present?
-      end
 
       attr_accessor :admin_user, :claim
 

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -15,7 +15,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless awaiting_task?(TASK_NAME)
+        return unless claim.awaiting_task?(TASK_NAME)
 
         # Order of matching matters so that subsequent conditions in methods fall through to execute the right thing
         no_match || partial_match || complete_match
@@ -36,10 +36,6 @@ module AutomatedChecks
 
       def active_alert?
         dqt_teacher_status.active_alert?
-      end
-
-      def awaiting_task?(task_name)
-        claim.tasks.none? { |task| task.name == task_name }
       end
 
       def complete_match

--- a/app/models/automated_checks/claim_verifiers/one_login_identity.rb
+++ b/app/models/automated_checks/claim_verifiers/one_login_identity.rb
@@ -9,7 +9,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless awaiting_task?(TASK_NAME)
+        return unless claim.awaiting_task?(TASK_NAME)
 
         if claim.identity_confirmed_with_onelogin?
           create_task(passed: true)
@@ -21,10 +21,6 @@ module AutomatedChecks
       private
 
       attr_accessor :claim
-
-      def awaiting_task?(task_name)
-        claim.tasks.none? { |task| task.name == task_name }
-      end
 
       def create_task(passed:, reason: nil)
         task = claim.tasks.build(

--- a/app/models/automated_checks/claim_verifiers/qualifications.rb
+++ b/app/models/automated_checks/claim_verifiers/qualifications.rb
@@ -15,7 +15,7 @@ module AutomatedChecks
       end
 
       def perform
-        return unless awaiting_task?(TASK_NAME)
+        return unless claim.awaiting_task?(TASK_NAME)
 
         no_match || complete_match
       end
@@ -24,10 +24,6 @@ module AutomatedChecks
 
       attr_accessor :admin_user, :claim
       attr_reader :dqt_teacher_status
-
-      def awaiting_task?(task_name)
-        claim.tasks.none? { |task| task.name == task_name }
-      end
 
       def complete_match
         return unless dqt_teacher_status.eligible?

--- a/app/models/automated_checks/claim_verifiers/student_loan_amount.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_amount.rb
@@ -11,7 +11,7 @@ module AutomatedChecks
 
       def perform
         return unless claim.policy == Policies::StudentLoans
-        return unless awaiting_task?
+        return unless claim.awaiting_task?(TASK_NAME)
 
         no_data || no_match || invalid_match || complete_match
       end
@@ -29,10 +29,6 @@ module AutomatedChecks
 
       def student_loans_data
         @student_loans_data ||= StudentLoansData.where(nino:, date_of_birth:)
-      end
-
-      def awaiting_task?
-        claim.tasks.where(name: TASK_NAME).count.zero?
       end
 
       def no_data

--- a/app/models/automated_checks/claim_verifiers/student_loan_amount.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_amount.rb
@@ -10,7 +10,6 @@ module AutomatedChecks
       end
 
       def perform
-        return unless claim.policy == Policies::StudentLoans
         return unless claim.awaiting_task?(TASK_NAME)
 
         no_data || no_match || invalid_match || complete_match

--- a/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
@@ -21,7 +21,7 @@ module AutomatedChecks
       def perform
         return unless claim.policy.auto_check_student_loan_plan_task?
         return unless claim.submitted_without_slc_data?
-        return unless awaiting_task?
+        return unless claim.awaiting_task?(TASK_NAME)
 
         student_loan_data_exists || nino_only_match_found || no_student_loan_data_entry
       end
@@ -42,10 +42,6 @@ module AutomatedChecks
 
       def student_loans_data_nino_only
         @student_loans_data_nino_only ||= StudentLoansData.where(nino:).where.not(date_of_birth:)
-      end
-
-      def awaiting_task?
-        claim.tasks.where(name: TASK_NAME).count.zero?
       end
 
       def student_loan_data_exists

--- a/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
+++ b/app/models/automated_checks/claim_verifiers/student_loan_plan.rb
@@ -19,8 +19,6 @@ module AutomatedChecks
       end
 
       def perform
-        return unless claim.policy.auto_check_student_loan_plan_task?
-        return unless claim.submitted_without_slc_data?
         return unless claim.awaiting_task?(TASK_NAME)
 
         student_loan_data_exists || nino_only_match_found || no_student_loan_data_entry

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -455,9 +455,7 @@ class Claim < ApplicationRecord
   end
 
   def awaiting_task?(task_name)
-    return false unless claim_checking_tasks.applicable_task_names.include?(task_name)
-
-    tasks.where(name: task_name).count.zero?
+    task_required?(task_name) && !task_completed?(task_name)
   end
 
   private
@@ -530,5 +528,13 @@ class Claim < ApplicationRecord
 
   def submittable_email_details?
     email_address.present? && email_verified == true
+  end
+
+  def task_required?(task_name)
+    claim_checking_tasks.applicable_task_names.include?(task_name)
+  end
+
+  def task_completed?(task_name)
+    tasks.where(name: task_name).exists?
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -454,6 +454,10 @@ class Claim < ApplicationRecord
     @claim_checking_tasks ||= policy::ClaimCheckingTasks.new(self)
   end
 
+  def awaiting_task?(task_name)
+    tasks.where(name: task_name).count.zero?
+  end
+
   private
 
   def one_login_idv_name_match?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -455,6 +455,8 @@ class Claim < ApplicationRecord
   end
 
   def awaiting_task?(task_name)
+    return false unless claim_checking_tasks.applicable_task_names.include?(task_name)
+
     tasks.where(name: task_name).count.zero?
   end
 

--- a/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/one_login_identity_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::OneLoginIdentity do
       let(:claim) do
         create(
           :claim,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
           identity_confirmed_with_onelogin: false
         )
       end
@@ -23,7 +24,12 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::OneLoginIdentity do
 
     context "when identity_confirmed_with_onelogin is true" do
       let(:claim) do
-        create(:claim, :submitted, :with_onelogin_idv_data)
+        create(
+          :claim,
+          :submitted,
+          :with_onelogin_idv_data,
+          policy: Policies::EarlyYearsTeachersFinancialIncentivePayments
+        )
       end
 
       it "creates a passed task" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1596,34 +1596,50 @@ RSpec.describe Claim, type: :model do
   describe "#awaiting_task?" do
     let(:claim) { create(:claim) }
 
-    let(:task_name) { "one_login_identity" }
-
     subject { claim.awaiting_task?(task_name) }
 
-    context "when the task is passed" do
-      before { claim.tasks.create!(name: task_name, passed: true) }
+    context "when the policy implements the task" do
+      let(:task_name) { "payroll_gender" }
 
-      it { is_expected.to be false }
-    end
+      context "when the task is required" do
+        context "when the task is passed" do
+          before { claim.tasks.create!(name: task_name, passed: true) }
 
-    context "when the task is failed" do
-      before { claim.tasks.create!(name: task_name, passed: false) }
+          it { is_expected.to be false }
+        end
 
-      it { is_expected.to be false }
-    end
+        context "when the task is failed" do
+          before { claim.tasks.create!(name: task_name, passed: false) }
 
-    context "when the claim is neither passed nor failed" do
-      before do
-        claim.tasks
-          .build(name: task_name, passed: nil)
-          .save!(context: :claim_verifier)
+          it { is_expected.to be false }
+        end
+
+        context "when the task is neither passed nor failed" do
+          before do
+            claim.tasks
+              .build(name: task_name, passed: nil)
+              .save!(context: :claim_verifier)
+          end
+
+          it { is_expected.to be false }
+        end
+
+        context "when the task is not persisted" do
+          it { is_expected.to be true }
+        end
       end
 
-      it { is_expected.to be false }
+      context "when the task is not required" do
+        before { claim.update!(payroll_gender: "male") }
+
+        it { is_expected.to be false }
+      end
     end
 
-    context "when the task is not persisted" do
-      it { is_expected.to be true }
+    context "when the policy does not implement the task" do
+      let(:task_name) { "onelogin_identity" }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1592,4 +1592,38 @@ RSpec.describe Claim, type: :model do
       end
     end
   end
+
+  describe "#awaiting_task?" do
+    let(:claim) { create(:claim) }
+
+    let(:task_name) { "one_login_identity" }
+
+    subject { claim.awaiting_task?(task_name) }
+
+    context "when the task is passed" do
+      before { claim.tasks.create!(name: task_name, passed: true) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the task is failed" do
+      before { claim.tasks.create!(name: task_name, passed: false) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the claim is neither passed nor failed" do
+      before do
+        claim.tasks
+          .build(name: task_name, passed: nil)
+          .save!(context: :claim_verifier)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the task is not persisted" do
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
Whether or not a given claim verifier runs is determined by quite a few places
in the app. This PR aims to, for some claim verifiers, reduce that to just two
places: Is the verifier in the list in the policy, is the task required.jo

This should make cutting over to persisted tasks a bit easier.

Ideally we'd lose the verifier's constant and what verifiers are run on claim
would be determined solely by the tasks on the claim but that's a bigger piece
of work.
