### PR TITLE
Show decisions have been undone

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -103,7 +103,10 @@ module Admin
     def admin_decision_details(decision)
       [].tap do |a|
         a << [translate("admin.decision.created_at"), l(decision.created_at)]
-        a << [translate("admin.decision.result"), decision.result.capitalize]
+        a << [
+          translate("admin.decision.result"),
+          decision.result.capitalize + (decision.undone? ? " (undone)" : "")
+        ]
         a << [translate("admin.decision.reasons"), rejected_reasons_list(decision)] if decision.rejected?
         a << [translate("admin.decision.notes"), simple_format(decision.notes, class: "govuk-body")] if decision.notes.present?
         a << [translate("admin.decision.created_by"), user_details(decision.created_by)] if decision.created_by_id?

--- a/app/views/admin/decisions/index.html.erb
+++ b/app/views/admin/decisions/index.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <%= render "admin/tasks/#{claim_summary_view}", claim: @claim, heading: "Claim decision" %>
 
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" data-test-id="decisions-container">
     <% @decisions.each do |decision| %>
       <% heading = (@decisions.first == decision ? "Claim decision details" : nil) %>
       <%= render "admin/claims/answer_section", {heading:, answers: admin_decision_details(decision)} %>

--- a/spec/features/admin/admin_amend_decision_spec.rb
+++ b/spec/features/admin/admin_amend_decision_spec.rb
@@ -30,5 +30,36 @@ RSpec.feature "Undoing a claim's decision" do
     expect(page).to have_content("Decision\nchanged from rejected to undecided")
     expect(page).to have_content("Change notes\nHere are some notes")
     expect(page).to have_content("by #{signed_in_user.full_name}")
+
+    visit new_admin_claim_decision_path(claim)
+    choose "Approve"
+    click_on "Confirm decision"
+
+    visit admin_claim_url(claim)
+    click_on "Amend claim"
+    click_on "Undo decision"
+    fill_in "Change notes", with: "Here are some notes"
+    click_on "Undo approval"
+
+    visit new_admin_claim_decision_path(claim)
+    choose "Approve"
+    click_on "Confirm decision"
+
+    visit admin_claim_decisions_path(claim)
+
+    within '[data-test-id="decisions-container"]' do
+      within ".govuk-summary-list:first-of-type" do
+        expect(page).to have_text "Result Rejected (undone)"
+      end
+
+      within ".govuk-summary-list:nth-of-type(2)" do
+        expect(page).to have_text "Result Approved (undone)"
+      end
+
+      within ".govuk-summary-list:last-of-type" do
+        expect(page).to have_text "Result Approved"
+        expect(page).not_to have_text "undone"
+      end
+    end
   end
 end

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/claim_tasks_index_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/claim_tasks_index_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Task index page for EYTFI claims" do
   it "shows an overview of the claim" do
+    travel_to DateTime.new(2026, 5, 13, 13, 30, 0)
+
     eligible_eytfi_provider = create(
       :eligible_eytfi_provider,
       urn: "EY123456",
@@ -95,6 +97,8 @@ RSpec.describe "Task index page for EYTFI claims" do
         value: "EY123456"
       )
     end
+
+    travel_back
   end
 
   it "shows the list of tasks" do


### PR DESCRIPTION
If a decision on a claim has been undone we need to display this on the
decisions page to avoid confusion, otherwise we receive bug reports that
a claim has been approved twice.
