### PR TITLE
Remove before worker boot callback

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,8 +41,3 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
-
-# Re-open log appenders after forking the process
-before_worker_boot do
-  SemanticLogger.reopen
-end


### PR DESCRIPTION
We don't run puma in cluster mode so all this code does is give us a
warning when the app boots.silence_fork_callback_warning.
See `terraform/application/config/production.tfvars.json:11` for the
command that boots the app.
