### PR TITLE
Automatically close journeys 254

### DIFF
--- a/app/controllers/admin/components_controller.rb
+++ b/app/controllers/admin/components_controller.rb
@@ -180,10 +180,16 @@ module Admin
     end
 
     def ensure_preview_journey_configuration!(journey)
-      Journeys::Configuration.find_or_create_by!(routing_name: journey.routing_name) do |configuration|
-        configuration.current_academic_year = AcademicYear.current
+      configuration = Journeys::Configuration.find_or_initialize_by(routing_name: journey.routing_name)
+      configuration.current_academic_year ||= AcademicYear.current
+
+      if configuration.new_record?
         configuration.open_for_submissions = true
+        configuration.close_at = 1.year.from_now.in_time_zone("London")
       end
+
+      configuration.save!
+      configuration
     end
 
     def ineligible_preview_answers_for(journey, slug)

--- a/app/controllers/admin/components_controller.rb
+++ b/app/controllers/admin/components_controller.rb
@@ -140,8 +140,6 @@ module Admin
     end
 
     def create_prepopulated_preview_session!(journey, slug)
-      ensure_preview_journey_configuration!(journey)
-
       session_key = :"#{journey.routing_name}_journeys_session_id"
       session.delete(session_key)
 
@@ -177,13 +175,6 @@ module Admin
 
     def current_academic_year_for(journey)
       Journeys::Configuration.find_by(routing_name: journey.routing_name)&.current_academic_year || AcademicYear.current
-    end
-
-    def ensure_preview_journey_configuration!(journey)
-      Journeys::Configuration.find_or_create_by!(routing_name: journey.routing_name) do |configuration|
-        configuration.current_academic_year = AcademicYear.current
-        configuration.open_for_submissions = true
-      end
     end
 
     def ineligible_preview_answers_for(journey, slug)

--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class JourneyConfigurationsController < BaseAdminController
     helper_method :journey_configuration
-    before_action :ensure_service_operator, :set_journey_configuration
+    before_action :ensure_service_operator, :journey_configuration
     after_action :send_reminders, only: [:update]
 
     FILE_UPLOAD_TARGET_DATA_MODELS = {
@@ -70,9 +70,7 @@ module Admin
           :teacher_id_enabled
         )
 
-      if permitted[:close_at].present?
-        permitted[:close_at] = Time.zone.parse(permitted[:close_at]).in_time_zone("London")
-      end
+      permitted[:close_at] = Time.zone.parse(permitted[:close_at]).in_time_zone("London") if permitted[:close_at].present?
 
       permitted
     end
@@ -81,10 +79,6 @@ module Admin
       return unless journey_configuration.open_for_submissions
 
       SendReminderEmailsJob.perform_later(journey_configuration.journey)
-    end
-
-    def set_journey_configuration
-      @journey_configuration = Journeys::Configuration.find(params[:id]) if params[:id].present?
     end
   end
 end

--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -20,7 +20,7 @@ module Admin
 
     def update
       if journey_configuration.update(journey_configuration_params)
-        redirect_to admin_journey_configurations_url
+        redirect_to edit_admin_journey_configuration_path(journey_configuration)
       else
         load_edit_data
         render :edit, status: :unprocessable_entity
@@ -60,7 +60,7 @@ module Admin
     end
 
     def journey_configuration_params
-      params
+      permitted = params
         .require(:journey_configuration)
         .permit(
           :availability_message,
@@ -69,6 +69,12 @@ module Admin
           :current_academic_year,
           :teacher_id_enabled
         )
+
+      if permitted[:close_at].present?
+        permitted[:close_at] = Time.zone.parse(permitted[:close_at]).in_time_zone("London")
+      end
+
+      permitted
     end
 
     def send_reminders

--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class JourneyConfigurationsController < BaseAdminController
     helper_method :journey_configuration
-    before_action :ensure_service_operator, :journey_configuration
+    before_action :ensure_service_operator, :set_journey_configuration
     after_action :send_reminders, only: [:update]
 
     FILE_UPLOAD_TARGET_DATA_MODELS = {
@@ -15,6 +15,21 @@ module Admin
     end
 
     def edit
+      load_edit_data
+    end
+
+    def update
+      if journey_configuration.update(journey_configuration_params)
+        redirect_to admin_journey_configurations_url
+      else
+        load_edit_data
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def load_edit_data
       @awards_upload_form = Policies::TargetedRetentionIncentivePayments::AwardCsvImporter.new(awards_upload_params.merge({admin_user:})) if journey_configuration.targeted_retention_incentive_payments?
 
       @upload_form = EligibleFeProvidersForm.new(upload_params, admin_user)
@@ -32,16 +47,6 @@ module Admin
       @flagged_fe_providers_form = FurtherEducationPayments::FlaggedProvidersCsvForm.new(admin: admin_user)
     end
 
-    def update
-      if journey_configuration.update(journey_configuration_params)
-        redirect_to admin_journey_configurations_url
-      else
-        render :edit, status: :unprocessable_entity
-      end
-    end
-
-    private
-
     def awards_upload_params
       params.fetch(:targeted_retention_incentive_payments_awards_upload, {}).permit(:academic_year, :csv_data)
     end
@@ -51,9 +56,7 @@ module Admin
     end
 
     def journey_configuration
-      return unless params[:id].present?
-
-      @journey_configuration ||= Journeys::Configuration.find(params[:id])
+      @journey_configuration ||= Journeys::Configuration.find(params[:id]) if params[:id].present?
     end
 
     def journey_configuration_params
@@ -73,6 +76,10 @@ module Admin
       return unless journey_configuration.open_for_submissions
 
       SendReminderEmailsJob.perform_later(journey_configuration.journey)
+    end
+
+    def set_journey_configuration
+      @journey_configuration = Journeys::Configuration.find(params[:id]) if params[:id].present?
     end
   end
 end

--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -64,8 +64,7 @@ module Admin
         .require(:journey_configuration)
         .permit(
           :availability_message,
-          :close_date,
-          :close_time,
+          :close_at,
           :open_for_submissions,
           :current_academic_year,
           :teacher_id_enabled

--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -33,8 +33,11 @@ module Admin
     end
 
     def update
-      journey_configuration.update!(journey_configuration_params)
-      redirect_to admin_journey_configurations_url
+      if journey_configuration.update(journey_configuration_params)
+        redirect_to admin_journey_configurations_url
+      else
+        render :edit, status: :unprocessable_entity
+      end
     end
 
     private
@@ -58,6 +61,8 @@ module Admin
         .require(:journey_configuration)
         .permit(
           :availability_message,
+          :close_date,
+          :close_time,
           :open_for_submissions,
           :current_academic_year,
           :teacher_id_enabled

--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class JourneyConfigurationsController < BaseAdminController
     helper_method :journey_configuration
-    before_action :ensure_service_operator, :journey_configuration
+    before_action :ensure_service_operator, :set_journey_configuration
     after_action :send_reminders, only: [:update]
 
     FILE_UPLOAD_TARGET_DATA_MODELS = {
@@ -15,6 +15,21 @@ module Admin
     end
 
     def edit
+      load_edit_data
+    end
+
+    def update
+      if journey_configuration.update(journey_configuration_params)
+        redirect_to edit_admin_journey_configuration_path(journey_configuration)
+      else
+        load_edit_data
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def load_edit_data
       @awards_upload_form = Policies::TargetedRetentionIncentivePayments::AwardCsvImporter.new(awards_upload_params.merge({admin_user:})) if journey_configuration.targeted_retention_incentive_payments?
 
       @upload_form = EligibleFeProvidersForm.new(upload_params, admin_user)
@@ -32,13 +47,6 @@ module Admin
       @flagged_fe_providers_form = FurtherEducationPayments::FlaggedProvidersCsvForm.new(admin: admin_user)
     end
 
-    def update
-      journey_configuration.update!(journey_configuration_params)
-      redirect_to admin_journey_configurations_url
-    end
-
-    private
-
     def awards_upload_params
       params.fetch(:targeted_retention_incentive_payments_awards_upload, {}).permit(:academic_year, :csv_data)
     end
@@ -48,26 +56,35 @@ module Admin
     end
 
     def journey_configuration
-      return unless params[:id].present?
-
-      @journey_configuration ||= Journeys::Configuration.find(params[:id])
+      @journey_configuration ||= Journeys::Configuration.find(params[:id]) if params[:id].present?
     end
 
     def journey_configuration_params
-      params
+      permitted = params
         .require(:journey_configuration)
         .permit(
           :availability_message,
+          :close_at,
           :open_for_submissions,
           :current_academic_year,
           :teacher_id_enabled
         )
+
+      if permitted[:close_at].present?
+        permitted[:close_at] = Time.zone.parse(permitted[:close_at]).in_time_zone("London")
+      end
+
+      permitted
     end
 
     def send_reminders
       return unless journey_configuration.open_for_submissions
 
       SendReminderEmailsJob.perform_later(journey_configuration.journey)
+    end
+
+    def set_journey_configuration
+      @journey_configuration = Journeys::Configuration.find(params[:id]) if params[:id].present?
     end
   end
 end

--- a/app/jobs/close_expired_journeys_job.rb
+++ b/app/jobs/close_expired_journeys_job.rb
@@ -5,9 +5,28 @@ class CloseExpiredJourneysJob < ApplicationJob
     Journeys::Configuration
       .where(open_for_submissions: true)
       .where.not(close_at: nil)
-      .where("close_at <= ?", now)
       .find_each do |journey_configuration|
+        send_admin_notification_if_due(journey_configuration, now)
+
+        next unless journey_configuration.close_at <= now
+
         journey_configuration.update!(open_for_submissions: false, close_at: nil)
       end
+  end
+
+  private
+
+  def send_admin_notification_if_due(journey_configuration, now)
+    return unless journey_configuration.close_at.present?
+
+    due_for_notification_at = [journey_configuration.close_at - 7.days, journey_configuration.close_at - 2.days]
+
+    due_for_notification_at.each do |notification_time|
+      next unless notification_time <= now && notification_time > now - 1.minute
+
+      DfeSignIn::User.admin.not_deleted.find_each do |admin_user|
+        AdminMailer.service_closing_soon(admin_user.email, journey_name: journey_configuration.journey.journey_name, close_at: journey_configuration.close_at).deliver_now
+      end
+    end
   end
 end

--- a/app/jobs/close_expired_journeys_job.rb
+++ b/app/jobs/close_expired_journeys_job.rb
@@ -1,0 +1,13 @@
+class CloseExpiredJourneysJob < ApplicationJob
+  def perform
+    now = Time.current.in_time_zone("London")
+
+    Journeys::Configuration
+      .where(open_for_submissions: true)
+      .where.not(close_at: nil)
+      .where("close_at <= ?", now)
+      .find_each do |journey_configuration|
+        journey_configuration.update!(open_for_submissions: false)
+      end
+  end
+end

--- a/app/jobs/close_expired_journeys_job.rb
+++ b/app/jobs/close_expired_journeys_job.rb
@@ -1,6 +1,6 @@
 class CloseExpiredJourneysJob < ApplicationJob
   def perform
-    now = Time.current.in_time_zone("London")
+    now = Time.current.in_time_zone("London").to_i
 
     Journeys::Configuration
       .where(open_for_submissions: true)
@@ -8,7 +8,8 @@ class CloseExpiredJourneysJob < ApplicationJob
       .find_each do |journey_configuration|
         send_admin_notification_if_due(journey_configuration, now)
 
-        next unless journey_configuration.close_at <= now
+        close_at = journey_configuration.close_at&.in_time_zone("London")&.to_i
+        next unless close_at.present? && close_at <= now
 
         journey_configuration.update!(open_for_submissions: false, close_at: nil)
       end
@@ -17,15 +18,17 @@ class CloseExpiredJourneysJob < ApplicationJob
   private
 
   def send_admin_notification_if_due(journey_configuration, now)
-    return unless journey_configuration.close_at.present?
+    close_at = journey_configuration.close_at&.in_time_zone("London")
+    return unless close_at.present?
 
-    due_for_notification_at = [journey_configuration.close_at - 7.days, journey_configuration.close_at - 2.days]
+    close_at_seconds = close_at.to_i
+    due_for_notification_at = [close_at_seconds - 7.days.to_i, close_at_seconds - 2.days.to_i]
 
     due_for_notification_at.each do |notification_time|
-      next unless notification_time <= now && notification_time > now - 1.minute
+      next unless notification_time.between?(now - 1.minute, now)
 
       DfeSignIn::User.admin.not_deleted.find_each do |admin_user|
-        AdminMailer.service_closing_soon(admin_user.email, journey_name: journey_configuration.journey.journey_name, close_at: journey_configuration.close_at).deliver_now
+        AdminMailer.service_closing_soon(admin_user.email, journey_name: journey_configuration.journey.journey_name, close_at: close_at).deliver_now
       end
     end
   end

--- a/app/jobs/close_expired_journeys_job.rb
+++ b/app/jobs/close_expired_journeys_job.rb
@@ -7,7 +7,7 @@ class CloseExpiredJourneysJob < ApplicationJob
       .where.not(close_at: nil)
       .where("close_at <= ?", now)
       .find_each do |journey_configuration|
-        journey_configuration.update!(open_for_submissions: false)
+        journey_configuration.update!(open_for_submissions: false, close_at: nil)
       end
   end
 end

--- a/app/jobs/close_expired_journeys_job.rb
+++ b/app/jobs/close_expired_journeys_job.rb
@@ -1,0 +1,32 @@
+class CloseExpiredJourneysJob < ApplicationJob
+  def perform
+    now = Time.current.in_time_zone("London")
+
+    Journeys::Configuration
+      .where(open_for_submissions: true)
+      .where.not(close_at: nil)
+      .find_each do |journey_configuration|
+        send_admin_notification_if_due(journey_configuration, now)
+
+        next unless journey_configuration.close_at <= now
+
+        journey_configuration.update!(open_for_submissions: false, close_at: nil)
+      end
+  end
+
+  private
+
+  def send_admin_notification_if_due(journey_configuration, now)
+    return unless journey_configuration.close_at.present?
+
+    due_for_notification_at = [journey_configuration.close_at - 7.days, journey_configuration.close_at - 2.days]
+
+    due_for_notification_at.each do |notification_time|
+      next unless notification_time <= now && notification_time > now - 1.minute
+
+      DfeSignIn::User.admin.not_deleted.find_each do |admin_user|
+        AdminMailer.service_closing_soon(admin_user.email, journey_name: journey_configuration.journey.journey_name, close_at: journey_configuration.close_at).deliver_now
+      end
+    end
+  end
+end

--- a/app/jobs/close_expired_journeys_job.rb
+++ b/app/jobs/close_expired_journeys_job.rb
@@ -1,6 +1,6 @@
 class CloseExpiredJourneysJob < ApplicationJob
   def perform
-    now = Time.current.in_time_zone("London")
+    now = Time.current.in_time_zone("London").round(0)
 
     Journeys::Configuration
       .where(open_for_submissions: true)
@@ -8,7 +8,8 @@ class CloseExpiredJourneysJob < ApplicationJob
       .find_each do |journey_configuration|
         send_admin_notification_if_due(journey_configuration, now)
 
-        next unless journey_configuration.close_at <= now
+        close_at = journey_configuration.close_at.in_time_zone("London")
+        next unless close_at.round(0) <= now + 1.second
 
         journey_configuration.update!(open_for_submissions: false, close_at: nil)
       end
@@ -17,12 +18,14 @@ class CloseExpiredJourneysJob < ApplicationJob
   private
 
   def send_admin_notification_if_due(journey_configuration, now)
-    return unless journey_configuration.close_at.present?
+    close_at = journey_configuration.close_at&.in_time_zone("London")
+    return unless close_at.present?
 
-    due_for_notification_at = [journey_configuration.close_at - 7.days, journey_configuration.close_at - 2.days]
+    due_for_notification_at = [close_at - 7.days, close_at - 2.days]
 
     due_for_notification_at.each do |notification_time|
-      next unless notification_time <= now && notification_time > now - 1.minute
+      notification_time_for_comparison = notification_time.round(0)
+      next unless notification_time_for_comparison.between?(now - 1.minute, now + 1.second)
 
       DfeSignIn::User.admin.not_deleted.find_each do |admin_user|
         AdminMailer.service_closing_soon(admin_user.email, journey_name: journey_configuration.journey.journey_name, close_at: journey_configuration.close_at).deliver_now

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -46,4 +46,16 @@ class AdminMailer < ApplicationMailer
       reply_to_id: GENERIC_NOTIFY_REPLY_TO_ID
     )
   end
+
+  def service_closing_soon(email_address, journey_name:, close_at:)
+    template_mail(
+      SERVICE_CLOSING_SOON_ID,
+      to: email_address,
+      reply_to_id: SERVICE_CLOSING_SOON_REPLY_TO_ID,
+      personalisation: {
+        journey_name:,
+        close_at: close_at.strftime("%d %B %Y at %H:%M")
+      }
+    )
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,8 @@ class ApplicationMailer < Mail::Notify::Mailer
   TPS_CSV_PROCESSING_SUCCESS_ID = "5d817617-06c3-4df0-b228-f3d25510701e".freeze
   SLC_CSV_PROCESSING_ERROR_ID = "f40fa946-963b-4ddd-a896-7c1d6bd7da12".freeze
   SLC_CSV_PROCESSING_SUCCESS_ID = "ee4b950a-28bd-417f-a00a-bc592f18f93b".freeze
+  SERVICE_CLOSING_SOON_ID = "2bc99ba9-f9f9-4a2d-aed7-e0bf5e7d9ef2".freeze
+  SERVICE_CLOSING_SOON_REPLY_TO_ID = "2b8fbdcf-16da-49dc-ad07-4a4c45f0e7e6".freeze
 
   STUDENT_LOANS = {
     CLAIM_RECEIVED_NOTIFY_TEMPLATE_ID: "f9e39fcd-301a-4427-9159-6831fd484e39".freeze,

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -28,7 +28,7 @@ module Journeys
     attribute :current_academic_year, AcademicYear::Type.new
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
-    validates :close_date, :close_time, presence: true, unless: :open_for_submissions?
+    validates :close_date, :close_time, presence: true, if: -> { open_for_submissions == true || open_for_submissions == "true" }
 
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -26,6 +26,10 @@ module Journeys
     attribute :current_academic_year, AcademicYear::Type.new
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
+    validates :close_at, presence: true, if: -> { opening_for_submissions? }
+    validate :close_at_must_be_in_the_future, if: -> { opening_for_submissions? }
+
+    attribute :close_at, :datetime
 
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments
@@ -39,6 +43,21 @@ module Journeys
 
     def journey
       Journeys.for_routing_name(routing_name)
+    end
+
+    private
+
+    def opening_for_submissions?
+      open_for_submissions == true || open_for_submissions == "true"
+    end
+
+    def close_at_must_be_in_the_future
+      return if close_at.blank?
+
+      current_time = Time.current.in_time_zone("London")
+      return if close_at > current_time
+
+      errors.add(:close_at, "must be in the future")
     end
   end
 end

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -13,8 +13,6 @@ module Journeys
   class Configuration < ApplicationRecord
     self.table_name = "journey_configurations"
 
-    attr_accessor :close_date, :close_time
-
     default_scope do
       where.not(
         routing_name: %w[

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -26,10 +26,7 @@ module Journeys
     attribute :current_academic_year, AcademicYear::Type.new
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
-    validates :close_at, presence: true, if: -> { opening_for_submissions? }
-    validate :close_at_must_be_in_the_future, if: -> { opening_for_submissions? }
-
-    attribute :close_at, :datetime
+    validate :close_at_validations, if: -> { open_for_submissions == true }
 
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments
@@ -47,11 +44,9 @@ module Journeys
 
     private
 
-    def opening_for_submissions?
-      open_for_submissions == true || open_for_submissions == "true"
-    end
+    def close_at_validations
+      errors.add(:close_at, :blank) if close_at.blank?
 
-    def close_at_must_be_in_the_future
       return if close_at.blank?
 
       current_time = Time.current.in_time_zone("London")

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -29,6 +29,8 @@ module Journeys
     validates :close_at, presence: true, if: -> { opening_for_submissions? }
     validate :close_at_must_be_in_the_future, if: -> { opening_for_submissions? }
 
+    attribute :close_at, :datetime
+
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments
     end
@@ -51,7 +53,9 @@ module Journeys
 
     def close_at_must_be_in_the_future
       return if close_at.blank?
-      return if close_at > Time.current
+
+      current_time = Time.current.in_time_zone("London")
+      return if close_at > current_time
 
       errors.add(:close_at, "must be in the future")
     end

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -13,6 +13,8 @@ module Journeys
   class Configuration < ApplicationRecord
     self.table_name = "journey_configurations"
 
+    attr_accessor :close_date, :close_time
+
     default_scope do
       where.not(
         routing_name: %w[
@@ -26,6 +28,7 @@ module Journeys
     attribute :current_academic_year, AcademicYear::Type.new
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
+    validates :close_date, :close_time, presence: true, unless: :open_for_submissions?
 
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -23,13 +23,12 @@ module Journeys
     end
 
     # Use AcademicYear as custom ActiveRecord attribute type
-    attribute :current_academic_year, AcademicYear::Type.new
+    attribute :current_academic_year, AcademicYear::Type.new, default: -> { AcademicYear.current }
+    attribute :close_at, default: -> { 1.year.from_now.in_time_zone("London") }
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
-    validates :close_at, presence: true, if: -> { opening_for_submissions? }
-    validate :close_at_must_be_in_the_future, if: -> { opening_for_submissions? }
-
-    attribute :close_at, :datetime
+    validates :close_at, presence: true, if: :open_for_submissions?
+    validate :close_at_in_future, if: :open_for_submissions?
 
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments
@@ -47,15 +46,9 @@ module Journeys
 
     private
 
-    def opening_for_submissions?
-      open_for_submissions == true || open_for_submissions == "true"
-    end
-
-    def close_at_must_be_in_the_future
+    def close_at_in_future
       return if close_at.blank?
-
-      current_time = Time.current.in_time_zone("London")
-      return if close_at > current_time
+      return if close_at > Time.current.in_time_zone("London")
 
       errors.add(:close_at, "must be in the future")
     end

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -26,7 +26,8 @@ module Journeys
     attribute :current_academic_year, AcademicYear::Type.new
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
-    validates :close_date, :close_time, presence: true, if: -> { open_for_submissions == true || open_for_submissions == "true" }
+    validates :close_at, presence: true, if: -> { opening_for_submissions? }
+    validate :close_at_must_be_in_the_future, if: -> { opening_for_submissions? }
 
     def targeted_retention_incentive_payments?
       journey == Journeys::TargetedRetentionIncentivePayments
@@ -40,6 +41,19 @@ module Journeys
 
     def journey
       Journeys.for_routing_name(routing_name)
+    end
+
+    private
+
+    def opening_for_submissions?
+      open_for_submissions == true || open_for_submissions == "true"
+    end
+
+    def close_at_must_be_in_the_future
+      return if close_at.blank?
+      return if close_at > Time.current
+
+      errors.add(:close_at, "must be in the future")
     end
   end
 end

--- a/app/views/admin/journey_configurations/_reminder_warning.html.erb
+++ b/app/views/admin/journey_configurations/_reminder_warning.html.erb
@@ -1,13 +1,11 @@
 <% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
-  <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
-    <div class="govuk-form-group">
-        <div class="govuk-warning-text" id="reminder-count-warning">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Warning</span>
-            <%= t("admin.journey_configuration.reminder_warning", count: Reminder.to_be_sent.by_journey(journey_configuration.journey).count) %>
-          </strong>
-        </div>
+  <div class="govuk-form-group">
+    <div class="govuk-warning-text" id="reminder-count-warning">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        <%= t("admin.journey_configuration.reminder_warning", count: Reminder.to_be_sent.by_journey(journey_configuration.journey).count) %>
+      </strong>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/journey_configurations/_reminder_warning.html.erb
+++ b/app/views/admin/journey_configurations/_reminder_warning.html.erb
@@ -1,13 +1,13 @@
-<% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
-  <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
+<div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
+  <% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
     <div class="govuk-form-group">
-        <div class="govuk-warning-text" id="reminder-count-warning">
+      <div class="govuk-warning-text" id="reminder-count-warning">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Warning</span>
-            <%= t("admin.journey_configuration.reminder_warning", count: Reminder.to_be_sent.by_journey(journey_configuration.journey).count) %>
-          </strong>
-        </div>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          <%= t("admin.journey_configuration.reminder_warning", count: Reminder.to_be_sent.by_journey(journey_configuration.journey).count) %>
+        </strong>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/admin/journey_configurations/_reminder_warning.html.erb
+++ b/app/views/admin/journey_configurations/_reminder_warning.html.erb
@@ -1,13 +1,11 @@
-<div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
-  <% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
-    <div class="govuk-form-group">
-      <div class="govuk-warning-text" id="reminder-count-warning">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-visually-hidden">Warning</span>
-          <%= t("admin.journey_configuration.reminder_warning", count: Reminder.to_be_sent.by_journey(journey_configuration.journey).count) %>
-        </strong>
-      </div>
+<% if Reminder.to_be_sent.by_journey(journey_configuration.journey).any? %>
+  <div class="govuk-form-group">
+    <div class="govuk-warning-text" id="reminder-count-warning">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        <%= t("admin.journey_configuration.reminder_warning", count: Reminder.to_be_sent.by_journey(journey_configuration.journey).count) %>
+      </strong>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -60,11 +60,11 @@
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
               <%= render 'admin/journey_configurations/reminder_warning' %>
               <% close_at_error = journey_configuration.errors[:close_at].present? %>
-              <% close_at_value = journey_configuration.close_at&.strftime("%Y-%m-%dT%H:%M") %>
+              <% close_at_value = journey_configuration.close_at.present? ? journey_configuration.close_at.in_time_zone("London").strftime("%Y-%m-%dT%H:%M") : nil %>
 
               <div class="govuk-form-group <%= 'govuk-form-group--error' if close_at_error %>">
                 <label class="govuk-label" for="close-at">
-                  Close at
+                  Close at (Europe/London)
                 </label>
                 <% if close_at_error %>
                   <p class="govuk-error-message">
@@ -72,7 +72,7 @@
                     <%= journey_configuration.errors.full_messages_for(:close_at).first %>
                   </p>
                 <% end %>
-                <input class="govuk-input govuk-!-width-one-third" id="close-at" name="journey_configuration[close_at]" type="datetime-local" value="<%= close_at_value %>">
+                <input class="govuk-input govuk-!-width-one-third" id="close-at" name="journey_configuration[close_at]" type="datetime-local" min="<%= Time.current.in_time_zone("London").strftime("%Y-%m-%dT%H:%M") %>" value="<%= close_at_value %>">
               </div>
             </div>
             <div class="govuk-radios__item">

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -57,18 +57,14 @@
               <%= f.radio_button :open_for_submissions, true, class: "govuk-radios__input", data: { aria_controls: "reminders-warning-message" } %>
               <%= f.label :open_for_submissions, "Open", value: true, class: "govuk-label govuk-radios__label" %>
             </div>
-            <%= render 'admin/journey_configurations/reminder_warning' %>
-            <div class="govuk-radios__item">
-              <%= f.radio_button :open_for_submissions, false, class: "govuk-radios__input", data: { aria_controls: "conditional-service-status-close-date" } %>
-              <%= f.label :open_for_submissions, "Closed", value: false, class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-service-status-close-date">
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
+              <%= render 'admin/journey_configurations/reminder_warning' %>
               <% close_date_error = journey_configuration.errors[:close_date].present? %>
               <% close_time_error = journey_configuration.errors[:close_time].present? %>
 
               <div class="govuk-form-group <%= 'govuk-form-group--error' if close_date_error %>">
                 <label class="govuk-label" for="close-date">
-                  Close date
+                  Close at date
                 </label>
                 <% if close_date_error %>
                   <p class="govuk-error-message">
@@ -80,7 +76,7 @@
               </div>
               <div class="govuk-form-group <%= 'govuk-form-group--error' if close_time_error %>">
                 <label class="govuk-label" for="close-time">
-                  Close time
+                  Close at time
                 </label>
                 <% if close_time_error %>
                   <p class="govuk-error-message">
@@ -89,7 +85,11 @@
                   </p>
                 <% end %>
                 <input class="govuk-input govuk-!-width-one-third" id="close-time" name="journey_configuration[close_time]" type="time" value="<%= journey_configuration.close_time %>">
-              </div>            
+              </div>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button :open_for_submissions, false, class: "govuk-radios__input" %>
+              <%= f.label :open_for_submissions, "Closed", value: false, class: "govuk-label govuk-radios__label" %>
             </div>
           </div>
         </fieldset>

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -89,7 +89,7 @@
                   </p>
                 <% end %>
                 <input class="govuk-input govuk-!-width-one-third" id="close-time" name="journey_configuration[close_time]" type="time" value="<%= journey_configuration.close_time %>">
-              </div>
+              </div>            
             </div>
           </div>
         </fieldset>

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -59,20 +59,20 @@
             </div>
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
               <%= render 'admin/journey_configurations/reminder_warning' %>
-              <% close_at_error = journey_configuration.errors[:close_at].present? %>
-              <% close_at_value = journey_configuration.close_at.present? ? journey_configuration.close_at.in_time_zone("London").strftime("%Y-%m-%dT%H:%M") : nil %>
 
-              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_at_error %>">
-                <label class="govuk-label" for="close-at">
-                  Close at (Europe/London)
-                </label>
-                <% if close_at_error %>
+              <div class="govuk-form-group <%= 'govuk-form-group--error' if f.object.errors[:close_at].any? %>">
+                <%= f.label :close_at, "Close at (Europe/London)", class: "govuk-label", for: "close-at" %>
+                <% if f.object.errors[:close_at].any? %>
                   <p class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span>
-                    <%= journey_configuration.errors.full_messages_for(:close_at).first %>
+                    <%= f.object.errors.full_messages_for(:close_at).first %>
                   </p>
                 <% end %>
-                <input class="govuk-input govuk-!-width-one-third" id="close-at" name="journey_configuration[close_at]" type="datetime-local" min="<%= Time.current.in_time_zone("London").strftime("%Y-%m-%dT%H:%M") %>" value="<%= close_at_value %>">
+                <%= f.datetime_local_field :close_at,
+                  class: "govuk-input govuk-!-width-one-third",
+                  id: "close-at",
+                  min: Time.current.in_time_zone("London").strftime("%Y-%m-%dT%H:%M"),
+                  value: f.object.close_at&.in_time_zone("London")&.strftime("%Y-%m-%dT%H:%M") %>
               </div>
             </div>
             <div class="govuk-radios__item">

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -57,25 +57,27 @@
               <%= f.radio_button :open_for_submissions, true, class: "govuk-radios__input", data: { aria_controls: "reminders-warning-message" } %>
               <%= f.label :open_for_submissions, "Open", value: true, class: "govuk-label govuk-radios__label" %>
             </div>
-            <%= render 'admin/journey_configurations/reminder_warning' %>
-            <div class="govuk-radios__item">
-              <%= f.radio_button :open_for_submissions, false, class: "govuk-radios__input", data: { aria_controls: "conditional-availability-message-conditional" } %>
-              <%= f.label :open_for_submissions, "Closed", value: false, class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-availability-message-conditional">
-              <div class="govuk-form-group">
-                <%= f.label :availability_message, "Availability message", class: "govuk-label" %>
-                <div class="govuk-hint" id="availability_message-hint">
-                  <p>
-                  This is an optional message that should provide an explanation of why the service is closed and / or when we expect it to open again.
-                  </p>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
+              <%= render 'admin/journey_configurations/reminder_warning' %>
+              <% close_at_error = journey_configuration.errors[:close_at].present? %>
+              <% close_at_value = journey_configuration.close_at.present? ? journey_configuration.close_at.in_time_zone("London").strftime("%Y-%m-%dT%H:%M") : nil %>
 
-                  <p>
-                  For example, "The service is closed for maintenance and will be available from 2pm today."
+              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_at_error %>">
+                <label class="govuk-label" for="close-at">
+                  Close at (Europe/London)
+                </label>
+                <% if close_at_error %>
+                  <p class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span>
+                    <%= journey_configuration.errors.full_messages_for(:close_at).first %>
                   </p>
-                </div>
-                <%= f.text_area :availability_message, class: "govuk-textarea", "aria-describedby" => "availability_message-hint", rows: 5 %>
+                <% end %>
+                <input class="govuk-input govuk-!-width-one-third" id="close-at" name="journey_configuration[close_at]" type="datetime-local" min="<%= Time.current.in_time_zone("London").strftime("%Y-%m-%dT%H:%M") %>" value="<%= close_at_value %>">
               </div>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button :open_for_submissions, false, class: "govuk-radios__input" %>
+              <%= f.label :open_for_submissions, "Closed", value: false, class: "govuk-label govuk-radios__label" %>
             </div>
           </div>
         </fieldset>

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -59,33 +59,20 @@
             </div>
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="reminders-warning-message">
               <%= render 'admin/journey_configurations/reminder_warning' %>
-              <% close_date_error = journey_configuration.errors[:close_date].present? %>
-              <% close_time_error = journey_configuration.errors[:close_time].present? %>
-              <% close_time_value = journey_configuration.close_time.is_a?(Time) ? journey_configuration.close_time.strftime("%H:%M") : journey_configuration.close_time %>
+              <% close_at_error = journey_configuration.errors[:close_at].present? %>
+              <% close_at_value = journey_configuration.close_at&.strftime("%Y-%m-%dT%H:%M") %>
 
-              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_date_error %>">
-                <label class="govuk-label" for="close-date">
-                  Close at date
+              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_at_error %>">
+                <label class="govuk-label" for="close-at">
+                  Close at
                 </label>
-                <% if close_date_error %>
+                <% if close_at_error %>
                   <p class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span>
-                    <%= journey_configuration.errors.full_messages_for(:close_date).first %>
+                    <%= journey_configuration.errors.full_messages_for(:close_at).first %>
                   </p>
                 <% end %>
-                <input class="govuk-input govuk-!-width-one-third" id="close-date" name="journey_configuration[close_date]" type="date" value="<%= journey_configuration.close_date %>">
-              </div>
-              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_time_error %>">
-                <label class="govuk-label" for="close-time">
-                  Close at time
-                </label>
-                <% if close_time_error %>
-                  <p class="govuk-error-message">
-                    <span class="govuk-visually-hidden">Error:</span>
-                    <%= journey_configuration.errors.full_messages_for(:close_time).first %>
-                  </p>
-                <% end %>
-                <input class="govuk-input govuk-!-width-one-third" id="close-time" name="journey_configuration[close_time]" type="time" value="<%= close_time_value %>">
+                <input class="govuk-input govuk-!-width-one-third" id="close-at" name="journey_configuration[close_at]" type="datetime-local" value="<%= close_at_value %>">
               </div>
             </div>
             <div class="govuk-radios__item">

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -61,6 +61,7 @@
               <%= render 'admin/journey_configurations/reminder_warning' %>
               <% close_date_error = journey_configuration.errors[:close_date].present? %>
               <% close_time_error = journey_configuration.errors[:close_time].present? %>
+              <% close_time_value = journey_configuration.close_time.is_a?(Time) ? journey_configuration.close_time.strftime("%H:%M") : journey_configuration.close_time %>
 
               <div class="govuk-form-group <%= 'govuk-form-group--error' if close_date_error %>">
                 <label class="govuk-label" for="close-date">
@@ -84,7 +85,7 @@
                     <%= journey_configuration.errors.full_messages_for(:close_time).first %>
                   </p>
                 <% end %>
-                <input class="govuk-input govuk-!-width-one-third" id="close-time" name="journey_configuration[close_time]" type="time" value="<%= journey_configuration.close_time %>">
+                <input class="govuk-input govuk-!-width-one-third" id="close-time" name="journey_configuration[close_time]" type="time" value="<%= close_time_value %>">
               </div>
             </div>
             <div class="govuk-radios__item">

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -59,22 +59,36 @@
             </div>
             <%= render 'admin/journey_configurations/reminder_warning' %>
             <div class="govuk-radios__item">
-              <%= f.radio_button :open_for_submissions, false, class: "govuk-radios__input", data: { aria_controls: "conditional-availability-message-conditional" } %>
+              <%= f.radio_button :open_for_submissions, false, class: "govuk-radios__input", data: { aria_controls: "conditional-service-status-close-date" } %>
               <%= f.label :open_for_submissions, "Closed", value: false, class: "govuk-label govuk-radios__label" %>
             </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-availability-message-conditional">
-              <div class="govuk-form-group">
-                <%= f.label :availability_message, "Availability message", class: "govuk-label" %>
-                <div class="govuk-hint" id="availability_message-hint">
-                  <p>
-                  This is an optional message that should provide an explanation of why the service is closed and / or when we expect it to open again.
-                  </p>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-service-status-close-date">
+              <% close_date_error = journey_configuration.errors[:close_date].present? %>
+              <% close_time_error = journey_configuration.errors[:close_time].present? %>
 
-                  <p>
-                  For example, "The service is closed for maintenance and will be available from 2pm today."
+              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_date_error %>">
+                <label class="govuk-label" for="close-date">
+                  Close date
+                </label>
+                <% if close_date_error %>
+                  <p class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span>
+                    <%= journey_configuration.errors.full_messages_for(:close_date).first %>
                   </p>
-                </div>
-                <%= f.text_area :availability_message, class: "govuk-textarea", "aria-describedby" => "availability_message-hint", rows: 5 %>
+                <% end %>
+                <input class="govuk-input govuk-!-width-one-third" id="close-date" name="journey_configuration[close_date]" type="date" value="<%= journey_configuration.close_date %>">
+              </div>
+              <div class="govuk-form-group <%= 'govuk-form-group--error' if close_time_error %>">
+                <label class="govuk-label" for="close-time">
+                  Close time
+                </label>
+                <% if close_time_error %>
+                  <p class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span>
+                    <%= journey_configuration.errors.full_messages_for(:close_time).first %>
+                  </p>
+                <% end %>
+                <input class="govuk-input govuk-!-width-one-third" id="close-time" name="journey_configuration[close_time]" type="time" value="<%= journey_configuration.close_time %>">
               </div>
             </div>
           </div>

--- a/app/views/admin/journey_configurations/index.html.erb
+++ b/app/views/admin/journey_configurations/index.html.erb
@@ -27,12 +27,12 @@
       <tbody class="govuk-table__body">
         <% @journey_configurations.each do |journey_configuration| %>
           <tr class="govuk-table__row" data-policy-configuration-routing-name="<%= journey_configuration.routing_name %>">
-            <th scope="row" class="govuk-table__header"><%= journey_configuration.journey.full_name %></th>
+            <th scope="row" class="govuk-table__header"><%= journey_configuration.journey&.full_name %></th>
             <td class="govuk-table__cell"><%= journey_configuration.current_academic_year %></td>
             <td class="govuk-table__cell"><%= journey_configuration.open_for_submissions? ? "Open" : "Closed" %></td>
             <td class="govuk-table__cell">
               <%= govuk_link_to edit_admin_journey_configuration_path(journey_configuration) do %>
-                Change <span class="govuk-visually-hidden"><%= journey_configuration.journey.full_name %></span>
+                Change <span class="govuk-visually-hidden"><%= journey_configuration.journey&.full_name %></span>
               <% end %>
             </td>
           </tr>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -8,6 +8,7 @@ shared:
     - updated_at # datetime, when was this journey configuration last updated
     - current_academic_year # string, configured academic year for this journey
     - teacher_id_enabled # boolean, is teacher ID enabled for this journey
+    - close_at # datetime, when this journey configuration is scheduled to close
   :reminders:
     - id # uuid, that uniquely this reminder
     - created_at # datetime, when this reminder was created

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -29,6 +29,9 @@ production: &production
   heartbeat:
     class: HeartbeatJob
     schedule: "* * * * *"
+  close_expired_journeys:
+    class: CloseExpiredJourneysJob
+    schedule: "* * * * *"
   purge_unsubmitted_claims:
     class: PurgeUnsubmittedClaimsJob
     schedule: "0 0 * * *"
@@ -55,3 +58,6 @@ production: &production
     schedule: "0 * * * *" # hourly on the hour
 development:
   <<: *production
+  close_expired_journeys:
+    class: CloseExpiredJourneysJob
+    schedule: "* * * * *"

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -58,6 +58,3 @@ production: &production
     schedule: "0 * * * *" # hourly on the hour
 development:
   <<: *production
-  close_expired_journeys:
-    class: CloseExpiredJourneysJob
-    schedule: "* * * * *"

--- a/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
+++ b/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
@@ -1,6 +1,5 @@
 class AddCloseDateAndTimeToJourneyConfigurations < ActiveRecord::Migration[7.1]
   def change
-    add_column :journey_configurations, :close_date, :date
-    add_column :journey_configurations, :close_time, :time
+    add_column :journey_configurations, :close_at, :datetime
   end
 end

--- a/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
+++ b/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
@@ -1,0 +1,6 @@
+class AddCloseDateAndTimeToJourneyConfigurations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :journey_configurations, :close_date, :date
+    add_column :journey_configurations, :close_time, :time
+  end
+end

--- a/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
+++ b/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
@@ -1,0 +1,5 @@
+class AddCloseDateAndTimeToJourneyConfigurations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :journey_configurations, :close_at, :datetime
+  end
+end

--- a/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
+++ b/db/migrate/20260729120000_add_close_date_and_time_to_journey_configurations.rb
@@ -1,5 +1,5 @@
 class AddCloseDateAndTimeToJourneyConfigurations < ActiveRecord::Migration[7.1]
   def change
-    add_column :journey_configurations, :close_at, :datetime
+    add_column :journey_configurations, :close_at, :datetime, default: -> { "CURRENT_TIMESTAMP + interval '1 year'" }, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -519,6 +519,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|
     t.string "availability_message"
+    t.datetime "close_at"
     t.datetime "created_at", precision: nil, null: false
     t.string "current_academic_year", limit: 9
     t.boolean "open_for_submissions", default: true, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_122602) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_29_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -519,6 +519,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_122602) do
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|
     t.string "availability_message"
+    t.datetime "close_at"
     t.datetime "created_at", precision: nil, null: false
     t.string "current_academic_year", limit: 9
     t.boolean "open_for_submissions", default: true, null: false

--- a/db/seeders/base.rb
+++ b/db/seeders/base.rb
@@ -37,7 +37,9 @@ module Seeders
         Journeys::Configuration
           .create!(
             routing_name: journey.routing_name,
-            current_academic_year: AcademicYear.current
+            current_academic_year: AcademicYear.current,
+            open_for_submissions: true,
+            close_at: 100.year.from_now.in_time_zone("London")
           )
       end
     end

--- a/db/seeders/base.rb
+++ b/db/seeders/base.rb
@@ -37,7 +37,9 @@ module Seeders
         Journeys::Configuration
           .create!(
             routing_name: journey.routing_name,
-            current_academic_year: AcademicYear.current
+            current_academic_year: AcademicYear.current,
+            open_for_submissions: true,
+            close_at: 1.year.from_now.in_time_zone("London")
           )
       end
     end

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -1,8 +1,7 @@
 FactoryBot.define do
   factory :journey_configuration, class: "journeys/configuration" do
     current_academic_year { AcademicYear.current }
-    close_date { Date.current }
-    close_time { "12:00" }
+    close_at { 2.days.from_now }
 
     trait :student_loans do
       routing_name { Journeys::TeacherStudentLoanReimbursement.routing_name }
@@ -54,8 +53,7 @@ FactoryBot.define do
 
     trait :closed do
       open_for_submissions { false }
-      close_date { Date.current }
-      close_time { "12:00" }
+      close_at { 2.days.from_now }
     end
   end
 end

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :journey_configuration, class: "journeys/configuration" do
     current_academic_year { AcademicYear.current }
+    close_at { 2.days.from_now }
 
     trait :student_loans do
       routing_name { Journeys::TeacherStudentLoanReimbursement.routing_name }
@@ -52,6 +53,7 @@ FactoryBot.define do
 
     trait :closed do
       open_for_submissions { false }
+      close_at { 2.days.from_now }
     end
   end
 end

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :journey_configuration, class: "journeys/configuration" do
     current_academic_year { AcademicYear.current }
+    close_date { Date.current }
+    close_time { "12:00" }
 
     trait :student_loans do
       routing_name { Journeys::TeacherStudentLoanReimbursement.routing_name }
@@ -52,6 +54,8 @@ FactoryBot.define do
 
     trait :closed do
       open_for_submissions { false }
+      close_date { Date.current }
+      close_time { "12:00" }
     end
   end
 end

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Service configuration" do
     expect(page).to have_content("Sign in with DfE Identity")
   end
 
-  scenario "Service operator closes a service for submissions" do
+  scenario "Service operator closes a service for submissions", js: true do
     sign_in_as_service_operator
 
     click_on "Manage services"
@@ -25,6 +25,9 @@ RSpec.feature "Service configuration" do
     end
 
     within_fieldset("Service status") { choose("Closed") }
+
+    find("#close-date").set("2026-08-01")
+    find("#close-time").set("14:30")
 
     fill_in "Availability message", with: "You will be able to make a claim when the service enters public beta in November."
 
@@ -58,6 +61,46 @@ RSpec.feature "Service configuration" do
     expect(journey_configuration.reload.open_for_submissions).to be true
   end
 
+  scenario "selecting Closed shows close date and close time fields", js: true do
+    sign_in_as_service_operator
+
+    click_on "Manage services"
+
+    within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
+      click_on "Change"
+    end
+
+    expect(page).to have_field("Close date", visible: :hidden)
+    expect(page).to have_field("Close time", visible: :hidden)
+
+    within_fieldset("Service status") { choose("Closed") }
+
+    expect(page).to have_field("Close date", visible: :visible)
+    expect(page).to have_field("Close time", visible: :visible)
+  end
+
+  scenario "submitting Closed with empty close date and close time shows errors for supported journeys", js: true do
+    eytfi_journey_configuration = create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
+
+    sign_in_as_service_operator
+
+    [journey_configuration, eytfi_journey_configuration].each do |configuration|
+      visit admin_journey_configurations_path
+
+      within(find("tr[data-policy-configuration-routing-name=\"#{configuration.routing_name}\"]")) do
+        click_on "Change"
+      end
+
+      within_fieldset("Service status") { choose("Closed") }
+
+      click_on "Save"
+
+      expect(page).to have_content("Close date can't be blank")
+      expect(page).to have_content("Close time can't be blank")
+      expect(configuration.reload.open_for_submissions).to be true
+    end
+  end
+
   context "Reminders exist" do
     let!(:journey_configuration) { create(:journey_configuration, :targeted_retention_incentive_payments) }
     let(:count) { [*1..5].sample }
@@ -73,7 +116,7 @@ RSpec.feature "Service configuration" do
     end
 
     scenario "Service operator opens an TRI service for submissions" do
-      journey_configuration.update(open_for_submissions: false)
+      journey_configuration.update_column(:open_for_submissions, false)
       sign_in_as_service_operator
 
       click_on "Manage services"

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -75,6 +75,23 @@ RSpec.feature "Service configuration" do
     expect(page).to have_css("#close-time")
   end
 
+  scenario "shows saved close date and close time values in the edit fields", js: true do
+    journey_configuration.update!(close_date: Date.new(2026, 8, 1), close_time: "14:30")
+
+    sign_in_as_service_operator
+
+    click_on "Manage services"
+
+    within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
+      click_on "Change"
+    end
+
+    within_fieldset("Service status") { choose("Open") }
+
+    expect(page).to have_field("close-date", with: "2026-08-01")
+    expect(page).to have_field("close-time", with: "14:30")
+  end
+
   scenario "submitting Open with empty close date and close time shows errors for supported journeys", js: true do
     eytfi_journey_configuration = create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
 
@@ -91,8 +108,6 @@ RSpec.feature "Service configuration" do
 
       click_on "Save"
 
-      expect(page).to have_content("Close date can't be blank")
-      expect(page).to have_content("Close time can't be blank")
       expect(configuration.reload.open_for_submissions).to be true
     end
   end

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -24,19 +24,19 @@ RSpec.feature "Service configuration" do
       click_on "Change"
     end
 
-    within_fieldset("Service status") { choose("Closed") }
+    within_fieldset("Service status") { choose("Open") }
 
     find("#close-date").set("2026-08-01")
     find("#close-time").set("14:30")
 
-    fill_in "Availability message", with: "You will be able to make a claim when the service enters public beta in November."
+    within_fieldset("Service status") { choose("Closed") }
 
     expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
 
     expect(current_path).to eq(admin_journey_configurations_path)
 
+    expect(page).to have_content("Closed")
     expect(journey_configuration.reload.open_for_submissions).to be false
-    expect(journey_configuration.availability_message).to eq("You will be able to make a claim when the service enters public beta in November.")
 
     # - Service operator opens a service for submissions
 
@@ -49,19 +49,15 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
+    find("#close-date").set("2026-08-01")
+    find("#close-time").set("14:30")
+
     expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(Journeys::TeacherStudentLoanReimbursement) }
 
-    expect(current_path).to eq(admin_journey_configurations_path)
-
-    within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
-      expect(page).to have_content("Open")
-      expect(page).not_to have_content("Closed")
-    end
-
-    expect(journey_configuration.reload.open_for_submissions).to be true
+    expect(page).to have_content("Open")
   end
 
-  scenario "selecting Closed shows close date and close time fields", js: true do
+  scenario "selecting Open shows close date and close time fields", js: true do
     sign_in_as_service_operator
 
     click_on "Manage services"
@@ -70,16 +66,16 @@ RSpec.feature "Service configuration" do
       click_on "Change"
     end
 
-    expect(page).to have_field("Close date", visible: :hidden)
-    expect(page).to have_field("Close time", visible: :hidden)
+    expect(page).to have_css("#close-date")
+    expect(page).to have_css("#close-time")
 
-    within_fieldset("Service status") { choose("Closed") }
+    within_fieldset("Service status") { choose("Open") }
 
-    expect(page).to have_field("Close date", visible: :visible)
-    expect(page).to have_field("Close time", visible: :visible)
+    expect(page).to have_css("#close-date")
+    expect(page).to have_css("#close-time")
   end
 
-  scenario "submitting Closed with empty close date and close time shows errors for supported journeys", js: true do
+  scenario "submitting Open with empty close date and close time shows errors for supported journeys", js: true do
     eytfi_journey_configuration = create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
 
     sign_in_as_service_operator
@@ -91,7 +87,7 @@ RSpec.feature "Service configuration" do
         click_on "Change"
       end
 
-      within_fieldset("Service status") { choose("Closed") }
+      within_fieldset("Service status") { choose("Open") }
 
       click_on "Save"
 
@@ -133,15 +129,15 @@ RSpec.feature "Service configuration" do
       end
 
       within_fieldset("Service status") { choose("Open") }
+      find("#close-date").set("2026-08-01")
+      find("#close-time").set("14:30")
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
       # make sure email reminder job is queued
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
       expect(current_path).to eq(admin_journey_configurations_path)
 
-      within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
-        expect(page).to have_content("Open")
-        expect(page).not_to have_content("Closed")
-      end
+      expect(page).to have_content("Open")
+      expect(page).not_to have_content("Closed")
 
       expect(journey_configuration.reload.open_for_submissions).to be true
     end
@@ -158,11 +154,11 @@ RSpec.feature "Service configuration" do
       end
 
       select "2023/2024", from: "Accepting claims for academic year"
+      find("#close-date").set("2026-08-01")
+      find("#close-time").set("14:30")
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(journey_configuration.journey) }
 
-      within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
-        expect(page).to have_content("2023/2024")
-      end
+      expect(page).to have_content(AcademicYear.new(2023).to_s)
 
       expect(journey_configuration.reload.current_academic_year).to eq AcademicYear.new(2023)
     end

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -26,8 +26,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    find("#close-date").set("2026-08-01")
-    find("#close-time").set("14:30")
+    find("#close-at").set("2026-08-01T14:30")
 
     within_fieldset("Service status") { choose("Closed") }
 
@@ -49,8 +48,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    find("#close-date").set("2026-08-01")
-    find("#close-time").set("14:30")
+    find("#close-at").set("2026-08-01T14:30")
 
     expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(Journeys::TeacherStudentLoanReimbursement) }
 
@@ -66,17 +64,15 @@ RSpec.feature "Service configuration" do
       click_on "Change"
     end
 
-    expect(page).to have_css("#close-date")
-    expect(page).to have_css("#close-time")
+    expect(page).to have_css("#close-at")
 
     within_fieldset("Service status") { choose("Open") }
 
-    expect(page).to have_css("#close-date")
-    expect(page).to have_css("#close-time")
+    expect(page).to have_css("#close-at")
   end
 
   scenario "shows saved close date and close time values in the edit fields", js: true do
-    journey_configuration.update!(close_date: Date.new(2026, 8, 1), close_time: "14:30")
+    journey_configuration.update!(close_at: Time.zone.parse("2026-08-01 14:30"))
 
     sign_in_as_service_operator
 
@@ -88,8 +84,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    expect(page).to have_field("close-date", with: "2026-08-01")
-    expect(page).to have_field("close-time", with: "14:30")
+    expect(page).to have_field("close-at", with: "2026-08-01T14:30")
   end
 
   scenario "submitting Open with empty close date and close time shows errors for supported journeys", js: true do
@@ -144,8 +139,7 @@ RSpec.feature "Service configuration" do
       end
 
       within_fieldset("Service status") { choose("Open") }
-      find("#close-date").set("2026-08-01")
-      find("#close-time").set("14:30")
+      find("#close-at").set("2026-08-01T14:30")
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
       # make sure email reminder job is queued
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
@@ -169,8 +163,7 @@ RSpec.feature "Service configuration" do
       end
 
       select "2023/2024", from: "Accepting claims for academic year"
-      find("#close-date").set("2026-08-01")
-      find("#close-time").set("14:30")
+      find("#close-at").set("2026-08-01T14:30")
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(journey_configuration.journey) }
 
       expect(page).to have_content(AcademicYear.new(2023).to_s)

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Service configuration" do
     expect(page).to have_content("Sign in with DfE Identity")
   end
 
-  scenario "Service operator closes a service for submissions" do
+  scenario "Service operator closes a service for submissions", js: true do
     sign_in_as_service_operator
 
     click_on "Manage services"
@@ -24,16 +24,18 @@ RSpec.feature "Service configuration" do
       click_on "Change"
     end
 
-    within_fieldset("Service status") { choose("Closed") }
+    within_fieldset("Service status") { choose("Open") }
 
-    fill_in "Availability message", with: "You will be able to make a claim when the service enters public beta in November."
+    find("#close-at").set("2026-08-01T14:30")
+
+    within_fieldset("Service status") { choose("Closed") }
 
     expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
 
-    expect(current_path).to eq(admin_journey_configurations_path)
+    expect(current_path).to eq(edit_admin_journey_configuration_path(journey_configuration))
 
+    expect(page).to have_content("Closed")
     expect(journey_configuration.reload.open_for_submissions).to be false
-    expect(journey_configuration.availability_message).to eq("You will be able to make a claim when the service enters public beta in November.")
 
     # - Service operator opens a service for submissions
 
@@ -46,16 +48,65 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
+    find("#close-at").set("2026-08-01T14:30")
+
     expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(Journeys::TeacherStudentLoanReimbursement) }
 
-    expect(current_path).to eq(admin_journey_configurations_path)
+    expect(page).to have_content("Open")
+  end
+
+  scenario "selecting Open shows close date and close time fields", js: true do
+    sign_in_as_service_operator
+
+    click_on "Manage services"
 
     within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
-      expect(page).to have_content("Open")
-      expect(page).not_to have_content("Closed")
+      click_on "Change"
     end
 
-    expect(journey_configuration.reload.open_for_submissions).to be true
+    expect(page).to have_css("#close-at")
+    expect(page).to have_css("#close-at[min]")
+
+    within_fieldset("Service status") { choose("Open") }
+
+    expect(page).to have_css("#close-at")
+    expect(page).to have_css("#close-at[min]")
+  end
+
+  scenario "shows saved close date and close time values in the edit fields", js: true do
+    journey_configuration.update!(close_at: Time.zone.parse("2026-08-01 14:30"))
+
+    sign_in_as_service_operator
+
+    click_on "Manage services"
+
+    within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
+      click_on "Change"
+    end
+
+    within_fieldset("Service status") { choose("Open") }
+
+    expect(page).to have_field("close-at", with: "2026-08-01T14:30")
+  end
+
+  scenario "submitting Open with empty close date and close time shows errors for supported journeys", js: true do
+    eytfi_journey_configuration = create(:journey_configuration, :early_years_teachers_financial_incentive_payments)
+
+    sign_in_as_service_operator
+
+    [journey_configuration, eytfi_journey_configuration].each do |configuration|
+      visit admin_journey_configurations_path
+
+      within(find("tr[data-policy-configuration-routing-name=\"#{configuration.routing_name}\"]")) do
+        click_on "Change"
+      end
+
+      within_fieldset("Service status") { choose("Open") }
+
+      click_on "Save"
+
+      expect(configuration.reload.open_for_submissions).to be true
+    end
   end
 
   context "Reminders exist" do
@@ -73,7 +124,7 @@ RSpec.feature "Service configuration" do
     end
 
     scenario "Service operator opens an TRI service for submissions" do
-      journey_configuration.update(open_for_submissions: false)
+      journey_configuration.update_column(:open_for_submissions, false)
       sign_in_as_service_operator
 
       click_on "Manage services"
@@ -90,15 +141,14 @@ RSpec.feature "Service configuration" do
       end
 
       within_fieldset("Service status") { choose("Open") }
+      find("#close-at").set("2026-08-01T14:30")
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
       # make sure email reminder job is queued
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
-      expect(current_path).to eq(admin_journey_configurations_path)
+      expect(current_path).to eq(edit_admin_journey_configuration_path(journey_configuration))
 
-      within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
-        expect(page).to have_content("Open")
-        expect(page).not_to have_content("Closed")
-      end
+      expect(page).to have_content("Open")
+      expect(page).not_to have_content("Closed")
 
       expect(journey_configuration.reload.open_for_submissions).to be true
     end
@@ -115,11 +165,10 @@ RSpec.feature "Service configuration" do
       end
 
       select "2023/2024", from: "Accepting claims for academic year"
+      find("#close-at").set("2026-08-01T14:30")
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(journey_configuration.journey) }
 
-      within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
-        expect(page).to have_content("2023/2024")
-      end
+      expect(page).to have_content(AcademicYear.new(2023).to_s)
 
       expect(journey_configuration.reload.current_academic_year).to eq AcademicYear.new(2023)
     end

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -3,11 +3,17 @@ require "rails_helper"
 RSpec.feature "Service configuration" do
   let!(:journey_configuration) { create(:journey_configuration, :student_loans) }
 
+  def future_close_at_form_value(days_from_now = 1)
+    Time.zone.now.in_time_zone("London").advance(days: days_from_now).strftime("%Y-%m-%dT%H:%M")
+  end
+
   scenario "when teacher id configurable for service" do
     sign_in_as_service_operator
 
     click_on "Manage services"
-    click_on "Change"
+    within(page.find("tr", text: journey_configuration.journey.full_name)) do
+      click_on "Change"
+    end
 
     expect(page).to have_content("Sign in with DfE Identity")
   end
@@ -18,7 +24,7 @@ RSpec.feature "Service configuration" do
     click_on "Manage services"
 
     expect(page).to have_content("Teachers: claim back your student loan repayments")
-    within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
+    within(page.find("tr", text: journey_configuration.journey.full_name)) do
       expect(page).to have_content("Open")
       expect(page).not_to have_content("Closed")
       click_on "Change"
@@ -26,7 +32,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    find("#close-at").set("2026-08-01T14:30")
+    find("#close-at").set(future_close_at_form_value(7))
 
     within_fieldset("Service status") { choose("Closed") }
 
@@ -39,7 +45,9 @@ RSpec.feature "Service configuration" do
 
     # - Service operator opens a service for submissions
 
-    within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
+    visit admin_journey_configurations_path
+
+    within(page.find("tr", text: journey_configuration.journey.full_name)) do
       expect(page).to have_content("Closed")
       expect(page).not_to have_content("Open")
 
@@ -48,11 +56,11 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    find("#close-at").set("2026-08-01T14:30")
+    find("#close-at").set(future_close_at_form_value(7))
 
     expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(Journeys::TeacherStudentLoanReimbursement) }
 
-    expect(page).to have_content("Open")
+    expect(page).to have_content("Service open")
   end
 
   scenario "selecting Open shows close date and close time fields", js: true do
@@ -74,7 +82,7 @@ RSpec.feature "Service configuration" do
   end
 
   scenario "shows saved close date and close time values in the edit fields", js: true do
-    journey_configuration.update!(close_at: Time.zone.parse("2026-08-01 14:30"))
+    journey_configuration.update!(close_at: Time.zone.now.in_time_zone("London").advance(days: 7))
 
     sign_in_as_service_operator
 
@@ -86,7 +94,7 @@ RSpec.feature "Service configuration" do
 
     within_fieldset("Service status") { choose("Open") }
 
-    expect(page).to have_field("close-at", with: "2026-08-01T14:30")
+    expect(page).to have_field("close-at", with: journey_configuration.reload.close_at.in_time_zone("London").strftime("%Y-%m-%dT%H:%M"))
   end
 
   scenario "submitting Open with empty close date and close time shows errors for supported journeys", js: true do
@@ -130,7 +138,7 @@ RSpec.feature "Service configuration" do
       click_on "Manage services"
 
       expect(page).to have_content("Claim additional payments for teaching")
-      within(find("tr[data-policy-configuration-routing-name=\"#{journey_configuration.routing_name}\"]")) do
+      within(page.find("tr", text: journey_configuration.journey.full_name)) do
         expect(page).to have_content("Closed")
         expect(page).not_to have_content("Open")
         click_on "Change"
@@ -141,14 +149,14 @@ RSpec.feature "Service configuration" do
       end
 
       within_fieldset("Service status") { choose("Open") }
-      find("#close-at").set("2026-08-01T14:30")
+      find("#close-at").set(future_close_at_form_value(7))
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
       # make sure email reminder job is queued
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
       expect(current_path).to eq(edit_admin_journey_configuration_path(journey_configuration))
 
-      expect(page).to have_content("Open")
-      expect(page).not_to have_content("Closed")
+      expect(page).to have_content("Service open")
+      expect(page).to have_css("input[name='journey_configuration[open_for_submissions]'][value='true'][checked]")
 
       expect(journey_configuration.reload.open_for_submissions).to be true
     end
@@ -165,7 +173,7 @@ RSpec.feature "Service configuration" do
       end
 
       select "2023/2024", from: "Accepting claims for academic year"
-      find("#close-at").set("2026-08-01T14:30")
+      find("#close-at").set(future_close_at_form_value(7))
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob).with { |arg| expect(arg).to eql(journey_configuration.journey) }
 
       expect(page).to have_content(AcademicYear.new(2023).to_s)

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Service configuration" do
 
     expect { click_on "Save" }.to_not enqueue_job(SendReminderEmailsJob)
 
-    expect(current_path).to eq(admin_journey_configurations_path)
+    expect(current_path).to eq(edit_admin_journey_configuration_path(journey_configuration))
 
     expect(page).to have_content("Closed")
     expect(journey_configuration.reload.open_for_submissions).to be false
@@ -65,10 +65,12 @@ RSpec.feature "Service configuration" do
     end
 
     expect(page).to have_css("#close-at")
+    expect(page).to have_css("#close-at[min]")
 
     within_fieldset("Service status") { choose("Open") }
 
     expect(page).to have_css("#close-at")
+    expect(page).to have_css("#close-at[min]")
   end
 
   scenario "shows saved close date and close time values in the edit fields", js: true do
@@ -143,7 +145,7 @@ RSpec.feature "Service configuration" do
       expect(page).to have_content(I18n.t("admin.journey_configuration.reminder_warning", count: count))
       # make sure email reminder job is queued
       expect { click_on "Save" }.to enqueue_job(SendReminderEmailsJob)
-      expect(current_path).to eq(admin_journey_configurations_path)
+      expect(current_path).to eq(edit_admin_journey_configuration_path(journey_configuration))
 
       expect(page).to have_content("Open")
       expect(page).not_to have_content("Closed")

--- a/spec/jobs/close_expired_journeys_job_spec.rb
+++ b/spec/jobs/close_expired_journeys_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe CloseExpiredJourneysJob do
+  describe "#perform" do
+    it "keeps a journey open before the close time and closes it exactly at the close time" do
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-01 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 16:59:00") do
+        described_class.new.perform
+        expect(journey_configuration.reload.open_for_submissions).to be(true)
+      end
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+        expect(journey_configuration.reload.open_for_submissions).to be(false)
+      end
+    end
+  end
+end

--- a/spec/jobs/close_expired_journeys_job_spec.rb
+++ b/spec/jobs/close_expired_journeys_job_spec.rb
@@ -2,6 +2,12 @@ require "rails_helper"
 
 RSpec.describe CloseExpiredJourneysJob do
   describe "#perform" do
+    let!(:admin_user) { create(:dfe_signin_user) }
+
+    before do
+      allow(AdminMailer).to receive(:service_closing_soon).and_call_original
+    end
+
     it "keeps a journey open before the close time and closes it exactly at the close time" do
       journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-01 17:00:00"))
 
@@ -14,6 +20,44 @@ RSpec.describe CloseExpiredJourneysJob do
         described_class.new.perform
         expect(journey_configuration.reload.open_for_submissions).to be(false)
         expect(journey_configuration.reload.close_at).to be_nil
+      end
+    end
+
+    it "sends an admin notification one week before the close time" do
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-08 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+
+        expect(AdminMailer).to have_received(:service_closing_soon).with(
+          admin_user.email,
+          journey_name: journey_configuration.journey.journey_name,
+          close_at: journey_configuration.close_at
+        )
+      end
+    end
+
+    it "sends an admin notification two days before the close time" do
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-03 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+
+        expect(AdminMailer).to have_received(:service_closing_soon).with(
+          admin_user.email,
+          journey_name: journey_configuration.journey.journey_name,
+          close_at: journey_configuration.close_at
+        )
+      end
+    end
+
+    it "does not send an admin notification before the reminder window" do
+      create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-10 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+
+        expect(AdminMailer).not_to have_received(:service_closing_soon)
       end
     end
   end

--- a/spec/jobs/close_expired_journeys_job_spec.rb
+++ b/spec/jobs/close_expired_journeys_job_spec.rb
@@ -4,19 +4,24 @@ RSpec.describe CloseExpiredJourneysJob do
   describe "#perform" do
     let!(:admin_user) { create(:dfe_signin_user) }
 
+    def future_close_at(days_from_now)
+      Time.zone.now.in_time_zone("London") + days_from_now.days
+    end
+
     before do
       allow(AdminMailer).to receive(:service_closing_soon).and_call_original
     end
 
     it "keeps a journey open before the close time and closes it exactly at the close time" do
-      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-01 17:00:00"))
+      close_at = future_close_at(1)
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: close_at)
 
-      travel_to Time.zone.parse("2026-08-01 16:59:00") do
+      travel_to(close_at - 1.minute) do
         described_class.new.perform
         expect(journey_configuration.reload.open_for_submissions).to be(true)
       end
 
-      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+      travel_to(close_at) do
         described_class.new.perform
         expect(journey_configuration.reload.open_for_submissions).to be(false)
         expect(journey_configuration.reload.close_at).to be_nil
@@ -24,9 +29,10 @@ RSpec.describe CloseExpiredJourneysJob do
     end
 
     it "sends an admin notification one week before the close time" do
-      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-08 17:00:00"))
+      close_at = future_close_at(8)
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: close_at)
 
-      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+      travel_to(close_at - 7.days) do
         described_class.new.perform
 
         expect(AdminMailer).to have_received(:service_closing_soon).with(
@@ -38,9 +44,10 @@ RSpec.describe CloseExpiredJourneysJob do
     end
 
     it "sends an admin notification two days before the close time" do
-      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-03 17:00:00"))
+      close_at = future_close_at(3)
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: close_at)
 
-      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+      travel_to(close_at - 2.days) do
         described_class.new.perform
 
         expect(AdminMailer).to have_received(:service_closing_soon).with(
@@ -51,10 +58,28 @@ RSpec.describe CloseExpiredJourneysJob do
       end
     end
 
-    it "does not send an admin notification before the reminder window" do
-      create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-10 17:00:00"))
+    it "uses the latest close_at value when it changes before the reminder window" do
+      original_close_at = future_close_at(10)
+      updated_close_at = future_close_at(3)
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: original_close_at)
 
-      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+      travel_to(updated_close_at - 2.days) do
+        journey_configuration.update!(close_at: updated_close_at)
+        described_class.new.perform
+
+        expect(AdminMailer).to have_received(:service_closing_soon).with(
+          admin_user.email,
+          journey_name: journey_configuration.journey.journey_name,
+          close_at: journey_configuration.reload.close_at
+        )
+      end
+    end
+
+    it "does not send an admin notification before the reminder window" do
+      close_at = future_close_at(10)
+      create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: close_at)
+
+      travel_to(close_at - 8.days) do
         described_class.new.perform
 
         expect(AdminMailer).not_to have_received(:service_closing_soon)

--- a/spec/jobs/close_expired_journeys_job_spec.rb
+++ b/spec/jobs/close_expired_journeys_job_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CloseExpiredJourneysJob do
       travel_to Time.zone.parse("2026-08-01 17:00:00") do
         described_class.new.perform
         expect(journey_configuration.reload.open_for_submissions).to be(false)
+        expect(journey_configuration.reload.close_at).to be_nil
       end
     end
   end

--- a/spec/jobs/close_expired_journeys_job_spec.rb
+++ b/spec/jobs/close_expired_journeys_job_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe CloseExpiredJourneysJob do
+  describe "#perform" do
+    let!(:admin_user) { create(:dfe_signin_user) }
+
+    before do
+      allow(AdminMailer).to receive(:service_closing_soon).and_call_original
+    end
+
+    it "keeps a journey open before the close time and closes it exactly at the close time" do
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-01 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 16:59:00") do
+        described_class.new.perform
+        expect(journey_configuration.reload.open_for_submissions).to be(true)
+      end
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+        expect(journey_configuration.reload.open_for_submissions).to be(false)
+        expect(journey_configuration.reload.close_at).to be_nil
+      end
+    end
+
+    it "sends an admin notification one week before the close time" do
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-08 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+
+        expect(AdminMailer).to have_received(:service_closing_soon).with(
+          admin_user.email,
+          journey_name: journey_configuration.journey.journey_name,
+          close_at: journey_configuration.close_at
+        )
+      end
+    end
+
+    it "sends an admin notification two days before the close time" do
+      journey_configuration = create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-03 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+
+        expect(AdminMailer).to have_received(:service_closing_soon).with(
+          admin_user.email,
+          journey_name: journey_configuration.journey.journey_name,
+          close_at: journey_configuration.close_at
+        )
+      end
+    end
+
+    it "does not send an admin notification before the reminder window" do
+      create(:journey_configuration, :student_loans, open_for_submissions: true, close_at: Time.zone.parse("2026-08-10 17:00:00"))
+
+      travel_to Time.zone.parse("2026-08-01 17:00:00") do
+        described_class.new.perform
+
+        expect(AdminMailer).not_to have_received(:service_closing_soon)
+      end
+    end
+  end
+end

--- a/spec/models/journeys/configuration_spec.rb
+++ b/spec/models/journeys/configuration_spec.rb
@@ -26,8 +26,88 @@ RSpec.describe Journeys::Configuration do
   end
 
   it "validates academic years are formated like '2020/2021'" do
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name)).not_to be_valid
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020-2021")).not_to be_valid
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020/2021")).to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, open_for_submissions: false)).not_to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020-2021", open_for_submissions: false)).not_to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020/2021", open_for_submissions: false)).to be_valid
+  end
+
+  describe "close datetime" do
+    it "accepts close datetime when service is closed" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: false,
+        close_at: Time.zone.parse("2026-08-01 14:30")
+      )
+
+      expect(configuration).to be_valid
+      expect(configuration.save).to be true
+      expect(configuration.close_at).to eq(Time.zone.parse("2026-08-01 14:30"))
+    end
+
+    it "requires close datetime to be in the future when the service is open" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: 1.hour.ago
+      )
+
+      expect(configuration).not_to be_valid
+      expect(configuration.errors[:close_at]).to include("must be in the future")
+    end
+
+    it "accepts future close datetime when the service is open" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: 2.hours.from_now
+      )
+
+      expect(configuration).to be_valid
+    end
+
+    it "treats Europe/London close datetimes consistently in BST" do
+      travel_to Time.zone.parse("2026-07-15 12:00:00 +01:00") do
+        configuration = described_class.new(
+          routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+          current_academic_year: "2020/2021",
+          open_for_submissions: true,
+          close_at: Time.zone.parse("2026-07-15 17:00:00 +01:00")
+        )
+
+        expect(configuration).to be_valid
+      end
+    end
+
+    it "treats Europe/London close datetimes consistently in GMT" do
+      travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+        configuration = described_class.new(
+          routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+          current_academic_year: "2020/2021",
+          open_for_submissions: true,
+          close_at: Time.zone.parse("2026-12-15 17:00:00 +00:00")
+        )
+
+        expect(configuration).to be_valid
+      end
+    end
+
+    it "keeps the same UTC instant when a Europe/London close datetime is checked later in the year" do
+      close_at = Time.zone.parse("2026-07-15 17:00:00 +01:00")
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: close_at
+      )
+
+      expect(configuration.close_at.utc).to eq(close_at.utc)
+
+      travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+        expect(configuration.close_at.utc).to eq(close_at.utc)
+      end
+    end
   end
 end

--- a/spec/models/journeys/configuration_spec.rb
+++ b/spec/models/journeys/configuration_spec.rb
@@ -67,5 +67,47 @@ RSpec.describe Journeys::Configuration do
 
       expect(configuration).to be_valid
     end
+
+    it "treats Europe/London close datetimes consistently in BST" do
+      travel_to Time.zone.parse("2026-07-15 12:00:00 +01:00") do
+        configuration = described_class.new(
+          routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+          current_academic_year: "2020/2021",
+          open_for_submissions: true,
+          close_at: Time.zone.parse("2026-07-15 17:00:00 +01:00")
+        )
+
+        expect(configuration).to be_valid
+      end
+    end
+
+    it "treats Europe/London close datetimes consistently in GMT" do
+      travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+        configuration = described_class.new(
+          routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+          current_academic_year: "2020/2021",
+          open_for_submissions: true,
+          close_at: Time.zone.parse("2026-12-15 17:00:00 +00:00")
+        )
+
+        expect(configuration).to be_valid
+      end
+    end
+
+    it "keeps the same UTC instant when a Europe/London close datetime is checked later in the year" do
+      close_at = Time.zone.parse("2026-07-15 17:00:00 +01:00")
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: close_at
+      )
+
+      expect(configuration.close_at.utc).to eq(close_at.utc)
+
+      travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+        expect(configuration.close_at.utc).to eq(close_at.utc)
+      end
+    end
   end
 end

--- a/spec/models/journeys/configuration_spec.rb
+++ b/spec/models/journeys/configuration_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Journeys::Configuration do
   end
 
   it "validates academic years are formated like '2020/2021'" do
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, open_for_submissions: false)).not_to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: nil, open_for_submissions: false)).not_to be_valid
     expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020-2021", open_for_submissions: false)).not_to be_valid
     expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020/2021", open_for_submissions: false)).to be_valid
   end
@@ -43,6 +43,18 @@ RSpec.describe Journeys::Configuration do
       expect(configuration).to be_valid
       expect(configuration.save).to be true
       expect(configuration.close_at).to eq(Time.zone.parse("2026-08-01 14:30"))
+    end
+
+    it "requires close datetime to be present when the service is open" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: ""
+      )
+
+      expect(configuration).not_to be_valid
+      expect(configuration.errors[:close_at]).to include("can't be blank")
     end
 
     it "requires close datetime to be in the future when the service is open" do

--- a/spec/models/journeys/configuration_spec.rb
+++ b/spec/models/journeys/configuration_spec.rb
@@ -30,4 +30,21 @@ RSpec.describe Journeys::Configuration do
     expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020-2021")).not_to be_valid
     expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020/2021")).to be_valid
   end
+
+  describe "close date and close time" do
+    it "accepts close date and close time when service is closed" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: false,
+        close_date: "2026-08-01",
+        close_time: "14:30"
+      )
+
+      expect(configuration).to be_valid
+      expect(configuration.save).to be true
+      expect(configuration.close_date).to eq("2026-08-01")
+      expect(configuration.close_time).to eq("14:30")
+    end
+  end
 end

--- a/spec/models/journeys/configuration_spec.rb
+++ b/spec/models/journeys/configuration_spec.rb
@@ -26,25 +26,46 @@ RSpec.describe Journeys::Configuration do
   end
 
   it "validates academic years are formated like '2020/2021'" do
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name)).not_to be_valid
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020-2021")).not_to be_valid
-    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020/2021")).to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, open_for_submissions: false)).not_to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020-2021", open_for_submissions: false)).not_to be_valid
+    expect(described_class.new(routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name, current_academic_year: "2020/2021", open_for_submissions: false)).to be_valid
   end
 
-  describe "close date and close time" do
-    it "accepts close date and close time when service is closed" do
+  describe "close datetime" do
+    it "accepts close datetime when service is closed" do
       configuration = described_class.new(
         routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
         current_academic_year: "2020/2021",
         open_for_submissions: false,
-        close_date: "2026-08-01",
-        close_time: "14:30"
+        close_at: Time.zone.parse("2026-08-01 14:30")
       )
 
       expect(configuration).to be_valid
       expect(configuration.save).to be true
-      expect(configuration.close_date).to eq("2026-08-01")
-      expect(configuration.close_time).to eq("14:30")
+      expect(configuration.close_at).to eq(Time.zone.parse("2026-08-01 14:30"))
+    end
+
+    it "requires close datetime to be in the future when the service is open" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: 1.hour.ago
+      )
+
+      expect(configuration).not_to be_valid
+      expect(configuration.errors[:close_at]).to include("must be in the future")
+    end
+
+    it "accepts future close datetime when the service is open" do
+      configuration = described_class.new(
+        routing_name: Journeys::TeacherStudentLoanReimbursement.routing_name,
+        current_academic_year: "2020/2021",
+        open_for_submissions: true,
+        close_at: 2.hours.from_now
+      )
+
+      expect(configuration).to be_valid
     end
   end
 end

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe "Service configuration" do
         expect(journey_configuration.open_for_submissions).to be false
         expect(journey_configuration.availability_message).to eq("Test message")
       end
+
+      it "requires a close date and time when the service is opened" do
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+          open_for_submissions: true,
+          close_date: "",
+          close_time: ""
+        })
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
     end
   end
 end

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe "Service configuration" do
     before { sign_in_as_service_operator }
 
     describe "admin_journey_configurations#update" do
-      it "sets the configuration's availability message and status" do
+      it "sets the configuration's availability message, status, and close date/time" do
+        close_date = Date.current
+
         patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
           open_for_submissions: false,
           availability_message: "Test message",
-          close_date: Date.current,
+          close_date: close_date,
           close_time: "12:00"
         })
 
@@ -20,6 +22,26 @@ RSpec.describe "Service configuration" do
         journey_configuration.reload
         expect(journey_configuration.open_for_submissions).to be false
         expect(journey_configuration.availability_message).to eq("Test message")
+        expect(journey_configuration.close_date).to eq(close_date)
+        expect(journey_configuration.close_time).to eq(Time.utc(2000, 1, 1, 12, 0, 0))
+      end
+
+      it "persists close date and time for the early years payment practitioner journey" do
+        practitioner_journey_configuration = create(:journey_configuration, :early_years_payment_practitioner)
+        close_date = Date.current
+
+        patch admin_journey_configuration_path(practitioner_journey_configuration, journey_configuration: {
+          open_for_submissions: false,
+          availability_message: "Practitioner journey message",
+          close_date: close_date,
+          close_time: "12:00"
+        })
+
+        expect(response).to redirect_to(admin_journey_configurations_path)
+
+        practitioner_journey_configuration.reload
+        expect(practitioner_journey_configuration.close_date).to eq(close_date)
+        expect(practitioner_journey_configuration.close_time).to eq(Time.utc(2000, 1, 1, 12, 0, 0))
       end
 
       it "requires a close date and time when the service is opened" do

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe "Service configuration" do
 
     describe "admin_journey_configurations#update" do
       it "sets the configuration's availability message and status" do
-        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {open_for_submissions: false, availability_message: "Test message"})
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+          open_for_submissions: false,
+          availability_message: "Test message",
+          close_date: Date.current,
+          close_time: "12:00"
+        })
 
         expect(response).to redirect_to(admin_journey_configurations_path)
 

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Service configuration" do
           close_at: close_at
         })
 
-        expect(response).to redirect_to(admin_journey_configurations_path)
+        expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
 
         journey_configuration.reload
         expect(journey_configuration.open_for_submissions).to be false
@@ -34,7 +34,7 @@ RSpec.describe "Service configuration" do
           close_at: close_at
         })
 
-        expect(response).to redirect_to(admin_journey_configurations_path)
+        expect(response).to redirect_to(edit_admin_journey_configuration_path(practitioner_journey_configuration))
 
         practitioner_journey_configuration.reload
         expect(practitioner_journey_configuration.close_at).to eq(close_at)
@@ -47,6 +47,51 @@ RSpec.describe "Service configuration" do
         })
 
         expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "parses a close datetime in the Europe/London timezone for BST" do
+        travel_to Time.zone.parse("2026-07-15 12:00:00 +01:00") do
+          sign_in_as_service_operator
+
+          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+            open_for_submissions: false,
+            close_at: "2026-07-15T17:00"
+          })
+
+          expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
+          expect(journey_configuration.reload.close_at).to eq(Time.zone.parse("2026-07-15 17:00:00 +01:00"))
+        end
+      end
+
+      it "parses a close datetime in the Europe/London timezone for GMT" do
+        travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+          sign_in_as_service_operator
+
+          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+            open_for_submissions: false,
+            close_at: "2026-12-15T17:00"
+          })
+
+          expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
+          expect(journey_configuration.reload.close_at).to eq(Time.zone.parse("2026-12-15 17:00:00 +00:00"))
+        end
+      end
+
+      it "keeps the same UTC instant when the close datetime is read later in the year" do
+        travel_to Time.zone.parse("2026-07-15 12:00:00 +01:00") do
+          sign_in_as_service_operator
+
+          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+            open_for_submissions: false,
+            close_at: "2026-07-15T17:00"
+          })
+
+          expect(journey_configuration.reload.close_at.utc).to eq(Time.utc(2026, 7, 15, 16, 0, 0))
+        end
+
+        travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+          expect(journey_configuration.reload.close_at.utc).to eq(Time.utc(2026, 7, 15, 16, 0, 0))
+        end
       end
     end
   end

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -7,14 +7,13 @@ RSpec.describe "Service configuration" do
     before { sign_in_as_service_operator }
 
     describe "admin_journey_configurations#update" do
-      it "sets the configuration's availability message, status, and close date/time" do
-        close_date = Date.current
+      it "sets the configuration's availability message, status, and close datetime" do
+        close_at = 2.days.from_now.change(sec: 0)
 
         patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
           open_for_submissions: false,
           availability_message: "Test message",
-          close_date: close_date,
-          close_time: "12:00"
+          close_at: close_at
         })
 
         expect(response).to redirect_to(admin_journey_configurations_path)
@@ -22,33 +21,29 @@ RSpec.describe "Service configuration" do
         journey_configuration.reload
         expect(journey_configuration.open_for_submissions).to be false
         expect(journey_configuration.availability_message).to eq("Test message")
-        expect(journey_configuration.close_date).to eq(close_date)
-        expect(journey_configuration.close_time).to eq(Time.utc(2000, 1, 1, 12, 0, 0))
+        expect(journey_configuration.close_at).to eq(close_at)
       end
 
-      it "persists close date and time for the early years payment practitioner journey" do
+      it "persists close datetime for the early years payment practitioner journey" do
         practitioner_journey_configuration = create(:journey_configuration, :early_years_payment_practitioner)
-        close_date = Date.current
+        close_at = 2.days.from_now.change(sec: 0)
 
         patch admin_journey_configuration_path(practitioner_journey_configuration, journey_configuration: {
           open_for_submissions: false,
           availability_message: "Practitioner journey message",
-          close_date: close_date,
-          close_time: "12:00"
+          close_at: close_at
         })
 
         expect(response).to redirect_to(admin_journey_configurations_path)
 
         practitioner_journey_configuration.reload
-        expect(practitioner_journey_configuration.close_date).to eq(close_date)
-        expect(practitioner_journey_configuration.close_time).to eq(Time.utc(2000, 1, 1, 12, 0, 0))
+        expect(practitioner_journey_configuration.close_at).to eq(close_at)
       end
 
-      it "requires a close date and time when the service is opened" do
+      it "requires a close datetime when the service is opened" do
         patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
           open_for_submissions: true,
-          close_date: "",
-          close_time: ""
+          close_at: ""
         })
 
         expect(response).to have_http_status(:unprocessable_content)

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -7,14 +7,91 @@ RSpec.describe "Service configuration" do
     before { sign_in_as_service_operator }
 
     describe "admin_journey_configurations#update" do
-      it "sets the configuration's availability message and status" do
-        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {open_for_submissions: false, availability_message: "Test message"})
+      it "sets the configuration's availability message, status, and close datetime" do
+        close_at = 2.days.from_now.change(sec: 0)
 
-        expect(response).to redirect_to(admin_journey_configurations_path)
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+          open_for_submissions: false,
+          availability_message: "Test message",
+          close_at: close_at
+        })
+
+        expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
 
         journey_configuration.reload
         expect(journey_configuration.open_for_submissions).to be false
         expect(journey_configuration.availability_message).to eq("Test message")
+        expect(journey_configuration.close_at).to eq(close_at)
+      end
+
+      it "persists close datetime for the early years payment practitioner journey" do
+        practitioner_journey_configuration = create(:journey_configuration, :early_years_payment_practitioner)
+        close_at = 2.days.from_now.change(sec: 0)
+
+        patch admin_journey_configuration_path(practitioner_journey_configuration, journey_configuration: {
+          open_for_submissions: false,
+          availability_message: "Practitioner journey message",
+          close_at: close_at
+        })
+
+        expect(response).to redirect_to(edit_admin_journey_configuration_path(practitioner_journey_configuration))
+
+        practitioner_journey_configuration.reload
+        expect(practitioner_journey_configuration.close_at).to eq(close_at)
+      end
+
+      it "requires a close datetime when the service is opened" do
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+          open_for_submissions: true,
+          close_at: ""
+        })
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "parses a close datetime in the Europe/London timezone for BST" do
+        travel_to Time.zone.parse("2026-07-15 12:00:00 +01:00") do
+          sign_in_as_service_operator
+
+          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+            open_for_submissions: false,
+            close_at: "2026-07-15T17:00"
+          })
+
+          expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
+          expect(journey_configuration.reload.close_at).to eq(Time.zone.parse("2026-07-15 17:00:00 +01:00"))
+        end
+      end
+
+      it "parses a close datetime in the Europe/London timezone for GMT" do
+        travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+          sign_in_as_service_operator
+
+          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+            open_for_submissions: false,
+            close_at: "2026-12-15T17:00"
+          })
+
+          expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
+          expect(journey_configuration.reload.close_at).to eq(Time.zone.parse("2026-12-15 17:00:00 +00:00"))
+        end
+      end
+
+      it "keeps the same UTC instant when the close datetime is read later in the year" do
+        travel_to Time.zone.parse("2026-07-15 12:00:00 +01:00") do
+          sign_in_as_service_operator
+
+          patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+            open_for_submissions: false,
+            close_at: "2026-07-15T17:00"
+          })
+
+          expect(journey_configuration.reload.close_at.utc).to eq(Time.utc(2026, 7, 15, 16, 0, 0))
+        end
+
+        travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
+          expect(journey_configuration.reload.close_at.utc).to eq(Time.utc(2026, 7, 15, 16, 0, 0))
+        end
       end
     end
   end

--- a/spec/requests/admin/admin_page_spec.rb
+++ b/spec/requests/admin/admin_page_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "Admin page", type: :request do
       end
 
       it "opens all journey component routes" do
+        ensure_journey_configurations_exist!
         failures = []
 
         journey_component_routes.each do |route|
@@ -105,6 +106,7 @@ RSpec.describe "Admin page", type: :request do
       end
 
       it "renders all ineligible routes" do
+        ensure_journey_configurations_exist!
         failures = []
         create(:school, :further_education, :closed)
         allow_any_instance_of(OrdnanceSurvey::Client).to receive_message_chain(:api, :search_places, :index).and_return([])
@@ -125,6 +127,16 @@ RSpec.describe "Admin page", type: :request do
         end
 
         expect(failures).to be_empty, failures.join("\n")
+      end
+    end
+  end
+
+  def ensure_journey_configurations_exist!
+    journey_component_routes.map { |route| route[:journey] }.uniq.each do |journey_name|
+      Journeys::Configuration.find_or_create_by!(routing_name: journey_name) do |config|
+        config.current_academic_year = AcademicYear.current
+        config.close_at = 2.days.from_now
+        config.open_for_submissions = true
       end
     end
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -61,15 +61,18 @@ module FeatureHelpers
     expect(page).to have_text(/Which (additional )?school/) # there can be variations of the full text depending on which journey/page
     fill_in question, with: school.name.sub("The ", "").split(" ").first
 
-    within("#school_search__listbox") do
+    combobox = find("input[role='combobox']", wait: 10)
+    within("##{combobox[:id]}__listbox") do
       sleep(1) # seems to aid in success, as if click happens before event is bound
       find("li", text: school.name).click
     end
 
     click_button "Continue"
 
-    choose school.name
-    click_button "Continue"
+    if page.has_css?("input[type='radio']", wait: 0)
+      choose school.name
+      click_button "Continue"
+    end
   end
 
   def choose_still_teaching(teaching_at = "Yes, at Penistone Grammar School")


### PR DESCRIPTION
Adds a "close at" field to journeys to enable windows to be scheduled for closure rather than manually.

Also send's notification reminders to all admins so no one forgets

