### PR TITLE
Display bank details on the claim show page

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -62,7 +62,10 @@ module Admin
         ["Date of birth", personal_data(claim, :date_of_birth) { |date| l(date) }],
         [translate("admin.national_insurance_number"), personal_data(claim, :national_insurance_number)],
         ["Address", personal_data(claim, :address, "<br>") { |address| sanitize(address.html_safe, tags: %w[br]) }],
-        [translate("#{claim.policy.locale_key}.admin.email_address", default: :"admin.email_address"), claim.email_address]
+        [translate("#{claim.policy.locale_key}.admin.email_address", default: :"admin.email_address"), claim.email_address],
+        ["Banking name", personal_data(claim, :banking_name)],
+        ["Bank account number", personal_data(claim, :bank_account_number)],
+        ["Bank sort code", personal_data(claim, :bank_sort_code)]
       ]
     end
 

--- a/app/models/policies/early_years_payments/admin_claim_details_presenter.rb
+++ b/app/models/policies/early_years_payments/admin_claim_details_presenter.rb
@@ -24,7 +24,10 @@ module Policies
           [translate("admin.mobile_number"), claim.mobile_number],
           [translate("#{claim.policy.locale_key}.admin.nursery_name"), claim.eligibility.eligible_ey_provider.nursery_name],
           [translate("#{claim.policy.locale_key}.admin.start_date"), formatted_date(claim.eligibility.start_date)],
-          [translate("#{claim.policy.locale_key}.admin.paye_reference"), claim.paye_reference]
+          [translate("#{claim.policy.locale_key}.admin.paye_reference"), claim.paye_reference],
+          ["Banking name", personal_data(claim.banking_name)],
+          ["Bank account number", personal_data(claim.bank_account_number)],
+          ["Bank sort code", personal_data(claim.bank_sort_code)]
         ]
       end
 

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Admin::ClaimsHelper do
         address_line_3: "Test Town",
         postcode: "AB1 2CD",
         date_of_birth: Date.new(1901, 1, 1),
-        eligibility_attributes: {teacher_reference_number: "1234567"}
+        eligibility_attributes: {teacher_reference_number: "1234567"},
+        banking_name: "B Wayne",
+        bank_account_number: "12345678",
+        bank_sort_code: "010101"
       )
     end
 
@@ -28,7 +31,10 @@ RSpec.describe Admin::ClaimsHelper do
         ["Date of birth", "1 January 1901"],
         [I18n.t("admin.national_insurance_number"), "AB123456C"],
         ["Address", "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
-        [I18n.t("admin.email_address"), "test@email.com"]
+        [I18n.t("admin.email_address"), "test@email.com"],
+        ["Banking name", "B Wayne"],
+        ["Bank account number", "12345678"],
+        ["Bank sort code", "010101"]
       ]
 
       expect(helper.admin_personal_details(claim)).to eq expected_answers
@@ -44,7 +50,10 @@ RSpec.describe Admin::ClaimsHelper do
           ["Date of birth", helper.personal_data_removed_text],
           [I18n.t("admin.national_insurance_number"), helper.personal_data_removed_text],
           ["Address".capitalize, helper.personal_data_removed_text],
-          [I18n.t("admin.email_address"), "test@email.com"]
+          [I18n.t("admin.email_address"), "test@email.com"],
+          ["Banking name", helper.personal_data_removed_text],
+          ["Bank account number", helper.personal_data_removed_text],
+          ["Bank sort code", helper.personal_data_removed_text]
         ]
 
         expect(helper.admin_personal_details(claim)).to eq expected_answers

--- a/spec/models/policies/early_years_payments/admin_claim_details_presenter_spec.rb
+++ b/spec/models/policies/early_years_payments/admin_claim_details_presenter_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe Policies::EarlyYearsPayments::AdminClaimDetailsPresenter do
       paye_reference: "123/A",
       provider_contact_name: "John Doe",
       submitted_at: Date.new(2020, 1, 4),
+      banking_name: "B Wayne",
+      bank_account_number: "12345678",
+      bank_sort_code: "123456",
       eligibility_attributes: {
         nursery_urn: eligible_ey_provider.urn,
         start_date: Date.new(2020, 1, 1),
@@ -79,7 +82,10 @@ RSpec.describe Policies::EarlyYearsPayments::AdminClaimDetailsPresenter do
           [I18n.t("admin.mobile_number"), nil],
           [I18n.t("early_years_payments.admin.nursery_name"), eligible_ey_provider.nursery_name],
           [I18n.t("early_years_payments.admin.start_date"), I18n.l(claim.eligibility.start_date)],
-          [I18n.t("early_years_payments.admin.paye_reference"), "123/A"]
+          [I18n.t("early_years_payments.admin.paye_reference"), "123/A"],
+          ["Banking name", nil],
+          ["Bank account number", nil],
+          ["Bank sort code", nil]
         ]
 
         expect(subject).to eq expected_answers
@@ -100,7 +106,10 @@ RSpec.describe Policies::EarlyYearsPayments::AdminClaimDetailsPresenter do
           [I18n.t("admin.mobile_number"), "07700900000"],
           [I18n.t("early_years_payments.admin.nursery_name"), eligible_ey_provider.nursery_name],
           [I18n.t("early_years_payments.admin.start_date"), I18n.l(claim.eligibility.start_date)],
-          [I18n.t("early_years_payments.admin.paye_reference"), "123/A"]
+          [I18n.t("early_years_payments.admin.paye_reference"), "123/A"],
+          ["Banking name", "B Wayne"],
+          ["Bank account number", "12345678"],
+          ["Bank sort code", "123456"]
         ]
 
         expect(subject).to eq expected_answers


### PR DESCRIPTION
Bank details were only visible on the amend claim page, which isn't
accessible on decided claims. Ops would like to be able to see the
details on decided claims so they can answer customer support queries.
