### PR TITLE
Allow scoping search to current AY

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -38,9 +38,14 @@ class Admin::ClaimsController < Admin::BaseAdminController
   end
 
   def search
+    @search = Claim::Search.new(
+      params[:query],
+      current_year_only: params[:current_year_only]
+    )
+
     return unless params[:query].present?
 
-    @claims = Claim::Search.new(params[:query]).claims
+    @claims = @search.claims
 
     if @claims.none?
       flash.now[:notice] = "Cannot find a claim for query \"#{params[:query]}\""

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -40,7 +40,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def search
     @search = Claim::Search.new(
       params[:query],
-      current_year_only: params[:current_year_only]
+      current_year_only: params.fetch(:current_year_only, true)
     )
 
     return unless params[:query].present?

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -38,22 +38,20 @@ class Admin::ClaimsController < Admin::BaseAdminController
   end
 
   def search
-    @search = Claim::Search.new(
-      params[:query],
-      current_year_only: params.fetch(:current_year_only, true)
-    )
+    search_params = params.fetch(:claim_search, {})
+    @search = Claim::Search.new(search_params.permit(:search_term, :current_year_only))
 
-    return unless params[:query].present?
+    return unless @search.search_term.present?
 
     @claims = @search.claims
 
     if @claims.none?
-      flash.now[:notice] = "Cannot find a claim for query \"#{params[:query]}\""
+      flash.now[:notice] = "Cannot find a claim for query \"#{@search.search_term}\""
     elsif @claims.one?
       claims_backlink_path!(search_admin_claims_path)
       redirect_to(admin_claim_tasks_url(@claims.first))
     else
-      claims_backlink_path!(search_admin_claims_path(query: params[:query]))
+      claims_backlink_path!(search_admin_claims_path(@search.params))
     end
   end
 

--- a/app/models/claim/search.rb
+++ b/app/models/claim/search.rb
@@ -3,7 +3,11 @@ class Claim
   # attributes defined in the `SEARCHABLE_ATTRIBUTES` or `policy::SEARCHABLE_ELIGIBILITY_ATTRIBUTES` constant. Both subject
   # and attribute are downcased, so the search is case-insensitive.
   class Search
-    attr_accessor :search_term, :current_year_only
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :search_term, :string
+    attribute :current_year_only, :boolean, default: true
 
     SEARCHABLE_CLAIM_ATTRIBUTES = %w[
       reference
@@ -11,9 +15,8 @@ class Claim
       surname
     ]
 
-    def initialize(search_term, current_year_only: false)
-      @search_term = search_term
-      @current_year_only = ActiveModel::Type::Boolean.new.cast(current_year_only)
+    def initialize(params)
+      super
     end
 
     def claims
@@ -68,6 +71,15 @@ class Claim
 
     def current_year_only?
       !!current_year_only
+    end
+
+    def params
+      {
+        model_name.param_key => {
+          search_term: search_term,
+          current_year_only: current_year_only
+        }
+      }
     end
 
     private

--- a/app/models/claim/search.rb
+++ b/app/models/claim/search.rb
@@ -3,7 +3,7 @@ class Claim
   # attributes defined in the `SEARCHABLE_ATTRIBUTES` or `policy::SEARCHABLE_ELIGIBILITY_ATTRIBUTES` constant. Both subject
   # and attribute are downcased, so the search is case-insensitive.
   class Search
-    attr_accessor :search_term
+    attr_accessor :search_term, :current_year_only
 
     SEARCHABLE_CLAIM_ATTRIBUTES = %w[
       reference
@@ -11,8 +11,9 @@ class Claim
       surname
     ]
 
-    def initialize(search_term)
+    def initialize(search_term, current_year_only: false)
       @search_term = search_term
+      @current_year_only = current_year_only
     end
 
     def claims
@@ -51,12 +52,22 @@ class Claim
         .joins(:school)
         .where("schools.name ILIKE ?", "%#{search_term}%")
 
-      claim_match_query
+      claim_scope = claim_match_query
         .or(Claim.where(eligibility_id: eligibility_ids))
         .or(Claim.where(id: claims_matched_on_payment_ids))
         .or(Claim.where(id: claims_matched_on_ey_provider_details))
         .or(Claim.where(eligibility_id: eligibilities_matched_on_eytfi_provider_details.select(:id)))
         .or(Claim.where(eligibility_id: eligibilities_matched_on_fe_provider_details.select(:id)))
+
+      if current_year_only?
+        claim_scope = Claim.current_academic_year.where(id: claim_scope.select(:id))
+      end
+
+      claim_scope
+    end
+
+    def current_year_only?
+      !!current_year_only
     end
 
     private

--- a/app/models/claim/search.rb
+++ b/app/models/claim/search.rb
@@ -13,7 +13,7 @@ class Claim
 
     def initialize(search_term, current_year_only: false)
       @search_term = search_term
-      @current_year_only = current_year_only
+      @current_year_only = ActiveModel::Type::Boolean.new.cast(current_year_only)
     end
 
     def claims

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -24,6 +24,7 @@
           hidden: true
         }
       ) do %>
+        <%= form.hidden_field(:current_year_only, value: false) %>
         <%= form.govuk_check_box(
           :current_year_only,
           true,

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -6,11 +6,34 @@
       Search for a claim
     </h1>
 
-    <%= form_with url: search_admin_claims_path, method: :get do |form| %>
+    <%= form_with url: search_admin_claims_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <div class="govuk-form-group">
         <%= form.label :query, "Enter a reference, email address, Teacher Reference Number, surname, payment ID, FE provider name, or EYTRP nursery name", class: "govuk-label" %>
-        <%= form.text_field :query, class: "govuk-input govuk-input--width-20" %>
+        <%= form.text_field(
+          :query,
+          class: "govuk-input govuk-input--width-20",
+          value: @search.search_term
+        ) %>
       </div>
+
+      <%= form.govuk_check_boxes_fieldset(
+        :current_year_only,
+        multiple: false,
+        small: true,
+        legend: {
+          hidden: true
+        }
+      ) do %>
+        <%= form.govuk_check_box(
+          :current_year_only,
+          true,
+          multiple: false,
+          label: {
+            text: "limit to current academic year"
+          },
+          checked: @search.current_year_only?
+        ) %>
+      <% end %>
 
       <div class="govuk-form-group">
         <%= form.submit "Search", class: "govuk-button" %>

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -6,11 +6,11 @@
       Search for a claim
     </h1>
 
-    <%= form_with url: search_admin_claims_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with model: @search, url: search_admin_claims_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <div class="govuk-form-group">
-        <%= form.label :query, "Enter a reference, email address, Teacher Reference Number, surname, payment ID, FE provider name, or EYTRP nursery name", class: "govuk-label" %>
+        <%= form.label :search_term, "Enter a reference, email address, Teacher Reference Number, surname, payment ID, FE provider name, or EYTRP nursery name", class: "govuk-label" %>
         <%= form.text_field(
-          :query,
+          :search_term,
           class: "govuk-input govuk-input--width-20",
           value: @search.search_term
         ) %>
@@ -24,15 +24,14 @@
           hidden: true
         }
       ) do %>
-        <%= form.hidden_field(:current_year_only, value: false) %>
         <%= form.govuk_check_box(
           :current_year_only,
-          true,
+          1,
+          0,
           multiple: false,
           label: {
             text: "limit to current academic year"
           },
-          checked: @search.current_year_only?
         ) %>
       <% end %>
 

--- a/spec/features/admin/admin_search_spec.rb
+++ b/spec/features/admin/admin_search_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature "Admin search" do
     sign_in_as_service_operator
   end
 
-  let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
-  let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }
+  let!(:claim1) { create(:claim, :current_academic_year, :submitted, surname: "Wayne") }
+  let!(:claim2) { create(:claim, :current_academic_year, :submitted, surname: "Wayne") }
 
   scenario "redirects a service operator to the claim if there is only one match" do
     visit search_admin_claims_path

--- a/spec/models/claim/search_spec.rb
+++ b/spec/models/claim/search_spec.rb
@@ -333,4 +333,30 @@ RSpec.describe Claim::Search do
       it { is_expected.to match_array([claim_1]) }
     end
   end
+
+  context "when scoped to the current academic year" do
+    subject { search.claims }
+
+    let(:search) do
+      described_class.new("test@example.com", current_year_only: true)
+    end
+
+    let!(:prior_year_claim) do
+      create(
+        :claim,
+        academic_year: AcademicYear.previous,
+        email_address: "test@example.com"
+      )
+    end
+
+    let!(:current_year_claim) do
+      create(
+        :claim,
+        academic_year: AcademicYear.current,
+        email_address: "test@example.com"
+      )
+    end
+
+    it { is_expected.to eq [current_year_claim] }
+  end
 end

--- a/spec/models/claim/search_spec.rb
+++ b/spec/models/claim/search_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Claim::Search do
-  subject(:search) { described_class.new(query) }
+  let(:search_params) { {search_term: query, current_year_only: false} }
+  subject(:search) { described_class.new(search_params) }
 
   let(:reference) { "abc123" }
   let(:email) { "foo@example.com" }
@@ -337,8 +338,8 @@ RSpec.describe Claim::Search do
   context "when scoped to the current academic year" do
     subject { search.claims }
 
-    let(:search) do
-      described_class.new("test@example.com", current_year_only: true)
+    let(:search_params) do
+      {search_term: "test@example.com", current_year_only: true}
     end
 
     let!(:prior_year_claim) do

--- a/spec/requests/admin/admin_claims_spec.rb
+++ b/spec/requests/admin/admin_claims_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe "Admin claims", type: :request do
   end
 
   describe "claims#search" do
-    let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
-    let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }
+    let!(:claim1) { create(:claim, :current_academic_year, :submitted, surname: "Wayne") }
+    let!(:claim2) { create(:claim, :current_academic_year, :submitted, surname: "Wayne") }
 
     it "redirects to a claim when one exists" do
       get search_admin_claims_path(query: claim1.reference)

--- a/spec/requests/admin/admin_claims_spec.rb
+++ b/spec/requests/admin/admin_claims_spec.rb
@@ -148,13 +148,21 @@ RSpec.describe "Admin claims", type: :request do
     let!(:claim2) { create(:claim, :current_academic_year, :submitted, surname: "Wayne") }
 
     it "redirects to a claim when one exists" do
-      get search_admin_claims_path(query: claim1.reference)
+      get search_admin_claims_path(
+        claim_search: {
+          search_term: claim1.reference
+        }
+      )
 
       expect(response).to redirect_to(admin_claim_tasks_path(claim1))
     end
 
     it "shows a list of matching claims if there are more than one" do
-      get search_admin_claims_path(query: "Wayne")
+      get search_admin_claims_path(
+        claim_search: {
+          search_term: "Wayne"
+        }
+      )
 
       expect(response.body).to include(claim1.reference)
       expect(response.body).to include(claim2.reference)
@@ -162,7 +170,11 @@ RSpec.describe "Admin claims", type: :request do
 
     it "shows an error if a claim can't be found" do
       reference = "12345678"
-      get search_admin_claims_path(query: reference)
+      get search_admin_claims_path(
+        claim_search: {
+          search_term: reference
+        }
+      )
 
       expected_flash = CGI.escapeHTML("Cannot find a claim for query \"#{reference}\"")
       expect(response.body).to include(expected_flash)


### PR DESCRIPTION
Request from the ops team to have the option to scope search results to
only the current academic year's claims.
