### PR TITLE
Add multiuse to service access codes

### DIFF
--- a/app/controllers/admin/service_access_links_controller.rb
+++ b/app/controllers/admin/service_access_links_controller.rb
@@ -7,15 +7,22 @@ module Admin
     end
 
     def create
-      journey_routing_name = params.expect("journey")
+      journey_routing_name = service_access_link_params[:journey]
 
       journey = Journeys.for_routing_name(journey_routing_name)
 
       raise ActiveRecord::RecordNotFound unless journey
 
-      code = Journeys::ServiceAccessCode.create!(journey: journey)
+      multiuse = ActiveModel::Type::Boolean.new.cast(service_access_link_params[:multiuse]) || false
+      code = Journeys::ServiceAccessCode.create!(journey: journey, multiuse: multiuse)
 
       redirect_to admin_service_access_link_path(code)
+    end
+
+    private
+
+    def service_access_link_params
+      params.permit(:journey, :multiuse)
     end
   end
 end

--- a/app/controllers/admin/service_access_links_controller.rb
+++ b/app/controllers/admin/service_access_links_controller.rb
@@ -7,15 +7,24 @@ module Admin
     end
 
     def create
-      journey_routing_name = params.expect("journey")
+      journey_routing_name = service_access_link_params[:journey]
 
       journey = Journeys.for_routing_name(journey_routing_name)
 
       raise ActiveRecord::RecordNotFound unless journey
 
-      code = Journeys::ServiceAccessCode.create!(journey: journey)
+      code = Journeys::ServiceAccessCode.create!(
+        journey: journey,
+        multiuse: ActiveModel::Type::Boolean.new.cast(service_access_link_params[:multi_use]) || false
+      )
 
       redirect_to admin_service_access_link_path(code)
+    end
+
+    private
+
+    def service_access_link_params
+      params.permit(:journey, :multi_use)
     end
   end
 end

--- a/app/models/journeys/service_access_code.rb
+++ b/app/models/journeys/service_access_code.rb
@@ -37,7 +37,9 @@ module Journeys
     end
 
     def active?
-      !used && !expired?
+      return false if expired?
+
+      !used || multiuse?
     end
 
     private

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -114,11 +114,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Create a service access link</h2>
+    <h2 class="govuk-heading-m">Create service access links</h2>
 
+    <p class="govuk-hint">
+      Single use links are for individual claimants and expire once used.
+    </p>
     <%= govuk_button_to(
       "Generate a new service access link",
       admin_service_access_links_path(journey: journey_configuration.routing_name)
+    ) %>
+
+    <p class="govuk-hint">
+      Multi use links are for eligible settings to provide access to multiple claimants.
+    </p>
+    <%= govuk_button_to(
+      "Generate a new multi use service access link",
+      admin_service_access_links_path(journey: journey_configuration.routing_name, multi_use: true)
     ) %>
   </div>
 </div>

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -114,11 +114,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Create a service access link</h2>
+    <h2 class="govuk-heading-m">Create service access links</h2>
 
+    <p class="govuk-hint">
+      Single use links are for individual claimants and expire once used.
+    </p>
     <%= govuk_button_to(
       "Generate a new service access link",
       admin_service_access_links_path(journey: journey_configuration.routing_name)
+    ) %>
+
+    <p class="govuk-hint">
+      Multiuse links are for eligible settings to provide access to multiple claimants.
+    </p>
+    <%= govuk_button_to(
+      "Generate a new multiuse service access link",
+      admin_service_access_links_path(journey: journey_configuration.routing_name, multiuse: true)
     ) %>
   </div>
 </div>

--- a/app/views/admin/service_access_links/show.html.erb
+++ b/app/views/admin/service_access_links/show.html.erb
@@ -23,17 +23,16 @@
     </p>
 
     <p class="govuk-body">
-      This link will expire
-      on <strong><%= l(@service_access_code.expires_at.to_date) %></strong>
+      This link will expire on <strong><%= l(@service_access_code.expires_at.to_date) %></strong>, 
+      the claimant can restart the journey as many times as they like.
     </p>
 
     <p class="govuk-body">
-      The link can only be used to submit one claim.
-    </p>
-
-    <p class="govuk-body">
-      Until the link expires, the claimant can restart the journey as many times
-      as they like.
+      <% if @service_access_code.multiuse? %>
+        This link can be used multiple times.
+      <% else %>
+        The link can only be used to submit one claim.
+      <% end %>
     </p>
 
     <p class="govuk-body">

--- a/app/views/admin/service_access_links/show.html.erb
+++ b/app/views/admin/service_access_links/show.html.erb
@@ -27,14 +27,20 @@
       on <strong><%= l(@service_access_code.expires_at.to_date) %></strong>
     </p>
 
-    <p class="govuk-body">
-      The link can only be used to submit one claim.
-    </p>
+    <% if @service_access_code.multiuse? %>
+      <p class="govuk-body">
+        This link can be used multiple times.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        The link can only be used to submit one claim.
+      </p>
 
-    <p class="govuk-body">
-      Until the link expires, the claimant can restart the journey as many times
-      as they like.
-    </p>
+      <p class="govuk-body">
+        The link expires on <strong><%= l(@service_access_code.expires_at.to_date) %></strong>, the claimant can restart the journey as many times
+        as they like.
+      </p>
+    <% end %>
 
     <p class="govuk-body">
       <strong>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -87,6 +87,7 @@
   - code
   - used
   - journey
+  - multiuse
   - created_at
   - updated_at
   :feature_flags:

--- a/db/migrate/20260805120000_add_multiuse_to_journeys_service_access_codes.rb
+++ b/db/migrate/20260805120000_add_multiuse_to_journeys_service_access_codes.rb
@@ -1,0 +1,5 @@
+class AddMultiuseToJourneysServiceAccessCodes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :journeys_service_access_codes, :multiuse, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260805120000_add_multiuse_to_journeys_service_access_codes.rb
+++ b/db/migrate/20260805120000_add_multiuse_to_journeys_service_access_codes.rb
@@ -1,0 +1,5 @@
+class AddMultiuseToJourneysServiceAccessCodes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :journeys_service_access_codes, :multiuse, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_122602) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -530,6 +530,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_122602) do
     t.string "code", null: false
     t.datetime "created_at", null: false
     t.string "journey", null: false
+    t.boolean "multiuse", default: false, null: false
     t.datetime "updated_at", null: false
     t.boolean "used", default: false, null: false
     t.index ["code"], name: "index_journeys_service_access_codes_on_code", unique: true

--- a/spec/features/admin/admin_service_access_links_spec.rb
+++ b/spec/features/admin/admin_service_access_links_spec.rb
@@ -32,4 +32,27 @@ RSpec.describe "Admin service access links" do
       )
     )
   end
+
+  it "allows an admin to create a multiuse service access code" do
+    sign_in_as_service_admin
+
+    visit "/admin"
+
+    click_on "Manage services"
+
+    click_on "Change Claim a targeted retention incentive payment for further education teachers"
+
+    click_on "Generate a new multiuse service access link"
+
+    link_field = find("#service_access_link")
+    service_access_code = Journeys::ServiceAccessCode.last
+
+    expect(link_field[:value]).to eq(
+      landing_page_url(
+        "further-education-payments",
+        service_access_code: "ABCDEFG"
+      )
+    )
+    expect(service_access_code.multiuse).to be(true)
+  end
 end

--- a/spec/features/admin/admin_service_access_links_spec.rb
+++ b/spec/features/admin/admin_service_access_links_spec.rb
@@ -32,4 +32,27 @@ RSpec.describe "Admin service access links" do
       )
     )
   end
+
+  it "allows an admin to create a multi use service access code" do
+    sign_in_as_service_admin
+
+    visit "/admin"
+
+    click_on "Manage services"
+
+    click_on "Change Claim a targeted retention incentive payment for further education teachers"
+
+    click_on "Generate a new multi use service access link"
+
+    link_field = find("#service_access_link")
+    service_access_code = Journeys::ServiceAccessCode.last
+
+    expect(link_field[:value]).to eq(
+      landing_page_url(
+        "further-education-payments",
+        service_access_code: "ABCDEFG"
+      )
+    )
+    expect(service_access_code.multiuse).to be(true)
+  end
 end

--- a/spec/models/journeys/service_access_code_spec.rb
+++ b/spec/models/journeys/service_access_code_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Journeys::ServiceAccessCode, type: :model do
     end
   end
 
+  describe "defaults" do
+    it "defaults multiuse to false" do
+      code = described_class.new
+
+      expect(code.multiuse).to be false
+    end
+  end
+
   describe "#mark_as_used!" do
     it "marks the access code as used" do
       code = create(:service_access_code)
@@ -111,6 +119,46 @@ RSpec.describe Journeys::ServiceAccessCode, type: :model do
         )
 
         code = service_access_code.code
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be false
+      end
+    end
+
+    context "when the code is used and multiuse" do
+      it "returns true" do
+        journey = Journeys::FurtherEducationPayments
+
+        service_access_code = create(
+          :service_access_code,
+          journey: journey,
+          used: true,
+          multiuse: true
+        )
+
+        code = service_access_code.code
+
+        expect(
+          described_class.permits_access?(code: code, journey: journey)
+        ).to be true
+      end
+    end
+
+    context "when the code is used, multiuse, and expired" do
+      it "returns false" do
+        journey = Journeys::FurtherEducationPayments
+
+        code = nil
+
+        travel_to 31.days.ago do
+          code = create(
+            :service_access_code,
+            journey: journey,
+            used: true,
+            multiuse: true
+          ).code
+        end
 
         expect(
           described_class.permits_access?(code: code, journey: journey)


### PR DESCRIPTION
Adds a multiple use option for generated magic links when we don't know the number of claimants a school needs to distribute the link to.