### PR TITLE
show matching claims task on task list

### DIFF
--- a/app/models/admin/task_list_form.rb
+++ b/app/models/admin/task_list_form.rb
@@ -11,7 +11,7 @@ module Admin
         end
 
         def display_status
-          if status == "na"
+          if status == "not_applicable"
             "N/A"
           else
             status.humanize
@@ -19,13 +19,7 @@ module Admin
         end
 
         def filter_status
-          if status == "no data" && TASK_STATUSES.fetch(name, {}).include?("no_data")
-            "no_data"
-          elsif status == "na" || status == "no data"
-            "incomplete"
-          else
-            status.tr(" ", "_")
-          end
+          status
         end
       end
 
@@ -60,9 +54,9 @@ module Admin
         @tasks ||= available_tasks.map do |task_name|
           if claim_tasks.include?(task_name)
             status, colour = ::Tasks.status(claim: claim, task_name: task_name)
-            Task.new(task_name, status, colour)
+            Task.new(task_name, status.downcase.tr(" ", "_"), colour)
           else
-            Task.new(task_name, "na", "blue")
+            Task.new(task_name, "not_applicable", "blue")
           end
         end
       end
@@ -75,8 +69,7 @@ module Admin
 
       def claim_tasks
         @claim_tasks ||= claim.policy::ClaimCheckingTasks.new(
-          claim,
-          skip_matching_claims_check: true
+          claim
         ).applicable_task_names
       end
     end
@@ -187,28 +180,37 @@ module Admin
     end
 
     def policy_tasks
-      TASKS.fetch(policy).excluding("matching_details")
+      TASKS.fetch(policy)
     end
 
     def selected_statuses_for(task_key)
       statuses.fetch(task_key.to_s, []).compact_blank
     end
 
-    DEFAULT_STATUSES = %w[passed failed incomplete].freeze
+    DEFAULT_STATUSES = %w[passed failed incomplete not_applicable].freeze
 
     TASK_STATUSES = {
+      "one_login_identity" => %w[
+        passed
+        failed
+        incomplete
+        no_data
+        not_applicable
+      ],
       "identity_confirmation" => %w[
         passed
         failed
         partial_match
         no_match
         incomplete
+        not_applicable
       ],
       "qualifications" => %w[
         passed
         failed
         no_match
         incomplete
+        not_applicable
       ],
       "census_subjects_taught" => %w[
         passed
@@ -216,6 +218,7 @@ module Admin
         no_match
         no_data
         incomplete
+        not_applicable
       ],
       "employment" => %w[
         passed
@@ -223,6 +226,7 @@ module Admin
         no_match
         no_data
         incomplete
+        not_applicable
       ],
       "student_loan_amount" => %w[
         passed
@@ -230,6 +234,7 @@ module Admin
         no_match
         no_data
         incomplete
+        not_applicable
       ],
       "student_loan_plan" => %w[
         passed
@@ -237,6 +242,7 @@ module Admin
         no_match
         no_data
         incomplete
+        not_applicable
       ]
     }
 

--- a/app/models/policies/claim_checking_tasks.rb
+++ b/app/models/policies/claim_checking_tasks.rb
@@ -2,9 +2,8 @@ module Policies
   class ClaimCheckingTasks
     attr_reader :claim
 
-    def initialize(claim, skip_matching_claims_check: false)
+    def initialize(claim)
       @claim = claim
-      @skip_matching_claims_check = skip_matching_claims_check
     end
 
     delegate :policy, to: :claim
@@ -47,18 +46,6 @@ module Policies
         # modify `claim.tasks`.
         claim.tasks.find_by(name: name) || Task.new(name: name, claim:)
       end
-    end
-
-    def skip_matching_claims_check?
-      !!@skip_matching_claims_check
-    end
-
-    def matching_claims
-      return @matching_claims if defined?(@matching_claims)
-
-      return Claim.none if skip_matching_claims_check?
-
-      @matching_claims = Claim::MatchingAttributeFinder.new(claim).matching_claims
     end
 
     def task_exists?(name)

--- a/app/models/policies/early_career_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_career_payments/claim_checking_tasks.rb
@@ -13,7 +13,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/early_years_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_payments/claim_checking_tasks.rb
@@ -11,7 +11,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
 
         tasks
       end

--- a/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/early_years_teachers_financial_incentive_payments/claim_checking_tasks.rb
@@ -11,7 +11,7 @@ module Policies
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
 
         tasks
       end

--- a/app/models/policies/further_education_payments/claim_checking_tasks.rb
+++ b/app/models/policies/further_education_payments/claim_checking_tasks.rb
@@ -16,7 +16,7 @@ module Policies
         tasks << "employment" if claim.eligibility.teacher_reference_number.present?
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
         tasks << "fe_provider_check" if task_exists?("fe_provider_check")
 

--- a/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
+++ b/app/models/policies/international_relocation_payments/claim_checking_tasks.rb
@@ -20,7 +20,7 @@ module Policies
         tasks << "employment_history" if claim.eligibility.changed_workplace_or_new_contract?
         tasks << "continuous_employment"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_amount"
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/claim_checking_tasks.rb
@@ -12,7 +12,7 @@ module Policies
         tasks << "employment"
         tasks << "student_loan_plan" if claim.submitted_without_slc_data?
         tasks << "payroll_details" if claim.must_manually_validate_bank_details?
-        tasks << "matching_details" if FeatureFlag.enabled?(:persist_matching_claims) ? task_exists?("matching_details") : matching_claims.exists?
+        tasks << "matching_details" if task_exists?("matching_details")
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks

--- a/spec/features/admin/admin_duplicate_claims_task_spec.rb
+++ b/spec/features/admin/admin_duplicate_claims_task_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Admin matching claims task" do
-  before do
-    FeatureFlag.enable! :persist_matching_claims
-  end
-
   context "when a new claim is submitted" do
     context "when the claim is not a duplicate" do
       before do
@@ -889,56 +885,6 @@ RSpec.describe "Admin matching claims task" do
           expect(page).to have_content other_duplicate.reference
         end
       end
-    end
-  end
-
-  # The feature flag exists so we can cut back to the old behaviour if
-  # something goes wrong. Once the backfill has run there are persisted
-  # `matching_details` tasks with `passed: nil` in the database, and turning the
-  # flag off has to leave those claims in a state an operator can still work.
-  context "when the feature flag is turned off after tasks have been persisted" do
-    let(:existing_claim) do
-      create(
-        :claim,
-        :submitted,
-        policy: Policies::TargetedRetentionIncentivePayments,
-        email_address: "seymour.skinner@springfield-elementary.edu"
-      )
-    end
-
-    let(:new_claim) { submit_a_claim }
-
-    before do
-      existing_claim
-
-      new_claim
-
-      FeatureFlag.disable!(:persist_matching_claims)
-
-      sign_in_as_service_operator
-    end
-
-    it "still shows the matching details task on the task list" do
-      visit admin_claim_tasks_path(new_claim)
-
-      within ".app-task-list" do
-        expect(page).to have_content "Matching details"
-      end
-    end
-
-    it "lets the operator answer the unanswered task" do
-      visit admin_claim_task_path(new_claim, name: "matching_details")
-
-      expect(new_claim.tasks.matching_details.sole.passed).to be_nil
-
-      expect(page).to have_field("Yes")
-      expect(page).to have_button("Save and continue")
-
-      choose "Yes"
-
-      click_on "Save and continue"
-
-      expect(new_claim.tasks.matching_details.sole.reload.passed).to be(true)
     end
   end
 

--- a/spec/features/admin/task_lists_spec.rb
+++ b/spec/features/admin/task_lists_spec.rb
@@ -270,4 +270,119 @@ RSpec.feature "Admin task list filtering" do
     expect(page).not_to have_content("EMPNONE")
     expect(page).not_to have_content("EMPNODAT")
   end
+
+  scenario "filters claims by duplicate status" do
+    FeatureFlag.enable!(:persist_matching_claims)
+
+    create(
+      :claim,
+      :submitted,
+      :current_academic_year,
+      policy: Policies::TargetedRetentionIncentivePayments,
+      reference: "AAAAAA"
+    )
+
+    claim_with_completed_task = create(
+      :claim,
+      :submitted,
+      :current_academic_year,
+      policy: Policies::TargetedRetentionIncentivePayments,
+      reference: "BBBBBB",
+      national_insurance_number: "AB123456C"
+    )
+
+    claim_with_failed_task = create(
+      :claim,
+      :submitted,
+      :current_academic_year,
+      policy: Policies::TargetedRetentionIncentivePayments,
+      reference: "CCCCCC",
+      national_insurance_number: "AB123456C"
+    )
+
+    create(
+      :claim,
+      :submitted,
+      :current_academic_year,
+      policy: Policies::TargetedRetentionIncentivePayments,
+      reference: "DDDDDD",
+      national_insurance_number: "AB123456C"
+    )
+
+    Claim.all.each do |claim|
+      AutomatedChecks::ClaimVerifiers::MatchingClaims.new(claim: claim).perform
+    end
+
+    claim_with_completed_task.tasks.matching_details.sole.update!(passed: true)
+
+    claim_with_failed_task.tasks.matching_details.sole.update!(passed: false)
+
+    sign_in_as_service_operator
+
+    visit admin_task_lists_path
+
+    click_on "School Targeted Retention Incentive"
+
+    expect(page).to have_content("4 claims found")
+    expect(page).to have_content("AAAAAA")
+    expect(page).to have_content("BBBBBB")
+    expect(page).to have_content("CCCCCC")
+    expect(page).to have_content("DDDDDD")
+
+    click_on "Show filters"
+
+    within_fieldset "Matching details" do
+      uncheck "Passed"
+      uncheck "Failed"
+      uncheck "Incomplete"
+      check "Not applicable"
+    end
+
+    click_on "Apply"
+
+    expect(page).to have_content("1 claims found")
+    expect(page).to have_content("AAAAAA")
+    expect(page).not_to have_content("BBBBBB")
+    expect(page).not_to have_content("CCCCCC")
+    expect(page).not_to have_content("DDDDDD")
+
+    within_fieldset "Matching details" do
+      uncheck "Not applicable"
+      check "Passed"
+    end
+
+    click_on "Apply"
+
+    expect(page).to have_content("1 claims found")
+    expect(page).to have_content("BBBBBB")
+    expect(page).not_to have_content("AAAAAA")
+    expect(page).not_to have_content("CCCCCC")
+    expect(page).not_to have_content("DDDDDD")
+
+    within_fieldset "Matching details" do
+      uncheck "Passed"
+      check "Failed"
+    end
+
+    click_on "Apply"
+
+    expect(page).to have_content("1 claims found")
+    expect(page).to have_content("CCCCCC")
+    expect(page).not_to have_content("AAAAAA")
+    expect(page).not_to have_content("BBBBBB")
+    expect(page).not_to have_content("DDDDDD")
+
+    within_fieldset "Matching details" do
+      uncheck "Failed"
+      check "Incomplete"
+    end
+
+    click_on "Apply"
+
+    expect(page).to have_content("1 claims found")
+    expect(page).to have_content("DDDDDD")
+    expect(page).not_to have_content("AAAAAA")
+    expect(page).not_to have_content("BBBBBB")
+    expect(page).not_to have_content("CCCCCC")
+  end
 end

--- a/spec/models/admin/task_list_form_spec.rb
+++ b/spec/models/admin/task_list_form_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Admin::TaskListForm do
 
         expect(claim_1_presenter.task("ey_eoi_cross_reference").status).to eq("passed")
         expect(claim_1_presenter.task("one_login_identity").status).to eq("incomplete")
-        expect(claim_1_presenter.task("ey_alternative_verification").status).to eq("na")
+        expect(claim_1_presenter.task("ey_alternative_verification").status).to eq("not_applicable")
         expect(claim_1_presenter.task("employment").status).to eq("failed")
         expect(claim_1_presenter.task("student_loan_plan").status).to eq("incomplete")
         expect(claim_1_presenter.task("payroll_details").status).to eq("incomplete")
@@ -65,7 +65,7 @@ RSpec.describe Admin::TaskListForm do
 
         expect(claim_2_presenter.task("ey_eoi_cross_reference").status).to eq("failed")
         expect(claim_2_presenter.task("one_login_identity").status).to eq("incomplete")
-        expect(claim_2_presenter.task("ey_alternative_verification").status).to eq("na")
+        expect(claim_2_presenter.task("ey_alternative_verification").status).to eq("not_applicable")
         expect(claim_2_presenter.task("employment").status).to eq("passed")
         expect(claim_2_presenter.task("student_loan_plan").status).to eq("incomplete")
         expect(claim_2_presenter.task("payroll_details").status).to eq("incomplete")
@@ -570,109 +570,50 @@ RSpec.describe Admin::TaskListForm do
     it "returns match-based statuses for employment" do
       form = described_class.new(policy_name: "early_years_payments")
       expect(form.task_statuses("employment")).to eq(
-        %w[passed failed no_match no_data incomplete]
+        %w[passed failed no_match no_data incomplete not_applicable]
       )
     end
 
     it "returns match-based statuses for identity confirmation" do
       form = described_class.new(policy_name: "targeted_retention_incentive_payments")
       expect(form.task_statuses("identity_confirmation")).to eq(
-        %w[passed failed partial_match no_match incomplete]
+        %w[passed failed partial_match no_match incomplete not_applicable]
       )
     end
 
     it "returns match-based statuses for qualifications" do
       form = described_class.new(policy_name: "targeted_retention_incentive_payments")
       expect(form.task_statuses("qualifications")).to eq(
-        %w[passed failed no_match incomplete]
+        %w[passed failed no_match incomplete not_applicable]
       )
     end
 
     it "returns no-data statuses for census subjects taught" do
       form = described_class.new(policy_name: "targeted_retention_incentive_payments")
       expect(form.task_statuses("census_subjects_taught")).to eq(
-        %w[passed failed no_match no_data incomplete]
+        %w[passed failed no_match no_data incomplete not_applicable]
       )
     end
 
     it "returns no-data statuses for student loan plan" do
       form = described_class.new(policy_name: "early_years_payments")
       expect(form.task_statuses("student_loan_plan")).to eq(
-        %w[passed failed no_match no_data incomplete]
+        %w[passed failed no_match no_data incomplete not_applicable]
       )
     end
 
     it "returns standard statuses for non-employment tasks" do
       form = described_class.new(policy_name: "early_years_payments")
       expect(form.task_statuses("ey_eoi_cross_reference")).to eq(
-        %w[passed failed incomplete]
+        %w[passed failed incomplete not_applicable]
       )
     end
 
     it "returns standard statuses for payroll gender" do
       form = described_class.new(policy_name: "early_years_payments")
       expect(form.task_statuses("payroll_gender")).to eq(
-        %w[passed failed incomplete]
+        %w[passed failed incomplete not_applicable]
       )
-    end
-  end
-
-  describe Admin::TaskListForm::ClaimPresenter::Task do
-    describe "#filter_status" do
-      it "returns 'no_match' for employment tasks with 'no match' status" do
-        task = described_class.new("employment", "No match", "red")
-        expect(task.filter_status).to eq("no_match")
-      end
-
-      it "returns 'full_match' for tasks with 'full match' status" do
-        task = described_class.new("identity_confirmation", "Full match", "green")
-        expect(task.filter_status).to eq("full_match")
-      end
-
-      it "returns 'partial_match' for tasks with 'partial match' status" do
-        task = described_class.new("identity_confirmation", "Partial match", "yellow")
-        expect(task.filter_status).to eq("partial_match")
-      end
-
-      it "returns 'no_match' for tasks with 'no match' status" do
-        task = described_class.new("identity_confirmation", "No match", "red")
-        expect(task.filter_status).to eq("no_match")
-      end
-
-      it "returns 'no_data' for employment tasks with 'no data' status" do
-        task = described_class.new("employment", "No data", "red")
-        expect(task.filter_status).to eq("no_data")
-      end
-
-      it "returns 'passed' for employment tasks with 'passed' status" do
-        task = described_class.new("employment", "Passed", "green")
-        expect(task.filter_status).to eq("passed")
-      end
-
-      it "returns 'failed' for employment tasks with 'failed' status" do
-        task = described_class.new("employment", "Failed", "red")
-        expect(task.filter_status).to eq("failed")
-      end
-
-      it "returns 'incomplete' for employment tasks with 'na' status" do
-        task = described_class.new("employment", "na", "blue")
-        expect(task.filter_status).to eq("incomplete")
-      end
-
-      it "returns 'no_data' for tasks with a no data status" do
-        task = described_class.new("census_subjects_taught", "No data", "red")
-        expect(task.filter_status).to eq("no_data")
-      end
-
-      it "returns 'incomplete' for non-employment tasks with 'no data' failure reasons" do
-        task = described_class.new("one_login_identity", "No data", "red")
-        expect(task.filter_status).to eq("incomplete")
-      end
-
-      it "returns 'incomplete' for non-employment tasks with 'na' status" do
-        task = described_class.new("identity_confirmation", "na", "blue")
-        expect(task.filter_status).to eq("incomplete")
-      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,7 +85,6 @@ RSpec.configure do |config|
     OmniAuth.config.mock_auth[:dfe] = nil
     OmniAuth.config.mock_auth[:tid] = nil
     OmniAuth.config.mock_auth[:default] = nil
-    FeatureFlag.enable!(:persist_matching_claims)
   end
 
   config.filter_run_excluding :smoke


### PR DESCRIPTION
Enable matching details task on claim task list.
Now the matching details task is persisted we can add the task to the admin task
list filters without slowing the page to a crawl.
This pr also fixes how the task list handles "not_applicable" tasks. Previously
the task list was conflating incomplete and not applicable, we need to be able
to separate these tasks statuses.

We also remove the "persist_matching_claims" feature flag as the back fill has
been run on production.
