### PR TITLE
Add COPD logic to uploads

### DIFF
--- a/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
+++ b/app/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job.rb
@@ -12,7 +12,8 @@ module EarlyYearsTeachersFinancialIncentivePayments
         "Provider town",
         "Postcode",
         "Eligible",
-        "Max claims"
+        "Max claims",
+        "COPD"
       ]
 
       include ActiveModel::Validations
@@ -21,19 +22,22 @@ module EarlyYearsTeachersFinancialIncentivePayments
 
       validates "Provider URN",
         presence: true,
-        length: {in: 6..8}
+        length: {in: 6..8},
+        unless: :copd?
 
       validates "Provider name",
         presence: true
 
       validates "Provider address line 1",
-        presence: true
+        presence: true,
+        unless: :copd?
 
       validates "Provider town",
         presence: true
 
       validates "Postcode",
-        presence: true
+        presence: true,
+        unless: :copd?
 
       validates "Eligible",
         presence: true,
@@ -59,6 +63,7 @@ module EarlyYearsTeachersFinancialIncentivePayments
             town: row["Provider town"],
             postcode: row["Postcode"],
             eligible: cast_bool(row["Eligible"]),
+            copd: cast_bool(row["COPD"]),
             max_claims: row["Max claims"].presence || 5,
             file_upload:
           )
@@ -70,7 +75,13 @@ module EarlyYearsTeachersFinancialIncentivePayments
 
       private
 
+      def copd?
+        cast_bool(row["COPD"])
+      end
+
       def cast_bool(value)
+        return false if value.blank?
+
         case value
         when "TRUE"
           true

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -518,6 +518,7 @@ shared:
     - file_upload_id # uuid, associated file upload. use this to work out academic year and latest version as this table is append only
     - sanitised_postcode # string, postcode of the provider normalised
     - max_claims # integer, max number of claims permitted for this nursery
+    - copd # boolean, is this provider childcare on domestic premises
   :active_storage_variant_records:
     - id # uuid, uniquely identifies this variant record
     - blob_id # uuid, the blob this variant was derived from

--- a/db/migrate/20260818000000_add_copd_to_eligible_eytfi_providers.rb
+++ b/db/migrate/20260818000000_add_copd_to_eligible_eytfi_providers.rb
@@ -1,0 +1,5 @@
+class AddCopdToEligibleEytfiProviders < ActiveRecord::Migration[8.1]
+  def change
+    add_column :eligible_eytfi_providers, :copd, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_18_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -327,6 +327,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_000000) do
     t.text "address_line_1"
     t.text "address_line_2"
     t.text "address_line_3"
+    t.boolean "copd", default: false, null: false
     t.datetime "created_at", null: false
     t.boolean "eligible", null: false
     t.uuid "file_upload_id", null: false

--- a/spec/factories/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers.rb
+++ b/spec/factories/policies/early_years_teachers_financial_incentive_payments/eligible_eytfi_providers.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     town { Faker::Address.city }
     postcode { "EC1N 2TD" }
     eligible { true }
+    copd { false }
     max_claims { 5 }
   end
 end

--- a/spec/fixtures/files/eligible_eytfi_providers.csv
+++ b/spec/fixtures/files/eligible_eytfi_providers.csv
@@ -1,3 +1,3 @@
-Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible,Max claims
-123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE,5
-EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE,10
+Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible,Max claims,COPD
+123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE,5,FALSE
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE,10,TRUE

--- a/spec/fixtures/files/eligible_eytfi_providers_with_error.csv
+++ b/spec/fixtures/files/eligible_eytfi_providers_with_error.csv
@@ -1,4 +1,4 @@
-Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible,Max claims
-123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE,5
-EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE,10
-EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FOO,10
+Provider URN,Provider name,Provider address line 1,Provider address line 2,Provider address line 3,Provider town,Postcode,Eligible,Max claims,COPD
+123456,Nursery 123456,1 Some Road,,,London,EC1N 2TD,TRUE,5,FALSE
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FALSE,10,TRUE
+EY234567,Nursery EY234567,2 Some Street,,,London,EC1N 2TD,FOO,10,FALSE

--- a/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
+++ b/spec/jobs/early_years_teachers_financial_incentive_payments/import_eligible_eytfi_providers_job_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
       it "saves errors on file upload" do
         subject.perform(file_upload)
 
-        expect(file_upload.reload.upload_errors).to eql(["Headers must be Provider URN, Provider name, Provider address line 1, Provider address line 2, Provider address line 3, Provider town, Postcode, Eligible, Max claims"])
+        expect(file_upload.reload.upload_errors).to eql(["Headers must be Provider URN, Provider name, Provider address line 1, Provider address line 2, Provider address line 3, Provider town, Postcode, Eligible, Max claims, COPD"])
       end
     end
   end
@@ -284,6 +284,33 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
         end
       end
 
+      context "when COPD is true" do
+        context "with missing URN, address and postcode" do
+          let(:row) do
+            CSV::Row.new(
+              described_class::HEADERS,
+              [
+                "",
+                "Some nursery",
+                "",
+                "",
+                "",
+                "Some Town",
+                "",
+                "TRUE",
+                "5",
+                "TRUE"
+              ],
+              true
+            )
+          end
+
+          it "skips URN, address and postcode validation" do
+            expect(subject).to be_valid
+          end
+        end
+      end
+
       context "is malformatted" do
         let(:row) do
           CSV::Row.new(
@@ -305,6 +332,34 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
         it "is not valid" do
           subject.valid?
           expect(subject.errors["Eligible"]).to be_present
+        end
+      end
+    end
+
+    context "copd" do
+      context "is missing" do
+        let(:row) do
+          CSV::Row.new(
+            described_class::HEADERS,
+            [
+              "123456",
+              "Some nursery",
+              "Some Road",
+              "Somewhere",
+              "Somewhere Else",
+              "Some Town",
+              "TE57 1NG",
+              "TRUE",
+              "5",
+              ""
+            ],
+            true
+          )
+        end
+
+        it "defaults to false" do
+          provider = subject.to_provider(file_upload:)
+          expect(provider.copd).to be false
         end
       end
     end
@@ -400,7 +455,8 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
           "London",
           "EC1N 2TD",
           "TRUE",
-          "5"
+          "5",
+          "FALSE"
         ],
         true
       )
@@ -419,6 +475,7 @@ RSpec.describe EarlyYearsTeachersFinancialIncentivePayments::ImportEligibleEytfi
           postcode: "EC1N 2TD",
           eligible: true,
           max_claims: 5,
+          copd: false,
           file_upload:
         )
 


### PR DESCRIPTION
COPD logic is needed to protect details of clients.

Changes:
- CSV upload
- CSV download
- Skip validations if COPD