### PR TITLE
[#224] remove ECP from data migration

### DIFF
--- a/db/data/20260730135238_persist_task_qualifications.rb
+++ b/db/data/20260730135238_persist_task_qualifications.rb
@@ -2,7 +2,6 @@
 
 relevant_policies = [
   Policies::StudentLoans,
-  Policies::EarlyCareerPayments,
   Policies::TargetedRetentionIncentivePayments
 ]
 


### PR DESCRIPTION
# Context

- https://github.com/DFE-Digital/claim-issues/issues/224
- ECP DQT record is no longer available hence removal here. This only affects a couple of handful of records
- Migration has already been ran but adding here for posterity