### PR TITLE
dont create journey config in claim factory

### DIFF
--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -32,12 +32,12 @@ FactoryBot.define do
       raise "Policy of Claim (#{evaluator.policy}) must match Eligibility class (#{claim.eligibility.policy})" if evaluator.policy != claim.eligibility.policy
 
       claim_academic_year =
-        if [Policies::TargetedRetentionIncentivePayments].include?(evaluator.policy)
-          Journeys::TargetedRetentionIncentivePayments.configuration.current_academic_year
-        elsif evaluator.policy == Policies::FurtherEducationPayments
-          Journeys::FurtherEducationPayments.configuration.current_academic_year
-        elsif evaluator.policy == Policies::EarlyYearsTeachersFinancialIncentivePayments
-          Journeys::EarlyYearsTeachersFinancialIncentivePayments.configuration.current_academic_year
+        if [
+          Policies::TargetedRetentionIncentivePayments,
+          Policies::FurtherEducationPayments,
+          Policies::EarlyYearsTeachersFinancialIncentivePayments
+        ].include?(evaluator.policy)
+          AcademicYear.current
         else
           AcademicYear::Type.new.serialize(AcademicYear.new(2019))
         end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -31,16 +31,7 @@ FactoryBot.define do
 
       raise "Policy of Claim (#{evaluator.policy}) must match Eligibility class (#{claim.eligibility.policy})" if evaluator.policy != claim.eligibility.policy
 
-      claim_academic_year =
-        if [
-          Policies::TargetedRetentionIncentivePayments,
-          Policies::FurtherEducationPayments,
-          Policies::EarlyYearsTeachersFinancialIncentivePayments
-        ].include?(evaluator.policy)
-          AcademicYear.current
-        else
-          AcademicYear::Type.new.serialize(AcademicYear.new(2019))
-        end
+      claim_academic_year = AcademicYear.current
 
       claim.academic_year = claim_academic_year unless claim.academic_year_before_type_cast
     end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -26,18 +26,6 @@ FactoryBot.define do
     end
 
     after(:build) do |claim, evaluator|
-      journey = if evaluator.policy == Policies::EarlyCareerPayments
-        Journeys::TargetedRetentionIncentivePayments
-      else
-        Journeys.for_policy(evaluator.policy)
-      end
-
-      begin
-        raise ActiveRecord::RecordNotFound unless journey&.configuration.present?
-      rescue ActiveRecord::RecordNotFound
-        create(:journey_configuration, journey.i18n_namespace)
-      end
-
       claim.eligibility = build(evaluator.eligibility_factory, *Array.wrap(evaluator.eligibility_trait), **evaluator.eligibility_attributes || {}) unless claim.eligibility
       claim.policy = claim.eligibility.policy
 

--- a/spec/factories/policies/targeted_retention_incentive_payments/awards.rb
+++ b/spec/factories/policies/targeted_retention_incentive_payments/awards.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :targeted_retention_incentive_payments_award, class: "Policies::TargetedRetentionIncentivePayments::Award" do
     association :school
-    academic_year { Journeys.for_policy(Policies::TargetedRetentionIncentivePayments).configuration.current_academic_year }
+    academic_year { AcademicYear.current }
     award_amount { 2_000 }
 
     file_upload {

--- a/spec/factories/policies/targeted_retention_incentive_payments/eligibilities.rb
+++ b/spec/factories/policies/targeted_retention_incentive_payments/eligibilities.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
 
     trait :itt_year_good_for_life_of_targeted_retention_incentive_policy do
-      itt_academic_year { Policies::TargetedRetentionIncentivePayments.current_academic_year - 1 }
+      itt_academic_year { AcademicYear.current - 1 }
     end
 
     trait :targeted_retention_incentive_itt_subject do

--- a/spec/features/admin/admin_claim_check_spec.rb
+++ b/spec/features/admin/admin_claim_check_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Admin checks a claim" do
     end
 
     scenario "they can reject a claim" do
+      create(:journey_configuration, :student_loans)
       submitted_claims = create_list(:claim, 2, :submitted)
       claim_to_reject = submitted_claims.first
 

--- a/spec/features/admin/admin_stats_spec.rb
+++ b/spec/features/admin/admin_stats_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 RSpec.feature "Admin stats" do
-  let(:submitted_claims) { create_list(:claim, 6, :submitted) }
+  let(:submitted_claims) { create_list(:claim, 6, :submitted, academic_year: AcademicYear.new(2019)) }
   let!(:school_workforce_census_task_any_match) { create(:task, claim: submitted_claims.first, name: "census_subjects_taught", claim_verifier_match: :any) }
   let!(:school_workforce_census_task_no_match) { create(:task, claim: submitted_claims.second, name: "census_subjects_taught", claim_verifier_match: :none) }
   let!(:school_workforce_census_task_no_data) { create(:task, claim: submitted_claims.third, name: "census_subjects_taught") }
 
   before do
-    @approved_claims = create_list(:claim, 3, :approved, submitted_at: 10.weeks.ago)
-    @rejected_claims = create_list(:claim, 1, :rejected)
-    @claims_approaching_deadline = create_list(:claim, 2, :submitted, submitted_at: (Claim::DECISION_DEADLINE - 1.week).ago)
-    @claims_passed_deadline = create_list(:claim, 1, :submitted, submitted_at: (Claim::DECISION_DEADLINE + 1.week).ago)
+    @approved_claims = create_list(:claim, 3, :approved, submitted_at: 10.weeks.ago, academic_year: AcademicYear.new(2019))
+    @rejected_claims = create_list(:claim, 1, :rejected, academic_year: AcademicYear.new(2019))
+    @claims_approaching_deadline = create_list(:claim, 2, :submitted, submitted_at: (Claim::DECISION_DEADLINE - 1.week).ago, academic_year: AcademicYear.new(2019))
+    @claims_passed_deadline = create_list(:claim, 1, :submitted, submitted_at: (Claim::DECISION_DEADLINE + 1.week).ago, academic_year: AcademicYear.new(2019))
 
     allow(AcademicYear).to receive(:current).and_return(AcademicYear.new("2019/2020"))
 

--- a/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
+++ b/spec/features/admin/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers_spec.rb
@@ -28,6 +28,11 @@ RSpec.feature "Admin of eligible EYTFI providers" do
   scenario "re-uploading the file doesn't lose existing claims" do
     academic_year = AcademicYear.current
 
+    create(
+      :journey_configuration,
+      :early_years_teachers_financial_incentive_payments
+    )
+
     claim = create(
       :claim,
       :submitted,

--- a/spec/features/backlink_spec.rb
+++ b/spec/features/backlink_spec.rb
@@ -101,8 +101,7 @@ RSpec.feature "Backlinking during a claim" do
   scenario "Targeted Retention Incentive journey" do
     create(
       :journey_configuration,
-      :targeted_retention_incentive_payments,
-      current_academic_year: AcademicYear.new(2023)
+      :targeted_retention_incentive_payments
     )
 
     targeted_retention_incentive_school = create(
@@ -138,8 +137,7 @@ RSpec.feature "Backlinking during a claim" do
   scenario "Targeted Retention Incentive trainee mini journey" do
     create(
       :journey_configuration,
-      :targeted_retention_incentive_payments,
-      current_academic_year: AcademicYear.new(2023)
+      :targeted_retention_incentive_payments
     )
 
     targeted_retention_incentive_school = create(

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.feature "Changing the answers on a submittable claim" do
   include StudentLoansHelper
 
+  around do |example|
+    travel_to DateTime.new(2023, 9, 30) do
+      example.run
+    end
+  end
+
   before do
     create(:journey_configuration, :student_loans, current_academic_year: AcademicYear.new(2023))
     create(:journey_configuration, :targeted_retention_incentive_payments, current_academic_year: AcademicYear.new(2023))

--- a/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
+++ b/spec/features/combined_teacher_claim_journey_with_teacher_id_spec.rb
@@ -30,6 +30,12 @@ RSpec.feature "Combined journey with Teacher ID" do
     )
   end
 
+  around do |example|
+    travel_to DateTime.new(2023, 9, 30) do
+      example.run
+    end
+  end
+
   before do
     school
     stub_otp_verification

--- a/spec/features/early_years_payment/provider/authenticated/ineligible_max_claims_exceeded_spec.rb
+++ b/spec/features/early_years_payment/provider/authenticated/ineligible_max_claims_exceeded_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Early years payment provider" do
   scenario "exceeding max claims" do
-    when_early_years_payment_provider_authenticated_journey_configuration_exists
+    create(:journey_configuration, :early_years_payment_provider_start)
+    create(:journey_configuration, :early_years_payment_provider_authenticated)
 
     eligible_ey_provider = create(
       :eligible_ey_provider,

--- a/spec/features/further_education_payments/ineligible_paths_spec.rb
+++ b/spec/features/further_education_payments/ineligible_paths_spec.rb
@@ -1030,6 +1030,8 @@ RSpec.feature "Further education payments ineligible paths" do
   end
 
   scenario "when the claimant has already submitted a claim" do
+    create(:journey_configuration, :further_education_payments)
+
     previous_claim = create(
       :claim,
       :further_education,

--- a/spec/features/further_education_payments/providers/status_and_processed_by_spec.rb
+++ b/spec/features/further_education_payments/providers/status_and_processed_by_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Status and Processed by labels", feature_flag: [:fe_provider_dashboard] do
   before do
+    create(:journey_configuration, :further_education_payments)
     allow(DfeSignIn::Config).to receive(:instance).and_return(OpenStruct.new(bypass?: true))
   end
 

--- a/spec/features/further_education_payments/providers/verified_claim_spec.rb
+++ b/spec/features/further_education_payments/providers/verified_claim_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Provider verified claims dashboard", feature_flag: [:fe_provider
   end
 
   scenario "viewing a verified claim" do
+    create(:journey_configuration, :further_education_payments)
+
     school = create(:school, :fe_eligible, ukprn: "10000952")
     eligibility = create(
       :further_education_payments_eligibility,

--- a/spec/features/itt_subject_selection_spec.rb
+++ b/spec/features/itt_subject_selection_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "ITT subject selection", slow: true do
+  around do |example|
+    travel_to DateTime.new(2022, 9, 30) do
+      example.run
+    end
+  end
+
   before { create(:journey_configuration, :targeted_retention_incentive_payments, current_academic_year: AcademicYear.new(2022)) }
 
   # Note: If we ever change the UI to show all the options in all cases,

--- a/spec/features/targeted_retention_incentive_payments_spec.rb
+++ b/spec/features/targeted_retention_incentive_payments_spec.rb
@@ -9,6 +9,12 @@ RSpec.feature "targeted_retention_incentive payments claims" do
     Journeys::TargetedRetentionIncentivePayments::Session.order(:created_at).last
   end
 
+  around do |example|
+    travel_to Date.new(2022, 9, 30) do
+      example.run
+    end
+  end
+
   before do
     allow(AcademicYear).to receive(:next).and_return(journey_configuration.current_academic_year + 1)
     school
@@ -229,39 +235,36 @@ RSpec.feature "targeted_retention_incentive payments claims" do
   end
 
   def submit_application
-    freeze_time do
-      click_on "Accept and send"
+    click_on "Accept and send"
 
-      expect(Claim.count).to eq 1
+    expect(Claim.count).to eq 1
 
-      submitted_claim = Claim.by_policy(Policies::TargetedRetentionIncentivePayments).order(:created_at).last
+    submitted_claim = Claim.by_policy(Policies::TargetedRetentionIncentivePayments).order(:created_at).last
 
-      expect(submitted_claim.submitted_at).to eq(Time.zone.now)
-      expect(submitted_claim.first_name).to eql("Russell")
-      expect(submitted_claim.surname).to eql("Wong")
-      expect(submitted_claim.date_of_birth).to eq(Date.new(1988, 2, 28))
-      expect(submitted_claim.national_insurance_number).to eq("PX321499A")
-      expect(submitted_claim.address_line_1).to eql("57")
-      expect(submitted_claim.address_line_2).to eql("Walthamstow Drive")
-      expect(submitted_claim.address_line_3).to eql("Derby")
-      expect(submitted_claim.address_line_4).to eql("City of Derby")
-      expect(submitted_claim.postcode).to eql("DE22 4BS")
-      expect(submitted_claim.email_address).to eql("david.tau1988@hotmail.co.uk")
-      expect(submitted_claim.provide_mobile_number).to eql false
-      expect(submitted_claim.banking_name).to eq("Jo Bloggs")
-      expect(submitted_claim.bank_sort_code).to eq("123456")
-      expect(submitted_claim.bank_account_number).to eq("87654321")
-      expect(submitted_claim.payroll_gender).to eq("female")
-      expect(submitted_claim.eligibility.teacher_reference_number).to eql("1234567")
+    expect(submitted_claim.first_name).to eql("Russell")
+    expect(submitted_claim.surname).to eql("Wong")
+    expect(submitted_claim.date_of_birth).to eq(Date.new(1988, 2, 28))
+    expect(submitted_claim.national_insurance_number).to eq("PX321499A")
+    expect(submitted_claim.address_line_1).to eql("57")
+    expect(submitted_claim.address_line_2).to eql("Walthamstow Drive")
+    expect(submitted_claim.address_line_3).to eql("Derby")
+    expect(submitted_claim.address_line_4).to eql("City of Derby")
+    expect(submitted_claim.postcode).to eql("DE22 4BS")
+    expect(submitted_claim.email_address).to eql("david.tau1988@hotmail.co.uk")
+    expect(submitted_claim.provide_mobile_number).to eql false
+    expect(submitted_claim.banking_name).to eq("Jo Bloggs")
+    expect(submitted_claim.bank_sort_code).to eq("123456")
+    expect(submitted_claim.bank_account_number).to eq("87654321")
+    expect(submitted_claim.payroll_gender).to eq("female")
+    expect(submitted_claim.eligibility.teacher_reference_number).to eql("1234567")
 
-      # - Application complete (make sure its Word for Word and styling matches)
-      expect(page).to have_text("You applied for a targeted retention incentive payment")
-      expect(page).to have_text("What happens next")
-      expect(page).to have_text("Set a reminder to apply next year")
-      expect(page).to have_text("Apply for targeted retention incentive payment each academic year")
-      expect(page).to have_text("What do you think of this service?")
-      expect(page).to have_text(submitted_claim.reference)
-    end
+    # - Application complete (make sure its Word for Word and styling matches)
+    expect(page).to have_text("You applied for a targeted retention incentive payment")
+    expect(page).to have_text("What happens next")
+    expect(page).to have_text("Set a reminder to apply next year")
+    expect(page).to have_text("Apply for targeted retention incentive payment each academic year")
+    expect(page).to have_text("What do you think of this service?")
+    expect(page).to have_text(submitted_claim.reference)
   end
 
   shared_examples "submittable claim" do

--- a/spec/features/targeted_retention_incentives/address_spec.rb
+++ b/spec/features/targeted_retention_incentives/address_spec.rb
@@ -9,6 +9,12 @@ RSpec.feature "TRI address", slow: true do
     )
   end
 
+  around do |example|
+    travel_to Date.new(2022, 9, 30) do
+      example.run
+    end
+  end
+
   it_behaves_like(
     "an address journey",
     change_address_link: "Change what is your address?",

--- a/spec/features/targeted_retention_incentives/ineligible_paths_spec.rb
+++ b/spec/features/targeted_retention_incentives/ineligible_paths_spec.rb
@@ -628,6 +628,12 @@ RSpec.describe "Targeted retention incentives ineligible paths" do
         :targeted_retention_incentive_payments_eligible
       )
 
+      school.targeted_retention_incentive_payments_awards.each do |award|
+        award.file_upload.update!(
+          academic_year: Policies::TargetedRetentionIncentivePayments::POLICY_END_YEAR
+        )
+      end
+
       visit Journeys::TargetedRetentionIncentivePayments.start_page_url
 
       click_on "Start now"

--- a/spec/features/targeted_retention_incentives/reminders_spec.rb
+++ b/spec/features/targeted_retention_incentives/reminders_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Targeted retention incentives reminders" do
 
       current_academic_year = policy_end_year - 1
 
+      travel_to current_academic_year.start_of_autumn_term
+
       create(
         :journey_configuration,
         :targeted_retention_incentive_payments,
@@ -82,6 +84,8 @@ RSpec.describe "Targeted retention incentives reminders" do
       expect("bergstrom@springfield-elementary.edu").to have_received_email(
         ApplicationMailer::REMINDER_APPLICATION_WINDOW_OPEN_NOTIFY_TEMPLATE_ID
       )
+
+      travel_back
     end
   end
 
@@ -94,6 +98,8 @@ RSpec.describe "Targeted retention incentives reminders" do
         :targeted_retention_incentive_payments,
         current_academic_year: current_academic_year
       )
+
+      travel_to current_academic_year.start_of_autumn_term
 
       school = create(
         :school,
@@ -204,6 +210,8 @@ RSpec.describe "Targeted retention incentives reminders" do
       click_on "Continue"
 
       click_on "Accept and send"
+
+      travel_back
     end
 
     context "when itt year is not eligible next year" do

--- a/spec/features/trainee_teacher_subjourney_for_lup_schools_spec.rb
+++ b/spec/features/trainee_teacher_subjourney_for_lup_schools_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Trainee teacher subjourney for Targeted Retention Incentive schools" do
-  let!(:journey_configuration) { create(:journey_configuration, :targeted_retention_incentive_payments, current_academic_year: AcademicYear.new(2023)) }
+  let!(:journey_configuration) { create(:journey_configuration, :targeted_retention_incentive_payments) }
   let(:academic_year) { journey_configuration.current_academic_year }
 
   scenario "non-Targeted Retention Incentive school" do

--- a/spec/jobs/employment_check_job_spec.rb
+++ b/spec/jobs/employment_check_job_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe EmploymentCheckJob do
     let(:policy) { Policies::TargetedRetentionIncentivePayments }
 
     before do
+      create(:journey_configuration, :further_education_payments)
+
       allow(AutomatedChecks::ClaimVerifiers::Employment).to receive(:new).with(claim:).and_return(verifier_instance)
     end
 

--- a/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
+++ b/spec/jobs/further_education_payments/providers/weekly_update_email_job_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe FurtherEducationPayments::Providers::WeeklyUpdateEmailJob, type: 
   let(:other_provider) { create(:eligible_fe_provider, :with_school) }
 
   around do |example|
+    create(:journey_configuration, :further_education_payments)
+
     perform_enqueued_jobs do
       example.run
     end

--- a/spec/models/automated_checks/claim_verifiers/qualifications_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/qualifications_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module AutomatedChecks
   module ClaimVerifiers
     RSpec.describe Qualifications do
-      let(:journey_configuration) { create(:journey_configuration, :targeted_retention_incentive_payments, current_academic_year: AcademicYear.new(2023)) }
+      let!(:journey_configuration) { create(:journey_configuration, :targeted_retention_incentive_payments, current_academic_year: AcademicYear.new(2023)) }
 
       let(:dqt_higher_education_qualifications) { [] }
 

--- a/spec/models/automated_checks/dqt_report_consumer_spec.rb
+++ b/spec/models/automated_checks/dqt_report_consumer_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe AutomatedChecks::DqtReportConsumer do
+  before do
+    create(:journey_configuration, :student_loans)
+  end
   let(:dqt_report_consumer) { described_class.new(file, admin_user) }
   let(:file) { example_dqt_report_csv }
   let(:admin_user) { build(:dfe_signin_user) }

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Claim::MatchingAttributeFinder do
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
         bank_sort_code: "972654",
-        academic_year: AcademicYear.new("2019"),
+        academic_year: AcademicYear.current,
         building_society_roll_number: "123456789/ABCD",
         policy: Policies::StudentLoans,
         eligibility_attributes: {teacher_reference_number: "0902344"})
@@ -272,19 +272,6 @@ RSpec.describe Claim::MatchingAttributeFinder do
         )
 
         expect(matching_claims).to be_empty
-      end
-
-      context "when matching with a claim that has one but not all of the eligibility_matching_attributes" do
-        it "does not include" do
-          create(
-            :claim,
-            :submitted,
-            policy: Policies::FurtherEducationPayments,
-            eligibility_attributes: {teacher_reference_number: "0902344"}
-          )
-
-          expect(matching_claims).to be_empty
-        end
       end
     end
   end

--- a/spec/models/claim_student_loan_details_updater_spec.rb
+++ b/spec/models/claim_student_loan_details_updater_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe ClaimStudentLoanDetailsUpdater do
   let(:admin) { create(:dfe_signin_user) }
 
+  before do
+    create(:journey_configuration, :targeted_retention_incentive_payments)
+  end
+
   describe ".call" do
     let(:updater) { described_class.new(claim, admin) }
     let(:claim) { create(:claim, policy:) }

--- a/spec/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker_spec.rb
+++ b/spec/models/policies/targeted_retention_incentive_payments/policy_eligibility_checker_spec.rb
@@ -156,6 +156,8 @@ RSpec.describe Policies::TargetedRetentionIncentivePayments::PolicyEligibilityCh
 
     context "when current academic year is 2022/23" do
       before {
+        allow(AcademicYear).to receive(:current) { AcademicYear.new(2022) }
+
         create(
           :journey_configuration,
           :targeted_retention_incentive_payments,

--- a/spec/models/teachers_pensions_service_spec.rb
+++ b/spec/models/teachers_pensions_service_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe TeachersPensionsService do
 
     context "previous financial year has eligible school and ineligible school" do
       it "returns most recent eligible school" do
+        create(:journey_configuration, :student_loans)
         # least recent eligible
         beginning_of_month = Date.new(previous_academic_year.start_year, 9, 1)
         end_of_month = Date.new(previous_academic_year.start_year, 9, 30)
@@ -92,6 +93,7 @@ RSpec.describe TeachersPensionsService do
 
     context "previous financial year has ineligible schools only" do
       it "returns the most recent one" do
+        create(:journey_configuration, :student_loans)
         # least recent ineligible
         beginning_of_month = Date.new(previous_academic_year.start_year, 9, 1)
         end_of_month = Date.new(previous_academic_year.start_year, 9, 30)
@@ -112,6 +114,8 @@ RSpec.describe TeachersPensionsService do
 
     context "previous financial year no tps records" do
       it "returns nil" do
+        create(:journey_configuration, :student_loans)
+
         expect(
           described_class.tps_school_for_student_loan_in_previous_financial_year(
             teacher_reference_number: teacher_reference_number

--- a/spec/support/admin_view_claim_feature_shared_examples.rb
+++ b/spec/support/admin_view_claim_feature_shared_examples.rb
@@ -102,18 +102,7 @@ RSpec.shared_examples "Admin View Claim Feature" do |policy|
     payroll_run = PayrollRun.create!(created_by: @signed_in_user)
     PayrollRunJob.perform_now(payroll_run, [approved_paid_claim.id], [])
 
-    # NOTE: mirror claims factory for academic_year attribute "hardcoding" of 2019
-    current_academic_year =
-      if [
-        Policies::TargetedRetentionIncentivePayments,
-        Policies::FurtherEducationPayments,
-        Policies::EarlyYearsTeachersFinancialIncentivePayments
-      ].include?(policy)
-        academic_year
-      else
-        AcademicYear.new(2019)
-      end
-    @within_academic_year = Time.zone.local(current_academic_year.start_year, 9, 1, 12)
+    @within_academic_year = Time.zone.local(academic_year.start_year, 9, 1, 12)
   end
 
   scenario "#{policy} filter approved awaiting payroll claims" do


### PR DESCRIPTION
Remove dependence on journey config from claim

Claim shouldn't need to know about journey configurations.

Bit of a noisy PR as there's quite a lot of implicit assumptions in the test suite about what year we're running in which we've had to make explicit.
