### PR TITLE
[#401] Journey configs uses uuid pkey over routing name

### DIFF
--- a/app/controllers/admin/eligible_ey_providers_controller.rb
+++ b/app/controllers/admin/eligible_ey_providers_controller.rb
@@ -11,7 +11,7 @@ module Admin
       with: -> do
         redirect_to(
           edit_admin_journey_configuration_path(
-            Journeys::EarlyYearsPayment::Provider::Authenticated.routing_name
+            journey_configuration
           ),
           alert: "Too many requests"
         )
@@ -27,7 +27,7 @@ module Admin
         @upload_form.run_import!
         flash[:notice] = @upload_form.importer.results_message
 
-        redirect_to edit_admin_journey_configuration_path(Journeys::EarlyYearsPayment::Provider::Authenticated.routing_name)
+        redirect_to edit_admin_journey_configuration_path(journey_configuration)
       end
     end
 

--- a/app/controllers/admin/eligible_eytfi_providers_controller.rb
+++ b/app/controllers/admin/eligible_eytfi_providers_controller.rb
@@ -11,7 +11,7 @@ module Admin
       with: -> do
         redirect_to(
           edit_admin_journey_configuration_path(
-            Journeys::FurtherEducationPayments.routing_name
+            journey_configuration
           ),
           alert: "Too many requests"
         )

--- a/app/controllers/admin/eligible_fe_providers_controller.rb
+++ b/app/controllers/admin/eligible_fe_providers_controller.rb
@@ -11,7 +11,7 @@ module Admin
       with: -> do
         redirect_to(
           edit_admin_journey_configuration_path(
-            Journeys::FurtherEducationPayments.routing_name
+            journey_configuration
           ),
           alert: "Too many requests"
         )
@@ -28,7 +28,7 @@ module Admin
         @upload_form.run_import!
         flash[:notice] = @upload_form.importer.results_message
 
-        redirect_to edit_admin_journey_configuration_path(Journeys::FurtherEducationPayments.routing_name, eligible_fe_providers_upload: {academic_year: @upload_form.academic_year})
+        redirect_to edit_admin_journey_configuration_path(journey_configuration, eligible_fe_providers_upload: {academic_year: @upload_form.academic_year})
       end
     end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,6 +1,7 @@
 ---
 shared:
   :journey_configurations:
+    - id # uuid, that uniquely identifies this journey configuration
     - routing_name # string, path used in URL for this journey
     - open_for_submissions # boolean, can this journey accept claims
     - availability_message # string, optional message users see when journey is closed
@@ -11,7 +12,7 @@ shared:
     - teacher_id_enabled # boolean, is teacher ID enabled for this journey
     - close_at # datetime, when this journey configuration is scheduled to close
   :reminders:
-    - id # uuid, that uniquely this reminder
+    - id # uuid, that uniquely identifies this reminder
     - created_at # datetime, when this reminder was created
     - updated_at # datetime, when this reminder was last updated
     - email_verified # boolean, has this email address been verified by OTP
@@ -260,7 +261,7 @@ shared:
     - breaks_in_employment # boolean, did claimant have any large gaps in employment
     - employment_history # jsonb, claimants employment history
   :schools:
-    - id # uuid, that internally idenitfies the school
+    - id # uuid, that internally identifies the school
     - urn # string, external school identifier
     - name # string, name of the school
     - street # string, location

--- a/db/migrate/20260902143904_add_uuid_id_to_journey_configs.rb
+++ b/db/migrate/20260902143904_add_uuid_id_to_journey_configs.rb
@@ -1,0 +1,7 @@
+class AddUuidIdToJourneyConfigs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :journey_configurations, :id, :uuid, default: "gen_random_uuid()", null: false
+
+    add_index :journey_configurations, :id, unique: true
+  end
+end

--- a/db/migrate/20260902144451_change_journey_config_pkey.rb
+++ b/db/migrate/20260902144451_change_journey_config_pkey.rb
@@ -1,0 +1,11 @@
+class ChangeJourneyConfigPkey < ActiveRecord::Migration[8.1]
+  def up
+    ApplicationRecord.connection.execute "ALTER TABLE journey_configurations DROP CONSTRAINT journey_configurations_pkey;"
+    ApplicationRecord.connection.execute "ALTER TABLE journey_configurations ADD PRIMARY KEY (id);"
+  end
+
+  def down
+    ApplicationRecord.connection.execute "ALTER TABLE journey_configurations DROP CONSTRAINT journey_configurations_pkey;"
+    ApplicationRecord.connection.execute "ALTER TABLE journey_configurations ADD PRIMARY KEY (routing_name);"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_02_144451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -519,15 +519,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_000000) do
     t.index ["current_school_id"], name: "index_irb_eligibilities_on_current_school_id"
   end
 
-  create_table "journey_configurations", primary_key: "routing_name", id: :string, force: :cascade do |t|
+  create_table "journey_configurations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "automatic_approvals", default: true, null: false
     t.string "availability_message"
     t.datetime "close_at"
     t.datetime "created_at", precision: nil, null: false
     t.string "current_academic_year", limit: 9
     t.boolean "open_for_submissions", default: true, null: false
+    t.string "routing_name", null: false
     t.boolean "teacher_id_enabled", default: true
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["id"], name: "index_journey_configurations_on_id", unique: true
   end
 
   create_table "journeys_service_access_codes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
# Context

- https://github.com/DFE-Digital/claim-issues/issues/401
- alter table `journey_configurations` so it is now backed by a `uuid` column named `id` as primary key rather than `routing_name` which is a string
- this will enable `routing_name` to contain duplicates which is not possible now