### PR TITLE
Added write permissions to workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-no-cache:
+    permissions:
+      packages: write
     outputs:
       docker-image-tag: ${{ steps.build-image.outputs.tag }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Context
This PR is to resolve a permissions issue preventing the build-no-cache workflow from completing successfully

### Changes proposed in this pull request
Add write packages permissions to the build-no-cache job

### Guidance to review
Check the following workflow run to confirm it is successful:
https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/32280583723