### PR TITLE
45/verify ammended bank details with hmrc

### DIFF
--- a/app/controllers/admin/amendments_controller.rb
+++ b/app/controllers/admin/amendments_controller.rb
@@ -19,6 +19,12 @@ class Admin::AmendmentsController < Admin::BaseAdminController
     )
 
     if @form.valid? && @form.save
+      if @form.amendment.bank_details_changed?
+        Admin::Claims::HmrcValidationJob.perform_now(@claim)
+
+        flash[:hmrc_bank_verification_claim_id] = @claim.id
+      end
+
       redirect_to admin_claim_tasks_url(@claim), notice: "Claim has been amended successfully"
     else
       render "new"

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -90,7 +90,11 @@ class Admin::TasksController < Admin::BaseAdminController
     params[:name] == "matching_details" || action_name == "create"
   end
 
-  class BannerMessage < Struct.new(:type, :title, :body, keyword_init: true); end
+  class BannerMessage < Struct.new(:type, :title, :body, keyword_init: true)
+    def success?
+      type.to_s == "success"
+    end
+  end
 
   def set_banner_messages
     messages = []
@@ -129,6 +133,22 @@ class Admin::TasksController < Admin::BaseAdminController
         type: :notification,
         title: messages.first,
         body: nil
+      )
+    end
+
+    if (claim_id = flash[:hmrc_bank_verification_claim_id])
+      flash.delete(:hmrc_bank_verification_claim_id)
+
+      claim = Claim.find(claim_id)
+
+      validation = Admin::HmrcBankVerificationPresenter.new(
+        claim.hmrc_bank_validation_responses.last
+      )
+
+      @banners << BannerMessage.new(
+        type: validation.success? ? :success : :notification,
+        title: validation.title,
+        body: view_context.govuk_list(validation.rows)
       )
     end
   end

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -6,7 +6,7 @@ class Admin::TasksController < Admin::BaseAdminController
 
   def index
     @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
-    @banner_messages = set_banner_messages
+    set_banner_messages
   end
 
   def show
@@ -90,6 +90,8 @@ class Admin::TasksController < Admin::BaseAdminController
     params[:name] == "matching_details" || action_name == "create"
   end
 
+  class BannerMessage < Struct.new(:type, :title, :body, keyword_init: true); end
+
   def set_banner_messages
     messages = []
 
@@ -112,7 +114,23 @@ class Admin::TasksController < Admin::BaseAdminController
       MSG
     end
 
-    messages
+    @banners = []
+
+    if messages.many?
+      @banners << BannerMessage.new(
+        type: :notification,
+        title: "This claim requires the following to be reviewed:",
+        body: view_context.govuk_list(messages, type: :bullet)
+      )
+    end
+
+    if messages.one?
+      @banners << BannerMessage.new(
+        type: :notification,
+        title: messages.first,
+        body: nil
+      )
+    end
   end
 
   def task_view(task)

--- a/app/forms/admin/amendment_form.rb
+++ b/app/forms/admin/amendment_form.rb
@@ -27,6 +27,7 @@ class Admin::AmendmentForm
 
   attr_reader :claim
   attr_reader :admin_user
+  attr_reader :amendment
 
   attribute :teacher_reference_number, :string
   attribute :national_insurance_number, :string
@@ -256,6 +257,8 @@ class Admin::AmendmentForm
       amendment = claim.amendments.build(**amendment_attributes)
       amendment.claim_changes = change_hash
       amendment.save!
+
+      @amendment = amendment
 
       eligibility.assign_attributes(eligibility_attributes)
       eligibility.save!

--- a/app/jobs/admin/claims/hmrc_validation_job.rb
+++ b/app/jobs/admin/claims/hmrc_validation_job.rb
@@ -1,0 +1,24 @@
+module Admin
+  module Claims
+    class HmrcValidationJob < ApplicationJob
+      def perform(claim)
+        response = Hmrc.client.verify_personal_bank_account(
+          claim.bank_sort_code,
+          claim.bank_account_number,
+          claim.banking_name
+        )
+
+        hmrc_bank_validation_responses = claim.hmrc_bank_validation_responses
+
+        hmrc_bank_validation_responses << {
+          code: response.status,
+          body: response.safe_body
+        }
+
+        claim.update!(
+          hmrc_bank_validation_responses: hmrc_bank_validation_responses
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/admin/claims/hmrc_validation_job.rb
+++ b/app/jobs/admin/claims/hmrc_validation_job.rb
@@ -1,18 +1,33 @@
 module Admin
   module Claims
     class HmrcValidationJob < ApplicationJob
+      TIMEOUT_SECONDS = 5
+
       def perform(claim)
         response = Hmrc.client.verify_personal_bank_account(
           claim.bank_sort_code,
           claim.bank_account_number,
-          claim.banking_name
+          claim.banking_name,
+          timeout: TIMEOUT_SECONDS
         )
 
+        record_response(claim, code: response.status, body: response.safe_body)
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed
+        record_response(
+          claim,
+          code: 504,
+          body: "HMRC bank validation request timed out"
+        )
+      end
+
+      private
+
+      def record_response(claim, code:, body:)
         hmrc_bank_validation_responses = claim.hmrc_bank_validation_responses
 
         hmrc_bank_validation_responses << {
-          code: response.status,
-          body: response.safe_body
+          code: code,
+          body: body
         }
 
         claim.update!(

--- a/app/models/admin/hmrc_bank_verification_presenter.rb
+++ b/app/models/admin/hmrc_bank_verification_presenter.rb
@@ -1,0 +1,78 @@
+module Admin
+  class HmrcBankVerificationPresenter
+    SORT_CODE_MESSAGES = {
+      "yes" => "Yes - sort code found",
+      "no" => "No - sort code not found"
+    }.freeze
+
+    ACCOUNT_NUMBER_MESSAGES = {
+      "yes" => "Yes - sort code and account number match",
+      "no" => "No - sort code and account number do not match"
+    }.freeze
+
+    NAME_MESSAGES = {
+      "yes" => "Yes - name matches the account holder name",
+      "partial" => "Partial - name partially matches the account holder name",
+      "no" => "No - name does not match the account holder name"
+    }.freeze
+
+    UNKNOWN_MESSAGE = "Unknown - HMRC did not return an answer"
+
+    def initialize(hmrc_bank_validation_response)
+      @body = hmrc_bank_validation_response.fetch("body")
+      @code = hmrc_bank_validation_response.fetch("code")
+    end
+
+    def success?
+      !errored? && sort_code_found? && account_number_matches? && name_matches?
+    end
+
+    def title
+      if success?
+        "Bank details verified with HMRC"
+      else
+        "Bank details could not be verified with HMRC"
+      end
+    end
+
+    def rows
+      [
+        "Sort code: #{SORT_CODE_MESSAGES.fetch(sort_code_present_on_eiscd, UNKNOWN_MESSAGE)}",
+        "Account number: #{ACCOUNT_NUMBER_MESSAGES.fetch(account_exists, UNKNOWN_MESSAGE)}",
+        "Name on the account: #{NAME_MESSAGES.fetch(name_matches, UNKNOWN_MESSAGE)}"
+      ]
+    end
+
+    def errored?
+      @code.to_i > 300
+    end
+
+    private
+
+    attr_reader :body
+
+    def sort_code_found?
+      sort_code_present_on_eiscd == "yes"
+    end
+
+    def account_number_matches?
+      account_exists == "yes"
+    end
+
+    def name_matches?
+      name_matches == "yes"
+    end
+
+    def sort_code_present_on_eiscd
+      body["sortCodeIsPresentOnEISCD"]
+    end
+
+    def account_exists
+      body["accountExists"]
+    end
+
+    def name_matches
+      body["nameMatches"]
+    end
+  end
+end

--- a/app/models/amendment.rb
+++ b/app/models/amendment.rb
@@ -8,6 +8,12 @@
 # - an array [old_value, new_value]
 # - nil, meaning that this personal data has been removed from the amendment
 class Amendment < ApplicationRecord
+  BANK_DETAIL_ATTRIBUTES = %w[
+    banking_name
+    bank_sort_code
+    bank_account_number
+  ].freeze
+
   belongs_to :claim
   belongs_to :created_by, class_name: "DfeSignIn::User"
   serialize :claim_changes, type: Hash
@@ -83,6 +89,11 @@ class Amendment < ApplicationRecord
   rescue ActiveRecord::RecordInvalid
     amendment.errors.merge!(decision.errors)
     amendment
+  end
+
+  def bank_details_changed?
+    change_keys = claim_changes.stringify_keys.keys
+    BANK_DETAIL_ATTRIBUTES.any? { |bank_attr| change_keys.include?(bank_attr) }
   end
 
   private

--- a/app/views/admin/tasks/_banner.html.erb
+++ b/app/views/admin/tasks/_banner.html.erb
@@ -5,22 +5,12 @@
     </h2>
   </div>
   <div class="govuk-notification-banner__content">
-    <% if messages.many? %>
-      <h3 class="govuk-notification-banner__heading">
-        This claim requires the following to be reviewed:
-      </h3>
+    <h3 class="govuk-notification-banner__heading">
+      <%= banner.title %>
+    </h3>
 
-      <ul>
-        <% messages.each do |message| %>
-          <li>
-            <%= message %>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="govuk-notification-banner__heading">
-        <%= messages.first %>
-      </p>
+    <% if banner.body.present? %>
+      <%= banner.body %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/tasks/_banner.html.erb
+++ b/app/views/admin/tasks/_banner.html.erb
@@ -1,4 +1,12 @@
-<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+<div
+    class="<%= class_names(
+      "govuk-notification-banner",
+      "govuk-notification-banner--success": banner.success?
+    ) %>"
+    role="region"
+    aria-labelledby="govuk-notification-banner-title"
+    data-module="govuk-notification-banner"
+>
   <div class="govuk-notification-banner__header">
     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
       Important

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -4,9 +4,7 @@
   <%= govuk_back_link href: claims_backlink_path %>
 <% end %>
 
-<% if @banner_messages.any? %>
-  <%= render partial: "banner", locals: { messages: @banner_messages } %>
-<% end %>
+<%= render partial: "banner", collection: @banners %>
 
 <% if @claim.attributes_flagged_by_risk_indicator.any? %>
   <div class="govuk-warning-text">

--- a/lib/hmrc/client.rb
+++ b/lib/hmrc/client.rb
@@ -14,8 +14,8 @@ module Hmrc
       self.logger = logger
     end
 
-    def verify_personal_bank_account(sort_code, account_number, name)
-      refresh_token_if_required!
+    def verify_personal_bank_account(sort_code, account_number, name, timeout: nil)
+      refresh_token_if_required!(timeout: timeout)
 
       payload = {
         account: {
@@ -27,7 +27,12 @@ module Hmrc
         }
       }.to_json
 
-      response = post_request("/misc/bank-account/verify/personal", payload, request_headers)
+      response = post_request(
+        "/misc/bank-account/verify/personal",
+        payload,
+        request_headers,
+        timeout: timeout
+      )
 
       BankAccountVerificationResponse.new(response)
     rescue ResponseError => e
@@ -39,11 +44,15 @@ module Hmrc
 
     attr_accessor :base_url, :client_id, :client_secret, :http_client, :logger, :token, :token_expiry
 
-    def refresh_token_if_required!
+    def refresh_token_if_required!(timeout:)
       return unless token_invalid?
 
       request_time = Time.zone.now
-      response = post_request!("/oauth/token", token_request_payload)
+      response = post_request!(
+        "/oauth/token",
+        token_request_payload,
+        timeout: timeout
+      )
 
       body = JSON.parse(response.body)
 
@@ -72,16 +81,19 @@ module Hmrc
       }
     end
 
-    def post_request(path, payload, headers = nil)
+    def post_request(path, payload, headers = nil, timeout: nil)
       http_client.post(
         "#{base_url}#{path}",
         payload,
         headers
-      )
+      ) do |request|
+        request.options.timeout = timeout if timeout
+        request.options.open_timeout = timeout if timeout
+      end
     end
 
-    def post_request!(path, payload, headers = nil)
-      response = post_request(path, payload, headers)
+    def post_request!(path, payload, headers = nil, timeout: nil)
+      response = post_request(path, payload, headers, timeout: timeout)
 
       if !response.success?
         logger.info("HMRC API error: response code #{response.status}")

--- a/spec/features/admin/admin_amend_claim_bank_details_spec.rb
+++ b/spec/features/admin/admin_amend_claim_bank_details_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+RSpec.feature "Admin amends a claims bank details",
+  :with_hmrc_bank_validation_enabled,
+  :with_stubbed_hmrc_client do
+  let(:claim) do
+    create(
+      :claim,
+      :submitted,
+      banking_name: "Seymour Skinner",
+      bank_sort_code: "010203",
+      bank_account_number: "47274828"
+    )
+  end
+
+  context "when bank details aren't changed" do
+    it "doesn't show a banner or validate with hmrc" do
+      sign_in_as_service_admin
+
+      visit new_admin_claim_amendment_path(claim)
+
+      fill_in "Email address", with: "seymoure.skinner"
+
+      fill_in "Change notes", with: "Test"
+
+      click_on "Amend claim"
+
+      expect(page).not_to have_css(".govuk-notification-banner")
+    end
+  end
+
+  context "when the bank details validate with hmrc" do
+    let(:hmrc_bank_verification_response_body) do
+      {
+        sortCodeIsPresentOnEISCD: "yes",
+        accountExists: "yes",
+        nameMatches: "yes"
+      }.to_json
+    end
+
+    it "shows the admin a success banner" do
+      sign_in_as_service_admin
+
+      visit new_admin_claim_amendment_path(claim)
+
+      fill_in "Banking name", with: "Seymour T Skinner"
+
+      fill_in "Change notes", with: "Test"
+
+      click_on "Amend claim"
+
+      expect(page).to have_css(".govuk-notification-banner")
+      expect(page).to have_css(".govuk-notification-banner--success")
+
+      expect(page).to have_content "Sort code: Yes - sort code found"
+
+      expect(page).to have_content(
+        "Account number: Yes - sort code and account number match"
+      )
+
+      expect(page).to have_content(
+        "Yes - name matches the account holder name"
+      )
+    end
+  end
+
+  context "when the bank details partially match with hmrc" do
+    let(:hmrc_bank_verification_response_body) do
+      {
+        sortCodeIsPresentOnEISCD: "yes",
+        accountExists: "yes",
+        nameMatches: "partial"
+      }.to_json
+    end
+
+    it "shows the admin a partial match banner" do
+      sign_in_as_service_admin
+
+      visit new_admin_claim_amendment_path(claim)
+
+      fill_in "Banking name", with: "Seymour T Skinner"
+
+      fill_in "Change notes", with: "Test"
+
+      click_on "Amend claim"
+
+      expect(page).to have_css(".govuk-notification-banner")
+
+      expect(page).to have_content "Sort code: Yes - sort code found"
+
+      expect(page).to have_content(
+        "Account number: Yes - sort code and account number match"
+      )
+
+      expect(page).to have_content(
+        "Partial - name partially matches the account holder name"
+      )
+    end
+  end
+
+  context "when the bank details fail validation with hmrc" do
+    let(:hmrc_bank_verification_response_body) do
+      {
+        sortCodeIsPresentOnEISCD: "yes",
+        accountExists: "no",
+        nameMatches: "no"
+      }.to_json
+    end
+
+    it "shows the admin a failure banner" do
+      sign_in_as_service_admin
+
+      visit new_admin_claim_amendment_path(claim)
+
+      fill_in "Banking name", with: "Seymour T Skinner"
+
+      fill_in "Change notes", with: "Test"
+
+      click_on "Amend claim"
+
+      expect(page).to have_css(".govuk-notification-banner")
+
+      expect(page).not_to have_css(".govuk-notification-banner--success")
+
+      expect(page).to have_content "Sort code: Yes - sort code found"
+
+      expect(page).to have_content(
+        "Account number: No - sort code and account number do not match"
+      )
+
+      expect(page).to have_content(
+        "No - name does not match the account holder name"
+      )
+    end
+  end
+
+  context "when the hmrc api returns an error", :with_hmrc_bank_validation_enabled, :with_failing_hmrc_bank_validation do
+    it "shows the admin failure banner" do
+      sign_in_as_service_admin
+
+      visit new_admin_claim_amendment_path(claim)
+
+      fill_in "Banking name", with: "Seymour T Skinner"
+
+      fill_in "Change notes", with: "Test"
+
+      click_on "Amend claim"
+
+      expect(page).to have_css(".govuk-notification-banner")
+
+      expect(page).not_to have_css(".govuk-notification-banner--success")
+
+      expect(page).to have_content(
+        "Sort code: Unknown - HMRC did not return an answer"
+      )
+
+      expect(page).to have_content(
+        "Account number: Unknown - HMRC did not return an answer"
+      )
+
+      expect(page).to have_content(
+        "Name on the account: Unknown - HMRC did not return an answer"
+      )
+    end
+  end
+end

--- a/spec/features/admin/admin_amend_claim_spec.rb
+++ b/spec/features/admin/admin_amend_claim_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 # and Targeted Retention Incentive instead. Keeping these here because they
 # at least cover TSLR and Maths & Physics (which
 # themselves are slightly different from ECP and Targeted Retention Incentive).
-RSpec.feature "Admin amends a claim" do
+RSpec.feature "Admin amends a claim", :with_stubbed_hmrc_client do
   let(:claim) do
     create(
       :claim,
@@ -266,7 +266,7 @@ RSpec.feature "Admin amends a claim" do
   end
 end
 
-RSpec.feature "Admin amends a claim" do
+RSpec.feature "Admin amends a claim", :with_stubbed_hmrc_client do
   before do
     create(:journey_configuration, :student_loans)
   end

--- a/spec/features/admin/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Admin checking a claim with inconsistent payroll information" do
+RSpec.feature "Admin checking a claim with inconsistent payroll information", :with_stubbed_hmrc_client do
   let(:personal_details) do
     {
       national_insurance_number: generate(:national_insurance_number),

--- a/spec/jobs/admin/claims/hmrc_validation_job_spec.rb
+++ b/spec/jobs/admin/claims/hmrc_validation_job_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe Admin::Claims::HmrcValidationJob do
+  let(:claim) do
+    create(
+      :claim,
+      :submitted,
+      banking_name: "Seymour Skinner",
+      bank_sort_code: "010203",
+      bank_account_number: "47274828",
+      hmrc_bank_validation_responses: []
+    )
+  end
+
+  subject(:perform_job) { described_class.new.perform(claim) }
+
+  describe "#perform", :with_stubbed_hmrc_client do
+    it "sends the claim's bank details to the HMRC API" do
+      perform_job
+
+      expect(
+        a_request(
+          :post,
+          "#{HMRC_TEST_BASE_URL}/misc/bank-account/verify/personal"
+        ).with(
+          body: {
+            account: {
+              sortCode: "010203",
+              accountNumber: "47274828"
+            },
+            subject: {
+              name: "Seymour Skinner"
+            }
+          }.to_json
+        )
+      ).to have_been_made
+    end
+
+    it "records the response on the claim" do
+      expect { perform_job }.to(
+        change { claim.reload.hmrc_bank_validation_responses }
+        .from([]).to(
+          [
+            {
+              "code" => 200,
+              "body" => {
+                "sortCodeIsPresentOnEISCD" => "yes",
+                "accountExists" => "yes",
+                "nameMatches" => "yes"
+              }
+            }
+          ]
+        )
+      )
+    end
+
+    context "when the details don't match" do
+      let(:name_match) { false }
+      let(:account_exists) { false }
+      let(:sort_code_correct) { false }
+
+      it "records the response on the claim" do
+        expect { perform_job }.to(
+          change { claim.reload.hmrc_bank_validation_responses }
+          .from([]).to(
+            [
+              {
+                "code" => 200,
+                "body" => {
+                  "sortCodeIsPresentOnEISCD" => "no",
+                  "accountExists" => "no",
+                  "nameMatches" => "no"
+                }
+              }
+            ]
+          )
+        )
+      end
+    end
+
+    context "when the claim has existing responses" do
+      let(:existing_response) do
+        {
+          "code" => 200,
+          "body" => {
+            "sortCodeIsPresentOnEISCD" => "yes",
+            "accountExists" => "yes",
+            "nameMatches" => "no"
+          }
+        }
+      end
+
+      before do
+        claim.update!(hmrc_bank_validation_responses: [existing_response])
+      end
+
+      it "appends the new response" do
+        perform_job
+
+        expect(claim.reload.hmrc_bank_validation_responses).to eq(
+          [
+            existing_response,
+            {
+              "code" => 200,
+              "body" => {
+                "sortCodeIsPresentOnEISCD" => "yes",
+                "accountExists" => "yes",
+                "nameMatches" => "yes"
+              }
+            }
+          ]
+        )
+      end
+    end
+  end
+
+  describe "#perform when the HMRC API errors", :with_failing_hmrc_bank_validation do
+    it "doesn't raise an error" do
+      expect { perform_job }.not_to raise_error
+    end
+
+    it "records the error response on the claim" do
+      expect { perform_job }.to(
+        change { claim.reload.hmrc_bank_validation_responses }
+        .from([]).to([{"code" => 429, "body" => "Test failure"}])
+      )
+    end
+  end
+end

--- a/spec/jobs/admin/claims/hmrc_validation_job_spec.rb
+++ b/spec/jobs/admin/claims/hmrc_validation_job_spec.rb
@@ -126,4 +126,34 @@ RSpec.describe Admin::Claims::HmrcValidationJob do
       )
     end
   end
+
+  describe "#perform when the HMRC API times out", :with_stubbed_hmrc_client do
+    it "records the timeout as an error response" do
+      claim = create(
+        :claim,
+        :submitted,
+        banking_name: "Seymour Skinner",
+        bank_sort_code: "010203",
+        bank_account_number: "47274828",
+        hmrc_bank_validation_responses: []
+      )
+
+      stub_request(
+        :post,
+        "#{HMRC_TEST_BASE_URL}/misc/bank-account/verify/personal"
+      ).to_timeout
+
+      expect { described_class.new.perform(claim) }.to(
+        change { claim.reload.hmrc_bank_validation_responses }
+        .from([]).to(
+          [
+            {
+              "code" => 504,
+              "body" => "HMRC bank validation request timed out"
+            }
+          ]
+        )
+      )
+    end
+  end
 end

--- a/spec/lib/hmrc/client_spec.rb
+++ b/spec/lib/hmrc/client_spec.rb
@@ -125,6 +125,40 @@ RSpec.describe Hmrc::Client do
       end
     end
 
+    it "applies an optional timeout to the token and verification requests" do
+      token_request_options = Struct.new(:timeout, :open_timeout).new
+      verification_request_options = Struct.new(:timeout, :open_timeout).new
+      requests = [
+        double(options: token_request_options),
+        double(options: verification_request_options)
+      ]
+      response = double(
+        body: {
+          "access_token" => token,
+          "expires_in" => token_expiry
+        }.to_json,
+        success?: true,
+        status: 200
+      )
+
+      allow(http_client).to receive(:post) do |*, &block|
+        block.call(requests.shift)
+        response
+      end
+
+      client.verify_personal_bank_account(
+        sort_code,
+        account_number,
+        name,
+        timeout: 5
+      )
+
+      expect(token_request_options.timeout).to eq(5)
+      expect(token_request_options.open_timeout).to eq(5)
+      expect(verification_request_options.timeout).to eq(5)
+      expect(verification_request_options.open_timeout).to eq(5)
+    end
+
     context "when there is a response error" do
       let(:response_code) { 429 }
       let(:response_success) { false }

--- a/spec/models/admin/hmrc_bank_verification_presenter_spec.rb
+++ b/spec/models/admin/hmrc_bank_verification_presenter_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe Admin::HmrcBankVerificationPresenter do
+  subject(:presenter) { described_class.new(response) }
+
+  let(:response) do
+    {
+      "code" => code,
+      "body" => body
+    }
+  end
+
+  let(:code) { 200 }
+
+  let(:body) do
+    {
+      "sortCodeIsPresentOnEISCD" => sort_code_present_on_eiscd,
+      "accountExists" => account_exists,
+      "nameMatches" => name_matches
+    }
+  end
+
+  let(:sort_code_present_on_eiscd) { "yes" }
+  let(:account_exists) { "yes" }
+  let(:name_matches) { "yes" }
+
+  describe "#errored?" do
+    context "when the response code is a success" do
+      let(:code) { 200 }
+
+      it { is_expected.not_to be_errored }
+    end
+
+    context "when the response code is a redirect" do
+      let(:code) { 300 }
+
+      it { is_expected.not_to be_errored }
+    end
+
+    context "when the response code is an error" do
+      let(:code) { 429 }
+
+      it { is_expected.to be_errored }
+    end
+  end
+
+  describe "#success?" do
+    context "when the sort code, account number and name all match" do
+      it { is_expected.to be_success }
+    end
+
+    context "when the sort code isn't found" do
+      let(:sort_code_present_on_eiscd) { "no" }
+
+      it { is_expected.not_to be_success }
+    end
+
+    context "when the account number doesn't match" do
+      let(:account_exists) { "no" }
+
+      it { is_expected.not_to be_success }
+    end
+
+    context "when the name doesn't match" do
+      let(:name_matches) { "no" }
+
+      it { is_expected.not_to be_success }
+    end
+
+    context "when the name partially matches" do
+      let(:name_matches) { "partial" }
+
+      it { is_expected.not_to be_success }
+    end
+
+    context "when HMRC didn't return an answer" do
+      let(:body) { {} }
+
+      it { is_expected.not_to be_success }
+    end
+
+    context "when the request errored" do
+      let(:code) { 429 }
+      let(:body) { "Test failure" }
+
+      it { is_expected.not_to be_success }
+    end
+  end
+
+  describe "#title" do
+    context "when the details were verified" do
+      it "reports success" do
+        expect(presenter.title).to eq("Bank details verified with HMRC")
+      end
+    end
+
+    context "when the details weren't verified" do
+      let(:name_matches) { "no" }
+
+      it "reports failure" do
+        expect(presenter.title).to eq(
+          "Bank details could not be verified with HMRC"
+        )
+      end
+    end
+  end
+
+  describe "#rows" do
+    context "when the details were verified" do
+      it "describes each check" do
+        expect(presenter.rows).to eq(
+          [
+            "Sort code: Yes - sort code found",
+            "Account number: Yes - sort code and account number match",
+            "Name on the account: Yes - name matches the account holder name"
+          ]
+        )
+      end
+    end
+
+    context "when the details weren't verified" do
+      let(:sort_code_present_on_eiscd) { "no" }
+      let(:account_exists) { "no" }
+      let(:name_matches) { "no" }
+
+      it "describes each check" do
+        expect(presenter.rows).to eq(
+          [
+            "Sort code: No - sort code not found",
+            "Account number: No - sort code and account number do not match",
+            "Name on the account: No - name does not match the account holder name"
+          ]
+        )
+      end
+    end
+
+    context "when the name partially matches" do
+      let(:name_matches) { "partial" }
+
+      it "describes the partial match" do
+        expect(presenter.rows.last).to eq(
+          "Name on the account: Partial - name partially matches the account holder name"
+        )
+      end
+    end
+
+    context "when HMRC didn't return an answer" do
+      let(:body) { {} }
+
+      it "describes each check as unknown" do
+        expect(presenter.rows).to eq(
+          [
+            "Sort code: Unknown - HMRC did not return an answer",
+            "Account number: Unknown - HMRC did not return an answer",
+            "Name on the account: Unknown - HMRC did not return an answer"
+          ]
+        )
+      end
+    end
+
+    context "when the request errored" do
+      let(:code) { 429 }
+      let(:body) { "Test failure" }
+
+      it "describes each check as unknown" do
+        expect(presenter.rows).to eq(
+          [
+            "Sort code: Unknown - HMRC did not return an answer",
+            "Account number: Unknown - HMRC did not return an answer",
+            "Name on the account: Unknown - HMRC did not return an answer"
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/admin/admin_amendments_spec.rb
+++ b/spec/requests/admin/admin_amendments_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Admin claim amendments" do
+RSpec.describe "Admin claim amendments", :with_stubbed_hmrc_client do
   let(:claim) do
     create(
       :claim,

--- a/spec/views/admin/tasks/index.html.erb_spec.rb
+++ b/spec/views/admin/tasks/index.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "admin/tasks/index.html.erb" do
       it "ues new task names" do
         assign(:claim, claim)
         assign(:claim_checking_tasks, claim_checking_tasks)
-        assign(:banner_messages, [])
+        assign(:banners, [])
 
         render
 
@@ -38,7 +38,7 @@ RSpec.describe "admin/tasks/index.html.erb" do
       it "ues old task names" do
         assign(:claim, claim)
         assign(:claim_checking_tasks, claim_checking_tasks)
-        assign(:banner_messages, [])
+        assign(:banners, [])
 
         render
 


### PR DESCRIPTION
# Verify bank detail amendments with hmrc.

When the ops team amend the bank details on a claim we now check the bank
details against the hmrc api and display the result as a notification banner.

The first commit does some faffing to make it easier to setup notification
banners. The second commit makes the api call to hmrc and shows the result in a
banner.
