### PR TITLE
Use normal logger in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -88,9 +88,17 @@ Rails.application.configure do
   config.hosts << "ecp.test"
 
   # https://technical-guidance.education.gov.uk/infrastructure/monitoring/logit/#ruby-on-rails
-  config.log_level = :debug                       # Or :info
-  config.log_format = :color                      # Console colorised non-json output
-  config.semantic_logger.backtrace_level = :debug # Show file and line number (expensive: not for production)
+  config.log_level = :debug # Or :info
+
+  # In development we prefer the plain Rails logger over rails_semantic_logger's
+  # structured output. Disabling `semantic` keeps the default Rails log
+  # subscribers (Started/Processing/Completed lines) instead of the semantic
+  # ones, and disabling the file appender stops it writing to log/*.json.
+  # The actual swap of Rails.logger back to a standard logger happens in
+  # config/initializers/use_standard_logger_in_development.rb, which runs after
+  # the engine has forced Rails.logger = SemanticLogger[Rails] during boot.
+  config.rails_semantic_logger.semantic = false
+  config.rails_semantic_logger.add_file_appender = false
 
   config.active_job.queue_adapter = :async
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -4,7 +4,9 @@ Rails.application.configure do
   config.log_tags = [:request_id]         # Prepend all log lines with the following tags
 end
 
-unless Rails.env.test?
+# Development uses the standard Rails logger (see config/environments/development.rb),
+# so there's no SemanticLogger appender to configure there.
+unless Rails.env.test? || Rails.env.development?
   SemanticLogger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: Rails.application.config.log_format)
   Rails.application.config.logger.info("Application logging to STDOUT")
 end

--- a/config/initializers/use_standard_logger_in_development.rb
+++ b/config/initializers/use_standard_logger_in_development.rb
@@ -1,0 +1,16 @@
+# In development we use the standard Rails logger instead of rails_semantic_logger.
+#
+# The rails_semantic_logger engine deletes Rails' own :initialize_logger
+# initializer and forces `Rails.logger = SemanticLogger[Rails]` during boot, so
+# we can't simply assign config.logger in config/environments/development.rb.
+# Files in config/initializers/ are loaded *after* the engine's
+# :initialize_logger initializer, so this is the earliest deterministic point at
+# which we can swap the logger back.
+#
+# Combined with `config.rails_semantic_logger.semantic = false` (set in
+# development.rb), this gives the plain, readable Rails log output.
+if Rails.env.development?
+  logger = ActiveSupport::Logger.new($stdout)
+  logger.formatter = Rails.application.config.log_formatter
+  Rails.logger = Rails.application.config.logger = ActiveSupport::TaggedLogging.new(logger)
+end


### PR DESCRIPTION
Semantic logger's output is hard to read.
