### PR TITLE
remove rack_session_access gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,6 @@ end
 group :test do
   gem "rspec-retry"
   gem "launchy"
-  gem "rack_session_access"
   gem "simplecov", require: false
   # Return null object for active record connection rather than raising error
   gem "activerecord-nulldb-adapter", github: "simpl1g/nulldb", ref: "3986f43f1680ee098ec51af1dc763bfe2d579efe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,9 +437,6 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rack_session_access (0.2.0)
-      builder (>= 2.0.0)
-      rack (>= 1.0.0)
     rackup (2.3.1)
       rack (>= 3)
     rails (8.1.3)
@@ -716,7 +713,6 @@ DEPENDENCIES
   pry
   puma (~> 7.2)
   rack-mini-profiler
-  rack_session_access
   rails (~> 8.1)
   rails_semantic_logger
   rb-readline

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,8 +64,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  config.middleware.use RackSessionAccess::Middleware
-
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "simplecov"
 require "faker"
-require "rack_session_access/capybara"
 
 Faker::Config.locale = "en-GB"
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -30,8 +30,4 @@ module RequestHelpers
     post "/admin/auth/dfe"
     follow_redirect!
   end
-
-  def set_session_data(data)
-    put ::RackSessionAccess.path, params: {data: ::RackSessionAccess.encode(data)}
-  end
 end


### PR DESCRIPTION
# Context

- removing `rack_session_access` gem as only referenced once in a test but never actually called