### PR TITLE
Stream validation errors to big query

### DIFF
--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -81,6 +81,7 @@ module FormSubmittable
           flash[:notice] = @form.flash_message if @form.flash_message
           redirect_to @form.redirect_to
         else
+          notify_analytics!(form: @form, slug: navigator.current_slug)
           render_template_for_current_slug
         end
       else
@@ -106,6 +107,20 @@ module FormSubmittable
       return if @form.auto_refresh.blank?
 
       response.headers["Refresh"] = @form.auto_refresh
+    end
+
+    def notify_analytics!(form:, slug:)
+      event = DfE::Analytics::Event.new
+        .with_type(:validation_error)
+        .with_request_details(request)
+        .with_data(
+          data: {
+            slug: slug,
+            errors: form.errors.as_json
+          }
+        )
+
+      DfE::Analytics::SendEvents.do([event])
     end
   end
 end

--- a/app/controllers/concerns/form_submittable.rb
+++ b/app/controllers/concerns/form_submittable.rb
@@ -110,6 +110,12 @@ module FormSubmittable
     end
 
     def notify_analytics!(form:, slug:)
+      errored_values = form.errors.map do |error|
+        {
+          error.attribute => form.try(error.attribute)
+        }
+      end
+
       event = DfE::Analytics::Event.new
         .with_type(:validation_error)
         .with_request_details(request)
@@ -117,6 +123,9 @@ module FormSubmittable
           data: {
             slug: slug,
             errors: form.errors.as_json
+          },
+          hidden_data: {
+            claimant_entered_values: errored_values
           }
         )
 

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,0 +1,2 @@
+shared:
+  - validation_error

--- a/spec/features/dfe_analytics_on_validation_error_spec.rb
+++ b/spec/features/dfe_analytics_on_validation_error_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "DfE Analytics on validation error" do
+  it "sends validation errors to dfe analytics" do
+    create(:journey_configuration, :further_education_payments)
+
+    visit landing_page_path(Journeys::FurtherEducationPayments.routing_name)
+
+    click_link "Start now"
+
+    expect(page).to have_content("Do you have a GOV.UK One Login account?")
+
+    # Don't choose an option to trigger validation error, expect the validation
+    # error to be sent to dfe analytics
+
+    expect(DfE::Analytics::SendEvents).to receive(:do) do |events|
+      expect(events.first.as_json["data"]).to eq([
+        {
+          "key" => "slug",
+          "value" => ["have-one-login-account"]
+        },
+        {
+          "key" => "errors",
+          "value" => [
+            {
+              have_one_login_account: [
+                "Select yes if you have a GOV.UK One Login account"
+              ]
+            }.to_json
+          ]
+        }
+      ])
+    end
+
+    click_button "Continue"
+
+    # Choose an option, expect the validation error not to be sent to dfe
+    # analytics
+
+    choose "Yes"
+
+    expect(DfE::Analytics::SendEvents).not_to receive(:do)
+
+    click_button "Continue"
+  end
+end

--- a/spec/features/dfe_analytics_on_validation_error_spec.rb
+++ b/spec/features/dfe_analytics_on_validation_error_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe "DfE Analytics on validation error" do
           ]
         }
       ])
+
+      expect(events.first.as_json["hidden_data"]).to eq([
+        {
+          "key" => "claimant_entered_values",
+          "value" => [{have_one_login_account: nil}.to_json]
+        }
+      ])
     end
 
     click_button "Continue"


### PR DESCRIPTION
Request from the analytics team to stream validation errors so they can
see what pages in the journey users get stuck on.
We do this at the controller level rather than in the form objects to
give us some flexibility, we call validate on the forms in the navigator
to determine which steps need completing so we want to avoid hitting
analytics there.
