### PR TITLE
Fix reinstated dsi users

### DIFF
--- a/app/models/dfe_sign_in/user.rb
+++ b/app/models/dfe_sign_in/user.rb
@@ -25,10 +25,9 @@ module DfeSignIn
     def self.from_session(session:, user_type:)
       user = where(dfe_sign_in_id: session.user_id, user_type:).first_or_initialize
 
-      return if user.deleted?
-
       user.role_codes = session.role_codes
       user.current_organisation_ukprn = session.organisation_ukprn
+      user.deleted_at = nil
 
       user
     end

--- a/spec/features/further_education_payments/providers/provider_verification_access_spec.rb
+++ b/spec/features/further_education_payments/providers/provider_verification_access_spec.rb
@@ -274,43 +274,4 @@ RSpec.feature "Provider verification access control", feature_flag: [:fe_provide
       )
     end
   end
-
-  context "when the user was deleted" do
-    it "shows authorization failure page with no service access" do
-      create(
-        :dfe_signin_user,
-        dfe_sign_in_id: "11111",
-        deleted_at: Time.zone.now,
-        user_type: "provider"
-      )
-
-      mock_dfe_sign_in_auth_session(
-        provider: :dfe_fe_provider,
-        auth_hash: {
-          uid: "11111",
-          extra: {
-            raw_info: {
-              organisation: {
-                id: "22222",
-                ukprn: fe_provider.ukprn
-              }
-            }
-          }
-        }
-      )
-
-      stub_dfe_sign_in_user_info_request(
-        "11111",
-        "22222",
-        Policies::FurtherEducationPayments::CLAIM_VERIFIER_DFE_SIGN_IN_ROLE_CODE,
-        user_type: "provider"
-      )
-
-      visit new_further_education_payments_providers_session_path
-
-      click_on "Start now"
-
-      expect(page).to have_content("You do not have access to this service")
-    end
-  end
 end

--- a/spec/models/dfe_sign_in/user_spec.rb
+++ b/spec/models/dfe_sign_in/user_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe DfeSignIn::User, type: :model do
       expect(user.dfe_sign_in_id).to eq("123")
       expect(user.role_codes).to eq(["some-role"])
     end
-
-    it "does not match deleted users" do
-      create(:dfe_signin_user, :deleted, dfe_sign_in_id: session.user_id, role_codes: [])
-      expect(user).to be_nil
-    end
   end
 
   describe "#full_name" do

--- a/spec/requests/admin/admin_authentication_spec.rb
+++ b/spec/requests/admin/admin_authentication_spec.rb
@@ -83,23 +83,6 @@ RSpec.describe "Admin authentication", type: :request do
       end
     end
 
-    context "when the user is deleted" do
-      let!(:user) { create(:dfe_signin_user, :deleted) }
-
-      it "returns an Unauthorised response and doesn’t set a session" do
-        stub_dfe_sign_in_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
-        post "/admin/auth/dfe"
-        expect(response).to redirect_to(admin_auth_callback_path)
-        follow_redirect!
-
-        expect(session[:user_id]).to be_nil
-        expect(session[:token]).to be_nil
-
-        expect(response.code).to eq("401")
-        expect(response.body).to include("Not authorised")
-      end
-    end
-
     context "when the callback from DfE Sign-in is for invalid credentials" do
       it "redirects to the auth failure page and doesn’t set a session" do
         OmniAuth.config.mock_auth[:dfe] = :invalid_credentials


### PR DESCRIPTION
There's an issue where
* A user is removed from DSI
* The daily `DfeSignIn::UserDataImporterJob` runs and marks the user as
  deleted
* The user is reinstated in DSI
* The user tries to sign in before the daily
  `DfeSignIn::UserDataImporterJob` has run

Before the job has run the user can't access the admin site, even though
they have access in DfE sign.

The `DfeSignIn::UserDataImporterJob` determines which users to mark as
deleted by finding the users who exist in our database but not in our
service in dfe signin.
Given `DfeSignIn::User.from_session` is populated with the oauth payload
from DSI after the user has been redirected to our service, we can infer
the user has access to our service so the `user.deleted?` check isn't
achieving anything (other than causing this edge case bug for reinstated
users).
