### PR TITLE
128 - Treat staging like a review app for auth bypasses and debug tooling

### DIFF
--- a/app/controllers/admin/components_controller.rb
+++ b/app/controllers/admin/components_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class ComponentsController < BaseAdminController
     before_action :ensure_service_operator
-    before_action -> { raise ActiveRecord::RecordNotFound if Rails.env.production? && !Rails.env.review_app? }
+    before_action -> { raise ActiveRecord::RecordNotFound if Rails.env.production? && !Rails.env.review_app_like? }
 
     PREVIEW_SESSION_LENGTH_IN_SECONDS = 2.hours.to_i
 

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -202,7 +202,7 @@ class ClaimsController < BasePublicController
   end
 
   def admin_component_preview_enabled_for_current_journey?
-    return false if Rails.env.production? && !Rails.env.review_app?
+    return false if Rails.env.production? && !Rails.env.review_app_like?
     preview = session[:admin_component_preview]
     return false unless preview.present?
 

--- a/app/forms/debug/sign_in_or_continue_form.rb
+++ b/app/forms/debug/sign_in_or_continue_form.rb
@@ -20,7 +20,7 @@ module Debug
     end
 
     def dqt_bypassable?
-      !ENV["ENVIRONMENT_NAME"].start_with?("review")
+      !Rails.env.review_app_like?
     end
 
     def dqt_induction_status_options

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -173,12 +173,8 @@ module ApplicationHelper
   ]
 
   def current_path_indexable?
-    return false if review_app?
+    return false if Rails.env.review_app_like?
 
     INDEXABLE_PATHS.any? { |path| current_page?(path) }
-  end
-
-  def review_app?
-    ENV["ENVIRONMENT_NAME"].start_with?("review")
   end
 end

--- a/app/jobs/dfe_sign_in/user_data_importer_job.rb
+++ b/app/jobs/dfe_sign_in/user_data_importer_job.rb
@@ -3,7 +3,7 @@ module DfeSignIn
     queue_as :user_data
 
     def perform
-      return if ENV["ENVIRONMENT_NAME"].start_with?("review")
+      return if Rails.env.review_app_like?
 
       Rails.logger.info "Importing DfE Sign-in user data..."
 

--- a/app/models/dfe_sign_in/config.rb
+++ b/app/models/dfe_sign_in/config.rb
@@ -5,7 +5,7 @@ module DfeSignIn
     end
 
     def bypass?
-      (Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_DFE_SIGN_IN"] == "true"
+      (Rails.env.development? || Rails.env.review_app_like?) && ENV["BYPASS_DFE_SIGN_IN"] == "true"
     end
 
     def issuer_uri

--- a/app/models/one_login/config.rb
+++ b/app/models/one_login/config.rb
@@ -12,7 +12,7 @@ class OneLogin::Config
   end
 
   def bypass?
-    (!Rails.env.production? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_ONELOGIN_SIGN_IN"] == "true"
+    (!Rails.env.production? || Rails.env.review_app_like?) && ENV["BYPASS_ONELOGIN_SIGN_IN"] == "true"
   end
 
   def issuer_uri

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -16,7 +16,7 @@ class PayrollRun < ApplicationRecord
   scope :this_month, -> { where(created_at: DateTime.now.all_month) }
 
   def self.allow_destroy?
-    ENV["ENVIRONMENT_NAME"].start_with?("review") ||
+    Rails.env.review_app_like? ||
       ENV["ENVIRONMENT_NAME"] == "test" ||
       Rails.env.development?
   end

--- a/app/models/teacher_auth/config.rb
+++ b/app/models/teacher_auth/config.rb
@@ -5,7 +5,7 @@ module TeacherAuth
     end
 
     def bypass?
-      (Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_TEACHER_AUTH"] == "true"
+      (Rails.env.development? || Rails.env.review_app_like?) && ENV["BYPASS_TEACHER_AUTH"] == "true"
     end
 
     def callback_path
@@ -29,7 +29,7 @@ module TeacherAuth
 
       @redirect_base_url = URI.parse(ENV["TEACHER_AUTH_REDIRECT_BASE_URL"].presence || "https://www.claim-additional-teaching-payment.service.gov.uk")
 
-      if ENV["ENVIRONMENT_NAME"].start_with?("review")
+      if Rails.env.review_app_like?
         @redirect_base_url.host = ENV["CANONICAL_HOSTNAME"]
       end
 

--- a/app/models/teacher_id/config.rb
+++ b/app/models/teacher_id/config.rb
@@ -5,7 +5,7 @@ module TeacherId
     end
 
     def bypass?
-      (Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review")) && ENV["BYPASS_DFE_SIGN_IN"] == "true"
+      (Rails.env.development? || Rails.env.review_app_like?) && ENV["BYPASS_DFE_SIGN_IN"] == "true"
     end
 
     def sign_in_endpoint_uri
@@ -19,7 +19,7 @@ module TeacherId
         @sign_in_redirect_uri = URI.parse(ENV["TID_BASE_URL"])
         @sign_in_redirect_uri.path = "/claim/auth/tid/callback"
 
-        if ENV["ENVIRONMENT_NAME"].start_with?("review")
+        if Rails.env.review_app_like?
           @sign_in_redirect_uri.host = ENV["CANONICAL_HOSTNAME"]
         end
       end

--- a/app/views/early_years_payment/practitioner/claims/_sign_in_1_start.html.erb
+++ b/app/views/early_years_payment/practitioner/claims/_sign_in_1_start.html.erb
@@ -23,7 +23,7 @@
   You must prove your identity using the GOV.UK One Login service in order to submit a claim for an incentive payment.
 </p>
 
-<% if Rails.env.development? || ENV["ENVIRONMENT_NAME"].start_with?("review") %>
+<% if Rails.env.development? || Rails.env.review_app_like? %>
   <%= form_with url: "/auth/onelogin", builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
     <%= f.govuk_text_field :uid,
       value: SecureRandom.uuid,

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -2,7 +2,7 @@ DfE::Analytics.configure do |config|
   # Whether to log events instead of sending them to BigQuery.
   #
   # config.log_only = true
-  config.log_only = (%w[development test].include?(ENV["RAILS_ENV"]) || ENV["ENVIRONMENT_NAME"].start_with?("review"))
+  config.log_only = (%w[development test].include?(ENV["RAILS_ENV"]) || ENV["ENVIRONMENT_NAME"].start_with?("review") || ENV["ENVIRONMENT_NAME"] == "staging")
 
   # Whether to use ActiveJob or dispatch events immediately.
   #

--- a/config/initializers/rails_env_extensions.rb
+++ b/config/initializers/rails_env_extensions.rb
@@ -1,6 +1,10 @@
 module RailsEnvExtensions
   def enable_home_components?
-    !production? || review_app? || staging_app? || test_app?
+    !production? || review_app_like? || test_app?
+  end
+
+  def review_app_like?
+    review_app? || staging_app?
   end
 
   def test_app?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-domain = if ENV["ENVIRONMENT_NAME"].start_with?("review")
+domain = if Rails.env.review_app_like?
   ENV["CANONICAL_HOSTNAME"]
 elsif !ENV["TID_BASE_URL"].nil?
   URI.parse(ENV["TID_BASE_URL"]).host

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,7 +140,7 @@ Rails.application.routes.draw do
   end
 
   if Rails.env.development? || Rails.env.test? ||
-      ENV["ENVIRONMENT_NAME"]&.start_with?("review") ||
+      Rails.env.review_app_like? ||
       ENV["ENVIRONMENT_NAME"] == "test"
     get "/testdata", to: "test_data#index", as: :test_data
     get "/testdata/download/:file_key", to: "test_data#download", as: :test_data_download

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ require_relative "seeders/review"
 
 seeder = if Rails.env.development?
   Seeders::Development.new
-elsif ENV["ENVIRONMENT_NAME"].start_with?("review")
+elsif Rails.env.review_app?
   Seeders::Review.new
 else
   Seeders::Null.new

--- a/spec/config/rails_env_extensions_spec.rb
+++ b/spec/config/rails_env_extensions_spec.rb
@@ -59,4 +59,20 @@ RSpec.describe RailsEnvExtensions do
       expect(Rails.env.review_app?).to be(false)
     end
   end
+
+  describe "#review_app_like?" do
+    it "returns true for review apps and staging" do
+      %w[review-123 staging].each do |environment_name|
+        allow(ENV).to receive(:[]).with("ENVIRONMENT_NAME").and_return(environment_name)
+
+        expect(Rails.env.review_app_like?).to be(true)
+      end
+    end
+
+    it "returns false for other environments" do
+      allow(ENV).to receive(:[]).with("ENVIRONMENT_NAME").and_return("test")
+
+      expect(Rails.env.review_app_like?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Add Rails.env.review_app_like? (review_app? || staging_app?) and use it everywhere a review-only check previously gated debug sign-in bypasses, the admin component preview, the /testdata route, and session cookie domain handling, so the new staging environment gets the same capabilities as review apps.

config/initializers/dfe_analytics.rb keeps an inline check since it loads before rails_env_extensions.rb alphabetically. db/seeds.rb is left on review_app? only, so seed data still only runs for review apps.

