### PR TITLE
Persist DQT data

### DIFF
--- a/app/jobs/claim_verifier_job.rb
+++ b/app/jobs/claim_verifier_job.rb
@@ -14,13 +14,15 @@ class ClaimVerifierJob < ApplicationJob
       Policies::EarlyYearsTeachersFinancialIncentivePayments
     ])
 
-    if claim.has_dqt_record?
-      Dqt::Teacher.new(claim.dqt_teacher_status)
-    elsif claim.eligibility.teacher_reference_number.present?
-      Dqt::Client.new.teacher.find(
+    if !claim.has_dqt_record? && claim.eligibility.teacher_reference_number.present?
+      dqt_teacher_status = Dqt::Client.new.teacher.find_raw(
         claim.eligibility.teacher_reference_number,
         include: "alerts,induction,routesToProfessionalStatuses"
       )
+
+      claim.update!(dqt_teacher_status: dqt_teacher_status)
     end
+
+    Dqt::Teacher.new(claim.dqt_teacher_status)
   end
 end

--- a/app/models/automated_checks/claim_verifiers/identity.rb
+++ b/app/models/automated_checks/claim_verifiers/identity.rb
@@ -17,7 +17,7 @@ module AutomatedChecks
       def perform
         return if task_exists?
 
-        if dqt_teacher_status.nil?
+        if dqt_teacher_status.not_found?
           create_note(body: "[DQT Identity] - Not matched")
           create_task(match: :none)
         else

--- a/app/models/automated_checks/dqt_report_csv_to_records.rb
+++ b/app/models/automated_checks/dqt_report_csv_to_records.rb
@@ -14,6 +14,7 @@ module AutomatedChecks
       :qualification_name,
       :surname,
       :teacher_reference_number,
+      :not_found?,
       keyword_init: true
     )
 

--- a/lib/dqt/objects/teacher.rb
+++ b/lib/dqt/objects/teacher.rb
@@ -1,5 +1,9 @@
 module Dqt
   class Teacher < Object
+    def not_found?
+      to_h.empty?
+    end
+
     def email_address
       string_reader(emailAddress)
     end

--- a/spec/features/admin/admin_fraud_prevention_spec.rb
+++ b/spec/features/admin/admin_fraud_prevention_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Admin fraud prevention" do
     claim = submit_claim(national_insurance_number: "AB123456C")
 
     # Stub dqt api call in verifiers job
-    dqt_teacher_resource = instance_double(Dqt::TeacherResource, find: nil)
+    dqt_teacher_resource = instance_double(Dqt::TeacherResource, find_raw: nil)
     dqt_client = instance_double(Dqt::Client, teacher: dqt_teacher_resource)
     allow(Dqt::Client).to receive(:new).and_return(dqt_client)
 

--- a/spec/jobs/claim_verifier_job_spec.rb
+++ b/spec/jobs/claim_verifier_job_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe ClaimVerifierJob do
         eligibility_attributes: {teacher_reference_number: "1234567"}
       )
     end
-    let(:dbl) { double(find: mock_payload) }
+    let(:dbl) { double(find_raw: mock_payload) }
     let(:verifier) { double(perform: true) }
-    let(:mock_payload) { Dqt::Teacher.new({"mock" => "mock"}) }
+    let(:mock_payload) { {"mock" => "mock"} }
 
     before do
       allow(Dqt::TeacherResource).to receive(:new).and_return(dbl)
@@ -22,7 +22,7 @@ RSpec.describe ClaimVerifierJob do
       let(:dqt_teacher_status) { {"test" => "test"} }
 
       it "does not request a new DQT payload" do
-        expect(dbl).not_to receive(:find)
+        expect(dbl).not_to receive(:find_raw)
         described_class.new.perform(claim)
       end
 
@@ -36,12 +36,12 @@ RSpec.describe ClaimVerifierJob do
       let(:dqt_teacher_status) { {} }
 
       it "does requests a new DQT payload" do
-        expect(dbl).to receive(:find)
+        expect(dbl).to receive(:find_raw)
         described_class.new.perform(claim)
       end
 
       it "performs the verifier job" do
-        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: mock_payload)
+        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: Dqt::Teacher.new(mock_payload))
         described_class.new.perform(claim)
       end
 
@@ -57,7 +57,7 @@ RSpec.describe ClaimVerifierJob do
 
         it "performs the verifier job but doesn't request dqt info" do
           expect(AutomatedChecks::ClaimVerifier).to receive(:new)
-          expect(dbl).not_to receive(:find)
+          expect(dbl).not_to receive(:find_raw)
           described_class.new.perform(claim)
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe ClaimVerifierJob do
 
       it "performs the verifier job but doesn't request dqt info" do
         expect(AutomatedChecks::ClaimVerifier).to receive(:new)
-        expect(dbl).not_to receive(:find)
+        expect(dbl).not_to receive(:find_raw)
         described_class.new.perform(claim)
       end
     end
@@ -77,12 +77,12 @@ RSpec.describe ClaimVerifierJob do
       let(:dqt_teacher_status) { nil }
 
       it "does requests a new DQT payload" do
-        expect(dbl).to receive(:find)
+        expect(dbl).to receive(:find_raw)
         described_class.new.perform(claim)
       end
 
       it "performs the verifier job" do
-        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: mock_payload)
+        expect(AutomatedChecks::ClaimVerifier).to receive(:new).with(claim:, dqt_teacher_status: Dqt::Teacher.new(mock_payload))
         described_class.new.perform(claim)
       end
 
@@ -98,7 +98,7 @@ RSpec.describe ClaimVerifierJob do
 
         it "performs the verifier job but doesn't request dqt info" do
           expect(AutomatedChecks::ClaimVerifier).to receive(:new)
-          expect(dbl).not_to receive(:find)
+          expect(dbl).not_to receive(:find_raw)
           described_class.new.perform(claim)
         end
       end

--- a/spec/lib/dqt/objects/teacher_spec.rb
+++ b/spec/lib/dqt/objects/teacher_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe Dqt::Teacher do
     }
   end
 
+  describe "#not_found?" do
+    it "is true when DQT did not return a record" do
+      teacher = described_class.new(nil)
+
+      expect(teacher).to be_not_found
+    end
+
+    it "is false when DQT returned a record" do
+      teacher = described_class.new(qualified_teaching_status_response)
+
+      expect(teacher).not_to be_not_found
+    end
+  end
+
   let(:dqt_higher_education_qualification_mathematics) do
     create(
       :dqt_higher_education_qualification,

--- a/spec/models/automated_checks/claim_verifiers/identity_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/identity_spec.rb
@@ -60,9 +60,11 @@ module AutomatedChecks
       let(:identity_args) do
         {
           claim: claim_arg,
-          dqt_teacher_status: Dqt::Client.new.teacher.find(
-            claim_arg.eligibility.teacher_reference_number,
-            include: "alerts,induction,routesToProfessionalStatuses"
+          dqt_teacher_status: Dqt::Teacher.new(
+            Dqt::Client.new.teacher.find_raw(
+              claim_arg.eligibility.teacher_reference_number,
+              include: "alerts,induction,routesToProfessionalStatuses"
+            )
           )
         }
       end


### PR DESCRIPTION
When we fetch DQT data from TRS save it on the claim rather than discard
it. Will be able to simplify some reporting and other things if we can
assume all claims that should have DQT data do have DQT data.
