### PR TITLE
2855 - Removes unused tf-file variable

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -20,7 +20,6 @@ env:
   GLOBAL_CONFIG_PATH: global_config
   TF_VARS_PATH: terraform/application/config
   TERRAFORM_BASE: terraform/application
-  TF_FILE: terraform.tf
   SERVICE_NAME: claim-additional-payments-for-teaching
   RESOURCE_GROUP_NAME: s189t01-capt-rv-rg
   STORAGE_ACCOUNT_NAME: s189t01captrvtfsa
@@ -52,7 +51,6 @@ jobs:
           resource-group-name: ${{ env.RESOURCE_GROUP_NAME }}
           storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
           terraform-base: ${{ env.TERRAFORM_BASE }}
-          tf-file: ${{ env.TF_FILE }}
           service-name: ${{ env.SERVICE_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-repo: ${{ github.repository }}


### PR DESCRIPTION
## Context

After adding the new reconcile review app workflow and scheduling the run, I found an errant variable declared and never used: tf-file.

## Changes proposed in this pull request

Remove reference to tf-file variable from workflow code.

## Guidance to review

Start a dry run (i.e., set to not delete review apps) of the workflow against the new branch, which should complete without warning about the unused the tf-file variable.

My dry run is here: [Dry run](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/30246904962)

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist

- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Applied DevOps label
- [x] Tested locally