### PR TITLE
2856 - Revert staging to define environment as staging

### DIFF
--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -2,7 +2,7 @@
     "cluster": "test",
     "namespace": "srtl-test",
     "config": "staging",
-    "environment": "review",
+    "environment": "staging",
     "canonical_hostname": "staging.claim-additional-teaching-payment.service.gov.uk",
     "web_replicas": 2,
     "startup_command":

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -8,7 +8,7 @@ DFE_SIGN_IN_API_CLIENT_ID: teacherpayments
 DFE_SIGN_IN_API_ENDPOINT: https://pp-api.signin.education.gov.uk/
 DFE_SIGN_IN_IDENTIFIER: teacherpayments
 DFE_SIGN_IN_ISSUER: https://pp-oidc.signin.education.gov.uk:443
-DFE_SIGN_IN_REDIRECT_BASE_URL: https://claim-additional-teaching-payment.service.gov.uk
+DFE_SIGN_IN_REDIRECT_BASE_URL: https://staging.claim-additional-teaching-payment.service.gov.uk
 
 DFE_SIGN_IN_INTERNAL_CLIENT_ID: teacherpaymentsadmin
 
@@ -29,7 +29,7 @@ SUPPRESS_DFE_ANALYTICS_INIT: true
 TID_SIGN_IN_API_ENDPOINT: https://preprod.teaching-identity.education.gov.uk:433
 TID_SIGN_IN_CLIENT_ID: claim
 TID_SIGN_IN_ISSUER: https://preprod.teaching-identity.education.gov.uk/
-TID_BASE_URL: https://claim-additional-teaching-payment.service.gov.uk/targeted-retention-incentive-payments/claim
+TID_BASE_URL: https://staging.claim-additional-teaching-payment.service.gov.uk/targeted-retention-incentive-payments/claim
 
 GOVUK_APP_DOMAIN: ""
 GOVUK_WEBSITE_ROOT: ""


### PR DESCRIPTION
### Context

Making the new staging environment more like review rather than test. 

### Changes proposed in this pull request

- Ensure the environment for staging is staging not review.

### Guidance to review

Run command `make staging terraform-plan`. This should produce a valid set of required resources.

### Link to Trello card

https://trello.com/c/bA2sFyil/2856-capt-add-staging-env

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
