### PR TITLE
persist check matching claims task

### DIFF
--- a/app/forms/admin/undo_decision_form.rb
+++ b/app/forms/admin/undo_decision_form.rb
@@ -27,7 +27,11 @@ module Admin
       return false if invalid?
 
       amendment = Amendment.undo_decision(decision, amendment_params.merge(created_by: current_admin))
-      amendment.persisted?
+      return false unless amendment.persisted?
+
+      AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+
+      true
     end
 
     def processable?

--- a/app/jobs/backfill_matching_details_task.rb
+++ b/app/jobs/backfill_matching_details_task.rb
@@ -1,0 +1,15 @@
+class BackfillMatchingDetailsTask < ApplicationJob
+  def self.enqueue
+    Claim
+      .by_academic_year(AcademicYear.current)
+      .find_each { |claim| perform_later(claim) }
+  end
+
+  def perform(claim)
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+  end
+
+  def priority
+    15
+  end
+end

--- a/app/models/automated_checks/claim_verifiers/matching_claims.rb
+++ b/app/models/automated_checks/claim_verifiers/matching_claims.rb
@@ -9,35 +9,16 @@ module AutomatedChecks
         ApplicationRecord.transaction do
           result = Claims::Match.update_matching_claims!(source_claim)
 
-          if result.removed_matches.any?
-            # remove the matching details task from the other claims only if
-            # * the task is not completed
-            # * the other claim is not decided
-            # * there are no _other_ match pairs on that claim
-            result.removed_matches
-              .select { |claim| Claims::Match.matching_claims(claim).none? }
-              .select { |claim| task_updateable?(claim) }
-              .each { |claim| remove_matching_details_task!(claim) }
-
-            if task_updateable?(source_claim) && Claims::Match.matching_claims(source_claim).none?
-              remove_matching_details_task!(source_claim)
-            end
+          result.removed_matches.each do |removed_match|
+            remove_match!(source_claim, removed_match)
+            remove_match!(removed_match, source_claim)
           end
 
           current_matches = result.new_matches + result.existing_matches
 
-          if current_matches.any?
-            # add the matching details task to matching claims only if
-            # * the other claim doesn't already have the task
-            # * the other claim is not decided
-            current_matches
-              .select { |claim| task_updateable?(claim) }
-              .select { |claim| !already_has_task?(claim) }
-              .each { |claim| add_matching_details_task!(claim) }
-
-            if task_updateable?(source_claim) && !already_has_task?(source_claim)
-              add_matching_details_task!(source_claim)
-            end
+          current_matches.each do |matching_claim|
+            record_match!(source_claim, matching_claim)
+            record_match!(matching_claim, source_claim)
           end
         end
       end
@@ -45,6 +26,46 @@ module AutomatedChecks
       private
 
       attr_reader :source_claim
+
+      def record_match!(target_claim, duplicate_claim)
+        return unless task_updateable?(target_claim)
+
+        task = target_claim.tasks.matching_details.last || target_claim.tasks.matching_details.new
+
+        data = task.data || {}
+
+        matches = Set.new(data["matching_claims"])
+
+        matches << duplicate_claim.reference
+
+        data["matching_claims"] = matches.to_a
+
+        task.data = data
+
+        task.save!(context: :claim_verifier)
+      end
+
+      def remove_match!(target_claim, duplicate_claim)
+        return unless task_updateable?(target_claim)
+
+        task = target_claim.tasks.matching_details.last
+
+        # If for some reason there isn't a task there's nothing to do
+        return unless task
+
+        data = task.data || {}
+
+        matches = Set.new(data["matching_claims"])
+        matches = matches.excluding(duplicate_claim.reference)
+
+        if matches.empty?
+          task.destroy!
+        else
+          data["matching_claims"] = matches.to_a
+          task.data = data
+          task.save!(context: :claim_verifier)
+        end
+      end
 
       def task_updateable?(claim)
         # Don't change the tasks history on a decided claim.
@@ -56,20 +77,6 @@ module AutomatedChecks
         else
           true
         end
-      end
-
-      def already_has_task?(claim)
-        claim.tasks.matching_details.exists?
-      end
-
-      def remove_matching_details_task!(claim)
-        task = claim.tasks.matching_details.last
-        task&.destroy!
-      end
-
-      def add_matching_details_task!(claim)
-        task = claim.tasks.matching_details.new
-        task.save!(context: :claim_verifier)
       end
     end
   end

--- a/app/models/automated_checks/claim_verifiers/matching_claims.rb
+++ b/app/models/automated_checks/claim_verifiers/matching_claims.rb
@@ -2,16 +2,75 @@ module AutomatedChecks
   module ClaimVerifiers
     class MatchingClaims
       def initialize(claim:)
-        @claim = claim
+        @source_claim = claim
       end
 
       def perform
-        Claims::Match.update_matching_claims!(claim)
+        ApplicationRecord.transaction do
+          result = Claims::Match.update_matching_claims!(source_claim)
+
+          if result.removed_matches.any?
+            # remove the matching details task from the other claims only if
+            # * the task is not completed
+            # * the other claim is not decided
+            # * there are no _other_ match pairs on that claim
+            result.removed_matches
+              .select { |claim| Claims::Match.matching_claims(claim).none? }
+              .select { |claim| task_updateable?(claim) }
+              .each { |claim| remove_matching_details_task!(claim) }
+
+            if task_updateable?(source_claim) && Claims::Match.matching_claims(source_claim).none?
+              remove_matching_details_task!(source_claim)
+            end
+          end
+
+          current_matches = result.new_matches + result.existing_matches
+
+          if current_matches.any?
+            # add the matching details task to matching claims only if
+            # * the other claim doesn't already have the task
+            # * the other claim is not decided
+            current_matches
+              .select { |claim| task_updateable?(claim) }
+              .select { |claim| !already_has_task?(claim) }
+              .each { |claim| add_matching_details_task!(claim) }
+
+            if task_updateable?(source_claim) && !already_has_task?(source_claim)
+              add_matching_details_task!(source_claim)
+            end
+          end
+        end
       end
 
       private
 
-      attr_reader :claim
+      attr_reader :source_claim
+
+      def task_updateable?(claim)
+        # Don't change the tasks history on a decided claim.
+        # If a new match has been found since the matching details task wass
+        # completed we don't change the task, though we will still show the
+        # warning, this is the existing behaviour.
+        if claim.decision_made? || claim.tasks.matching_details.last&.completed?
+          false
+        else
+          true
+        end
+      end
+
+      def already_has_task?(claim)
+        claim.tasks.matching_details.exists?
+      end
+
+      def remove_matching_details_task!(claim)
+        task = claim.tasks.matching_details.last
+        task&.destroy!
+      end
+
+      def add_matching_details_task!(claim)
+        task = claim.tasks.matching_details.new
+        task.save!(context: :claim_verifier)
+      end
     end
   end
 end

--- a/app/models/automated_checks/claim_verifiers/matching_claims.rb
+++ b/app/models/automated_checks/claim_verifiers/matching_claims.rb
@@ -9,16 +9,18 @@ module AutomatedChecks
         ApplicationRecord.transaction do
           result = Claims::Match.update_matching_claims!(source_claim)
 
-          result.removed_matches.each do |removed_match|
-            remove_match!(source_claim, removed_match)
-            remove_match!(removed_match, source_claim)
-          end
+          if FeatureFlag.enabled?(:persist_matching_claims)
+            result.removed_matches.each do |removed_match|
+              remove_match!(source_claim, removed_match)
+              remove_match!(removed_match, source_claim)
+            end
 
-          current_matches = result.new_matches + result.existing_matches
+            current_matches = result.new_matches + result.existing_matches
 
-          current_matches.each do |matching_claim|
-            record_match!(source_claim, matching_claim)
-            record_match!(matching_claim, source_claim)
+            current_matches.each do |matching_claim|
+              record_match!(source_claim, matching_claim)
+              record_match!(matching_claim, source_claim)
+            end
           end
         end
       end

--- a/app/models/claims/match.rb
+++ b/app/models/claims/match.rb
@@ -64,18 +64,22 @@ module Claims
       match
     end
 
+    class Result < Struct.new(:new_matches, :existing_matches, :removed_matches); end
+
     def self.update_matching_claims!(claim)
       finder = Claim::MatchingAttributeFinder.new(claim)
 
-      matching_claims = finder.matching_claims
-
       existing_matches = matching_claims(claim)
+
+      matching_claims = finder.matching_claims
 
       new_matches = matching_claims - existing_matches
 
       no_longer_matching = existing_matches - matching_claims
 
       still_matching = existing_matches & matching_claims
+
+      result = Result.new(new_matches, still_matching, no_longer_matching)
 
       ApplicationRecord.transaction do
         new_matches.each do |matching_claim|
@@ -98,6 +102,8 @@ module Claims
           claim.matching_attributes_last_checked_at = Time.current
         end
       end
+
+      result
     end
 
     def other(claim)

--- a/app/models/policies/claim_checking_tasks.rb
+++ b/app/models/policies/claim_checking_tasks.rb
@@ -68,5 +68,12 @@ module Policies
         claim.tasks.exists?(name: name)
       end
     end
+
+    # Temporary shim until all claims have a persisted matching details task
+    def persisting_tasks_shim(name)
+      if name == "matching_details" && !task_exists?(name)
+        AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+      end
+    end
   end
 end

--- a/app/models/policies/claim_checking_tasks.rb
+++ b/app/models/policies/claim_checking_tasks.rb
@@ -71,6 +71,10 @@ module Policies
 
     # Temporary shim until all claims have a persisted matching details task
     def persisting_tasks_shim(name)
+      # Skip the shim if we're rendering the admin task list page otherwise it
+      # will slow to a crawl!
+      return if skip_matching_claims_check?
+
       if name == "matching_details" && !task_exists?(name)
         AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
       end

--- a/app/models/policies/early_career_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_career_payments/claim_checking_tasks.rb
@@ -4,6 +4,8 @@ module Policies
   module EarlyCareerPayments
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
 
         tasks << "identity_confirmation"

--- a/app/models/policies/early_career_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_career_payments/claim_checking_tasks.rb
@@ -15,7 +15,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/early_career_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_career_payments/claim_checking_tasks.rb
@@ -13,7 +13,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -4,6 +4,8 @@ module Policies
   module EarlyYearsPayments
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
         tasks << "ey_eoi_cross_reference" unless year_1_of_ey?
         tasks += identity_task_names

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -13,7 +13,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
 
         tasks
       end

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -11,7 +11,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
 
         tasks
       end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -2,6 +2,8 @@ module Policies
   module EarlyYearsTeachersFinancialIncentivePayments
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
 
         tasks << "provider_claim_count" if add_provider_claim_count_task? || task_exists?("provider_claim_count")

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -13,7 +13,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
 
         tasks
       end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -11,7 +11,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
 
         tasks
       end

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -16,7 +16,7 @@ module Policies
         tasks << "employment" if claim.eligibility.teacher_reference_number.present?
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
         tasks << "fe_provider_check" if task_exists?("fe_provider_check")
 

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -18,7 +18,7 @@ module Policies
         tasks << "employment" if claim.eligibility.teacher_reference_number.present?
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
         tasks << "fe_provider_check" if task_exists?("fe_provider_check")
 

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -4,6 +4,8 @@ module Policies
   module FurtherEducationPayments
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
 
         tasks << "one_login_identity"

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -20,7 +20,7 @@ module Policies
         tasks << "employment_history" if claim.eligibility.changed_workplace_or_new_contract?
         tasks << "continuous_employment"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -4,6 +4,8 @@ module Policies
   module InternationalRelocationPayments
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
 
         tasks << "first_year_application" unless claim.tasks.previous_payment.exists?

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -22,7 +22,7 @@ module Policies
         tasks << "employment_history" if claim.eligibility.changed_workplace_or_new_contract?
         tasks << "continuous_employment"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -14,7 +14,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_amount"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_amount"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -4,6 +4,8 @@ module Policies
   module StudentLoans
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
 
         tasks << "identity_confirmation"

--- a/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
@@ -4,6 +4,8 @@ module Policies
   module TargetedRetentionIncentivePayments
     class ClaimCheckingTasks < Policies::ClaimCheckingTasks
       def applicable_task_names
+        persisting_tasks_shim("matching_details")
+
         tasks = []
 
         tasks << "identity_confirmation"

--- a/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
@@ -14,7 +14,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if task_exists?("matching_details")
+        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -93,7 +93,7 @@ class Task < ApplicationRecord
   # persisted sso we need to know if the task has an outcome to determine
   # completeness.
   def completed?
-    if name == "matching_details"
+    if name == "matching_details" && FeatureFlag.enabled?(:persist_matching_claims)
       !passed.nil?
     else
       persisted?

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -88,8 +88,16 @@ class Task < ApplicationRecord
     name == "identity_confirmation"
   end
 
+  # We're migrating what it means for a task to be completed. Originally
+  # the task being persisted meant it was completed. Now incomplete tasks can be
+  # persisted sso we need to know if the task has an outcome to determine
+  # completeness.
   def completed?
-    persisted?
+    if name == "matching_details"
+      !passed.nil?
+    else
+      persisted?
+    end
   end
 
   def blocks_approval?

--- a/app/views/admin/tasks/matching_details.html.erb
+++ b/app/views/admin/tasks/matching_details.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <% if @form.task.persisted? %>
+    <% if @form.task.completed? %>
       <%= render "task_outcome", task: @form.task %>
     <% elsif @claim.policy.task_available?(@form.task) %>
       <%= render "form", task_name: "matching_details", claim: @claim %>

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -183,7 +183,9 @@ FactoryBot.define do
         case claim.policy
         when Policies::EarlyYearsPayments
           claim.claim_checking_tasks.applicable_task_names.each do |task_name|
-            create(:task, :automated, :passed, name: task_name, claim: claim)
+            unless claim.tasks.where(name: task_name).exists?
+              create(:task, :automated, :passed, name: task_name, claim: claim)
+            end
           end
         else
           claim.claim_checking_tasks.blocking_approval.each do |task|

--- a/spec/features/admin/admin_claim_with_matching_details_spec.rb
+++ b/spec/features/admin/admin_claim_with_matching_details_spec.rb
@@ -11,6 +11,9 @@ RSpec.feature "Admin checking a claim with matching details" do
     claim = create(:claim, :submitted, policy: Policies::StudentLoans)
     claim_with_matching_details = create(:claim, :submitted, eligibility_attributes: {teacher_reference_number: claim.eligibility.teacher_reference_number})
 
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim_with_matching_details).perform
+
     click_on "Claims"
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
@@ -51,7 +54,7 @@ RSpec.feature "Admin checking a claim with matching details" do
     )
 
     # Matching claim
-    create(
+    matching_claim = create(
       :claim,
       :submitted,
       bank_sort_code: "123456",
@@ -59,6 +62,9 @@ RSpec.feature "Admin checking a claim with matching details" do
         teacher_reference_number: claim.eligibility.teacher_reference_number
       }
     )
+
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: matching_claim).perform
 
     visit admin_claim_tasks_path(claim)
 
@@ -74,7 +80,10 @@ RSpec.feature "Admin checking a claim with matching details" do
 
   scenario "admin forgets to select an option" do
     claim = create(:claim, :submitted, policy: Policies::StudentLoans)
-    create(:claim, :submitted, eligibility_attributes: {teacher_reference_number: claim.eligibility.teacher_reference_number})
+    other_claim = create(:claim, :submitted, eligibility_attributes: {teacher_reference_number: claim.eligibility.teacher_reference_number})
+
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+    AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: other_claim).perform
 
     click_on "Claims"
     find("a[href='#{admin_claim_tasks_path(claim)}']").click

--- a/spec/features/admin/admin_duplicate_claims_task_spec.rb
+++ b/spec/features/admin/admin_duplicate_claims_task_spec.rb
@@ -1,0 +1,775 @@
+require "rails_helper"
+
+RSpec.describe "Admin matching claims task" do
+  context "when a new claim is submitted" do
+    context "when the claim is not a duplicate" do
+      before do
+        claim = submit_a_claim
+
+        sign_in_as_service_operator
+
+        visit admin_claim_tasks_path(claim)
+      end
+
+      it "doesn't add the matching claims task" do
+        within ".app-task-list" do
+          expect(page).not_to have_content "Matching details"
+        end
+      end
+
+      it "doesn't show the matching claims warning" do
+        expect(page).not_to have_content(
+          "Multiple claims with matching details have been made"
+        )
+      end
+    end
+
+    context "when the claim is a duplicate" do
+      context "when the other claim has been decided" do
+        it "adds a task to the new claim" do
+          create(
+            :claim,
+            :approved,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu"
+          )
+
+          new_claim = submit_a_claim
+
+          sign_in_as_service_operator
+
+          visit admin_claim_tasks_path(new_claim)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+          end
+        end
+
+        it "doesn't change the tasks on the other claim" do
+          existing_claim = create(
+            :claim,
+            :approved,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu"
+          )
+
+          submit_a_claim
+
+          sign_in_as_service_operator
+
+          visit admin_claim_tasks_path(existing_claim)
+
+          within ".app-task-list" do
+            expect(page).not_to have_content "Matching details"
+          end
+        end
+
+        it "shows a warning on both claims" do
+          existing_claim = create(
+            :claim,
+            :approved,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu"
+          )
+
+          new_claim = submit_a_claim
+
+          sign_in_as_service_operator
+
+          visit admin_claim_tasks_path(new_claim)
+
+          expect(page).to have_content(
+            "Multiple claims with matching details have been made"
+          )
+
+          visit admin_claim_tasks_path(existing_claim)
+
+          expect(page).to have_content(
+            "Multiple claims with matching details have been made"
+          )
+        end
+      end
+
+      context "when the other claim has not been decided" do
+        context "when the other claim doens't have a matching details task" do
+          it "adds the matching details task to both claims" do
+            existing_claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            new_claim = submit_a_claim
+
+            sign_in_as_service_operator
+
+            visit admin_claim_tasks_path(new_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+
+            visit admin_claim_tasks_path(existing_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "shows a warning on both claims" do
+            existing_claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            new_claim = submit_a_claim
+
+            sign_in_as_service_operator
+
+            visit admin_claim_tasks_path(new_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(existing_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+
+        context "when the other claim has a completed matching details task" do
+          it "adds a task to the new claim" do
+            existing_claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            create(
+              :task,
+              name: "matching_details",
+              claim: existing_claim,
+              passed: true
+            )
+
+            new_claim = submit_a_claim
+
+            sign_in_as_service_operator
+
+            visit admin_claim_tasks_path(new_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "doesn't change the tasks on the other claim" do
+            existing_claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            create(
+              :task,
+              name: "matching_details",
+              claim: existing_claim,
+              passed: true
+            )
+
+            submit_a_claim
+
+            sign_in_as_service_operator
+
+            visit admin_claim_tasks_path(existing_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+              expect(page).to have_content(
+                "Review matching details from other claims Passed"
+              )
+            end
+          end
+
+          it "shows a warning on both claims" do
+            existing_claim = create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            create(
+              :task,
+              name: "matching_details",
+              claim: existing_claim,
+              passed: true
+            )
+
+            new_claim = submit_a_claim
+
+            sign_in_as_service_operator
+
+            visit admin_claim_tasks_path(new_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(existing_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+      end
+    end
+  end
+
+  context "when a claim is amended" do
+    context "when a duplicate claim is amended" do
+      context "when it is still a duplicate" do
+        it "shows the matching details task on both claims" do
+          amended_claim = create(
+            :claim,
+            :submitted,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu"
+          )
+
+          other_claim = submit_a_claim
+
+          sign_in_as_service_operator
+
+          visit new_admin_claim_amendment_path(amended_claim)
+
+          fill_in "Postcode", with: "TE57 1NG"
+          fill_in "Change notes", with: "Updated postcode"
+
+          click_on "Amend claim"
+
+          visit admin_claim_tasks_path(other_claim)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+          end
+
+          visit admin_claim_tasks_path(other_claim)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+          end
+        end
+
+        it "shows a warning on both claims" do
+          amended_claim = create(
+            :claim,
+            :submitted,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu"
+          )
+
+          other_claim = submit_a_claim
+
+          sign_in_as_service_operator
+
+          visit new_admin_claim_amendment_path(amended_claim)
+
+          fill_in "Postcode", with: "TE57 1NG"
+          fill_in "Change notes", with: "Updated postcode"
+
+          click_on "Amend claim"
+
+          visit admin_claim_tasks_path(other_claim)
+
+          expect(page).to have_content(
+            "Multiple claims with matching details have been made"
+          )
+
+          visit admin_claim_tasks_path(other_claim)
+
+          expect(page).to have_content(
+            "Multiple claims with matching details have been made"
+          )
+        end
+      end
+
+      context "when it is no longer a duplicate" do
+        context "when the matching details task has been completed on the other claim" do
+          let(:amended_claim) do
+            create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+          end
+
+          let(:other_claim) do
+            submit_a_claim
+          end
+
+          before do
+            amended_claim
+
+            other_claim
+
+            sign_in_as_service_operator
+
+            # Complete task
+            visit admin_claim_tasks_path(other_claim)
+
+            click_on "Review matching details from other claims"
+
+            choose "Yes"
+
+            click_on "Save and continue"
+
+            # Amend claim
+            visit new_admin_claim_amendment_path(amended_claim)
+
+            fill_in(
+              "Email address",
+              with: "edna.krabappel@springfield-elementary.edu"
+            )
+
+            fill_in "Change notes", with: "Updated email address"
+
+            click_on "Amend claim"
+          end
+
+          it "removes the matching details task from the amended claim" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            within ".app-task-list" do
+              expect(page).not_to have_content "Matching details"
+            end
+          end
+
+          it "doesn't remove the matching details task on the other claim" do
+            visit admin_claim_tasks_path(other_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "doesn't show a warning on either claim" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            expect(page).not_to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(other_claim)
+
+            expect(page).not_to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+
+        context "when the matching claims task has not been completed" do
+          let(:amended_claim) do
+            create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu"
+            )
+          end
+
+          let(:other_claim) do
+            submit_a_claim
+          end
+
+          before do
+            amended_claim
+
+            other_claim
+
+            sign_in_as_service_operator
+
+            # Amend claim
+            visit new_admin_claim_amendment_path(amended_claim)
+
+            fill_in(
+              "Email address",
+              with: "edna.krabappel@springfield-elementary.edu"
+            )
+
+            fill_in "Change notes", with: "Updated postcode"
+
+            click_on "Amend claim"
+          end
+
+          it "removes the matching details task on both claims" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            within ".app-task-list" do
+              expect(page).not_to have_content "Matching details"
+            end
+
+            visit admin_claim_tasks_path(other_claim)
+
+            within ".app-task-list" do
+              expect(page).not_to have_content "Matching details"
+            end
+          end
+
+          it "doesn't show a warning on either claim" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            expect(page).not_to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(other_claim)
+
+            expect(page).not_to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+
+        context "when the other claim has other duplciates" do
+          let(:amended_claim) do
+            create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "seymour.skinner@springfield-elementary.edu",
+              national_insurance_number: "AB222222C"
+            )
+          end
+
+          let(:other_duplicate) do
+            create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "elizabeth.hoover@springfield-elementary.edu",
+              national_insurance_number: "AB222222C"
+            )
+          end
+
+          let(:new_claim) do
+            submit_a_claim
+          end
+
+          before do
+            amended_claim
+
+            other_duplicate
+
+            new_claim
+
+            sign_in_as_service_operator
+
+            # Amend claim
+            visit new_admin_claim_amendment_path(amended_claim)
+
+            fill_in(
+              "Email address",
+              with: "edna.krabappel@springfield-elementary.edu"
+            )
+
+            fill_in "Change notes", with: "Updated postcode"
+
+            click_on "Amend claim"
+          end
+
+          it "removes the matching claims task from the new claim" do
+            visit admin_claim_tasks_path(new_claim)
+
+            within ".app-task-list" do
+              expect(page).not_to have_content "Matching details"
+            end
+          end
+
+          it "doesn't remove the matching claims task from the other claim" do
+            visit admin_claim_tasks_path(other_duplicate)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "doesn't remove the matching claims task from the other duplciate" do
+            visit admin_claim_tasks_path(other_duplicate)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "shows the warning on the other claim and duplicate but not the new claim" do
+            visit admin_claim_tasks_path(new_claim)
+
+            expect(page).not_to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(other_duplicate)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(other_duplicate)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+      end
+    end
+
+    context "when a non duplicate claim is amended" do
+      context "when it is still not a duplicate" do
+        let(:amended_claim) do
+          create(
+            :claim,
+            :submitted,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "edna-krabappel@springfield-elementary.edu"
+          )
+        end
+
+        let(:other_claim) do
+          submit_a_claim
+        end
+
+        before do
+          amended_claim
+
+          other_claim
+
+          sign_in_as_service_operator
+
+          # Amend claim
+          visit new_admin_claim_amendment_path(amended_claim)
+
+          fill_in("Postcode", with: "TE57 1NG")
+
+          fill_in "Change notes", with: "Updated postcode"
+
+          click_on "Amend claim"
+        end
+
+        it "doesn't add a matching details task" do
+          visit admin_claim_tasks_path(amended_claim)
+
+          within ".app-task-list" do
+            expect(page).not_to have_content "Matching details"
+          end
+
+          visit admin_claim_tasks_path(other_claim)
+
+          within ".app-task-list" do
+            expect(page).not_to have_content "Matching details"
+          end
+        end
+
+        it "doesn't show a warning" do
+          visit admin_claim_tasks_path(amended_claim)
+
+          expect(page).not_to have_content(
+            "Multiple claims with matching details have been made"
+          )
+
+          visit admin_claim_tasks_path(other_claim)
+
+          expect(page).not_to have_content(
+            "Multiple claims with matching details have been made"
+          )
+        end
+      end
+
+      context "when it is now a duplicate" do
+        context "when the other claim has been decided" do
+          let(:amended_claim) do
+            create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "edna-krabappel@springfield-elementary.edu"
+            )
+          end
+
+          let(:decided_claim) do
+            submit_a_claim
+          end
+
+          before do
+            amended_claim
+
+            decided_claim
+
+            sign_in_as_service_operator
+
+            # Decide claim
+            visit admin_claim_tasks_path(decided_claim)
+
+            click_on "Approve or reject this claim"
+
+            # click on approve
+            choose "Approve"
+
+            click_on "Confirm decision"
+
+            # Amend claim
+            visit new_admin_claim_amendment_path(amended_claim)
+
+            fill_in(
+              "Email address",
+              with: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            fill_in "Change notes", with: "Updated email address"
+
+            click_on "Amend claim"
+          end
+
+          it "adds a matching details task to the amended claim" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "doesn't add a new matching details task to the decided claim" do
+            visit admin_claim_tasks_path(decided_claim)
+
+            within ".app-task-list" do
+              expect(page).not_to have_content "Matching details"
+              expect(page).not_to have_content(
+                "Review matching details from other claims Passed"
+              )
+            end
+          end
+
+          it "shows the warning on both claims" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(decided_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+
+        context "when the other claim has not been decided" do
+          let(:amended_claim) do
+            create(
+              :claim,
+              :submitted,
+              policy: Policies::TargetedRetentionIncentivePayments,
+              email_address: "edna-krabappel@springfield-elementary.edu"
+            )
+          end
+
+          let(:other_claim) do
+            submit_a_claim
+          end
+
+          before do
+            amended_claim
+
+            other_claim
+
+            sign_in_as_service_operator
+
+            # Amend claim
+            visit new_admin_claim_amendment_path(amended_claim)
+
+            fill_in(
+              "Email address",
+              with: "seymour.skinner@springfield-elementary.edu"
+            )
+
+            fill_in "Change notes", with: "Updated email address"
+
+            click_on "Amend claim"
+          end
+
+          it "adds the matching details task to both claims" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+
+            visit admin_claim_tasks_path(other_claim)
+
+            within ".app-task-list" do
+              expect(page).to have_content "Matching details"
+            end
+          end
+
+          it "shows a warning on both claims" do
+            visit admin_claim_tasks_path(amended_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+
+            visit admin_claim_tasks_path(other_claim)
+
+            expect(page).to have_content(
+              "Multiple claims with matching details have been made"
+            )
+          end
+        end
+      end
+    end
+  end
+
+  def submit_a_claim
+    create(
+      :journey_configuration,
+      :further_education_payments
+    )
+
+    session = create(
+      :further_education_payments_session,
+      answers: attributes_for(
+        :further_education_payments_answers,
+        :submittable,
+        email_address: "seymour.skinner@springfield-elementary.edu"
+      )
+    )
+
+    form = Journeys::FurtherEducationPayments::CheckYourAnswersForm.new(
+      journey_session: session,
+      journey: Journeys::FurtherEducationPayments,
+      params: ActionController::Parameters.new(
+        claim: {
+          claimant_declaration: true
+        }
+      )
+    )
+
+    perform_enqueued_jobs do
+      expect(form.save).to be(true)
+    end
+
+    Claim.find_by!(journey_session: session)
+  end
+end

--- a/spec/features/admin/admin_duplicate_claims_task_spec.rb
+++ b/spec/features/admin/admin_duplicate_claims_task_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Admin matching claims task" do
+  before do
+    FeatureFlag.enable! :persist_matching_claims
+  end
+
   context "when a new claim is submitted" do
     context "when the claim is not a duplicate" do
       before do

--- a/spec/features/admin/admin_duplicate_claims_task_spec.rb
+++ b/spec/features/admin/admin_duplicate_claims_task_spec.rb
@@ -802,6 +802,79 @@ RSpec.describe "Admin matching claims task" do
           )
         end
       end
+
+      context "when a former duplicate still has matches" do
+        let(:other_duplicate) do
+          create(
+            :claim,
+            :submitted,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "edna.krabappel@springfield-elementary.edu",
+            national_insurance_number: "AB121212B"
+          )
+        end
+
+        let(:former_duplicate) do
+          create(
+            :claim,
+            :submitted,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu",
+            national_insurance_number: "AB121212B"
+          )
+        end
+
+        let(:amended_claim) do
+          submit_a_claim
+        end
+
+        before do
+          other_duplicate
+
+          former_duplicate
+
+          amended_claim
+
+          sign_in_as_service_operator
+
+          visit new_admin_claim_amendment_path(amended_claim)
+
+          fill_in(
+            "Email address",
+            with: "elisabeth.hoover@springfield-elementary.edu"
+          )
+
+          fill_in "Change notes", with: "Updated email address"
+
+          click_on "Amend claim"
+        end
+
+        it "removes the task from on the amended claim" do
+          visit admin_claim_tasks_path(amended_claim)
+
+          within ".app-task-list" do
+            expect(page).not_to have_content "Matching details"
+          end
+        end
+
+        it "keeps the task on the other duplicates" do
+          # claim is still a duplicate by NINO with another claim
+          visit admin_claim_tasks_path(other_duplicate)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+          end
+
+          visit admin_claim_tasks_path(former_duplicate)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+            click_on "Review matching details from other claims"
+          end
+
+          expect(page).to have_content other_duplicate.reference
+        end
+      end
     end
   end
 

--- a/spec/features/admin/admin_duplicate_claims_task_spec.rb
+++ b/spec/features/admin/admin_duplicate_claims_task_spec.rb
@@ -739,6 +739,66 @@ RSpec.describe "Admin matching claims task" do
         end
       end
     end
+
+    context "when a claim is reopened" do
+      context "when a duplicate claim has been submitted in the interim" do
+        let(:reopened_claim) do
+          create(
+            :claim,
+            :submitted,
+            policy: Policies::TargetedRetentionIncentivePayments,
+            email_address: "seymour.skinner@springfield-elementary.edu"
+          )
+        end
+
+        let(:duplicate_claim) do
+          submit_a_claim
+        end
+
+        before do
+          reopened_claim
+
+          create(:decision, :rejected, claim: reopened_claim)
+
+          duplicate_claim
+
+          sign_in_as_service_operator
+
+          visit new_admin_claim_amendment_path(reopened_claim)
+          click_link "Undo decision"
+          fill_in "Change notes", with: "test"
+          click_button "Undo rejection"
+        end
+
+        it "shows the matching details task on both claims" do
+          visit admin_claim_tasks_path(duplicate_claim)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+          end
+
+          visit admin_claim_tasks_path(reopened_claim)
+
+          within ".app-task-list" do
+            expect(page).to have_content "Matching details"
+          end
+        end
+
+        it "show the matching details warning on both claim" do
+          visit admin_claim_tasks_path(reopened_claim)
+
+          expect(page).to have_content(
+            "Multiple claims with matching details have been made"
+          )
+
+          visit admin_claim_tasks_path(duplicate_claim)
+
+          expect(page).to have_content(
+            "Multiple claims with matching details have been made"
+          )
+        end
+      end
+    end
   end
 
   def submit_a_claim

--- a/spec/features/admin/approvals_spec.rb
+++ b/spec/features/admin/approvals_spec.rb
@@ -178,7 +178,10 @@ RSpec.describe "Approvals" do
         click_on "Confirm decision"
 
         expect(page.body)
-          .to have_content(/Duplicate claims have already been approved with references #{approved_claim_1.reference}, #{approved_claim_2.reference}/)
+          .to have_content(/Duplicate claims have already been approved with references .*#{approved_claim_2.reference}.*/)
+
+        expect(page.body)
+          .to have_content(/Duplicate claims have already been approved with references .*#{approved_claim_1.reference}.*/)
       end
     end
   end

--- a/spec/models/automated_checks/claim_verifiers/matching_claims_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/matching_claims_spec.rb
@@ -106,15 +106,16 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
     end
 
     it "does not add a task to the source claim when it has been decided" do
-      other_claim = create_claim(
-        email_address: "duplicate@example.com",
-        created_at: 2.days.ago
-      )
       source_claim = create_claim(
         email_address: "duplicate@example.com",
         created_at: 1.day.ago
       )
       create(:decision, claim: source_claim, approved: true)
+
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
 
       described_class.new(claim: source_claim).perform
 

--- a/spec/models/automated_checks/claim_verifiers/matching_claims_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/matching_claims_spec.rb
@@ -1,0 +1,396 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
+  describe "#perform" do
+    it "does not add a task when the claim has no matches" do
+      claim = create_claim(email_address: "source@example.com")
+
+      described_class.new(claim: claim).perform
+
+      expect(claim.tasks.matching_details).to be_empty
+    end
+
+    it "adds an incomplete matching details task to both claims for a new match" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details.sole).not_to be_completed
+      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "does not add another task when a claim already has an incomplete task" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      source_task = create_incomplete_matching_details_task(source_claim)
+      other_task = create_incomplete_matching_details_task(other_claim)
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+    end
+
+    it "does not change a completed task when a new match is found" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      completed_task = create(
+        :task,
+        :passed,
+        claim: other_claim,
+        name: "matching_details"
+      )
+
+      described_class.new(claim: source_claim).perform
+
+      expect(other_claim.tasks.matching_details).to contain_exactly(completed_task)
+      expect(source_claim.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "does not add a task to a decided claim when a new match is found" do
+      decided_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      create(:decision, claim: decided_claim, approved: true)
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+
+      described_class.new(claim: source_claim).perform
+
+      expect(decided_claim.tasks.matching_details).to be_empty
+      expect(source_claim.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "does not change the source claim's completed task when a new match is found" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      completed_task = create(
+        :task,
+        :failed,
+        claim: source_claim,
+        name: "matching_details"
+      )
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(completed_task)
+      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "does not add a task to the source claim when it has been decided" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      create(:decision, claim: source_claim, approved: true)
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to be_empty
+      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "does not change tasks when the set of matching claims has not changed" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      source_task = create_incomplete_matching_details_task(source_claim)
+      other_task = create_incomplete_matching_details_task(other_claim)
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+    end
+
+    it "adds missing tasks when a persisted match has not changed" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details.sole).not_to be_completed
+      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "rolls back match changes when persisting a task fails" do
+      create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      invalid_task = Task.new
+      invalid_task.errors.add(:base, "task could not be saved")
+      error = ActiveRecord::RecordInvalid.new(invalid_task)
+      allow_any_instance_of(Task).to receive(:save!).and_raise(error)
+
+      expect {
+        described_class.new(claim: source_claim).perform
+      }.to raise_error(error)
+
+      expect(Claims::Match.matching_claims(source_claim)).to be_empty
+    end
+
+    it "removes incomplete tasks from both claims when their only match is removed" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      create_incomplete_matching_details_task(source_claim)
+      create_incomplete_matching_details_task(other_claim)
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to be_empty
+      expect(other_claim.tasks.matching_details).to be_empty
+    end
+
+    it "does not remove a completed task when a match is removed" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      create_incomplete_matching_details_task(source_claim)
+      completed_task = create(
+        :task,
+        :passed,
+        claim: other_claim,
+        name: "matching_details"
+      )
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to be_empty
+      expect(other_claim.tasks.matching_details).to contain_exactly(completed_task)
+    end
+
+    it "does not remove the source claim's completed task when a match is removed" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      completed_task = create(
+        :task,
+        :failed,
+        claim: source_claim,
+        name: "matching_details"
+      )
+      create_incomplete_matching_details_task(other_claim)
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(completed_task)
+      expect(other_claim.tasks.matching_details).to be_empty
+    end
+
+    it "does not remove a task from a decided claim when a match is removed" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      create_incomplete_matching_details_task(source_claim)
+      other_task = create_incomplete_matching_details_task(other_claim)
+      create(:decision, claim: other_claim, approved: true)
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to be_empty
+      expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+    end
+
+    it "does not remove the source claim's task when it has been decided" do
+      other_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 2.days.ago
+      )
+      source_claim = create_claim(
+        email_address: "duplicate@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      source_task = create_incomplete_matching_details_task(source_claim)
+      create_incomplete_matching_details_task(other_claim)
+      create(:decision, claim: source_claim, approved: true)
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect(other_claim.tasks.matching_details).to be_empty
+    end
+
+    it "keeps the other claim's task when it still has another match" do
+      source_claim = create_claim(
+        email_address: "source-and-other@example.com",
+        national_insurance_number: "AB000001C",
+        created_at: 3.days.ago
+      )
+      other_claim = create_claim(
+        email_address: "source-and-other@example.com",
+        national_insurance_number: "AB000002C",
+        created_at: 2.days.ago
+      )
+      remaining_match = create_claim(
+        email_address: "remaining@example.com",
+        national_insurance_number: "AB000002C",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, other_claim)
+      Claims::Match.create_match!(other_claim, remaining_match)
+      create_incomplete_matching_details_task(source_claim)
+      other_task = create_incomplete_matching_details_task(other_claim)
+      create_incomplete_matching_details_task(remaining_match)
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to be_empty
+      expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+      expect(remaining_match.tasks.matching_details.sole).not_to be_completed
+    end
+
+    it "keeps the source claim's task when it still has another match" do
+      source_claim = create_claim(
+        email_address: "removed@example.com",
+        national_insurance_number: "AB000001C",
+        created_at: 3.days.ago
+      )
+      removed_match = create_claim(
+        email_address: "removed@example.com",
+        national_insurance_number: "AB000002C",
+        created_at: 2.days.ago
+      )
+      remaining_match = create_claim(
+        email_address: "remaining@example.com",
+        national_insurance_number: "AB000001C",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, removed_match)
+      Claims::Match.create_match!(source_claim, remaining_match)
+      source_task = create_incomplete_matching_details_task(source_claim)
+      create_incomplete_matching_details_task(removed_match)
+      remaining_task = create_incomplete_matching_details_task(remaining_match)
+      source_claim.update!(email_address: "changed@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect(removed_match.tasks.matching_details).to be_empty
+      expect(remaining_match.tasks.matching_details).to contain_exactly(remaining_task)
+    end
+
+    it "handles a removed match and a new match in the same check" do
+      source_claim = create_claim(
+        email_address: "old@example.com",
+        created_at: 3.days.ago
+      )
+      removed_match = create_claim(
+        email_address: "old@example.com",
+        created_at: 2.days.ago
+      )
+      new_match = create_claim(
+        email_address: "new@example.com",
+        created_at: 1.day.ago
+      )
+      Claims::Match.create_match!(source_claim, removed_match)
+      source_task = create_incomplete_matching_details_task(source_claim)
+      create_incomplete_matching_details_task(removed_match)
+      source_claim.update!(email_address: "new@example.com")
+
+      described_class.new(claim: source_claim).perform
+
+      expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect(removed_match.tasks.matching_details).to be_empty
+      expect(new_match.tasks.matching_details.sole).not_to be_completed
+    end
+  end
+
+  def create_claim(email_address:, created_at: Time.current, national_insurance_number: nil)
+    attributes = {
+      email_address: email_address,
+      created_at: created_at,
+      academic_year: AcademicYear.current
+    }
+    attributes[:national_insurance_number] = national_insurance_number if national_insurance_number
+
+    create(:claim, :submitted, **attributes)
+  end
+
+  def create_incomplete_matching_details_task(claim)
+    task = claim.tasks.matching_details.new(name: "matching_details")
+    task.save!(context: :claim_verifier)
+    task
+  end
+end

--- a/spec/models/automated_checks/claim_verifiers/matching_claims_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/matching_claims_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
 
       described_class.new(claim: source_claim).perform
 
-      expect(source_claim.tasks.matching_details.sole).not_to be_completed
-      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(source_claim, other_claim)
+      expect_incomplete_matching_details_task(other_claim, source_claim)
     end
 
     it "does not add another task when a claim already has an incomplete task" do
@@ -42,6 +42,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
 
       expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
       expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+      expect_matching_claim_references(source_task, other_claim)
+      expect_matching_claim_references(other_task, source_claim)
     end
 
     it "does not change a completed task when a new match is found" do
@@ -63,7 +65,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
       described_class.new(claim: source_claim).perform
 
       expect(other_claim.tasks.matching_details).to contain_exactly(completed_task)
-      expect(source_claim.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(source_claim, other_claim)
     end
 
     it "does not add a task to a decided claim when a new match is found" do
@@ -80,7 +82,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
       described_class.new(claim: source_claim).perform
 
       expect(decided_claim.tasks.matching_details).to be_empty
-      expect(source_claim.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(source_claim, decided_claim)
     end
 
     it "does not change the source claim's completed task when a new match is found" do
@@ -102,7 +104,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
       described_class.new(claim: source_claim).perform
 
       expect(source_claim.tasks.matching_details).to contain_exactly(completed_task)
-      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(other_claim, source_claim)
     end
 
     it "does not add a task to the source claim when it has been decided" do
@@ -120,10 +122,10 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
       described_class.new(claim: source_claim).perform
 
       expect(source_claim.tasks.matching_details).to be_empty
-      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(other_claim, source_claim)
     end
 
-    it "does not change tasks when the set of matching claims has not changed" do
+    it "does not add tasks when the set of matching claims has not changed" do
       other_claim = create_claim(
         email_address: "duplicate@example.com",
         created_at: 2.days.ago
@@ -133,13 +135,15 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         created_at: 1.day.ago
       )
       Claims::Match.create_match!(source_claim, other_claim)
-      source_task = create_incomplete_matching_details_task(source_claim)
-      other_task = create_incomplete_matching_details_task(other_claim)
+      source_task = create_incomplete_matching_details_task(source_claim, matching_claims: [other_claim])
+      other_task = create_incomplete_matching_details_task(other_claim, matching_claims: [source_claim])
 
       described_class.new(claim: source_claim).perform
 
       expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
       expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+      expect_matching_claim_references(source_task, other_claim)
+      expect_matching_claim_references(other_task, source_claim)
     end
 
     it "adds missing tasks when a persisted match has not changed" do
@@ -155,8 +159,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
 
       described_class.new(claim: source_claim).perform
 
-      expect(source_claim.tasks.matching_details.sole).not_to be_completed
-      expect(other_claim.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(source_claim, other_claim)
+      expect_incomplete_matching_details_task(other_claim, source_claim)
     end
 
     it "rolls back match changes when persisting a task fails" do
@@ -190,8 +194,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         created_at: 1.day.ago
       )
       Claims::Match.create_match!(source_claim, other_claim)
-      create_incomplete_matching_details_task(source_claim)
-      create_incomplete_matching_details_task(other_claim)
+      create_incomplete_matching_details_task(source_claim, matching_claims: [other_claim])
+      create_incomplete_matching_details_task(other_claim, matching_claims: [source_claim])
       source_claim.update!(email_address: "changed@example.com")
 
       described_class.new(claim: source_claim).perform
@@ -210,7 +214,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         created_at: 1.day.ago
       )
       Claims::Match.create_match!(source_claim, other_claim)
-      create_incomplete_matching_details_task(source_claim)
+      create_incomplete_matching_details_task(source_claim, matching_claims: [other_claim])
       completed_task = create(
         :task,
         :passed,
@@ -241,7 +245,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         claim: source_claim,
         name: "matching_details"
       )
-      create_incomplete_matching_details_task(other_claim)
+      create_incomplete_matching_details_task(other_claim, matching_claims: [source_claim])
       source_claim.update!(email_address: "changed@example.com")
 
       described_class.new(claim: source_claim).perform
@@ -260,8 +264,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         created_at: 1.day.ago
       )
       Claims::Match.create_match!(source_claim, other_claim)
-      create_incomplete_matching_details_task(source_claim)
-      other_task = create_incomplete_matching_details_task(other_claim)
+      create_incomplete_matching_details_task(source_claim, matching_claims: [other_claim])
+      other_task = create_incomplete_matching_details_task(other_claim, matching_claims: [source_claim])
       create(:decision, claim: other_claim, approved: true)
       source_claim.update!(email_address: "changed@example.com")
 
@@ -269,6 +273,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
 
       expect(source_claim.tasks.matching_details).to be_empty
       expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
+      expect_matching_claim_references(other_task, source_claim)
     end
 
     it "does not remove the source claim's task when it has been decided" do
@@ -281,14 +286,15 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         created_at: 1.day.ago
       )
       Claims::Match.create_match!(source_claim, other_claim)
-      source_task = create_incomplete_matching_details_task(source_claim)
-      create_incomplete_matching_details_task(other_claim)
+      source_task = create_incomplete_matching_details_task(source_claim, matching_claims: [other_claim])
+      create_incomplete_matching_details_task(other_claim, matching_claims: [source_claim])
       create(:decision, claim: source_claim, approved: true)
       source_claim.update!(email_address: "changed@example.com")
 
       described_class.new(claim: source_claim).perform
 
       expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect_matching_claim_references(source_task, other_claim)
       expect(other_claim.tasks.matching_details).to be_empty
     end
 
@@ -310,16 +316,21 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
       )
       Claims::Match.create_match!(source_claim, other_claim)
       Claims::Match.create_match!(other_claim, remaining_match)
-      create_incomplete_matching_details_task(source_claim)
-      other_task = create_incomplete_matching_details_task(other_claim)
-      create_incomplete_matching_details_task(remaining_match)
+      create_incomplete_matching_details_task(source_claim, matching_claims: [other_claim])
+      other_task = create_incomplete_matching_details_task(
+        other_claim,
+        matching_claims: [source_claim, remaining_match]
+      )
+      remaining_task = create_incomplete_matching_details_task(remaining_match, matching_claims: [other_claim])
       source_claim.update!(email_address: "changed@example.com")
 
       described_class.new(claim: source_claim).perform
 
       expect(source_claim.tasks.matching_details).to be_empty
       expect(other_claim.tasks.matching_details).to contain_exactly(other_task)
-      expect(remaining_match.tasks.matching_details.sole).not_to be_completed
+      expect_matching_claim_references(other_task, remaining_match)
+      expect(remaining_match.tasks.matching_details).to contain_exactly(remaining_task)
+      expect_matching_claim_references(remaining_task, other_claim)
     end
 
     it "keeps the source claim's task when it still has another match" do
@@ -340,16 +351,21 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
       )
       Claims::Match.create_match!(source_claim, removed_match)
       Claims::Match.create_match!(source_claim, remaining_match)
-      source_task = create_incomplete_matching_details_task(source_claim)
-      create_incomplete_matching_details_task(removed_match)
-      remaining_task = create_incomplete_matching_details_task(remaining_match)
+      source_task = create_incomplete_matching_details_task(
+        source_claim,
+        matching_claims: [removed_match, remaining_match]
+      )
+      create_incomplete_matching_details_task(removed_match, matching_claims: [source_claim])
+      remaining_task = create_incomplete_matching_details_task(remaining_match, matching_claims: [source_claim])
       source_claim.update!(email_address: "changed@example.com")
 
       described_class.new(claim: source_claim).perform
 
       expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect_matching_claim_references(source_task, remaining_match)
       expect(removed_match.tasks.matching_details).to be_empty
       expect(remaining_match.tasks.matching_details).to contain_exactly(remaining_task)
+      expect_matching_claim_references(remaining_task, source_claim)
     end
 
     it "handles a removed match and a new match in the same check" do
@@ -366,15 +382,16 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
         created_at: 1.day.ago
       )
       Claims::Match.create_match!(source_claim, removed_match)
-      source_task = create_incomplete_matching_details_task(source_claim)
-      create_incomplete_matching_details_task(removed_match)
+      source_task = create_incomplete_matching_details_task(source_claim, matching_claims: [removed_match])
+      create_incomplete_matching_details_task(removed_match, matching_claims: [source_claim])
       source_claim.update!(email_address: "new@example.com")
 
       described_class.new(claim: source_claim).perform
 
-      expect(source_claim.tasks.matching_details).to contain_exactly(source_task)
+      expect(source_claim.tasks.matching_details).not_to include(source_task)
+      expect_incomplete_matching_details_task(source_claim, new_match)
       expect(removed_match.tasks.matching_details).to be_empty
-      expect(new_match.tasks.matching_details.sole).not_to be_completed
+      expect_incomplete_matching_details_task(new_match, source_claim)
     end
   end
 
@@ -389,9 +406,27 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::MatchingClaims do
     create(:claim, :submitted, **attributes)
   end
 
-  def create_incomplete_matching_details_task(claim)
-    task = claim.tasks.matching_details.new(name: "matching_details")
+  def create_incomplete_matching_details_task(claim, matching_claims: [])
+    task = claim.tasks.matching_details.new(
+      name: "matching_details",
+      data: {matching_claims: matching_claims.map(&:reference)}
+    )
     task.save!(context: :claim_verifier)
     task
+  end
+
+  def expect_incomplete_matching_details_task(claim, *matching_claims)
+    task = claim.tasks.matching_details.sole
+
+    expect(task).not_to be_completed
+    expect_matching_claim_references(task, *matching_claims)
+  end
+
+  def expect_matching_claim_references(task, *matching_claims)
+    data = task.reload.data || {}
+
+    expect(Array(data["matching_claims"] || data[:matching_claims])).to contain_exactly(
+      *matching_claims.map(&:reference)
+    )
   end
 end

--- a/spec/models/payment_confirmation_upload_spec.rb
+++ b/spec/models/payment_confirmation_upload_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe PaymentConfirmationUpload do
+  before do
+    # TODO - remove this once the backfill for persisting tasks has been run on
+    # production and we no longer need a shim for the policy task lists.
+    # The shim checks for matching claims and this spec is too tricky to modify
+    # to set the claims up realistically (ie they don't all have the same
+    # timestamp)
+    allow(AutomatedChecks::ClaimVerifiers::MatchingClaims).to(
+      receive(:new) { double(perform: true) }
+    )
+  end
+
   subject(:payment_confirmation_upload) do
     described_class.new(payroll_run, file, admin_user)
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
     OmniAuth.config.mock_auth[:dfe] = nil
     OmniAuth.config.mock_auth[:tid] = nil
     OmniAuth.config.mock_auth[:default] = nil
+    FeatureFlag.enable!(:persist_matching_claims)
   end
 
   config.filter_run_excluding :smoke


### PR DESCRIPTION
Persist matching details tasks

When a claim is changed we need to update the matching details tasks.
This is a bit tricky now we're persisting tasks rather than calculating
if the task is needed on the fly.

When a claim is changed we need to recalculate if the matching details
task is now required, or if it needs to be removed. If the claim is now
a duplicate we set the matching details task on it and any of it's
duplicate claims. If the claim is no longer a duplicate we remove the
matching details task from the claim and any of it's duplicates unless:
* the former duplicate has other duplicates
* the claim is persisted
* the matching details task has been completed

We don't "reset" a completed matching details task if a new duplicate is
found, this matches the existing behaviour. Whether or not we want to
undo the matching details task if a new duplicate is submitted, which
would be a change in behaviour, is a decision for the product team.

There's two scenarios where the behaviour on this branch is different from
master.

1.) Duplicate comes in for an already decided claim.
On master we add the matching details task to the task list on the decided
claim. On this branch we do not (though we still show the warning).
I think the behaviour on master is incorrect. For claims that have been decided
the task list shouldn't change, as it's a snap shot of what was done to approve
/ reject the claim.

2.) Matching details task was decided (approved / rejected) and the duplicate
was resolved by amending one of the claims.
On master the task is removed from the task list. On this branch the task
remains in the task list.
I think the behaviour on master is also incorrect. If the task has been
completed then it should remain in the task list. It's not much of a problem on
master, affecting only 5 out of the 15K claims we've tested against.
