### PR TITLE
2856 - Workflow to manually deploy to test

### DIFF
--- a/.github/workflows/build_and_deploy_test.yml
+++ b/.github/workflows/build_and_deploy_test.yml
@@ -1,0 +1,142 @@
+name: Manual Build and deploy to test
+
+on:
+  workflow_dispatch:
+
+concurrency: deploy-${{ github.ref }}
+
+permissions:
+  packages: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      docker-image-tag: ${{ steps.build-image.outputs.tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and push docker image
+        id: build-image
+        uses: DFE-Digital/github-actions/build-docker-image@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: web
+          context: .
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
+
+
+  manual_deploy:
+    name: Deploy to test environment
+    runs-on: ubuntu-latest
+    needs: [build]
+    environment:
+      name: test
+      url: ${{ steps.deploy.outputs.environment_url }}
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: ./.github/actions/deploy-environment
+        id: deploy
+        with:
+          environment: test
+          docker-image: ${{ needs.build.outputs.docker-image-tag }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          aks-namespace: srtl-test
+          aks-deployment: claim-additional-payments-for-teaching-test
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run smoke tests
+        shell: bash
+        run: bundle exec rspec spec/smoke -t smoke:true -b
+        env:
+          RAILS_ENV: test
+          SMOKE_TEST_APP_HOST: ${{ vars.SMOKE_TEST_APP_HOST }}
+          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
+          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+
+      - name: Notify teams channel failure
+        if: ${{ failure() }}
+        uses: DFE-Digital/github-actions/send-to-teams-channel@master
+        with:
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          title: Failure deploying release to test
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          message: Failure deploying release to test - Docker tag ${{ needs.build.outputs.docker-image-tag }}
+
+
+  deploy_domains_infra:
+    name: Deploy Domains Infrastructure
+    runs-on: ubuntu-latest
+    needs: [manual_deploy]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy Domains Infrastructure
+        id: deploy_domains_infra
+        uses: DFE-Digital/github-actions/deploy-domains-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+
+  deploy_domains_env:
+    name: Deploy Domains to test environment
+    runs-on: ubuntu-latest
+    needs: [deploy_domains_infra]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy Domains Environment
+        id: deploy_domains_env
+        uses: DFE-Digital/github-actions/deploy-domains-env@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          environment: test
+          healthcheck: healthcheck
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}


### PR DESCRIPTION
### Context

A deploy to test environment workflow. 

### Changes proposed in this pull request

- A new workflow build_and_deploy_test.yml.

### Guidance to review

Create a branch from this branch and add the following to the `on:` section. Push to the test branch which will run the workflow as shown [here](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/29594829176/job/87934220019).

```yml
  push:
    branches:
      - 2856-deploy-test-wf-test
```

### Link to Trello card

https://trello.com/c/bA2sFyil/2856-capt-add-staging-env

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally