### PR TITLE
Show who to send the link to

### DIFF
--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -102,6 +102,10 @@ module Journeys
       true
     end
 
+    def provider_journey?
+      false
+    end
+
     private
 
     def all_forms_mapping

--- a/app/models/journeys/early_years_payment/provider/alternative_idv.rb
+++ b/app/models/journeys/early_years_payment/provider/alternative_idv.rb
@@ -47,6 +47,10 @@ module Journeys
             .provider_alternative_idv_request(claim)
             .deliver_later
         end
+
+        def self.provider_journey?
+          true
+        end
       end
     end
   end

--- a/app/models/journeys/early_years_payment/provider/authenticated.rb
+++ b/app/models/journeys/early_years_payment/provider/authenticated.rb
@@ -25,6 +25,10 @@ module Journeys
           ExpiredLinkForm
         ]
         START_WITH_MAGIC_LINK = true
+
+        def self.provider_journey?
+          true
+        end
       end
     end
   end

--- a/app/models/journeys/early_years_payment/provider/start.rb
+++ b/app/models/journeys/early_years_payment/provider/start.rb
@@ -13,6 +13,10 @@ module Journeys
           CheckYourEmailForm,
           IneligibleForm
         ]
+
+        def self.provider_journey?
+          true
+        end
       end
     end
   end

--- a/app/views/admin/service_access_links/show.html.erb
+++ b/app/views/admin/service_access_links/show.html.erb
@@ -37,7 +37,10 @@
     </p>
 
     <p class="govuk-body">
-      <strong>Send this link to the claimant</strong>
+      <strong>
+        Send this link to the
+        <%= @service_access_code.journey_class.provider_journey? ? "provider" : "claimant" %>
+      </strong>
     </p>
 
     <%= text_field_tag(


### PR DESCRIPTION
On the create magic link page we need to specify whether the link should
be sent to the claimant or the provider to avoid confusion.
