### PR TITLE
Remove eligibility criteria section from methodology

### DIFF
--- a/app/views/early_years_teachers_financial_incentive_payments/methodology.html.erb
+++ b/app/views/early_years_teachers_financial_incentive_payments/methodology.html.erb
@@ -64,35 +64,6 @@
       Phase 2 LA areas will be shared in due course.
     </p>
 
-    <h2 id="eligible-group-based-settings" class="govuk-heading-m">Eligible group‑based settings</h2>
-
-    <p class="govuk-body">
-      To be an eligible setting, you must be:
-    </p>
-
-    <%= govuk_list [
-      "registered in England with Ofsted on the Early Years Register or an early years childminder agency, 
-      to provide early years childcare on either domestic premises or non‑domestic premises",
-      "delivering funded early years entitlements",
-      "not be an ineligible setting"
-    ], type: :bullet %>
-
-    <p class="govuk-body">
-      Settings that are ineligible:
-    </p>
-
-    <%= govuk_list [
-      "childminders",
-      "school based settings, including independent schools<sup><a href=\"#footnote-3\">[footnote 3]</a></sup>".html_safe,
-      "settings run by the governing body of a maintained school"
-    ], type: :bullet %>
-
-    <p class="govuk-body">
-      This criteria reflects evidence that group‑based settings face greater workforce challenges than school‑based settings and we 
-      are prioritising the recognition payments for settings where there is greatest need. We know that staff in group‑based settings are paid less on average<sup><a href="#footnote-4">[footnote 4]</a></sup>, 
-      staff turnover is higher<sup><a href="#footnote-5">[footnote 5]</a></sup> and fewer staff in group-based settings hold Level 6 qualifications.<sup><a href="#footnote-6">[footnote 6]</a></sup>
-    </p>
-
     <h2 id="updates-eligibility" class="govuk-heading-m">Updates to the eligibility criteria</h2>
 
     <p class="govuk-body">


### PR DESCRIPTION
Removed details about eligible and ineligible settings for early years financial incentive payments (these are being moved to the guidance page).

