### PR TITLE
Allow filtering tasks by academic year

### DIFF
--- a/app/controllers/admin/task_lists_controller.rb
+++ b/app/controllers/admin/task_lists_controller.rb
@@ -22,6 +22,7 @@ module Admin
     def task_list_params
       params.fetch(Admin::TaskListForm.model_name.param_key, {}).permit(
         :policy_name,
+        :academic_year,
         :show_filter_controls,
         :clear_statuses,
         :assignee_id,

--- a/app/models/admin/task_list_form.rb
+++ b/app/models/admin/task_list_form.rb
@@ -147,6 +147,7 @@ module Admin
     include ActiveModel::Attributes
 
     attribute :policy_name, :string, default: "early_years_payments"
+    attribute :academic_year, :string, default: -> { AcademicYear.current.to_s }
     attribute :show_filter_controls, :boolean, default: false
     attribute :statuses, default: {}
     attribute :clear_statuses, :boolean, default: false
@@ -163,6 +164,12 @@ module Admin
 
     def policy
       @policy ||= Policies.all.find { |p| p.locale_key == policy_name }
+    end
+
+    def academic_year_select_options
+      (AcademicYear.new(2025)..AcademicYear.current).map do |year|
+        Form::Option.new(id: year.to_s, name: year.to_s.gsub("/", " / "))
+      end
     end
 
     def show_filter_controls?
@@ -254,7 +261,9 @@ module Admin
       {
         model_name.param_key => {
           policy_name: policy_name,
+          academic_year: academic_year,
           statuses: statuses,
+          clear_statuses: clear_statuses,
           show_filter_controls: show_filter_controls?,
           assignee_id: assignee_id
         }.merge(merge)
@@ -288,7 +297,7 @@ module Admin
       return @claim_scope if defined?(@claim_scope)
 
       @claim_scope = Claim
-        .by_academic_year(AcademicYear.current)
+        .by_academic_year(academic_year)
         .awaiting_decision
         .by_policy(policy)
 

--- a/app/views/admin/task_lists/index.html.erb
+++ b/app/views/admin/task_lists/index.html.erb
@@ -10,6 +10,28 @@
       <%= @presenter.policy.short_name %>
     </h1>
 
+    <section id="academic-year-filter">
+      <%= form_with(
+        model: @presenter,
+        url: admin_task_lists_path,
+        method: :get,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |f| %>
+        <% preserved_params = @presenter.applied_params.transform_values { |params| params.except(:academic_year) } %>
+        <% URI.decode_www_form(preserved_params.to_query).each do |name, value| %>
+          <%= hidden_field_tag name, value, id: nil %>
+        <% end %>
+        <%= f.govuk_collection_select(
+          :academic_year,
+          @presenter.academic_year_select_options,
+          :id,
+          :name,
+          label: { text: "Academic year" }
+        ) %>
+        <%= f.govuk_submit "Select academic year" %>
+      <% end %>
+    </section>
+
     <section id="policy-buttons">
       <% Policies.all.select(&:active?).each do |policy| %>
         <%= govuk_button_link_to(
@@ -17,6 +39,7 @@
           admin_task_lists_path(
             @presenter.applied_params(
               policy_name: policy.locale_key,
+              clear_statuses: false,
               statuses: {}
             )
           ),
@@ -55,6 +78,7 @@
         builder: GOVUKDesignSystemFormBuilder::FormBuilder
       ) do |f| %>
         <%= f.hidden_field :policy_name, value: f.object.policy.locale_key %>
+        <%= f.hidden_field :academic_year, id: nil %>
         <%= f.hidden_field(
           :show_filter_controls,
           value: f.object.show_filter_controls?
@@ -64,7 +88,7 @@
           <%= govuk_button_link_to(
             "Check all",
             admin_task_lists_path(
-              f.object.applied_params(statuses: f.object.all_statuses)
+              f.object.applied_params(statuses: f.object.all_statuses, clear_statuses: false)
             ),
             secondary: true,
           ) %>

--- a/spec/features/admin/task_lists_spec.rb
+++ b/spec/features/admin/task_lists_spec.rb
@@ -1,6 +1,52 @@
 require "rails_helper"
 
 RSpec.feature "Admin task list filtering" do
+  scenario "selects an academic year and preserves it across policy and filter changes" do
+    travel_to Date.new(2026, 9, 1) do
+      current_claim = create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: "2026/2027")
+      previous_claim = create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: "2025/2026")
+      create(:claim, :submitted, policy: Policies::StudentLoans, academic_year: "2024/2025")
+
+      sign_in_as_service_operator
+      visit admin_task_lists_path
+      click_on "Student Loans"
+
+      expect(page).to have_select("Academic year", selected: "2026 / 2027", options: ["2025 / 2026", "2026 / 2027"])
+      expect(page).to have_link(current_claim.reference)
+      expect(page).not_to have_link(previous_claim.reference)
+
+      select "2025 / 2026", from: "Academic year"
+      click_on "Select academic year"
+
+      expect(page).to have_content("1 claims found")
+      expect(page).to have_link(previous_claim.reference)
+      expect(page).not_to have_link(current_claim.reference)
+
+      click_on "Show filters"
+      click_on "Apply"
+      expect(page).to have_link(previous_claim.reference)
+      expect(page).to have_select("Academic year", selected: "2025 / 2026")
+
+      click_on "Uncheck all"
+      select "2026 / 2027", from: "Academic year"
+      click_on "Select academic year"
+      expect(page).to have_content("0 claims found")
+
+      click_on "Check all"
+      expect(page).to have_link(current_claim.reference)
+      select "2025 / 2026", from: "Academic year"
+      click_on "Select academic year"
+
+      click_on "Early Years Financial Incentive Payments"
+      click_on "Student Loans"
+      expect(page).to have_link(previous_claim.reference)
+
+      click_on "Export CSV"
+      expect(page.body).to include(previous_claim.reference)
+      expect(page.body).not_to include(current_claim.reference)
+    end
+  end
+
   scenario "filters claims by task statuses and assignee" do
     admin_alice = create(
       :dfe_signin_user,


### PR DESCRIPTION
Adds an academic year select to the admin task list page so ops can continue to work on the previous AY's claims.

