### PR TITLE
170/self serve service access links

### DIFF
--- a/app/controllers/admin/service_access_links_controller.rb
+++ b/app/controllers/admin/service_access_links_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class ServiceAccessLinksController < BaseAdminController
+    before_action :ensure_service_operator
+
+    def show
+      @service_access_code = Journeys::ServiceAccessCode.find params[:id]
+    end
+
+    def create
+      journey_routing_name = params.expect("journey")
+
+      journey = Journeys.for_routing_name(journey_routing_name)
+
+      raise ActiveRecord::RecordNotFound unless journey
+
+      code = Journeys::ServiceAccessCode.create!(journey: journey)
+
+      redirect_to admin_service_access_link_path(code)
+    end
+  end
+end

--- a/app/models/journeys/service_access_code.rb
+++ b/app/models/journeys/service_access_code.rb
@@ -19,6 +19,10 @@ module Journeys
       update!(used: true)
     end
 
+    def journey_class
+      journey.constantize
+    end
+
     private
 
     def generate_code

--- a/app/models/journeys/service_access_code.rb
+++ b/app/models/journeys/service_access_code.rb
@@ -12,7 +12,12 @@ module Journeys
     validates :code, presence: true, uniqueness: true
 
     def self.permits_access?(code:, journey:)
-      code.present? && for_journey(journey).unused.exists?(code: code)
+      return false unless code.present?
+
+      link = for_journey(journey).find_by(code: code)
+      return false unless link
+
+      link.active?
     end
 
     def mark_as_used!
@@ -21,6 +26,18 @@ module Journeys
 
     def journey_class
       journey.constantize
+    end
+
+    def expires_at
+      created_at + 30.days
+    end
+
+    def expired?
+      expires_at.past?
+    end
+
+    def active?
+      !used && !expired?
     end
 
     private

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -109,3 +109,16 @@
 <% if lookup_context.exists?("admin/journey_configurations/_edit_#{journey_configuration.routing_name.underscore}") %>
   <%= render partial: "admin/journey_configurations/edit_#{journey_configuration.routing_name.underscore}" %>
 <% end %>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Create a service access link</h2>
+
+    <%= govuk_button_to(
+      "Generate a new service access link",
+      admin_service_access_links_path(journey: journey_configuration.routing_name)
+    ) %>
+  </div>
+</div>

--- a/app/views/admin/service_access_links/show.html.erb
+++ b/app/views/admin/service_access_links/show.html.erb
@@ -40,11 +40,17 @@
       <strong>Send this link to the claimant</strong>
     </p>
 
-    <pre>
-      <%= landing_page_url(
+    <%= text_field_tag(
+      "service_access_link",
+      landing_page_url(
         @service_access_code.journey_class.routing_name,
         service_access_code: @service_access_code.code
-      ) %>
-    </pre>
+      ),
+      class: "govuk-input",
+      readonly: true,
+      data: {
+        copy_to_clipboard: "true"
+      }
+    ) %>
   </div>
 </div>

--- a/app/views/admin/service_access_links/show.html.erb
+++ b/app/views/admin/service_access_links/show.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:page_title) { page_title("Service access link") } %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link(
+    href: edit_admin_journey_configuration_path(
+      @service_access_code.journey_class.configuration
+    )
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-xl">
+      <%= @service_access_code.journey_class.journey_name %>
+    </span>
+
+    <h1 class="govuk-heading-xl">
+      Service access link
+    </h1>
+
+    <p class="govuk-body">
+      This link will allow a claimant access to a closed service.
+    </p>
+
+    <p class="govuk-body">
+      The link will remain active until the claimant submits a claim.
+    </p>
+
+    <p class="govuk-body">
+      They can restart the journey as many times as they like.
+    </p>
+
+    <p class="govuk-body">
+      <strong>Send this link to the claimant</strong>
+    </p>
+
+    <pre>
+      <%= landing_page_url(
+        @service_access_code.journey_class.routing_name,
+        service_access_code: @service_access_code.code
+      ) %>
+    </pre>
+  </div>
+</div>

--- a/app/views/admin/service_access_links/show.html.erb
+++ b/app/views/admin/service_access_links/show.html.erb
@@ -23,11 +23,17 @@
     </p>
 
     <p class="govuk-body">
-      The link will remain active until the claimant submits a claim.
+      This link will expire
+      on <strong><%= l(@service_access_code.expires_at.to_date) %></strong>
     </p>
 
     <p class="govuk-body">
-      They can restart the journey as many times as they like.
+      The link can only be used to submit one claim.
+    </p>
+
+    <p class="govuk-body">
+      Until the link expires, the claimant can restart the journey as many times
+      as they like.
     </p>
 
     <p class="govuk-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,8 @@ Rails.application.routes.draw do
       resource :flagged_providers_csv, only: [:update]
     end
 
+    resources :service_access_links, only: [:create, :show]
+
     get "refresh-session", to: "sessions#refresh", as: :refresh_session
 
     patch "allocate/:id", to: "allocations#allocate", as: :allocate

--- a/spec/features/admin/admin_service_access_links_spec.rb
+++ b/spec/features/admin/admin_service_access_links_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Admin service access links" do
+  before do
+    create(
+      :journey_configuration,
+      :further_education_payments,
+      :closed,
+      availability_message: "This service is closed for submissions"
+    )
+
+    allow(Reference).to receive(:new) { double(to_s: "ABCDEFG") }
+  end
+
+  it "allows an admin to create a service access code" do
+    sign_in_as_service_operator
+
+    visit "/admin"
+
+    click_on "Manage services"
+
+    click_on "Change Claim a targeted retention incentive payment for further education teachers"
+
+    click_on "Generate a new service access link"
+
+    expect(page).to have_content(
+      landing_page_url(
+        "further-education-payments",
+        service_access_code: "ABCDEFG"
+      )
+    )
+  end
+end

--- a/spec/features/admin/admin_service_access_links_spec.rb
+++ b/spec/features/admin/admin_service_access_links_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe "Admin service access links" do
 
     click_on "Generate a new service access link"
 
-    expect(page).to have_content(
+    link_field = find("#service_access_link")
+
+    expect(link_field[:value]).to eq(
       landing_page_url(
         "further-education-payments",
         service_access_code: "ABCDEFG"

--- a/spec/models/journeys/service_access_code_spec.rb
+++ b/spec/models/journeys/service_access_code_spec.rb
@@ -118,7 +118,23 @@ RSpec.describe Journeys::ServiceAccessCode, type: :model do
       end
     end
 
-    context "when the code is for the correct journey and unused" do
+    context "when the code is expired" do
+      it "returns false" do
+        journey = Journeys::FurtherEducationPayments
+
+        code = nil
+
+        travel_to 31.days.ago do
+          code = create(:service_access_code, journey: journey).code
+        end
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be false
+      end
+    end
+
+    context "when the code is for the correct journey, unused, not expired" do
       it "returns true" do
         journey = Journeys::FurtherEducationPayments
 


### PR DESCRIPTION
# Make generating service access links self serve

Previously the ops team would have to reach out to us devs to generate these
service access links. The requests are frequent enough that we want to make this
self serve.
