### PR TITLE
[#224] Persist task census subjects taught

### DIFF
--- a/app/models/automated_checks/claim_verifiers/census_subjects_taught.rb
+++ b/app/models/automated_checks/claim_verifiers/census_subjects_taught.rb
@@ -64,6 +64,8 @@ module AutomatedChecks
           SchoolWorkforceCensus::ECP_ELIGIBLE_SUBJECTS
         ].reduce({}, :update)
 
+        return [] if claim.eligibility.eligible_itt_subject.nil?
+
         ecp_subjects[claim.eligibility.eligible_itt_subject.to_sym]
       end
 

--- a/app/models/automated_checks/claim_verifiers/census_subjects_taught.rb
+++ b/app/models/automated_checks/claim_verifiers/census_subjects_taught.rb
@@ -17,7 +17,13 @@ module AutomatedChecks
       def perform
         return unless awaiting_task?(TASK_NAME)
 
-        no_data || no_match || any_match
+        if school_workforce_census.blank?
+          create_task(match: nil)
+        elsif school_workforce_census.empty? || !eligible?
+          create_task(match: :none)
+        else
+          create_task(match: :any, passed: true)
+        end
       end
 
       private
@@ -33,24 +39,6 @@ module AutomatedChecks
         return if school_workforce_census.empty?
 
         @school_workforce_census_subjects = school_workforce_census.map(&:subject_description_sfr)
-      end
-
-      def no_data
-        return if school_workforce_census.present?
-
-        create_task(match: nil)
-      end
-
-      def no_match
-        return unless school_workforce_census.empty? || !eligible?
-
-        create_task(match: :none)
-      end
-
-      def any_match
-        return unless eligible?
-
-        create_task(match: :any, passed: true)
       end
 
       def eligible?

--- a/db/data/20260715102334_persist_task_census_subjects_taught.rb
+++ b/db/data/20260715102334_persist_task_census_subjects_taught.rb
@@ -1,0 +1,20 @@
+# Run me with `rails runner db/data/20260715102334_persist_task_census_subjects_taught.rb`
+
+relevant_policies = [
+  Policies::StudentLoans,
+  Policies::TargetedRetentionIncentivePayments,
+  Policies::EarlyCareerPayments
+]
+
+relevant_policies.each do |policy|
+  claims = Claim.where(policy:)
+  tasks = Task.where(name: "census_subjects_taught", claim: claims)
+  delta = claims.pluck(:id) - tasks.pluck(:claim_id)
+
+  claims_without_task = Claim.where(id: delta)
+
+  claims_without_task.find_each do |claim|
+    verifier = AutomatedChecks::ClaimVerifiers::CensusSubjectsTaught.new(claim:)
+    verifier.perform
+  end
+end


### PR DESCRIPTION
# Context

- https://github.com/DFE-Digital/claim-issues/issues/224
- Future `CensusSubjectsTaught` tasks are persisted to db when verifier called
- Add data migration to persist missing tasks to database