### PR TITLE
Block auto automatic_approvals on demand

### DIFF
--- a/app/controllers/admin/journey_configurations_controller.rb
+++ b/app/controllers/admin/journey_configurations_controller.rb
@@ -1,7 +1,8 @@
 module Admin
   class JourneyConfigurationsController < BaseAdminController
     helper_method :journey_configuration
-    before_action :ensure_service_operator, :journey_configuration
+    before_action :journey_configuration
+    before_action :ensure_service_admin, only: [:update], if: -> { automatic_approvals_update_requested? }
     after_action :send_reminders, only: [:update]
 
     FILE_UPLOAD_TARGET_DATA_MODELS = {
@@ -20,6 +21,7 @@ module Admin
 
     def update
       if journey_configuration.update(journey_configuration_params)
+        flash[:success] = automatic_approvals_flash_message if journey_configuration.saved_change_to_automatic_approvals?
         redirect_to edit_admin_journey_configuration_path(journey_configuration)
       else
         load_edit_data
@@ -67,7 +69,8 @@ module Admin
           :close_at,
           :open_for_submissions,
           :current_academic_year,
-          :teacher_id_enabled
+          :teacher_id_enabled,
+          :automatic_approvals
         )
 
       permitted[:close_at] = Time.zone.parse(permitted[:close_at]).in_time_zone("London") if permitted[:close_at].present?
@@ -75,10 +78,23 @@ module Admin
       permitted
     end
 
+    def automatic_approvals_update_requested?
+      return false unless params[:journey_configuration].key?(:automatic_approvals)
+
+      ActiveModel::Type::Boolean.new.cast(params[:journey_configuration][:automatic_approvals]) != journey_configuration.automatic_approvals
+    end
+
     def send_reminders
       return unless journey_configuration.open_for_submissions
 
       SendReminderEmailsJob.perform_later(journey_configuration.journey)
+    end
+
+    def automatic_approvals_flash_message
+      return unless journey_configuration.saved_change_to_automatic_approvals?
+
+      status = journey_configuration.automatic_approvals ? "on" : "off"
+      "Automatic approvals for submitted claims are turned #{status}"
     end
   end
 end

--- a/app/models/base_policy.rb
+++ b/app/models/base_policy.rb
@@ -102,6 +102,10 @@ module BasePolicy
     true
   end
 
+  def automatic_approvals?
+    Journeys.for_policy(self).configuration.automatic_approvals
+  end
+
   def admin_tasks_presenter(claim)
     self::AdminTasksPresenter.new(claim)
   end

--- a/app/models/claim_auto_approval.rb
+++ b/app/models/claim_auto_approval.rb
@@ -6,7 +6,7 @@ class ClaimAutoApproval
   end
 
   def eligible?
-    approvable? && auto_approvable?
+    claim.policy.automatic_approvals? && approvable? && auto_approvable?
   end
 
   def auto_approve!

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -1,7 +1,9 @@
 module Journeys
   module Base
     def configuration
-      Configuration.find(routing_name)
+      # Intentionally fail fast if a journey configuration row has not been set up.
+      # The service is expected to create this record in admin configuration before use.
+      Configuration.find_by!(routing_name: routing_name)
     end
 
     def start_page_url

--- a/app/models/journeys/configuration.rb
+++ b/app/models/journeys/configuration.rb
@@ -25,6 +25,7 @@ module Journeys
     # Use AcademicYear as custom ActiveRecord attribute type
     attribute :current_academic_year, AcademicYear::Type.new, default: -> { AcademicYear.current }
     attribute :close_at, default: -> { 1.year.from_now.in_time_zone("London") }
+    attribute :automatic_approvals, :boolean, default: true
 
     validates :current_academic_year_before_type_cast, format: {with: AcademicYear::ACADEMIC_YEAR_REGEXP}
     validates :close_at, presence: true, if: :open_for_submissions?

--- a/app/views/admin/journey_configurations/edit.html.erb
+++ b/app/views/admin/journey_configurations/edit.html.erb
@@ -80,8 +80,28 @@
               <%= f.label :open_for_submissions, "Closed", value: false, class: "govuk-label govuk-radios__label" %>
             </div>
           </div>
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          <h3 class="govuk-heading-s">Automatic approvals for submitted claims</h3>
+
+          <legend class="govuk-fieldset__legend">
+            Automatic approvals
+          </legend>
+
+          <div class="govuk-radios" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <%= f.radio_button :automatic_approvals, true, class: "govuk-radios__input" %>
+              <%= f.label :automatic_approvals, "On", value: true, class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button :automatic_approvals, false, class: "govuk-radios__input" %>
+              <%= f.label :automatic_approvals, "Off", value: false, class: "govuk-label govuk-radios__label" %>
+            </div>
+          </div>
         </fieldset>
       </div>
+
 
       <% if journey_configuration.teacher_id_configurable? %>
         <div class="govuk-form-group">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -66,9 +66,13 @@
 
       <main class="govuk-main-wrapper app-main-class" id="main-content">
         <% flash.each do |name, msg| %>
-          <div class="govuk-body-l govuk-flash__<%= name %>">
-            <%= msg %>
-          </div>
+          <% if name == "success" %>
+            <%= govuk_notification_banner(title_text: "Success", success: true) { |nb| nb.with_heading(text: msg) } %>
+          <% else %>
+            <div class="govuk-body-l govuk-flash__<%= name %>">
+              <%= msg %>
+            </div>
+          <% end %>
         <% end %>
 
         <%= yield %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -7,6 +7,7 @@ shared:
     - created_at # datetime, when was this journey configuration created
     - updated_at # datetime, when was this journey configuration last updated
     - current_academic_year # string, configured academic year for this journey
+    - automatic_approvals # boolean, whether automatic approvals are enabled for this journey
     - teacher_id_enabled # boolean, is teacher ID enabled for this journey
     - close_at # datetime, when this journey configuration is scheduled to close
   :reminders:

--- a/db/migrate/20260813000000_add_automatic_approvals_to_journey_configurations.rb
+++ b/db/migrate/20260813000000_add_automatic_approvals_to_journey_configurations.rb
@@ -1,0 +1,5 @@
+class AddAutomaticApprovalsToJourneyConfigurations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :journey_configurations, :automatic_approvals, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -518,6 +518,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
   end
 
   create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|
+    t.boolean "automatic_approvals", default: true, null: false
     t.string "availability_message"
     t.datetime "close_at"
     t.datetime "created_at", precision: nil, null: false

--- a/spec/factories/journey_configurations.rb
+++ b/spec/factories/journey_configurations.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :journey_configuration, class: "journeys/configuration" do
     current_academic_year { AcademicYear.current }
     close_at { 2.days.from_now }
+    automatic_approvals { true }
 
     trait :student_loans do
       routing_name { Journeys::TeacherStudentLoanReimbursement.routing_name }

--- a/spec/features/admin/approvals_spec.rb
+++ b/spec/features/admin/approvals_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Approvals" do
   before do
+    create(:journey_configuration, :early_years_payment_provider_start)
     stub_const("Policies::EarlyYearsPayments::APPROVED_MIN_QA_THRESHOLD", 0)
   end
 

--- a/spec/features/admin/configure_services_spec.rb
+++ b/spec/features/admin/configure_services_spec.rb
@@ -18,6 +18,42 @@ RSpec.feature "Service configuration" do
     expect(page).to have_content("Sign in with DfE Identity")
   end
 
+  scenario "Service admin toggles automatic approvals for submitted claims" do
+    sign_in_as_service_admin
+
+    click_on "Manage services"
+    within(page.find("tr", text: journey_configuration.journey.full_name)) do
+      click_on "Change"
+    end
+
+    expect(page).to have_content("Automatic approvals for submitted claims")
+    expect(page).to have_content("Automatic approvals")
+    within_fieldset("Automatic approvals") { choose("Off") }
+
+    click_on "Save"
+
+    expect(journey_configuration.reload.automatic_approvals).to be false
+    expect(page).to have_content("Automatic approvals for submitted claims are turned off")
+  end
+
+  scenario "Service operator can't toggle automatic approvals for submitted claims" do
+    sign_in_as_service_operator
+
+    click_on "Manage services"
+    within(page.find("tr", text: journey_configuration.journey.full_name)) do
+      click_on "Change"
+    end
+
+    expect(page).to have_content("Automatic approvals for submitted claims")
+    expect(page).to have_content("Automatic approvals")
+    within_fieldset("Automatic approvals") { choose("Off") }
+
+    click_on "Save"
+
+    expect(journey_configuration.reload.automatic_approvals).to be true
+    expect(page).to have_content("Not authorised")
+  end
+
   scenario "Service operator closes a service for submissions", js: true do
     sign_in_as_service_operator
 

--- a/spec/models/claim_auto_approval_spec.rb
+++ b/spec/models/claim_auto_approval_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe ClaimAutoApproval do
   subject(:claim_auto_approval) { described_class.new(claim) }
 
+  before do
+    create(:journey_configuration, :student_loans)
+  end
+
   let(:claim) { create(:claim, :submitted) }
   let(:applicable_task_names) { ClaimCheckingTasks.new(claim).applicable_task_names }
 
@@ -48,6 +52,31 @@ RSpec.describe ClaimAutoApproval do
       end
 
       it { is_expected.to eq(true) }
+    end
+
+    context "when the policy disables automatic approvals" do
+      before do
+        allow(claim.policy).to receive(:automatic_approvals?).and_return(false)
+        applicable_task_names.each do |task|
+          create(:task, :automated, :passed, name: task, claim:)
+        end
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when the claim is approvable and auto-approvable but policy automatic approvals is false" do
+      before do
+        applicable_task_names.each do |task|
+          create(:task, :automated, :passed, name: task, claim:)
+        end
+
+        allow(claim.policy).to receive(:automatic_approvals?).and_return(false)
+      end
+
+      it "does not auto-approve the claim" do
+        expect { claim_auto_approval.auto_approve! }.not_to change(Decision, :count)
+      end
     end
 
     context "when some claim's tasks passed manually" do

--- a/spec/models/journeys/configuration_spec.rb
+++ b/spec/models/journeys/configuration_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Journeys::Configuration do
         expect(student_loans.journey).to eq(Journeys::TeacherStudentLoanReimbursement)
       end
     end
+
+    describe "#configuration" do
+      it "raises when the journey configuration is missing" do
+        journey = Journeys::EarlyYearsPayment::Provider::Authenticated
+        Journeys::Configuration.where(routing_name: journey.routing_name).delete_all
+
+        expect { journey.configuration }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   it "validates academic years are formated like '2020/2021'" do

--- a/spec/requests/admin/admin_configure_services_spec.rb
+++ b/spec/requests/admin/admin_configure_services_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe "Service configuration" do
     before { sign_in_as_service_operator }
 
     describe "admin_journey_configurations#update" do
+      it "does not allow automatic approvals to be edited" do
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+          automatic_approvals: false
+        })
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(journey_configuration.reload.automatic_approvals).to be true
+      end
+
       it "sets the configuration's availability message, status, and close datetime" do
         close_at = 2.days.from_now.change(sec: 0)
 
@@ -92,6 +101,21 @@ RSpec.describe "Service configuration" do
         travel_to Time.zone.parse("2026-12-15 12:00:00 +00:00") do
           expect(journey_configuration.reload.close_at.utc).to eq(Time.utc(2026, 7, 15, 16, 0, 0))
         end
+      end
+    end
+  end
+
+  context "when signed in as a service admin" do
+    before { sign_in_as_service_admin }
+
+    describe "admin_journey_configurations#update" do
+      it "allows automatic approvals to be edited" do
+        patch admin_journey_configuration_path(journey_configuration, journey_configuration: {
+          automatic_approvals: false
+        })
+
+        expect(response).to redirect_to(edit_admin_journey_configuration_path(journey_configuration))
+        expect(journey_configuration.reload.automatic_approvals).to be false
       end
     end
   end


### PR DESCRIPTION
Journey configurations are always created

block auto approvals on the whole policy

