### PR TITLE
Fix flake

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -49,7 +49,13 @@ module FeatureHelpers
 
     expect(page).to have_text(/Which (additional )?school/) # there can be variations of the full text depending on which journey/page
     fill_in question, with: school.name.sub("The ", "").split(" ").first
-    click_button "Continue"
+
+    begin
+      find(:button, "Continue").trigger("click")
+    rescue Capybara::NotSupportedByDriverError
+      # We're using this helper from a non js spec
+      click_button "Continue"
+    end
 
     choose school.name
     click_button "Continue"


### PR DESCRIPTION
Sometimes the continue button is obscured by the school search drop down. Using `trigger` will click the element even if it's not visible, probably more maintainable than faffing with resizing the browser window.
Capybara's rack driver doesn't support trigger, so we have a rescue block to handle that.

