### PR TITLE
Speed up payroll index page

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -5,9 +5,14 @@ module Admin
     before_action :ensure_service_operator
 
     def index
-      @payroll_runs = PayrollRun
-        .includes(:payments, :payment_confirmations)
-        .order(created_at: :desc)
+      @payroll_runs = if FeatureFlag.enabled?(:payroll_speed_up)
+        PayrollRun
+          .order(created_at: :desc)
+      else
+        PayrollRun
+          .includes(:payments, :payment_confirmations)
+          .order(created_at: :desc)
+      end
     end
 
     def new

--- a/app/jobs/payroll_run_back_fill_job.rb
+++ b/app/jobs/payroll_run_back_fill_job.rb
@@ -1,0 +1,17 @@
+class PayrollRunBackFillJob < ApplicationJob
+  def perform
+    payroll_runs = PayrollRun
+      .includes(:payments, :payment_confirmations)
+      .order(created_at: :desc)
+
+    payroll_runs.each do |payroll_run|
+      payroll_run.update!(
+        claims_count: payroll_run.number_of_claims_for_policy(:all, filter: :claims),
+        topups_count: payroll_run.number_of_claims_for_policy(:all, filter: :topups),
+        total_confirmed_payments: payroll_run.payments.where.not(confirmation: nil).count,
+        payments_count: payroll_run.payments.count,
+        payment_confirmation_uploaded: payroll_run.payment_confirmations.any?
+      )
+    end
+  end
+end

--- a/app/jobs/payroll_run_job.rb
+++ b/app/jobs/payroll_run_job.rb
@@ -24,6 +24,13 @@ class PayrollRunJob < ApplicationJob
         Event.insert_all(grouped_claim_attributes, record_timestamps: true)
       end
 
+      payroll_run.update!(
+        claims_count: payroll_run.number_of_claims_for_policy(:all, filter: :claims),
+        topups_count: payroll_run.number_of_claims_for_policy(:all, filter: :topups),
+        total_confirmed_payments: 0,
+        payments_count: payroll_run.payments.count
+      )
+
       payroll_run.complete!
     end
   rescue => e

--- a/app/models/payment_confirmation_upload.rb
+++ b/app/models/payment_confirmation_upload.rb
@@ -42,6 +42,11 @@ class PaymentConfirmationUpload
 
       raise ActiveRecord::Rollback if errors.any?
 
+      payroll_run.update!(
+        total_confirmed_payments: payroll_run.payments.where.not(confirmation: nil).count,
+        payment_confirmation_uploaded: true
+      )
+
       payments.each_with_index do |payment, index|
         ApplicationMailer.deliver_later_with_throttling(
           PaymentMailer.confirmation(payment),

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -21,6 +21,30 @@ class PayrollRun < ApplicationRecord
       Rails.env.development?
   end
 
+  def claims_count
+    if FeatureFlag.enabled?(:payroll_speed_up)
+      super
+    else
+      number_of_claims_for_policy(:all, filter: :claims)
+    end
+  end
+
+  def topups_count
+    if FeatureFlag.enabled?(:payroll_speed_up)
+      super
+    else
+      number_of_claims_for_policy(:all, filter: :topups)
+    end
+  end
+
+  def total_confirmed_payments
+    if FeatureFlag.enabled?(:payroll_speed_up)
+      super
+    else
+      payments.where.not(confirmation: nil).count
+    end
+  end
+
   def total_award_amount
     payments.sum(:award_amount)
   end
@@ -31,10 +55,6 @@ class PayrollRun < ApplicationRecord
 
   def total_claim_amount_for_policy(policy, filter: :all)
     line_items(policy, filter: filter).sum(&:award_amount)
-  end
-
-  def total_confirmed_payments
-    payments.where.not(confirmation: nil).count
   end
 
   def all_payments_confirmed?
@@ -50,7 +70,11 @@ class PayrollRun < ApplicationRecord
   private
 
   def payments_count
-    @payments_count ||= payments.count
+    if FeatureFlag.enabled?(:payroll_speed_up)
+      super
+    else
+      @payments_count ||= payments.count
+    end
   end
 
   class LineItem < Struct.new(:id, :award_amount, keyword_init: true); end

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -37,6 +37,14 @@ class PayrollRun < ApplicationRecord
     end
   end
 
+  def payments_count
+    if FeatureFlag.enabled?(:payroll_speed_up)
+      super
+    else
+      @payments_count ||= payments.count
+    end
+  end
+
   def total_confirmed_payments
     if FeatureFlag.enabled?(:payroll_speed_up)
       super
@@ -58,9 +66,13 @@ class PayrollRun < ApplicationRecord
   end
 
   def all_payments_confirmed?
-    return @all_payments_confirmed if defined?(@all_payments_confirmed)
+    if FeatureFlag.enabled?(:payroll_speed_up)
+      payment_confirmation_uploaded? && total_confirmed_payments == payments_count
+    else
+      return @all_payments_confirmed if defined?(@all_payments_confirmed)
 
-    @all_payments_confirmed = payment_confirmations.any? && total_confirmed_payments == payments_count
+      @all_payments_confirmed = payment_confirmations.any? && total_confirmed_payments == payments_count
+    end
   end
 
   def download_triggered?
@@ -68,14 +80,6 @@ class PayrollRun < ApplicationRecord
   end
 
   private
-
-  def payments_count
-    if FeatureFlag.enabled?(:payroll_speed_up)
-      super
-    else
-      @payments_count ||= payments.count
-    end
-  end
 
   class LineItem < Struct.new(:id, :award_amount, keyword_init: true); end
 

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -34,15 +34,15 @@
         <% @payroll_runs.each do |payroll_run| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= l(payroll_run.created_at.to_date) %></th>
-            <td class="govuk-table__cell"><%= payroll_run.number_of_claims_for_policy(:all, filter: :claims) %></td>
-            <td class="govuk-table__cell"><%= payroll_run.number_of_claims_for_policy(:all, filter: :topups) %></td>
+            <td class="govuk-table__cell"><%= payroll_run.claims_count %></td>
+            <td class="govuk-table__cell"><%= payroll_run.topups_count %></td>
             <td class="govuk-table__cell">
               <% if payroll_run.all_payments_confirmed? %>
                 Uploaded
               <% else %>
                 <%= link_to new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run), class: "govuk-link" do %>
                   Upload <span class="govuk-visually-hidden"> <%= l(payroll_run.created_at.to_date, format: :month_year) %> payment confirmation report </span>
-                  (<%= payroll_run.total_confirmed_payments %>/<%= payroll_run.payments.count %> uploaded)
+                  (<%= payroll_run.total_confirmed_payments %>/<%= payroll_run.payments_count %> uploaded)
                 <% end %>
               <% end %>
             </td>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -174,6 +174,11 @@ shared:
     - scheduled_payment_date # date, when the payment is scheduled to happen
     - confirmation_report_uploaded_by_id # uuid, references admin that uploaded the confirmation
     - status # string, state of the payroll run, defaults to pending
+    - claims_count # integer, number of claims in this payroll run
+    - topups_count # integer, number of topups in this payroll run
+    - total_confirmed_payments # integer, number of confirmed payments
+    - payments_count # integer, number of payments in this payroll run
+    - payment_confirmation_uploaded # boolean, has the confirmation report been uploaded
   :student_loans_eligibilities:
     - id # uuid, that identifies the eligibility
     - created_at # datetime, timestamp when eligibility was created

--- a/db/migrate/20260706122602_add_calculated_columns_to_payroll_run.rb
+++ b/db/migrate/20260706122602_add_calculated_columns_to_payroll_run.rb
@@ -1,0 +1,8 @@
+class AddCalculatedColumnsToPayrollRun < ActiveRecord::Migration[8.1]
+  def change
+    add_column :payroll_runs, :claims_count, :integer
+    add_column :payroll_runs, :topups_count, :integer
+    add_column :payroll_runs, :total_confirmed_payments, :integer
+    add_column :payroll_runs, :payments_count, :integer
+  end
+end

--- a/db/migrate/20260706122602_add_calculated_columns_to_payroll_run.rb
+++ b/db/migrate/20260706122602_add_calculated_columns_to_payroll_run.rb
@@ -4,5 +4,6 @@ class AddCalculatedColumnsToPayrollRun < ActiveRecord::Migration[8.1]
     add_column :payroll_runs, :topups_count, :integer
     add_column :payroll_runs, :total_confirmed_payments, :integer
     add_column :payroll_runs, :payments_count, :integer
+    add_column :payroll_runs, :payment_confirmation_uploaded, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -599,6 +599,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_122602) do
     t.uuid "created_by_id"
     t.datetime "downloaded_at", precision: nil
     t.uuid "downloaded_by_id"
+    t.boolean "payment_confirmation_uploaded", default: false
     t.integer "payments_count"
     t.date "scheduled_payment_date"
     t.string "status", default: "pending", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_131626) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_06_122602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -593,13 +593,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_131626) do
   end
 
   create_table "payroll_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "claims_count"
     t.uuid "confirmation_report_uploaded_by_id"
     t.datetime "created_at", precision: nil, null: false
     t.uuid "created_by_id"
     t.datetime "downloaded_at", precision: nil
     t.uuid "downloaded_by_id"
+    t.integer "payments_count"
     t.date "scheduled_payment_date"
     t.string "status", default: "pending", null: false
+    t.integer "topups_count"
+    t.integer "total_confirmed_payments"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["confirmation_report_uploaded_by_id"], name: "index_payroll_runs_on_confirmation_report_uploaded_by_id"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"

--- a/spec/factories/payroll_runs.rb
+++ b/spec/factories/payroll_runs.rb
@@ -23,6 +23,8 @@ FactoryBot.define do
       confirmed_batches { nil }
     end
 
+    payments_count { claims_counts.values.sum }
+
     after(:create) do |payroll_run, evaluator|
       evaluator.claims_counts.each do |policies, count|
         policies = Array(policies)
@@ -37,6 +39,8 @@ FactoryBot.define do
     end
 
     trait :with_confirmations do
+      payment_confirmation_uploaded { true }
+      total_confirmed_payments { claims_counts.values.sum }
       payment_traits { %i[with_figures] }
 
       after(:create) do |payroll_run, evaluator|

--- a/spec/models/payment_confirmation_upload_spec.rb
+++ b/spec/models/payment_confirmation_upload_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe PaymentConfirmationUpload do
       let!(:payroll_run) do
         create(:payroll_run, :with_confirmations, confirmed_batches: 1, claims_counts: {
           Policies::StudentLoans => 2, Policies::EarlyCareerPayments => 1
-        })
+        }, total_confirmed_payments: 2)
       end
 
       let(:csv) do

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -346,12 +346,7 @@ RSpec.describe PayrollRun, type: :model do
     let(:payroll_run) do
       create(:payroll_run, :with_confirmations, confirmed_batches: 2, claims_counts: {
         Policies::StudentLoans => 5
-      })
-    end
-    let(:batch_size) { 2 }
-
-    before do
-      stub_const("#{described_class}::MAX_BATCH_SIZE", batch_size)
+      }, total_confirmed_payments: 4)
     end
 
     it { is_expected.to eq(4) }
@@ -360,26 +355,28 @@ RSpec.describe PayrollRun, type: :model do
   describe "#all_payments_confirmed?" do
     subject { payroll_run.all_payments_confirmed? }
 
-    let(:payroll_run) do
-      create(:payroll_run,
-        :with_confirmations,
-        confirmed_batches: confirmed_batches,
-        claims_counts: {Policies::StudentLoans => 5})
-    end
-    let(:batch_size) { 2 }
-
-    before do
-      stub_const("#{described_class}::MAX_BATCH_SIZE", batch_size)
-    end
-
     context "when some payments have not been confirmed" do
-      let(:confirmed_batches) { 2 }
+      let(:payroll_run) do
+        create(
+          :payroll_run,
+          payment_confirmation_uploaded: true,
+          total_confirmed_payments: 1,
+          payments_count: 2
+        )
+      end
 
       it { is_expected.to eq(false) }
     end
 
     context "when all payments have been confirmed" do
-      let(:confirmed_batches) { 3 }
+      let(:payroll_run) do
+        create(
+          :payroll_run,
+          payment_confirmation_uploaded: true,
+          total_confirmed_payments: 2,
+          payments_count: 2
+        )
+      end
 
       it { is_expected.to eq(true) }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
     OmniAuth.config.mock_auth[:dfe] = nil
     OmniAuth.config.mock_auth[:tid] = nil
     OmniAuth.config.mock_auth[:default] = nil
+    FeatureFlag.enable!(:payroll_speed_up)
   end
 
   config.filter_run_excluding :smoke


### PR DESCRIPTION
# Speed up payroll run index page

Payroll index page does a lot of calculations, all of which can be cached.
We've feature flagged the changes so we can keep the old behaviour until the
backfill is done, then flip the feature flag over. The feature flag and new
methods will be deleted in a follow up pr.

## Benchmarks

Master
```
Completed 200 OK in 3813ms (Views: 1508.3ms | ActiveRecord: 2269.2ms (246 queries, 1 cached) | GC: 226.5ms)
```

Branch
```
Completed 200 OK in 54ms (Views: 38.2ms | ActiveRecord: 6.3ms (4 queries, 1 cached) | GC: 2.9ms)
```

## Deploying
Merge
Run the backfill job
Flip the feature flag
Merge the clean up pr https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4784

## Note
We should probably cache the calculations used on the payroll run show actions
but as that's only looking at a single payroll run the page is returned quite
quickly.
