### PR TITLE
223/projected payroll

### DIFF
--- a/app/controllers/admin/payroll_projections_controller.rb
+++ b/app/controllers/admin/payroll_projections_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class PayrollProjectionsController < BaseAdminController
+    before_action :ensure_service_operator
+
+    def show
+      @projection = Payroll::Projection.new
+    end
+  end
+end

--- a/app/models/payroll/projection.rb
+++ b/app/models/payroll/projection.rb
@@ -1,0 +1,57 @@
+module Payroll
+  class Projection
+    def total_award_amount
+      claim_scope.sum(:award_amount)
+    end
+
+    def number_of_claims_for_policy(policy)
+      claim_scope.by_policy(policy).count
+    end
+
+    def total_claim_amount_for_policy(policy)
+      claim_scope.by_policy(policy).sum(:award_amount)
+    end
+
+    def number_of_topups_for_policy(policy)
+      topup_scope.joins(:claim).merge(Claim.by_policy(policy)).count
+    end
+
+    def total_topup_amount_for_policy(policy)
+      topup_scope.joins(:claim).merge(Claim.by_policy(policy)).sum(:award_amount)
+    end
+
+    def claims_count
+      claim_scope.count
+    end
+
+    def topups_count
+      topup_scope.count
+    end
+
+    def month_name
+      next_payroll_run_date.strftime("%B")
+    end
+
+    private
+
+    def claim_scope
+      scope = Claim.where(id: Claim.where.missing(:payments))
+      scope = scope.not_rejected.where(decision_deadline: ..next_payroll_run_date)
+      scope = scope.or(Claim.where(id: Claim.payrollable.select(:id)))
+      scope.with_award_amounts
+    end
+
+    # Topups will go into the nearest payroll run
+    def topup_scope
+      Topup.payrollable
+    end
+
+    def previous_payroll_run_date
+      PayrollRun.maximum(:created_at)
+    end
+
+    def next_payroll_run_date
+      previous_payroll_run_date + 1.month
+    end
+  end
+end

--- a/app/views/admin/payroll_projections/show.html.erb
+++ b/app/views/admin/payroll_projections/show.html.erb
@@ -1,0 +1,73 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @projection.month_name %> payroll run projection
+    </h1>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: "Total claims") %>
+        <% row.with_value(text: @projection.claims_count) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: "Top ups") %>
+        <% row.with_value(text: @projection.topups_count) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: "Total award amount") %>
+        <% row.with_value(
+          text: number_to_currency(@projection.total_award_amount)
+        ) %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <%= govuk_table do |table| %>
+      <% table.with_caption(
+        size: "m",
+        text: "Summary of claim amounts by service"
+      ) %>
+
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Service") %>
+          <% row.with_cell(text: "Number of claims") %>
+          <% row.with_cell(text: "Total claimed amount") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% Policies.all.each do |policy| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: policy.short_name) %>
+            <% row.with_cell(
+              text: @projection.number_of_claims_for_policy(policy)
+            ) %>
+            <% row.with_cell(
+              text: number_to_currency(
+                @projection.total_claim_amount_for_policy(policy)
+              )
+            ) %>
+          <% end %>
+        <% end %>
+
+        <% Policies.all.each do |policy| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: "#{policy.short_name} Top Ups") %>
+            <% row.with_cell(
+              text: @projection.number_of_topups_for_policy(policy)
+            ) %>
+            <% row.with_cell(
+              text: number_to_currency(
+                @projection.total_topup_amount_for_policy(policy)
+              )
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -7,7 +7,8 @@
     </h1>
 
     <div class="govuk-inset-text">
-      The next payroll run must be with DfE Payroll on or before <%= l(next_payroll_file_due_date) %>
+      The next payroll run must be with DfE Payroll on or before
+      <%= govuk_link_to(l(next_payroll_file_due_date), admin_payroll_projection_path) %>
     </div>
 
     <%= link_to(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resource :payroll_projection, only: :show
+
     resources :payments, only: :show
 
     resources :journey_configurations, only: [:index, :edit, :update], path: "journey-configurations"

--- a/spec/models/payroll/projection_spec.rb
+++ b/spec/models/payroll/projection_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+
+RSpec.describe Payroll::Projection do
+  let!(:previous_payroll_run) { create(:payroll_run, created_at: 1.day.ago) }
+
+  let!(:undecided_out_of_range) do
+    create(
+      :claim,
+      policy: Policies::FurtherEducationPayments,
+      decision_deadline: 2.months.from_now,
+      eligibility_attributes: {
+        award_amount: 2
+      }
+    )
+  end
+
+  let!(:undecided_in_range) do
+    create(
+      :claim,
+      policy: Policies::FurtherEducationPayments,
+      decision_deadline: 3.weeks.from_now,
+      eligibility_attributes: {
+        award_amount: 3
+      }
+    )
+  end
+
+  let!(:approved) do
+    # decision date out of range but approved so in next payroll run
+    create(
+      :claim,
+      :approved,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      decision_deadline: 2.months.from_now,
+      eligibility_attributes: {
+        award_amount: 5
+      }
+    )
+  end
+
+  let!(:rejected) do
+    # rejected claim, not included
+    create(
+      :claim,
+      :rejected,
+      policy: Policies::EarlyYearsTeachersFinancialIncentivePayments,
+      decision_deadline: 1.day.from_now,
+      eligibility_attributes: {
+        award_amount: 7
+      }
+    )
+  end
+
+  let!(:paid) do
+    # paid claim, not included
+    create(
+      :claim,
+      :approved,
+      policy: Policies::StudentLoans,
+      decision_deadline: 2.months.from_now,
+      eligibility_attributes: {
+        award_amount: 11
+      }
+    ).tap do |claim|
+      create(:payment, claims: [claim], payroll_run: previous_payroll_run)
+    end
+  end
+
+  let!(:topped_up) do
+    # Paid claim, topped up, included
+    create(
+      :claim,
+      :approved,
+      policy: Policies::StudentLoans,
+      decision_deadline: 6.months.ago,
+      eligibility_attributes: {
+        award_amount: 13
+      }
+    ).tap do |claim|
+      create(:payment, claims: [claim], payroll_run: previous_payroll_run)
+
+      create(:topup, claim: claim, award_amount: 17)
+    end
+  end
+
+  let!(:paid_topup) do
+    # Paid claim, topped up, included
+    create(
+      :claim,
+      :approved,
+      policy: Policies::TargetedRetentionIncentivePayments,
+      decision_deadline: 6.months.ago,
+      eligibility_attributes: {
+        award_amount: 19
+      }
+    ).tap do |claim|
+      create(:payment, claims: [claim], payroll_run: previous_payroll_run)
+
+      create(
+        :topup,
+        claim: claim,
+        award_amount: 23,
+        payment: create(:payment, payroll_run: previous_payroll_run)
+      )
+    end
+  end
+
+  let!(:projection) { described_class.new }
+
+  describe "#total_award_amount" do
+    subject { projection.total_award_amount }
+
+    it do
+      is_expected.to eq(undecided_in_range.award_amount + approved.award_amount)
+    end
+  end
+
+  describe "#number_of_claims_for_policy" do
+    subject do
+      projection.number_of_claims_for_policy(Policies::FurtherEducationPayments)
+    end
+
+    it { is_expected.to eq 1 }
+  end
+
+  describe "#total_claim_amount_for_policy" do
+    subject do
+      projection.total_claim_amount_for_policy(Policies::FurtherEducationPayments)
+    end
+
+    it { is_expected.to eq 3 }
+  end
+
+  describe "#number_of_topups_for_policy" do
+    context "when no topups for policy" do
+      subject do
+        projection.number_of_topups_for_policy(Policies::TargetedRetentionIncentivePayments)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "when topup for policy" do
+      subject do
+        projection.number_of_topups_for_policy(Policies::StudentLoans)
+      end
+
+      it { is_expected.to eq 1 }
+    end
+  end
+
+  describe "#total_topup_amount_for_policy" do
+    context "when no topups for policy" do
+      subject do
+        projection.total_topup_amount_for_policy(Policies::FurtherEducationPayments)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "when topup for policy" do
+      subject do
+        projection.total_topup_amount_for_policy(Policies::StudentLoans)
+      end
+
+      it { is_expected.to eq 17 }
+    end
+  end
+
+  describe "#claims_count" do
+    subject { projection.claims_count }
+
+    it { is_expected.to eq [undecided_in_range, approved].size }
+  end
+
+  describe "#topups_count" do
+    subject { projection.topups_count }
+
+    it { is_expected.to eq [topped_up].size }
+  end
+end


### PR DESCRIPTION
Add payroll projection

Shows an estimate of next month's payroll.
Unpaid approved claims always go into the next month's payroll.
Unpaid topups always go into the next month's payroll.
We then assume all undecided claims with a decision deadline before the
next month's payroll will end up being approved before payroll runs and
thus fall into the payroll.

