### PR TITLE
data retention refactor part 2

### DIFF
--- a/app/jobs/policies/data_retention/apply_policy_job.rb
+++ b/app/jobs/policies/data_retention/apply_policy_job.rb
@@ -3,10 +3,14 @@ module Policies
     class ApplyPolicyJob < ApplicationJob
       def perform(claim)
         change_set = claim.policy::DataRetention::Policy.apply(claim)
+        return unless change_set.any_changes?
+
         expired_eligibility_attachments = change_set.expired_eligibility_attachments
 
         ApplicationRecord.transaction do
           claim.journey_session&.update!(answers: {})
+
+          backup_claim!(claim)
 
           claim.update!(change_set.new_claim_attributes)
           claim.eligibility.update!(change_set.new_eligibility_attributes)
@@ -21,6 +25,20 @@ module Policies
 
       def priority
         10
+      end
+
+      private
+
+      def backup_claim!(claim)
+        Policies::DataRetention::Recovery.create!(
+          claim: claim,
+          destroy_at: 1.week.from_now,
+          payload: {
+            claim_attributes: claim.attributes,
+            eligibility_attributes: claim.eligibility.attributes,
+            amendments_attributes: claim.amendments.map(&:attributes)
+          }
+        )
       end
     end
   end

--- a/app/jobs/policies/data_retention/remove_recovery_records_job.rb
+++ b/app/jobs/policies/data_retention/remove_recovery_records_job.rb
@@ -1,0 +1,11 @@
+module Policies
+  module DataRetention
+    class RemoveRecoveryRecordsJob < ApplicationJob
+      def perform
+        scope = Recovery.where(destroy_at: ..Date.today.beginning_of_day)
+
+        scope.find_each(&:destroy!)
+      end
+    end
+  end
+end

--- a/app/models/policies/data_retention.rb
+++ b/app/models/policies/data_retention.rb
@@ -1,0 +1,5 @@
+module Policies::DataRetention
+  def self.table_name_prefix
+    "policies_data_retention_"
+  end
+end

--- a/app/models/policies/data_retention/change_set.rb
+++ b/app/models/policies/data_retention/change_set.rb
@@ -84,6 +84,10 @@ module Policies
         claim_attribute_changed?(attr) || eligibility_attribute_changed?(attr)
       end
 
+      def any_changes?
+        expired_claim_attributes.any? || expired_eligibility_attributes.any?
+      end
+
       private
 
       def claim_attribute_changed?(attr)

--- a/app/models/policies/data_retention/recovery.rb
+++ b/app/models/policies/data_retention/recovery.rb
@@ -1,0 +1,7 @@
+module Policies
+  module DataRetention
+    class Recovery < ApplicationRecord
+      belongs_to :claim
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -201,3 +201,10 @@
   - description
   - created_at
   - updated_at
+  :policies_data_retention_recoveries:
+  - id
+  - claim_id
+  - created_at
+  - destroy_at
+  - payload
+  - updated_at

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -38,6 +38,9 @@ production: &production
   purge_unsubmitted_claims:
     class: PurgeUnsubmittedClaimsJob
     schedule: "0 0 * * *"
+  remove_recovery_records:
+    class: Policies::DataRetention::RemoveRecoveryRecordsJob
+    schedule: "30 1 * * 0"
   school_data_import:
     class: SchoolDataImporterJob
     schedule: "0 12 * * *"

--- a/db/migrate/20260826133511_create_policies_data_retention_recoveries.rb
+++ b/db/migrate/20260826133511_create_policies_data_retention_recoveries.rb
@@ -1,0 +1,11 @@
+class CreatePoliciesDataRetentionRecoveries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :policies_data_retention_recoveries, id: :uuid do |t|
+      t.belongs_to :claim, null: false, foreign_key: true, type: :uuid
+      t.datetime :destroy_at, null: false
+      t.jsonb :payload
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -638,6 +638,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_144451) do
     t.index ["updated_at"], name: "index_payroll_runs_on_updated_at"
   end
 
+  create_table "policies_data_retention_recoveries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "claim_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "destroy_at", null: false
+    t.jsonb "payload"
+    t.datetime "updated_at", null: false
+    t.index ["claim_id"], name: "index_policies_data_retention_recoveries_on_claim_id"
+  end
+
   create_table "reminders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
@@ -999,6 +1008,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_144451) do
   add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "confirmation_report_uploaded_by_id"
   add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "downloaded_by_id"
+  add_foreign_key "policies_data_retention_recoveries", "claims"
   add_foreign_key "schools", "local_authority_districts"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/jobs/policies/data_retention/remove_recovery_records_job_spec.rb
+++ b/spec/jobs/policies/data_retention/remove_recovery_records_job_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Policies::DataRetention::RemoveRecoveryRecordsJob do
+  describe "#perform" do
+    let(:claim) { create(:claim) }
+
+    context "when the recovery record is due to be destroyed" do
+      it "deletes the record" do
+        recovery = Policies::DataRetention::Recovery.create!(
+          claim: claim,
+          payload: [],
+          destroy_at: Date.yesterday.end_of_day
+        )
+
+        travel_to(Date.today.beginning_of_day) do
+          described_class.perform_now
+        end
+
+        expect { recovery.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when the recovery record is not due to be destroyed" do
+      it "does not delete the record" do
+        Policies::DataRetention::Recovery.create!(
+          claim: claim,
+          payload: [],
+          destroy_at: Date.today.end_of_day
+        )
+
+        travel_to(Date.today.beginning_of_day) do
+          described_class.perform_now
+        end
+
+        expect(Policies::DataRetention::Recovery.count).to be(1)
+      end
+    end
+  end
+end

--- a/spec/jobs/policies/data_retention/targeted_retention_incentive_payments_spec.rb
+++ b/spec/jobs/policies/data_retention/targeted_retention_incentive_payments_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Policies::DataRetention::PoliciesJob do
       end
 
       context "when the claim is paid" do
-        it "scrubs personal data" do
+        before do
           create(:decision, :approved, claim: claim)
           create(
             :payment,
@@ -178,7 +178,9 @@ RSpec.describe Policies::DataRetention::PoliciesJob do
 
           claim.reload
           claim.eligibility.reload
+        end
 
+        it "scrubs personal data" do
           aggregate_failures do
             expect(claim).to(
               have_attributes(scrubbed_claim_attributes.index_with(nil))
@@ -192,6 +194,21 @@ RSpec.describe Policies::DataRetention::PoliciesJob do
               eligibility_attributes.merge(teacher_reference_number: "")
             )
           end
+        end
+
+        it "creates a recovery record" do
+          recovery = Policies::DataRetention::Recovery.find_by!(claim: claim)
+
+          expect(recovery.payload).to include(
+            "claim_attributes" => include(
+              "id" => claim.id,
+              "first_name" => "John"
+            ),
+            "eligibility_attributes" => include(
+              "id" => claim.eligibility_id,
+              "teacher_reference_number" => "1234567"
+            )
+          )
         end
       end
     end


### PR DESCRIPTION
Add simple recovery mechanisim

When we purge a claim we keep a copy of the claim's fields in a back up
record for a week. This is to avoid any issues with purging data and may
save us the headache of having to restore from a backup of the database.

We considered only storing the attributes that were redacted but that
was overly complicated for what we need, want to keep this simple!

We also considered adding in a recovery mechanism but decided against
this as the code would, hopefully, be rarely exercised and fall out of
date. Having a copy of the data is the main thing, actually writing it
back on to the claim can be done if we ever need it.

