### PR TITLE
[#224] Persist fe provider v2 task

### DIFF
--- a/app/forms/admin/amendments/further_education_payments_form.rb
+++ b/app/forms/admin/amendments/further_education_payments_form.rb
@@ -43,8 +43,6 @@ module Admin
             #{original_start_year}
           TEXT
 
-          existing_provider_verification_task.destroy!
-          claim.reload
           AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2.new(claim).perform
 
           claim.notes.create!(

--- a/app/models/automated_checks/claim_verifiers/fe_provider_verification_v2.rb
+++ b/app/models/automated_checks/claim_verifiers/fe_provider_verification_v2.rb
@@ -11,16 +11,30 @@ module AutomatedChecks
       end
 
       def perform
-        return if task_already_persisted?
-
         if passable?
-          create_task(passed: true)
-        elsif failed_checks.any?
-          create_task(passed: false, data: {failed_checks: failed_checks})
+          if existing_task
+            existing_task.update(passed: true)
+          else
+            create_task(passed: true)
+          end
+        elsif provider_verification_completed? && failed_checks.any?
+          if existing_task
+            existing_task.update(passed: false, data: {failed_checks: failed_checks})
+          else
+            create_task(passed: false, data: {failed_checks: failed_checks})
+          end
+        elsif existing_task
+          existing_task.update(passed: nil)
+        else
+          create_task(passed: nil)
         end
       end
 
       private
+
+      def existing_task
+        @existing_task ||= claim.tasks.find_by(name: TASK_NAME)
+      end
 
       def create_task(passed:, data: nil)
         task = claim.tasks.build(
@@ -39,10 +53,11 @@ module AutomatedChecks
       end
 
       def passable?
-        failed_checks.empty? &&
-          provider_confirms_claimant_answers? &&
-          provider_indicates_no_measures? &&
-          provider_indicates_claimant_is_interested_in_becoming_qualified?
+        provider_verification_completed?
+          && failed_checks.empty?
+          && provider_confirms_claimant_answers?
+          && provider_indicates_no_measures?
+          && provider_indicates_claimant_is_interested_in_becoming_qualified?
       end
 
       def provider_confirms_claimant_answers?
@@ -61,6 +76,10 @@ module AutomatedChecks
 
       def provider_indicates_claimant_is_interested_in_becoming_qualified?
         eligibility.provider_verification_teaching_qualification != "no_not_planned"
+      end
+
+      def provider_verification_completed?
+        eligibility.provider_verification_completed_at
       end
 
       def failed_checks
@@ -121,10 +140,6 @@ module AutomatedChecks
         end
 
         @failed_checks
-      end
-
-      def task_already_persisted?
-        claim.tasks.any? { |task| task.name == TASK_NAME }
       end
     end
   end

--- a/db/data/20260716110754_persist_task_fe_provider_verification_v2.rb
+++ b/db/data/20260716110754_persist_task_fe_provider_verification_v2.rb
@@ -1,0 +1,18 @@
+# Run me with `rails runner db/data/20260716110754_persist_task_fe_provider_verification_v2.rb`
+
+relevant_policies = [
+  Policies::FurtherEducationPayments
+]
+
+relevant_policies.each do |policy|
+  claims = Claim.where(policy:, academic_year: AcademicYear.new("2025/2026"))
+  tasks = Task.where(name: "fe_provider_verification_v2", claim: claims)
+  delta = claims.pluck(:id) - tasks.pluck(:claim_id)
+
+  claims_without_task = Claim.where(id: delta)
+
+  claims_without_task.find_each do |claim|
+    verifier = AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2.new(claim)
+    verifier.perform
+  end
+end

--- a/spec/forms/admin/amendments/further_education_payments_form_spec.rb
+++ b/spec/forms/admin/amendments/further_education_payments_form_spec.rb
@@ -86,19 +86,24 @@ RSpec.describe Admin::Amendments::FurtherEducationPaymentsForm, type: :model do
 
     context "when provider verification task is present and further_education_teaching_start_year is changed" do
       let(:claim) do
-        create(:claim, :further_education, :submitted,
+        create(
+          :claim,
+          :further_education,
+          :submitted,
           eligibility_attributes: provider_verification_attributes.merge(
+            provider_verification_completed_at: 1.day.ago,
             further_education_teaching_start_year: "2023"
-          ))
+          )
+        )
       end
 
       before do
         AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2.new(claim).perform
       end
 
-      it "destroys the old task, reruns the automated check and creates a note" do
-        original_task = claim.tasks.find_by(name: "fe_provider_verification_v2")
-        expect(original_task.passed).to be(true)
+      it "reruns the automated check and creates a note" do
+        task = claim.tasks.find_by(name: "fe_provider_verification_v2")
+        expect(task.passed).to be(true)
 
         form = described_class.new(
           claim: claim,
@@ -110,14 +115,7 @@ RSpec.describe Admin::Amendments::FurtherEducationPaymentsForm, type: :model do
         )
 
         expect(form.save).to be_truthy
-
-        claim.reload
-
-        expect(claim.tasks.find_by(id: original_task.id)).to be_nil
-
-        new_task = claim.tasks.find_by(name: "fe_provider_verification_v2")
-        expect(new_task).to be_present
-        expect(new_task.passed).to be(false)
+        expect(task.reload.passed).to be(false)
 
         note = claim.notes.find_by(label: "fe_provider_verification_v2")
         expect(note).to be_present

--- a/spec/models/automated_checks/claim_verifiers/fe_provider_verification_v2_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/fe_provider_verification_v2_spec.rb
@@ -13,11 +13,12 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
     end
 
     context "automatically failing the task" do
-      context "when the provider has sellected no for teaching responsibilities" do
+      context "when the provider has selected no for teaching responsibilities" do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_teaching_responsibilities: false
+            provider_verification_teaching_responsibilities: false,
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -36,7 +37,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
           build(
             :further_education_payments_eligibility,
             further_education_teaching_start_year: "2023",
-            provider_verification_teaching_start_year: "2020"
+            provider_verification_teaching_start_year: "2020",
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -54,7 +56,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_half_teaching_hours: false
+            provider_verification_half_teaching_hours: false,
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -72,7 +75,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_half_timetabled_teaching_time: false
+            provider_verification_half_timetabled_teaching_time: false,
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -90,7 +94,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_performance_measures: true
+            provider_verification_performance_measures: true,
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -108,7 +113,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_disciplinary_action: true
+            provider_verification_disciplinary_action: true,
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -126,7 +132,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_teaching_qualification: "no_not_planned"
+            provider_verification_teaching_qualification: "no_not_planned",
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -144,7 +151,8 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         let(:eligibility) do
           build(
             :further_education_payments_eligibility,
-            provider_verification_continued_employment: false
+            provider_verification_continued_employment: false,
+            provider_verification_completed_at: 1.day.ago
           )
         end
 
@@ -182,10 +190,10 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
           )
         end
 
-        it "does not persist a task" do
+        it "persists an unpassed task" do
           expect {
             subject.perform
-          }.to not_change(Task, :count)
+          }.to change { Task.where(passed: nil).count }.by(1)
         end
       end
 
@@ -403,6 +411,7 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
       let(:eligibility) do
         build(
           :further_education_payments_eligibility,
+          :provider_verification_completed,
           provider_verification_teaching_responsibilities: true,
           further_education_teaching_start_year: "2023",
           provider_verification_teaching_start_year: "2023",
@@ -427,6 +436,87 @@ RSpec.describe AutomatedChecks::ClaimVerifiers::FeProviderVerificationV2 do
         expect(task.passed?).to be true
         expect(task.manual?).to be false
         expect(task.data).to be nil
+      end
+    end
+
+    context "when task already exists" do
+      before do
+        task = claim.tasks.new(
+          name: "fe_provider_verification_v2",
+          passed: nil
+        )
+
+        task.save(validate: false)
+      end
+
+      let(:eligibility) do
+        build(
+          :further_education_payments_eligibility
+        )
+      end
+
+      context "and now passes" do
+        let(:eligibility) do
+          build(
+            :further_education_payments_eligibility,
+            :provider_verification_completed,
+            provider_verification_teaching_responsibilities: true,
+            further_education_teaching_start_year: "2023",
+            provider_verification_teaching_start_year: "2023",
+            provider_verification_half_teaching_hours: true,
+            provider_verification_half_timetabled_teaching_time: true,
+            provider_verification_performance_measures: false,
+            provider_verification_disciplinary_action: false,
+            provider_verification_contract_type: "permanent",
+            contract_type: "permanent",
+            provider_verification_teaching_qualification: "yes",
+            provider_verification_continued_employment: true,
+            provider_verification_teaching_hours_per_week: "more_than_20",
+            teaching_hours_per_week: "more_than_20"
+          )
+        end
+
+        it "does not create another task" do
+          expect { subject.perform }.to not_change(Task, :count)
+        end
+
+        it "updates existing task as passing" do
+          task = claim.tasks.find_by(name: "fe_provider_verification_v2")
+
+          expect { subject.perform }.to change { task.reload.passed }.from(nil).to(true)
+        end
+      end
+
+      context "and now fails" do
+        let(:eligibility) do
+          build(
+            :further_education_payments_eligibility,
+            :provider_verification_completed,
+            provider_verification_teaching_responsibilities: false
+          )
+        end
+
+        it "does not create another task" do
+          expect { subject.perform }.to not_change(Task, :count)
+        end
+
+        it "updates existing task as failing" do
+          task = claim.tasks.find_by(name: "fe_provider_verification_v2")
+
+          expect { subject.perform }.to change { task.reload.passed }.from(nil).to(false)
+        end
+      end
+
+      context "and now neither passes or fails" do
+        it "does not create another task" do
+          expect { subject.perform }.to not_change(Task, :count)
+        end
+
+        it "does not change passed value" do
+          task = claim.tasks.find_by(name: "fe_provider_verification_v2")
+
+          expect { subject.perform }.not_to change { task.reload.passed }
+        end
       end
     end
   end


### PR DESCRIPTION
# Context

- https://github.com/DFE-Digital/claim-issues/issues/224
- Task is now idempotent and can be run as many times as needed
- Will update `passed` depending on state
- Amendment form no longer destroys task to recreate. task is simply re-ran which will update the value
- Added data migration that will persist all non-existent tasks