### PR TITLE
280 - Extract award amount validation into policy rules objects

### DIFF
--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -94,6 +94,12 @@ module BasePolicy
     10_000.00
   end
 
+  # Policies that constrain the size of an award define an AwardAmountRules and
+  # overwrite this. `record` is whichever model owns the award amount.
+  def award_amount_rules(record)
+    nil
+  end
+
   def current_academic_year
     Journeys.for_policy(self).configuration.current_academic_year
   end

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -96,6 +96,10 @@ module Policies
       "962b3044-cdd4-4dbe-b6ea-c461530b3dc6"
     end
 
+    def award_amount_rules(record)
+      AwardAmountRules.new(record)
+    end
+
     # Returns the AcademicYear during or after which teachers must have completed
     # their Initial Teacher Training and been awarded QTS to be eligible to make
     # a claim. Anyone qualifying before this academic year should not be able to

--- a/app/models/policies/student_loans/award_amount_rules.rb
+++ b/app/models/policies/student_loans/award_amount_rules.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Policies
+  module StudentLoans
+    class AwardAmountRules
+      MAX_AWARD_AMOUNT = 99_999
+      MAX_AMENDED_AWARD_AMOUNT = 5_000
+
+      def initialize(record)
+        @record = record
+      end
+
+      def validate(context: nil)
+        monetary_amount_validator.validate(record)
+
+        if amendment?(context) && record.award_amount_changed?
+          amended_award_range_validator.validate(record)
+        end
+      end
+
+      private
+
+      attr_reader :record
+
+      def amendment?(context)
+        Array(context).include?(:amendment)
+      end
+
+      def monetary_amount_validator
+        ActiveModel::Validations::NumericalityValidator.new(
+          attributes: [:award_amount],
+          message: "Enter a valid monetary amount",
+          allow_nil: true,
+          greater_than_or_equal_to: 0,
+          less_than_or_equal_to: MAX_AWARD_AMOUNT
+        )
+      end
+
+      def amended_award_range_validator
+        ::AwardRangeValidator.new(
+          attributes: [:award_amount],
+          max: MAX_AMENDED_AWARD_AMOUNT
+        )
+      end
+    end
+  end
+end

--- a/app/models/policies/student_loans/eligibility.rb
+++ b/app/models/policies/student_loans/eligibility.rb
@@ -42,8 +42,7 @@ module Policies
       validates :employment_status, on: [:submit], presence: {message: ->(object, _data) { "Select if you still work at #{object.claim_school_name}, another school or no longer teach in England" }}
       validates :had_leadership_position, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}
       validates :mostly_performed_leadership_duties, on: [:submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
-      validates_numericality_of :award_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99999
-      validates :award_amount, on: :amendment, award_range: {max: 5_000}, if: :award_amount_changed?
+      validate :validate_award_amount
       validates :teacher_reference_number, on: :amendment, presence: {message: "Enter your teacher reference number"}
       validate :validate_teacher_reference_number_length
 
@@ -88,6 +87,10 @@ module Policies
       end
 
       private
+
+      def validate_award_amount
+        policy.award_amount_rules(self).validate(context: validation_context)
+      end
 
       def eligibility_checker
         @eligibility_checker ||= PolicyEligibilityChecker.new(answers: self)

--- a/app/models/policies/targeted_retention_incentive_payments.rb
+++ b/app/models/policies/targeted_retention_incentive_payments.rb
@@ -111,6 +111,10 @@ module Policies
       Award.by_academic_year(claim.academic_year).maximum(:award_amount)
     end
 
+    def award_amount_rules(record)
+      AwardAmountRules.new(record)
+    end
+
     def set_a_reminder?(itt_academic_year)
       selectable_itt_years_for_claim_year(AcademicYear.next).include?(itt_academic_year)
     end

--- a/app/models/policies/targeted_retention_incentive_payments/award_amount_rules.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/award_amount_rules.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Policies
+  module TargetedRetentionIncentivePayments
+    class AwardAmountRules
+      include ActiveSupport::NumberHelper
+
+      def initialize(record)
+        @record = record
+      end
+
+      def validate(context: nil)
+        validate_award_amount_in_range if amendment?(context)
+      end
+
+      private
+
+      attr_reader :record
+
+      def amendment?(context)
+        Array(context).include?(:amendment)
+      end
+
+      def validate_award_amount_in_range
+        return if record.award_amount&.between?(1, max_award_amount)
+
+        record.errors.add(
+          :award_amount,
+          "Enter a positive amount up to #{number_to_currency(max_award_amount)} (inclusive)"
+        )
+      end
+
+      def max_award_amount
+        @max_award_amount ||= Award.by_academic_year(academic_year).maximum(:award_amount)
+      end
+
+      # NOTE: this reads the current academic year rather than the year of the
+      # claim being amended, which is wrong for a claim from an earlier year.
+      # Preserved as-is from the eligibility validation this was extracted from;
+      # it becomes record.academic_year once award_amount lives on Claim.
+      def academic_year
+        TargetedRetentionIncentivePayments.current_academic_year
+      end
+    end
+  end
+end

--- a/app/models/policies/targeted_retention_incentive_payments/eligibility.rb
+++ b/app/models/policies/targeted_retention_incentive_payments/eligibility.rb
@@ -7,15 +7,13 @@ module Policies
         Policies::TargetedRetentionIncentivePayments
       end
 
-      include ActiveSupport::NumberHelper
-
       self.table_name = "targeted_retention_incentive_payments_eligibilities"
       has_one :claim, as: :eligibility, inverse_of: :eligibility
       belongs_to :current_school, optional: true, class_name: "School"
 
       before_validation :normalise_teacher_reference_number, if: :teacher_reference_number_changed?
 
-      validate :award_amount_must_be_in_range, on: :amendment
+      validate :validate_award_amount
       validates :teacher_reference_number, on: :amendment, presence: {message: "Enter your teacher reference number"}
       validate :validate_teacher_reference_number_length
 
@@ -62,13 +60,8 @@ module Policies
 
       private
 
-      def award_amount_must_be_in_range
-        claim_year = policy.current_academic_year
-        max = TargetedRetentionIncentivePayments::Award.by_academic_year(claim_year).maximum(:award_amount)
-
-        unless award_amount&.between?(1, max)
-          errors.add(:award_amount, "Enter a positive amount up to #{number_to_currency(max)} (inclusive)")
-        end
+      def validate_award_amount
+        policy.award_amount_rules(self).validate(context: validation_context)
       end
     end
   end

--- a/spec/features/admin/admin_amend_award_amount_limits_spec.rb
+++ b/spec/features/admin/admin_amend_award_amount_limits_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+# CHARACTERISATION SPEC — documents current behaviour, not desired behaviour.
+#
+# Award amount limits are declared `on: :amendment`, but Admin::AmendmentForm#save
+# calls `eligibility.save!` in the *default* context, so those rules never run when
+# an award is amended through the admin UI. They only run via Amendment.amend_claim,
+# which uses `claim.save(context: :amendment)` and propagates the context through
+# autosave (see spec/models/claim_student_loan_details_updater_spec.rb:352).
+#
+# This is expected to invert when award_amount moves onto Claim: the rules will then
+# hang off the record the form itself saves, and these scenarios should start failing.
+RSpec.feature "Admin amends an award amount past its limit" do
+  before { @signed_in_user = sign_in_as_service_operator }
+
+  def amend_award_to(claim, amount, label: "Award amount")
+    visit admin_claim_path(claim)
+    click_on "Amend claim"
+    fill_in label, with: amount
+    fill_in "Change notes", with: "Probing the award amount limit"
+    click_on "Amend claim"
+  end
+
+  context "with a Student Loans claim" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        eligibility: build(:student_loans_eligibility, :eligible, award_amount: 550)
+      )
+    end
+
+    before { create(:journey_configuration, :student_loans) }
+
+    # The two scenarios below are the decisive pair: same form, same field, two rules.
+    # Only the context-gated one is skipped, which is what pins the cause on the
+    # validation context rather than on the dispatch being broken.
+    scenario "the amendment-only £5,000 limit does not stop the amendment" do
+      expect {
+        amend_award_to(claim, "5001", label: "Student loan repayment amount")
+      }.to change { claim.reload.amendments.size }.by(1)
+
+      expect(claim.eligibility.award_amount).to eq(5_001)
+      expect(page).not_to have_content("Enter a positive amount up to £5,000.00")
+
+      # ...while the rule itself considers that value invalid on amendment. Built
+      # rather than reloaded because the rule is guarded by `award_amount_changed?`,
+      # which is false on a freshly loaded record.
+      expect(
+        build(:student_loans_eligibility, :eligible, award_amount: 5_001)
+      ).not_to be_valid(:amendment)
+    end
+
+    # The unconditional rule *does* run here, which is what proves the dispatch is
+    # wired up and only the context-gated rule is being skipped. Admin::AmendmentForm
+    # does not validate the award amount itself though — it only guards against
+    # changing it on policies that disallow it — so `eligibility.save!` raises instead
+    # of the form re-rendering with an error. That is a 500 for the operator, and is
+    # pre-existing: the rule was equally unconditional as `validates_numericality_of`
+    # before it was extracted into AwardAmountRules.
+    scenario "the unconditional £99,999 limit raises rather than showing an error" do
+      expect {
+        amend_award_to(claim, "100001", label: "Student loan repayment amount")
+      }.to raise_error(
+        ActiveRecord::RecordInvalid,
+        /Award amount Enter a valid monetary amount/
+      )
+
+      expect(claim.reload.amendments).to be_empty
+      expect(claim.eligibility.award_amount).to eq(550)
+    end
+  end
+
+  context "with a Targeted Retention Incentive claim" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::TargetedRetentionIncentivePayments,
+        eligibility: build(
+          :targeted_retention_incentive_payments_eligibility,
+          :eligible,
+          award_amount: 2_000
+        )
+      )
+    end
+
+    before do
+      create(:journey_configuration, :targeted_retention_incentive_payments)
+      create(:targeted_retention_incentive_payments_award, award_amount: 3_000)
+    end
+
+    scenario "the award table maximum does not stop the amendment" do
+      expect {
+        amend_award_to(claim, "3001")
+      }.to change { claim.reload.amendments.size }.by(1)
+
+      expect(claim.eligibility.award_amount).to eq(3_001)
+
+      # TRI has no `award_amount_changed?` guard, so the very record the form just
+      # saved is invalid in the amendment context.
+      expect(claim.eligibility).not_to be_valid(:amendment)
+    end
+  end
+
+  context "with a Further Education claim" do
+    let(:claim) do
+      create(
+        :claim,
+        :submitted,
+        policy: Policies::FurtherEducationPayments,
+        eligibility: build(
+          :further_education_payments_eligibility,
+          :eligible,
+          award_amount: 2_000
+        )
+      )
+    end
+
+    before { create(:journey_configuration, :further_education_payments) }
+
+    # Control case: FE lists :award_amount in AMENDABLE_ATTRIBUTES but declares no
+    # rule at all, so this passes regardless of validation context. Documents the
+    # separate FE gap rather than the context behaviour.
+    scenario "any amount is accepted because no rule exists" do
+      expect {
+        amend_award_to(claim, "99999")
+      }.to change { claim.reload.amendments.size }.by(1)
+
+      expect(claim.eligibility.award_amount).to eq(99_999)
+    end
+  end
+end

--- a/spec/models/base_policy_spec.rb
+++ b/spec/models/base_policy_spec.rb
@@ -91,4 +91,25 @@ RSpec.describe BasePolicy, type: :model do
       expect(Policies::TestPolicy.decision_deadline_date(claim)).to eql((claim.submitted_at + 19.weeks).to_date)
     end
   end
+
+  describe "#award_amount_rules" do
+    it "is nil for a policy that does not constrain award size" do
+      expect(Policies::TestPolicy.award_amount_rules(build(:claim))).to be_nil
+    end
+
+    # Guards the dispatch in each eligibility, which deliberately does not use safe
+    # navigation: if one of these overrides is dropped, award validation stops
+    # running entirely.
+    {
+      Policies::StudentLoans => Policies::StudentLoans::AwardAmountRules,
+      Policies::TargetedRetentionIncentivePayments =>
+        Policies::TargetedRetentionIncentivePayments::AwardAmountRules
+    }.each do |policy, rules_class|
+      it "returns #{rules_class} for #{policy}" do
+        record = build(:"#{policy.to_s.underscore}_eligibility")
+
+        expect(policy.award_amount_rules(record)).to be_a(rules_class)
+      end
+    end
+  end
 end

--- a/spec/models/policies/student_loans/award_amount_rules_spec.rb
+++ b/spec/models/policies/student_loans/award_amount_rules_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::StudentLoans::AwardAmountRules do
+  # The rules are duck typed on whatever record owns the award amount, so they
+  # keep working when award_amount moves from Eligibility onto Claim.
+  let(:record) { build(:student_loans_eligibility) }
+
+  def validate(context: nil)
+    record.errors.clear
+    described_class.new(record).validate(context:)
+    record.errors[:award_amount]
+  end
+
+  describe "the monetary amount rule" do
+    it "applies in every context" do
+      record.award_amount = 100_000
+
+      expect(validate).to include("Enter a valid monetary amount")
+      expect(validate(context: :amendment)).to include("Enter a valid monetary amount")
+    end
+
+    it "rejects values that are not a monetary amount" do
+      record.award_amount = "don’t know"
+      expect(validate).to include("Enter a valid monetary amount")
+
+      record.award_amount = "£1,234.56"
+      expect(validate).to include("Enter a valid monetary amount")
+    end
+
+    it "rejects negative values" do
+      record.award_amount = "-99"
+
+      expect(validate).to include("Enter a valid monetary amount")
+    end
+
+    it "allows zero, nil and amounts up to the maximum" do
+      record.award_amount = 0
+      expect(validate).to be_empty
+
+      record.award_amount = nil
+      expect(validate).to be_empty
+
+      record.award_amount = described_class::MAX_AWARD_AMOUNT
+      expect(validate).to be_empty
+    end
+  end
+
+  describe "the amended award range rule" do
+    let(:message) { "Enter a positive amount up to £5,000.00 (inclusive)" }
+
+    it "only applies on amendment" do
+      record.award_amount = described_class::MAX_AMENDED_AWARD_AMOUNT + 1
+
+      expect(validate).to be_empty
+      expect(validate(context: :amendment)).to include(message)
+    end
+
+    it "allows amounts up to the maximum" do
+      record.award_amount = described_class::MAX_AMENDED_AWARD_AMOUNT
+
+      expect(validate(context: :amendment)).to be_empty
+    end
+
+    it "rejects zero" do
+      record.award_amount = 0
+
+      expect(validate(context: :amendment)).to include(message)
+    end
+
+    it "does not apply when the award amount is unchanged" do
+      record = create(:student_loans_eligibility)
+      record.update_column(:award_amount, described_class::MAX_AMENDED_AWARD_AMOUNT + 1)
+
+      described_class.new(record.reload).validate(context: :amendment)
+
+      expect(record.errors[:award_amount]).to be_empty
+    end
+  end
+end

--- a/spec/models/policies/targeted_retention_incentive_payments/award_amount_rules_spec.rb
+++ b/spec/models/policies/targeted_retention_incentive_payments/award_amount_rules_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::TargetedRetentionIncentivePayments::AwardAmountRules do
+  # The rules are duck typed on whatever record owns the award amount, so they
+  # keep working when award_amount moves from Eligibility onto Claim.
+  let(:record) { build(:targeted_retention_incentive_payments_eligibility) }
+  let(:message) { "Enter a positive amount up to £3,000.00 (inclusive)" }
+
+  before do
+    create(:journey_configuration, :targeted_retention_incentive_payments)
+    create(:targeted_retention_incentive_payments_award, award_amount: 3_000)
+  end
+
+  def validate(context: nil)
+    record.errors.clear
+    described_class.new(record).validate(context:)
+    record.errors[:award_amount]
+  end
+
+  it "only applies on amendment" do
+    record.award_amount = 3_001
+
+    expect(validate).to be_empty
+    expect(validate(context: :amendment)).to include(message)
+  end
+
+  it "bounds the award by the largest award for the academic year" do
+    record.award_amount = 3_000
+    expect(validate(context: :amendment)).to be_empty
+
+    record.award_amount = 3_001
+    expect(validate(context: :amendment)).to include(message)
+  end
+
+  it "rejects zero and nil" do
+    record.award_amount = 0
+    expect(validate(context: :amendment)).to include(message)
+
+    record.award_amount = nil
+    expect(validate(context: :amendment)).to include(message)
+  end
+
+  it "applies regardless of whether the award amount changed" do
+    record = create(:targeted_retention_incentive_payments_eligibility)
+    record.update_column(:award_amount, 3_001)
+
+    described_class.new(record.reload).validate(context: :amendment)
+
+    expect(record.errors[:award_amount]).to include(message)
+  end
+end


### PR DESCRIPTION
Preparation for moving award_amount onto claims. SL and TRI are the only policies constraining award size and their rules differ in shape, so each now owns an AwardAmountRules object reached via BasePolicy#award_amount_rules, following the existing ClaimCheckingTasks/AdminTasksPresenter dispatch idiom. The objects are duck typed on whatever record owns the award amount, so they move with the column unchanged.

No behaviour change; all existing specs pass unedited. TRI's current_academic_year bug is preserved deliberately and fixed when the rules move onto Claim.

Adds a characterisation spec documenting that on: :amendment rules do not fire through the admin amendment UI, and pinning a pre-existing 500 when a Student Loans award is amended above £99,999.

