### PR TITLE
370/tslr teacher auth

### DIFF
--- a/app/controllers/journeys/teacher_student_loan_reimbursement/bypass_auth_controller.rb
+++ b/app/controllers/journeys/teacher_student_loan_reimbursement/bypass_auth_controller.rb
@@ -1,0 +1,37 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class BypassAuthController < BasePublicController
+      def callback
+        @form = Debug::TeacherAuth::SignInForm.new(
+          journey_session: journey_session,
+          journey: Journeys::TeacherStudentLoanReimbursement,
+          params: params
+        )
+
+        if @form.save
+          Debug::TeacherAuth::FetchQualificationsJob.perform_later(
+            journey_session
+          )
+
+          redirect_to claim_path(
+            current_journey_routing_name,
+            navigator.next_slug
+          )
+        else
+          render "student_loans/claims/sign_in"
+        end
+      end
+
+      private
+
+      def navigator
+        @navigator ||= Journeys::Navigator.new(
+          current_slug: "sign-in",
+          journey_session: journey_session,
+          params: params,
+          session: session
+        )
+      end
+    end
+  end
+end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -39,6 +39,10 @@ class Form
     Claim.model_name
   end
 
+  def self.form_key
+    name.demodulize.underscore.downcase.dasherize.gsub(/-form$/, "")
+  end
+
   def self.i18n_error_message(path, args = {})
     ->(object, _) { object.i18n_errors_path(path, args) }
   end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/debug/teacher_auth/sign_in_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/debug/teacher_auth/sign_in_form.rb
@@ -16,6 +16,8 @@ module Journeys
           attribute :sub, :string
           attribute :qts_award_date, :date
           attribute :national_insurance_number, :string
+          attribute :active_alert, :boolean
+          attribute :qts_record_found, :boolean
 
           validates :first_name, presence: true
           validates :last_name, presence: true
@@ -23,7 +25,7 @@ module Journeys
           validates :email, presence: true
           validates :trn, presence: true
           validates :sub, presence: true
-          validates :qts_award_date, presence: true
+          validates :qts_award_date, presence: true, if: :qts_record_found
 
           # Base form makes it tricky to do this nicely
           after_initialize do
@@ -46,6 +48,10 @@ module Journeys
               nil
             end
             self.qts_award_date = qts_award_date if qts_award_date
+
+            if !qts_record_found
+              self.qts_award_date = nil
+            end
           end
 
           def default_qts_award_date
@@ -79,6 +85,14 @@ module Journeys
             ].join
           end
 
+          def default_active_alert
+            false
+          end
+
+          def default_qts_record_found
+            true
+          end
+
           def save
             return false unless valid?
 
@@ -100,19 +114,42 @@ module Journeys
 
           private
 
-          # These details will be pulled from the TRS /v3/person end point
+          # These details will be pulled from the TRS API
+          # We write them to the personal details fields on the claim and store
+          # them separatley so we can check if they've changed.
           def details_requested_from_api_call
-            {
-              dqt_teacher_status: {
+            dqt_teacher_status = {}
+
+            if qts_record_found
+              dqt_teacher_status = dqt_teacher_status.merge(
                 qts: {
                   holdsFrom: qts_award_date.iso8601
                 }
-              },
+              )
+            end
+
+            if active_alert
+              dqt_teacher_status = dqt_teacher_status.merge(
+                alerts: [
+                  {
+                    startDate: "2026-09-01",
+                    endDate: nil
+                  }
+                ]
+              )
+            end
+
+            {
+              dqt_teacher_status: dqt_teacher_status,
               first_name: first_name,
               middle_name: middle_name,
               surname: last_name,
               national_insurance_number: national_insurance_number,
-              date_of_birth: date_of_birth
+              date_of_birth: date_of_birth,
+              teacher_auth_first_name: first_name,
+              teacher_auth_last_name: last_name,
+              teacher_auth_national_insurance_number: national_insurance_number,
+              teacher_auth_date_of_birth: date_of_birth
             }
           end
 

--- a/app/forms/journeys/teacher_student_loan_reimbursement/debug/teacher_auth/sign_in_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/debug/teacher_auth/sign_in_form.rb
@@ -1,0 +1,126 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    module Debug
+      module TeacherAuth
+        class SignInForm < ::Debug::TeacherAuth::SignInForm
+          def self.form_key
+            "sign-in"
+          end
+
+          attribute :first_name, :string
+          attribute :middle_name, :string
+          attribute :last_name, :string
+          attribute :date_of_birth, :date
+          attribute :email, :string
+          attribute :trn, :string
+          attribute :sub, :string
+          attribute :qts_award_date, :date
+          attribute :national_insurance_number, :string
+
+          validates :first_name, presence: true
+          validates :last_name, presence: true
+          validates :date_of_birth, presence: true
+          validates :email, presence: true
+          validates :trn, presence: true
+          validates :sub, presence: true
+          validates :qts_award_date, presence: true
+
+          # Base form makes it tricky to do this nicely
+          after_initialize do
+            year = permitted_params["date_of_birth(1i)"].to_i
+            month = permitted_params["date_of_birth(2i)"].to_i
+            day = permitted_params["date_of_birth(3i)"].to_i
+            date_of_birth = begin
+              Date.new(year, month, day)
+            rescue
+              nil
+            end
+            self.date_of_birth = date_of_birth if date_of_birth
+
+            year = permitted_params["qts_award_date(1i)"].to_i
+            month = permitted_params["qts_award_date(2i)"].to_i
+            day = permitted_params["qts_award_date(3i)"].to_i
+            qts_award_date = begin
+              Date.new(year, month, day)
+            rescue
+              nil
+            end
+            self.qts_award_date = qts_award_date if qts_award_date
+          end
+
+          def default_qts_award_date
+            Policies::StudentLoans::POLICY_START_YEAR.start_of_autumn_term
+          end
+
+          def default_first_name
+            default_verified_name.split(" ").first
+          end
+
+          def default_middle_name
+            default_verified_name.split(" ").excluding(
+              default_first_name,
+              default_last_name
+            ).presence&.join(" ")
+          end
+
+          def default_last_name
+            default_verified_name.split(" ").last
+          end
+
+          def default_date_of_birth
+            default_verified_date_of_birth
+          end
+
+          def default_national_insurance_number
+            [
+              ("A".."Z").to_a.sample(2).flatten +
+                (0..9).to_a.sample(6).flatten +
+                [("A".."D").to_a.sample]
+            ].join
+          end
+
+          def save
+            return false unless valid?
+
+            journey_session.answers.update!(
+              teacher_auth_teacher_reference_number: trn,
+              teacher_auth_email: email,
+              teacher_auth_verified_name: teacher_auth_verified_name,
+              teacher_auth_verified_date_of_birth: date_of_birth,
+              teacher_auth_one_login_uid: sub,
+              teacher_auth_completed_at: Time.zone.now,
+              identity_confirmed_with_onelogin: true,
+              onelogin_idv_at: Time.zone.now,
+              details_check: true,
+              teacher_reference_number: trn,
+              trs_data_fetched_at: nil,
+              **details_requested_from_api_call
+            )
+          end
+
+          private
+
+          # These details will be pulled from the TRS /v3/person end point
+          def details_requested_from_api_call
+            {
+              dqt_teacher_status: {
+                qts: {
+                  holdsFrom: qts_award_date.iso8601
+                }
+              },
+              first_name: first_name,
+              middle_name: middle_name,
+              surname: last_name,
+              national_insurance_number: national_insurance_number,
+              date_of_birth: date_of_birth
+            }
+          end
+
+          def teacher_auth_verified_name
+            [first_name, middle_name, last_name].join(" ")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/qualifications_check_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/qualifications_check_form.rb
@@ -1,0 +1,21 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class QualificationsCheckForm < Form
+      def save
+        true
+      end
+
+      def redirect_to_next_slug?
+        completed?
+      end
+
+      def completed?
+        journey_session.answers.trs_data_fetched_at.present?
+      end
+
+      def auto_refresh
+        3
+      end
+    end
+  end
+end

--- a/app/forms/journeys/teacher_student_loan_reimbursement/sign_in_form.rb
+++ b/app/forms/journeys/teacher_student_loan_reimbursement/sign_in_form.rb
@@ -1,0 +1,13 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    class SignInForm < Form
+      def save
+        true
+      end
+
+      def completed?
+        journey_session.answers.teacher_auth_completed_at
+      end
+    end
+  end
+end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -22,7 +22,7 @@ class SelectEmailForm < Form
 
   def determine_dependant_attributes
     if email_address_check == true
-      self.email_address = email_address_from_teacher_id
+      self.email_address = authenticated_email_address
       self.email_verified = true
     else
       self.email_address = nil
@@ -30,7 +30,7 @@ class SelectEmailForm < Form
     end
   end
 
-  def email_address_from_teacher_id
-    answers.teacher_id_user_info["email"]
+  def authenticated_email_address
+    answers.authenticated_email_address
   end
 end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -144,7 +144,11 @@ module Admin
     end
 
     def claim_route(claim)
-      claim.logged_in_with_tid? ? I18n.t("admin.claim_route_with_tid") : I18n.t("admin.claim_route_not_tid")
+      if claim.policy == Policies::StudentLoans && claim.eligibility.teacher_auth_completed_at
+        "Signed in with teacher auth"
+      else
+        claim.logged_in_with_tid? ? I18n.t("admin.claim_route_with_tid") : I18n.t("admin.claim_route_not_tid")
+      end
     end
 
     def identity_confirmation_task_claim_verifier_match_status_tag(claim)

--- a/app/jobs/journeys/teacher_student_loan_reimbursement/debug/teacher_auth/fetch_qualifications_job.rb
+++ b/app/jobs/journeys/teacher_student_loan_reimbursement/debug/teacher_auth/fetch_qualifications_job.rb
@@ -1,0 +1,19 @@
+module Journeys
+  module TeacherStudentLoanReimbursement
+    module Debug
+      module TeacherAuth
+        class FetchQualificationsJob < ApplicationJob
+          JOB_SLEEP_SECONDS = 5
+
+          def perform(journey_session)
+            # Sleep to simulate fetching DQT teacher status from TRS
+            # In debug we set this in the controller from the debug form's value
+            sleep JOB_SLEEP_SECONDS
+
+            journey_session.answers.update!(trs_data_fetched_at: Time.zone.now)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/automated_checks/claim_verifiers/teacher_auth_identity_confirmation.rb
+++ b/app/models/automated_checks/claim_verifiers/teacher_auth_identity_confirmation.rb
@@ -1,0 +1,103 @@
+module AutomatedChecks
+  module ClaimVerifiers
+    class TeacherAuthIdentityConfirmation
+      TASK_NAME = "teacher_auth_identity_confirmation"
+
+      def initialize(claim:)
+        @claim = claim
+        @eligibility = claim.eligibility
+      end
+
+      def perform
+        return if claim.tasks.teacher_auth_identity_confirmation.exists?
+
+        notes = []
+
+        unless national_insurance_number_matched?
+          notes << create_field_note(
+            field: "National insurance number",
+            claimant: claim.national_insurance_number,
+            teacher_auth: eligibility.teacher_auth_national_insurance_number
+          )
+        end
+
+        unless name_matched?
+          notes << create_field_note(
+            field: "Name",
+            claimant: claim.full_name,
+            teacher_auth: "#{eligibility.teacher_auth_first_name} #{eligibility.teacher_auth_last_name}"
+          )
+        end
+
+        unless date_of_birth_matched?
+          notes << create_field_note(
+            field: "Date of birth",
+            claimant: claim.date_of_birth,
+            teacher_auth: eligibility.teacher_auth_date_of_birth
+          )
+        end
+
+        if Dqt::Teacher.new(claim.dqt_teacher_status).active_alert?
+          notes << claim.notes.create!(
+            label: TASK_NAME,
+            body: "IMPORTANT: Teacher’s identity has an active alert. Speak to manager before checking this claim.",
+            important: true
+          )
+        end
+
+        task = if notes.any?
+          claim.tasks.build(
+            name: TASK_NAME,
+            claim_verifier_match: :any,
+            passed: nil,
+            manual: false
+          )
+        else
+          claim.tasks.build(
+            name: TASK_NAME,
+            claim_verifier_match: :all,
+            passed: true,
+            manual: false
+          )
+        end
+
+        task.save!(context: :claim_verifier)
+
+        task
+      end
+
+      private
+
+      attr_reader :claim, :eligibility
+
+      def national_insurance_number_matched?
+        claim.national_insurance_number == eligibility.teacher_auth_national_insurance_number
+      end
+
+      def name_matched?
+        claim.first_name == eligibility.teacher_auth_first_name
+        && claim.surname == eligibility.teacher_auth_last_name
+      end
+
+      def date_of_birth_matched?
+        claim.date_of_birth == eligibility.teacher_auth_date_of_birth
+      end
+
+      def active_alert?
+        claim.dqt_teacher_record.active_alert?
+      end
+
+      def create_field_note(field:, claimant:, teacher_auth:)
+        body = <<~HTML
+          [Teacher Auth Identity] - #{field} not matched:
+          <pre>
+            Claimant:     <span class="dark-grey">"</span><span class="red">#{claimant}</span><span class="dark-grey">"</span>
+            Teacher Auth: <span class="dark-grey">"</span><span class="green">#{teacher_auth}</span><span class="dark-grey">"</span>
+          </pre>
+        HTML
+
+        claim.notes.create!(label: TASK_NAME, body: body)
+      end
+    end
+  end
+end

--- a/app/models/journeys/base.rb
+++ b/app/models/journeys/base.rb
@@ -169,7 +169,7 @@ module Journeys
       mapping = {}
 
       forms.map do |form|
-        key = form.name.demodulize.underscore.downcase.dasherize.gsub(/-form$/, "")
+        key = form.try(:form_key) || form.name.demodulize.underscore.downcase.dasherize.gsub(/-form$/, "")
         mapping[key] = form
       end
 

--- a/app/models/journeys/session_answers.rb
+++ b/app/models/journeys/session_answers.rb
@@ -123,16 +123,6 @@ module Journeys
       trn_from_tid? && recent_tps_school.present?
     end
 
-    # NOTE getting the trn from answers.teacher_id_user_info was the previous
-    # implementation, TODO switch to `answers.teacher_reference_number` as it's
-    # set in the sign in or continue form at the same time.
-    def recent_tps_school
-      @recent_tps_school ||= TeachersPensionsService.recent_tps_school(
-        claim_date: session.created_at,
-        teacher_reference_number: teacher_id_user_info["trn"]
-      )
-    end
-
     def address_present?
       address_line_1.present? && postcode.present?
     end

--- a/app/models/journeys/targeted_retention_incentive_payments/session_answers.rb
+++ b/app/models/journeys/targeted_retention_incentive_payments/session_answers.rb
@@ -139,6 +139,16 @@ module Journeys
 
         dqt_record.itt_subjects.map(&:titleize)
       end
+
+      # NOTE getting the trn from answers.teacher_id_user_info was the previous
+      # implementation, TODO switch to `answers.teacher_reference_number` as it's
+      # set in the sign in or continue form at the same time.
+      def recent_tps_school
+        @recent_tps_school ||= TeachersPensionsService.recent_tps_school(
+          claim_date: session.created_at,
+          teacher_reference_number: teacher_id_user_info["trn"]
+        )
+      end
     end
   end
 end

--- a/app/models/journeys/targeted_retention_incentive_payments/session_answers.rb
+++ b/app/models/journeys/targeted_retention_incentive_payments/session_answers.rb
@@ -149,6 +149,10 @@ module Journeys
           teacher_reference_number: teacher_id_user_info["trn"]
         )
       end
+
+      def authenticated_email_address
+        teacher_id_user_info["email"]
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement.rb
@@ -10,25 +10,36 @@ module Journeys
     I18N_NAMESPACE = "student_loans"
     POLICIES = [Policies::StudentLoans]
 
-    FORMS = [
-      ClaimSchoolForm,
-      ClaimSchoolResultsForm,
-      QualificationDetailsForm,
-      QtsYearForm,
-      SubjectsTaughtForm,
-      StillTeachingForm,
-      StillTeachingTpsForm,
-      LeadershipPositionForm,
-      MostlyPerformedLeadershipDutiesForm,
-      ResetClaimForm,
-      SelectClaimSchoolForm,
-      SelectHomeAddressForm,
-      EligibilityConfirmedForm,
-      StudentLoanAmountForm,
-      CheckYourAnswersForm,
-      ConfirmationForm,
-      IneligibleForm
-    ].freeze
+    def forms
+      array = []
+
+      array << if TeacherAuth::Config.instance.bypass?
+        Debug::TeacherAuth::SignInForm
+      else
+        SignInForm
+      end
+
+      array + [
+        ClaimSchoolForm,
+        ClaimSchoolResultsForm,
+        QualificationsCheckForm,
+        QualificationDetailsForm,
+        QtsYearForm,
+        SubjectsTaughtForm,
+        StillTeachingForm,
+        StillTeachingTpsForm,
+        LeadershipPositionForm,
+        MostlyPerformedLeadershipDutiesForm,
+        ResetClaimForm,
+        SelectClaimSchoolForm,
+        SelectHomeAddressForm,
+        EligibilityConfirmedForm,
+        StudentLoanAmountForm,
+        CheckYourAnswersForm,
+        ConfirmationForm,
+        IneligibleForm
+      ].freeze
+    end
 
     def requires_student_loan_details?
       true

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -86,6 +86,16 @@ module Journeys
             teacher_reference_number: teacher_id_user_info["trn"]
           )
       end
+
+      # NOTE getting the trn from answers.teacher_id_user_info was the previous
+      # implementation, TODO switch to `answers.teacher_reference_number` as it's
+      # set in the sign in or continue form at the same time.
+      def recent_tps_school
+        @recent_tps_school ||= TeachersPensionsService.recent_tps_school(
+          claim_date: session.created_at,
+          teacher_reference_number: teacher_id_user_info["trn"]
+        )
+      end
     end
   end
 end

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -25,6 +25,10 @@ module Journeys
       attribute :teacher_auth_one_login_uid, :string, pii: true
       attribute :teacher_auth_completed_at, :datetime, pii: false
       attribute :trs_data_fetched_at, :datetime, pii: false
+      attribute :teacher_auth_first_name, :string, pii: true
+      attribute :teacher_auth_last_name, :string, pii: true
+      attribute :teacher_auth_national_insurance_number, :string, pii: true
+      attribute :teacher_auth_date_of_birth, :date, pii: true
 
       def dqt_teacher_record
         return unless dqt_teacher_status.present?

--- a/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/session_answers.rb
@@ -18,6 +18,14 @@ module Journeys
       attribute :claim_school_somewhere_else, :boolean, pii: false
       attribute :student_loan_amount_seen, :boolean, pii: false
 
+      attribute :teacher_auth_teacher_reference_number, :string, pii: true
+      attribute :teacher_auth_email, :string, pii: true
+      attribute :teacher_auth_verified_name, :string, pii: true
+      attribute :teacher_auth_verified_date_of_birth, :date, pii: false
+      attribute :teacher_auth_one_login_uid, :string, pii: true
+      attribute :teacher_auth_completed_at, :datetime, pii: false
+      attribute :trs_data_fetched_at, :datetime, pii: false
+
       def dqt_teacher_record
         return unless dqt_teacher_status.present?
 
@@ -83,18 +91,35 @@ module Journeys
       def tps_school_for_student_loan_in_previous_financial_year
         @tps_school_for_student_loan_in_previous_financial_year ||=
           TeachersPensionsService.tps_school_for_student_loan_in_previous_financial_year(
-            teacher_reference_number: teacher_id_user_info["trn"]
+            teacher_reference_number: authenticated_trn
           )
       end
 
-      # NOTE getting the trn from answers.teacher_id_user_info was the previous
-      # implementation, TODO switch to `answers.teacher_reference_number` as it's
-      # set in the sign in or continue form at the same time.
       def recent_tps_school
         @recent_tps_school ||= TeachersPensionsService.recent_tps_school(
           claim_date: session.created_at,
-          teacher_reference_number: teacher_id_user_info["trn"]
+          teacher_reference_number: authenticated_trn
         )
+      end
+
+      def has_recent_tps_school?
+        recent_tps_school.present?
+      end
+
+      def authenticated_trn
+        if FeatureFlag.enabled?(:student_loans_teacher_auth)
+          teacher_auth_teacher_reference_number
+        else
+          teacher_id_user_info["trn"]
+        end
+      end
+
+      def authenticated_email_address
+        if FeatureFlag.enabled?(:student_loans_teacher_auth)
+          teacher_auth_email
+        else
+          teacher_id_user_info["email"]
+        end
       end
     end
   end

--- a/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
+++ b/app/models/journeys/teacher_student_loan_reimbursement/slug_sequence.rb
@@ -11,9 +11,11 @@ module Journeys
     # reflects the sequence based on the claim's current state.
     class SlugSequence
       SLUGS = [
+        "sign-in",
         "sign-in-or-continue",
         "reset-claim",
         "qualification-details",
+        "qualifications-check",
         "qts-year",
         "select-claim-school",
         "claim-school",
@@ -63,11 +65,20 @@ module Journeys
       end
 
       def slugs
-        [].tap do |sequence|
-          sequence.push(*eligibility_slugs)
-          sequence.push(*personal_details_slugs)
-          sequence.push(*payment_details_slugs)
-          sequence.push(*results_slugs)
+        if FeatureFlag.enabled?(:student_loans_teacher_auth)
+          [].tap do |sequence|
+            sequence.push(*teacher_auth_eligibility_slugs)
+            sequence.push(*teacher_auth_personal_details_slugs)
+            sequence.push(*teacher_auth_payment_details_slugs)
+            sequence.push(*results_slugs)
+          end
+        else
+          [].tap do |sequence|
+            sequence.push(*eligibility_slugs)
+            sequence.push(*personal_details_slugs)
+            sequence.push(*payment_details_slugs)
+            sequence.push(*results_slugs)
+          end
         end
       end
 
@@ -84,6 +95,60 @@ module Journeys
       end
 
       private
+
+      def teacher_auth_eligibility_slugs
+        [].tap do |slugs|
+          slugs << "sign-in"
+          slugs << "qualifications-check" if answers.trs_data_fetched_at.blank?
+          slugs << "qualification-details" if answers.has_dqt_data_for_claim?
+          slugs << "qts-year" unless answers.qualifications_details_check?
+          slugs << "select-claim-school" if answers.has_tps_school_for_student_loan_in_previous_financial_year?
+          slugs << "claim-school" if answers.claim_school_somewhere_else != false
+          slugs << "claim-school-results" if answers.claim_school_id.blank? || answers.provision_search.present?
+          slugs << "subjects-taught"
+          slugs << "still-teaching-tps" if answers.has_recent_tps_school?
+          slugs << "still-teaching" unless answers.has_recent_tps_school?
+          slugs << "current-school" unless answers.employed_at_claim_school? || answers.employed_at_recent_tps_school?
+          slugs << "select-current-school" unless answers.employed_at_claim_school? || answers.employed_at_recent_tps_school?
+          slugs << "leadership-position"
+          slugs << "mostly-performed-leadership-duties" if answers.had_leadership_position?
+          slugs << "eligibility-confirmed"
+        end
+      end
+
+      def teacher_auth_personal_details_slugs
+        [].tap do |slugs|
+          slugs << "information-provided"
+          # Checking the payroll gender here is a work around for how the
+          # navigator behaves. When initially going through the journey we want
+          # to skip the personal details form as we've pulled that data from
+          # TRS, however we still want to let the user correct the data from
+          # check the answers page. payroll_gender is the last question in the
+          # journey so if that's set then we can put the personal details form
+          # in the slug sequence for the navigator to pick it up and allow
+          # changing the answer.
+          # Occasionally TRS data may be missing the NINO so we also have a check
+          # that the personal details form is valid.
+          slugs << "personal-details" if personal_details_form.invalid? || answers.payroll_gender.present?
+          slugs << "student-loan-amount"
+          slugs << "postcode-search"
+          slugs << "select-home-address" if answers.postcode_searched?
+          slugs << "address" unless answers.postcode_searched?
+          slugs << "select-email" if answers.teacher_auth_email
+          slugs << "email-address" unless answers.email_address_check?
+          slugs << "email-verification" unless answers.email_address_check? || answers.email_verified?
+          slugs << "provide-mobile-number"
+          slugs << "mobile-number" unless doesnt_want_to_provide_mobile_number?
+          slugs << "mobile-verification" unless doesnt_want_to_provide_mobile_number?
+        end
+      end
+
+      def teacher_auth_payment_details_slugs
+        [].tap do |slugs|
+          slugs << "personal-bank-account"
+          slugs << "gender"
+        end
+      end
 
       def eligibility_slugs
         [].tap do |slugs|

--- a/app/models/policies/claim_checking_tasks.rb
+++ b/app/models/policies/claim_checking_tasks.rb
@@ -21,7 +21,7 @@ module Policies
     end
 
     def identity_status
-      task = claim.tasks.detect { |t| t.name == "identity_confirmation" }
+      task = identity_confirmation_task
 
       if task.nil?
         "Unverified"
@@ -39,6 +39,10 @@ module Policies
     end
 
     private
+
+    def identity_confirmation_task
+      claim.tasks.detect { |t| t.name == "identity_confirmation" }
+    end
 
     def all_tasks
       @all_tasks ||= applicable_task_names.map do |name|

--- a/app/models/policies/student_loans.rb
+++ b/app/models/policies/student_loans.rb
@@ -13,15 +13,24 @@ module Policies
 
     extend self
 
-    VERIFIERS = [
-      AutomatedChecks::ClaimVerifiers::Identity,
-      AutomatedChecks::ClaimVerifiers::Qualifications,
-      AutomatedChecks::ClaimVerifiers::CensusSubjectsTaught,
-      AutomatedChecks::ClaimVerifiers::Employment,
-      AutomatedChecks::ClaimVerifiers::StudentLoanAmount,
-      AutomatedChecks::ClaimVerifiers::FraudRisk,
-      AutomatedChecks::ClaimVerifiers::MatchingClaims
-    ].freeze
+    def verifiers_for_claim(claim)
+      verifiers = []
+
+      verifiers << if claim.eligibility.teacher_auth_completed_at
+        AutomatedChecks::ClaimVerifiers::TeacherAuthIdentityConfirmation
+      else
+        AutomatedChecks::ClaimVerifiers::Identity
+      end
+
+      verifiers + [
+        AutomatedChecks::ClaimVerifiers::Qualifications,
+        AutomatedChecks::ClaimVerifiers::CensusSubjectsTaught,
+        AutomatedChecks::ClaimVerifiers::Employment,
+        AutomatedChecks::ClaimVerifiers::StudentLoanAmount,
+        AutomatedChecks::ClaimVerifiers::FraudRisk,
+        AutomatedChecks::ClaimVerifiers::MatchingClaims
+      ].freeze
+    end
 
     POLICY_START_YEAR = AcademicYear.new(2013).freeze
     POLICY_END_YEAR = AcademicYear.new(2020).freeze

--- a/app/models/policies/student_loans/claim_checking_tasks.rb
+++ b/app/models/policies/student_loans/claim_checking_tasks.rb
@@ -6,7 +6,7 @@ module Policies
       def applicable_task_names
         tasks = []
 
-        tasks << "identity_confirmation"
+        tasks << identity_confirmation_task_name
         tasks << "qualifications"
         tasks << "census_subjects_taught"
         tasks << "employment"
@@ -16,6 +16,20 @@ module Policies
         tasks << "payroll_gender" if claim.payroll_gender_missing? || task_exists?("payroll_gender")
 
         tasks
+      end
+
+      private
+
+      def identity_confirmation_task_name
+        if claim.eligibility.teacher_auth_completed_at
+          "teacher_auth_identity_confirmation"
+        else
+          "identity_confirmation"
+        end
+      end
+
+      def identity_confirmation_task
+        claim.tasks.detect { |t| t.name == identity_confirmation_task_name }
       end
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,6 +11,7 @@ class Task < ApplicationRecord
     one_login_identity
     previous_payment
     identity_confirmation
+    teacher_auth_identity_confirmation
     alternative_identity_verification
     fe_alternative_verification
     ey_eoi_cross_reference

--- a/app/views/admin/tasks/teacher_auth_identity_confirmation.html.erb
+++ b/app/views/admin/tasks/teacher_auth_identity_confirmation.html.erb
@@ -1,0 +1,50 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{@claim.policy.short_name}") } %>
+
+<% content_for :back_link do %>
+  <%= govuk_back_link href: admin_claim_tasks_path(@claim) %>
+<% end %>
+
+<%= form_with(
+  model: @form,
+  scope: :form,
+  url: root_path,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
+  <%= f.govuk_error_summary %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <%= render(
+    claim_summary_view,
+    claim: @claim,
+    heading: "Identity confirmation"
+  ) %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= @form.task.name.humanize %></h2>
+  </div>
+
+  <% unless @tasks_presenter.identity_confirmation.empty? %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render(
+        "admin/claims/answers",
+        answers: @tasks_presenter.identity_confirmation
+      ) %>
+    </div>
+  <% end %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@form.task.passed.nil? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= render "form", task_name: "identity_confirmation", claim: @claim %>
+    <% end %>
+
+    <%= render "task_notes_section" %>
+
+    <%= render(
+      partial: "admin/task_pagination",
+      locals: { task_pagination: @task_pagination }
+    ) %>
+  </div>
+</div>

--- a/app/views/claims/select_email.html.erb
+++ b/app/views/claims/select_email.html.erb
@@ -29,7 +29,7 @@
           <%= f.govuk_radio_button(
             :email_address_check,
             true,
-            label: { text: f.object.email_address_from_teacher_id },
+            label: { text: f.object.authenticated_email_address },
             link_errors: true
           ) %>
 
@@ -47,7 +47,6 @@
     <% end %>
   </div>
 </div>
-
 
 
 

--- a/app/views/student_loans/claims/qualifications_check.html.erb
+++ b/app/views/student_loans/claims/qualifications_check.html.erb
@@ -1,0 +1,29 @@
+<% content_for(
+  :page_title,
+  page_title(
+    @form.t(:title),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= @form.t(:title) %>
+    </h1>
+
+    <p class="govuk-body">
+      We are checking your qualifications, this will take a few moments.
+      If the page does not reload, press the continue button below.
+    </p>
+
+    <%= form_with(
+      model: @form,
+      url: @form.url,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/student_loans/claims/sign_in.html.erb
+++ b/app/views/student_loans/claims/sign_in.html.erb
@@ -1,0 +1,78 @@
+<% content_for(
+  :page_title,
+  page_title(
+    @form.t(:title),
+    journey: current_journey_routing_name,
+    show_error: @form.errors.any?
+  )
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @form.t(:title) %></h1>
+
+    <% if TeacherAuth::Config.instance.bypass? %>
+      <h2 class="govuk-heading-l">Bypass Teacher Auth</h2>
+
+      <%= form_with(
+        model: @form,
+        url: "/student-loans/bypass-auth/teacher",
+        method: :post,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |f| %>
+        <%= f.govuk_text_field(
+          :first_name,
+          label: { text: "First name" },
+          width: 20
+        ) %>
+
+        <%= f.govuk_text_field(
+          :middle_name,
+          label: { text: "Middle name" },
+          width: 20
+        ) %>
+
+        <%= f.govuk_text_field(
+          :last_name,
+          label: { text: "Last name" },
+          width: 20
+        ) %>
+
+        <%= f.govuk_date_field(
+          :date_of_birth,
+          date_of_birth: true,
+          legend: { text: "Date of Birth" }
+        ) %>
+
+        <%= f.govuk_text_field(
+          :national_insurance_number,
+          label: { text: "National Insurance number" }
+        ) %>
+
+
+        <%= f.govuk_text_field(
+          :email,
+          width: 20
+        ) %>
+
+        <%= f.govuk_text_field(
+          :trn,
+          width: 10,
+          label: { text: "TRN" }
+        ) %>
+
+        <%= f.govuk_text_field(
+          :sub,
+          label: { text: "One Login UID" }
+        ) %>
+
+        <%= f.govuk_date_field(
+          :qts_award_date,
+          legend: { text: "QTS award date" }
+        ) %>
+
+        <%= f.govuk_submit %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/student_loans/claims/sign_in.html.erb
+++ b/app/views/student_loans/claims/sign_in.html.erb
@@ -66,10 +66,44 @@
           label: { text: "One Login UID" }
         ) %>
 
-        <%= f.govuk_date_field(
-          :qts_award_date,
-          legend: { text: "QTS award date" }
-        ) %>
+        <%= f.govuk_radio_buttons_fieldset(
+          :qts_record_found,
+          legend: {
+            size: "m",
+            text: "QTS record found"
+          }
+        ) do %>
+          <%= f.govuk_radio_button(
+            :qts_record_found,
+            true,
+            label: { text: "yes"}
+          ) do %>
+            <%= f.govuk_date_field(
+              :qts_award_date,
+              legend: { text: "QTS award date" }
+            ) %>
+          <% end %>
+
+          <%= f.govuk_radio_button(
+            :qts_record_found,
+            false,
+            label: { text: "no"}
+          ) %>
+        <% end %>
+
+        <%= f.govuk_check_boxes_fieldset(
+          :active_alert,
+          multiple: false,
+          legend: { text: "Active alert" }
+        ) do %>
+          <%= f.govuk_check_box(
+            :active_alert,
+            1,
+            0,
+            multiple: false,
+            label: { text: "Enable" }
+          ) %>
+        <% end %>
 
         <%= f.govuk_submit %>
       <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -203,6 +203,17 @@ shared:
     - mostly_performed_leadership_duties # boolean, was the claimant mostly fulfilling leadship duties
     - claim_school_somewhere_else # boolean, are they claiming against another school
     - teacher_reference_number # string, TRN external identifier
+    - teacher_auth_completed_at # datetime, when the user completed teacher auth
+    - teacher_auth_date_of_birth # date, date of birth returned from TRS
+    - teacher_auth_email # string, email returned from TRS
+    - teacher_auth_first_name # string, first name returned from TRS
+    - teacher_auth_last_name # string, last name returned from TRS
+    - teacher_auth_national_insurance_number # string, NINO returned from TRS
+    - teacher_auth_one_login_uid # string, OL identifier
+    - teacher_auth_teacher_reference_number # string, TRN from TRS
+    - teacher_auth_verified_date_of_birth # date, date of birth from TRS
+    - teacher_auth_verified_name # string, full name returned from TRS
+    - trs_data_fetched_at # datetime, when we fetched qualfications from TRS
   :early_career_payments_eligibilities:
     - id # uuid, that identifies the eligiblity
     - nqt_in_academic_year_after_itt # boolean, is claimant teaching as newly qualified teacher

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -29,6 +29,15 @@
     - teacher_reference_number
   :student_loans_eligibilities:
     - teacher_reference_number
+    - teacher_auth_date_of_birth
+    - teacher_auth_email
+    - teacher_auth_first_name
+    - teacher_auth_last_name
+    - teacher_auth_national_insurance_number
+    - teacher_auth_one_login_uid
+    - teacher_auth_teacher_reference_number
+    - teacher_auth_verified_date_of_birth
+    - teacher_auth_verified_name
   :further_education_payments_eligibilities:
     - teacher_reference_number
     - claimant_date_of_birth

--- a/config/locales/admin.yml
+++ b/config/locales/admin.yml
@@ -87,6 +87,9 @@ en:
       identity_confirmation:
         name: Identity confirmation
         title: "Confirm the claimant made the claim"
+      teacher_auth_identity_confirmation:
+        name: Identity confirmation
+        title: "Confirm the claimant made the claim"
       fe_provider_check:
         name: Provider flagging
         title: "Check the provider's response"
@@ -218,6 +221,12 @@ en:
       student_loan_repayment_amount: "Student loan repayment amount"
       student_loan_repayment_plan: "Student loan repayment plan"
       task_questions:
+        teacher_auth_identity_confirmation:
+          title: "Did %{claim_full_name} submit the claim?"
+          body:
+            match:
+              any: "The claimant’s identity matches teacher auth's records. See %{link}."
+              all: "The claimant’s identity matches teacher auth's records. See %{link}."
         identity_confirmation:
           title: "Did %{claim_full_name} submit the claim?"
           body:

--- a/config/locales/student_loans.yml
+++ b/config/locales/student_loans.yml
@@ -5,6 +5,8 @@ en:
       prepared_date: "31 July 2019"
       updated_date: "28 July 2022"
     forms:
+      sign_in:
+        title: "Sign in with GOV.UK One Login"
       claim_school:
         questions:
           claim_school: "Which school were you employed to teach at between %{financial_year}?"
@@ -102,6 +104,8 @@ en:
       qualification_details:
         errors:
           qualifications_details_check: "Select yes if your qualification details are correct"
+      qualifications_check:
+        title: "Checking qualifications"
       email_verification:
         errors:
           one_time_password:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,15 @@ Rails.application.routes.draw do
     scope path: "/", constraints: {journey: Regexp.new(Journeys.all.map(&:routing_name).join("|"))} do
       get "landing-page", to: "static_pages#landing_page", as: :landing_page
     end
+
+    scope constraints: {journey: "student-loans"} do
+      if TeacherAuth::Config.instance.bypass? || Rails.env.test?
+        post(
+          "bypass-auth/teacher",
+          to: "journeys/teacher_student_loan_reimbursement/bypass_auth#callback"
+        )
+      end
+    end
   end
 
   constraints lambda { |req| req.format == :json } do

--- a/db/migrate/20260909151033_add_trs_fields_to_student_loans_eligibilities.rb
+++ b/db/migrate/20260909151033_add_trs_fields_to_student_loans_eligibilities.rb
@@ -1,0 +1,13 @@
+class AddTrsFieldsToStudentLoansEligibilities < ActiveRecord::Migration[8.1]
+  def change
+    change_table :student_loans_eligibilities do |t|
+      t.column :teacher_auth_teacher_reference_number, :string
+      t.column :teacher_auth_email, :citext
+      t.column :teacher_auth_verified_name, :text
+      t.column :teacher_auth_verified_date_of_birth, :date
+      t.column :teacher_auth_one_login_uid, :text
+      t.column :teacher_auth_completed_at, :datetime
+      t.column :trs_data_fetched_at, :datetime
+    end
+  end
+end

--- a/db/migrate/20260910103252_add_more_trs_fields_to_loans.rb
+++ b/db/migrate/20260910103252_add_more_trs_fields_to_loans.rb
@@ -1,0 +1,10 @@
+class AddMoreTrsFieldsToLoans < ActiveRecord::Migration[8.1]
+  def change
+    change_table :student_loans_eligibilities do |t|
+      t.column :teacher_auth_first_name, :string
+      t.column :teacher_auth_last_name, :string
+      t.column :teacher_auth_national_insurance_number, :string
+      t.column :teacher_auth_date_of_birth, :date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_02_144451) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_151033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -868,7 +868,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_144451) do
     t.string "qts_award_year"
     t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
     t.boolean "taught_eligible_subjects"
+    t.datetime "teacher_auth_completed_at"
+    t.citext "teacher_auth_email"
+    t.text "teacher_auth_one_login_uid"
+    t.string "teacher_auth_teacher_reference_number"
+    t.date "teacher_auth_verified_date_of_birth"
+    t.text "teacher_auth_verified_name"
     t.string "teacher_reference_number", limit: 11
+    t.datetime "trs_data_fetched_at"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["claim_school_id"], name: "index_student_loans_eligibilities_on_claim_school_id"
     t.index ["created_at"], name: "index_student_loans_eligibilities_on_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_09_151033) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_10_103252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -869,7 +869,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_09_151033) do
     t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
     t.boolean "taught_eligible_subjects"
     t.datetime "teacher_auth_completed_at"
+    t.date "teacher_auth_date_of_birth"
     t.citext "teacher_auth_email"
+    t.string "teacher_auth_first_name"
+    t.string "teacher_auth_last_name"
+    t.string "teacher_auth_national_insurance_number"
     t.text "teacher_auth_one_login_uid"
     t.string "teacher_auth_teacher_reference_number"
     t.date "teacher_auth_verified_date_of_birth"

--- a/spec/features/tslr/tslr_claim_journey_with_teacher_auth_by_pass_spec.rb
+++ b/spec/features/tslr/tslr_claim_journey_with_teacher_auth_by_pass_spec.rb
@@ -174,7 +174,9 @@ RSpec.describe "TSLR claim with teacher auth by pass" do
       expect(page).to have_content("student loan repayment amount")
       click_button "Continue"
 
-      click_button "Confirm and send"
+      perform_enqueued_jobs do
+        click_button "Confirm and send"
+      end
 
       expect(page).to have_content "Claim submitted"
 
@@ -205,11 +207,33 @@ RSpec.describe "TSLR claim with teacher auth by pass" do
         value: "Signed in with teacher auth"
       )
 
-      expect(task_status("Identity confirmation")).to eq "Passed"
+      expect(task_status("Identity confirmation")).to eq "Partial match"
       expect(task_status("Qualifications")).to eq "Passed"
 
       click_on "Confirm the claimant made the claim"
-      expect(page).to have "check we've updated the task notes"
+      expect(page).to have_text("[Teacher Auth Identity] - Name not matched:")
+      expect(page).to have_text(
+        'Claimant: "Walter Seymour Skinner" Teacher Auth: "Seymour Skinner"'
+      )
+      expect(page).to have_text(
+        "[Teacher Auth Identity] - National insurance number not matched:"
+      )
+      expect(page).to have_text(
+        'Claimant: "AA123456C" Teacher Auth: "AB123456C"'
+      )
+      # Date of birth wasn't changed from check answers page
+      expect(page).not_to have_text(
+        "[Teacher Auth Identity] - Date of birth not matched:"
+      )
+
+      choose "Yes"
+      click_on "Save and continue"
+
+      expect(page).to have_text "Qualifications"
+
+      within ".hmcts-timeline" do
+        expect(page).to have_text "QTS award date: #{qts_year}-09-01"
+      end
     end
   end
 

--- a/spec/features/tslr/tslr_claim_journey_with_teacher_auth_by_pass_spec.rb
+++ b/spec/features/tslr/tslr_claim_journey_with_teacher_auth_by_pass_spec.rb
@@ -1,0 +1,182 @@
+require "rails_helper"
+
+RSpec.describe "TSLR claim with teacher auth by pass" do
+  context "when QTS year is confirmed and a TPS school is found" do
+    before do
+      FeatureFlag.enable!(:student_loans_teacher_auth)
+      allow(TeacherAuth::Config.instance).to receive(:bypass?) { true }
+
+      stub_const(
+        "Journeys::TeacherStudentLoanReimbursement::Debug::TeacherAuth::FetchQualificationsJob::JOB_SLEEP_SECONDS",
+        0
+      )
+
+      journey_configuration = create(:journey_configuration, :student_loans)
+      previous_academic_year = journey_configuration.current_academic_year - 1
+      within_beginning_of_month = Date.new(previous_academic_year.start_year, 10, 1)
+      within_end_of_month = Date.new(previous_academic_year.start_year, 10, 31)
+
+      school = create(
+        :school,
+        :student_loans_eligible,
+        name: "Springfield Elementary"
+      )
+
+      create(
+        :teachers_pensions_service,
+        teacher_reference_number: "1234567",
+        start_date: within_beginning_of_month,
+        end_date: within_end_of_month,
+        school_urn: school.establishment_number,
+        la_urn: school.local_authority.code
+      )
+
+      create(
+        :school,
+        :student_loans_eligible,
+        name: "Shelbyville Grammar"
+      )
+    end
+
+    it "uses the details returned from teacher auth" do
+      visit landing_page_path(
+        Journeys::TeacherStudentLoanReimbursement.routing_name
+      )
+
+      click_on "Start now"
+
+      fill_in "First name", with: "Seymour"
+      fill_in "Middle name", with: "T"
+      fill_in "Last name", with: "Skinner"
+
+      within_fieldset "Date of Birth" do
+        fill_in "Day", with: 1
+        fill_in "Month", with: 1
+        fill_in "Year", with: 1980
+      end
+
+      fill_in "National Insurance number", with: "AB123456C"
+
+      fill_in "Email", with: "seymour.skinner@springfield-elementary.edu"
+
+      fill_in "TRN", with: "1234567"
+
+      qts_year = AcademicYear.current.start_year - Policies::StudentLoans::ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR
+
+      within_fieldset "QTS award date" do
+        fill_in "Day", with: 1
+        fill_in "Month", with: 9
+        fill_in "Year", with: qts_year
+      end
+
+      perform_enqueued_jobs do
+        click_button "Continue"
+      end
+
+      expect(page).to have_content(
+        "Academic year you completed your Initial Teacher Training (ITT)"
+      )
+      expect(page).to have_content("Are these details correct?")
+      choose "Yes"
+      click_button "Continue"
+
+      expect(page).to have_text(
+        StudentLoansHelper.tap { |m| m.extend(m) }.claim_school_question
+      )
+      choose "Springfield Elementary"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "Which of the following subjects did you teach at Springfield Elementary"
+      )
+      check "Physics"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "Are you still employed to teach at a school in England?"
+      )
+      choose "Yes, at another school"
+      click_button "Continue"
+
+      fill_in(
+        "Which school are you currently employed to teach at",
+        with: "Shelbyville Grammar"
+      )
+      click_button "Continue"
+      choose "Shelbyville Grammar"
+      click_button "Continue"
+
+      expect(page).to have_content "Were you employed in a leadership position"
+      choose "No"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "You are eligible to claim back student loan repayments"
+      )
+      click_button "Continue"
+
+      expect(page).to have_content("How we will use the information you provide")
+      click_button "Continue"
+
+      expect(page).to have_content("student loan repayment amount")
+      click_button "Continue"
+
+      expect(page).to have_content("What is your home address?")
+      click_button "Enter your address manually"
+      fill_in "House number or name", with: "Test house"
+      fill_in "Building and street", with: "Test street"
+      fill_in "Town or city", with: "Test town"
+      fill_in "Postcode", with: "TE57 1NG"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "Which email address should we use to contact you?"
+      )
+      choose "seymour.skinner@springfield-elementary.edu"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "Would you like to provide your mobile number?"
+      )
+      choose "No"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "Enter the bank account details your salary is paid into"
+      )
+      fill_in "Name on the account", with: "S Skinner"
+      fill_in "Sort code", with: "000000"
+      fill_in "Account number", with: "00000000"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "How is your gender recorded on your school’s payroll system?"
+      )
+      choose "Male"
+      click_button "Continue"
+
+      expect(page).to have_content(
+        "Check your answers before sending your application"
+      )
+      click_on "Change what is your full name"
+
+      expect(page).to have_text "Personal details"
+
+      fill_in "First name", with: "Walter"
+      fill_in "Middle name", with: "Seymour"
+      fill_in "Last name", with: "Skinner"
+
+      fill_in "What is your National Insurance number?", with: "AA123456C"
+
+      click_button "Continue"
+
+      # When personal details are changed we re check for student loan
+      expect(page).to have_content("student loan repayment amount")
+      click_button "Continue"
+
+      click_button "Confirm and send"
+
+      expect(page).to have_content "Claim submitted"
+    end
+  end
+end

--- a/spec/features/tslr/tslr_claim_journey_with_teacher_auth_by_pass_spec.rb
+++ b/spec/features/tslr/tslr_claim_journey_with_teacher_auth_by_pass_spec.rb
@@ -177,6 +177,43 @@ RSpec.describe "TSLR claim with teacher auth by pass" do
       click_button "Confirm and send"
 
       expect(page).to have_content "Claim submitted"
+
+      match = page.text.match(/Your reference number (?<ref>.*)\n/)
+
+      claim = Claim.find_by! reference: match[:ref]
+
+      sign_in_as_service_admin
+
+      visit admin_claim_tasks_path(claim)
+
+      expect(page).to have_summary_item(key: "TRN", value: "1234567")
+      expect(page).to have_summary_item(key: "NI number", value: "AA123456C")
+      expect(page).to(
+        have_summary_item(key: "Full name", value: "Walter Seymour Skinner")
+      )
+      expect(page).to(
+        have_summary_item(key: "Date of birth", value: "1 January 1980")
+      )
+      expect(page).to(
+        have_summary_item(
+          key: "Email address",
+          value: "seymour.skinner@springfield-elementary.edu"
+        )
+      )
+      expect(page).to have_summary_item(
+        key: "Claim route",
+        value: "Signed in with teacher auth"
+      )
+
+      expect(task_status("Identity confirmation")).to eq "Passed"
+      expect(task_status("Qualifications")).to eq "Passed"
+
+      click_on "Confirm the claimant made the claim"
+      expect(page).to have "check we've updated the task notes"
     end
+  end
+
+  def task(name)
+    page.find("h2", text: name).sibling("*").find("strong", class: ["app-task-list__task-completed"])
   end
 end

--- a/spec/models/automated_checks/claim_verifier_spec.rb
+++ b/spec/models/automated_checks/claim_verifier_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe AutomatedChecks::ClaimVerifier do
         end
 
         before do
-          claim.policy::VERIFIERS.each_with_index do |verifier, index|
+          claim.policy.verifiers_for_claim(claim).each_with_index do |verifier, index|
             allow(verifier).to receive(:new).and_return(verifiers[index])
           end
         end

--- a/spec/models/automated_checks/claim_verifiers/teacher_auth_identity_confirmation_spec.rb
+++ b/spec/models/automated_checks/claim_verifiers/teacher_auth_identity_confirmation_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.describe AutomatedChecks::ClaimVerifiers::TeacherAuthIdentityConfirmation do
+  describe "#perform" do
+    context "when national_insurance_number doesn't match" do
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::StudentLoans,
+          national_insurance_number: "AB123456C",
+          eligibility_attributes: {
+            teacher_auth_national_insurance_number: "AA111111C"
+          },
+          dqt_teacher_status: {
+            qts: {
+              holdsFrom: "2014-01-01"
+            }
+          }
+        )
+      end
+
+      before { described_class.new(claim: claim).perform }
+
+      it "adds a note to the claim" do
+        expect(
+          claim.notes.by_label("teacher_auth_identity_confirmation").where(
+            "body ILIKE ?", "%National insurance number%"
+          ).count
+        ).to eq 1
+      end
+
+      it "doesn't pass the task" do
+        task = claim.tasks.teacher_auth_identity_confirmation.sole
+
+        expect(task.passed).to eq nil
+        expect(task.manual).to be false
+      end
+    end
+
+    context "when name doesn't match" do
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::StudentLoans,
+          first_name: "Seymour",
+          surname: "Skinner",
+          eligibility_attributes: {
+            teacher_auth_first_name: "Walter",
+            teacher_auth_last_name: "Skinner"
+          },
+          dqt_teacher_status: {
+            qts: {
+              holdsFrom: "2014-01-01"
+            }
+          }
+        )
+      end
+
+      before { described_class.new(claim: claim).perform }
+
+      it "adds a note to the claim" do
+        expect(
+          claim.notes.by_label("teacher_auth_identity_confirmation").where(
+            "body ILIKE ?", "%Name%"
+          ).count
+        ).to eq 1
+      end
+
+      it "doesn't pass the task" do
+        task = claim.tasks.teacher_auth_identity_confirmation.sole
+
+        expect(task.passed).to eq nil
+        expect(task.manual).to be false
+      end
+    end
+
+    context "when date_of_birth doesn't match" do
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::StudentLoans,
+          date_of_birth: Date.new(1980, 1, 1),
+          eligibility_attributes: {
+            teacher_auth_date_of_birth: Date.new(1970, 1, 1)
+          },
+          dqt_teacher_status: {
+            qts: {
+              holdsFrom: "2014-01-01"
+            }
+          }
+        )
+      end
+
+      before { described_class.new(claim: claim).perform }
+
+      it "adds a note to the claim" do
+        expect(
+          claim.notes.by_label("teacher_auth_identity_confirmation").where(
+            "body ILIKE ?", "%Date of birth%"
+          ).count
+        ).to eq 1
+      end
+
+      it "doesn't pass the task" do
+        task = claim.tasks.teacher_auth_identity_confirmation.sole
+
+        expect(task.passed).to eq nil
+        expect(task.manual).to be false
+      end
+    end
+
+    context "when active alert" do
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::StudentLoans,
+          dqt_teacher_status: {
+            alerts: [
+              {
+                startDate: "2026-02-03",
+                endDate: nil
+              }
+            ],
+            qts: {
+              holdsFrom: "2014-01-01"
+            }
+          }
+        )
+      end
+
+      before { described_class.new(claim: claim).perform }
+
+      it "adds a note to the claim" do
+        note = claim.notes.by_label("teacher_auth_identity_confirmation").where(
+          "body ILIKE ?", "%active alert%"
+        ).sole
+
+        expect(note).to be_important
+      end
+
+      it "doesn't pass the task" do
+        task = claim.tasks.teacher_auth_identity_confirmation.sole
+
+        expect(task.passed).to eq nil
+        expect(task.manual).to be false
+      end
+    end
+
+    context "when everything matches and there's not alert" do
+      let(:claim) do
+        create(
+          :claim,
+          policy: Policies::StudentLoans,
+          first_name: "Seymour",
+          surname: "Skinner",
+          date_of_birth: Date.new(1970, 1, 1),
+          national_insurance_number: "AB123456C",
+          eligibility_attributes: {
+            teacher_auth_first_name: "Seymour",
+            teacher_auth_last_name: "Skinner",
+            teacher_auth_date_of_birth: Date.new(1970, 1, 1),
+            teacher_auth_national_insurance_number: "AB123456C"
+          },
+          dqt_teacher_status: {
+            qts: {
+              holdsFrom: "2014-01-01"
+            }
+          }
+        )
+      end
+
+      before { described_class.new(claim: claim).perform }
+
+      it "doesn't create any notes" do
+        expect(
+          claim.notes.by_label("teacher_auth_identity_confirmation")
+        ).to be_empty
+      end
+
+      it "passes the task" do
+        task = claim.tasks.teacher_auth_identity_confirmation.sole
+
+        expect(task.passed).to eq true
+        expect(task.manual).to be false
+      end
+    end
+  end
+end

--- a/spec/models/student_loans_spec.rb
+++ b/spec/models/student_loans_spec.rb
@@ -5,18 +5,6 @@ RSpec.describe Policies::StudentLoans, type: :model do
 
   it { is_expected.to include(BasePolicy) }
 
-  it do
-    expect(subject::VERIFIERS).to eq([
-      AutomatedChecks::ClaimVerifiers::Identity,
-      AutomatedChecks::ClaimVerifiers::Qualifications,
-      AutomatedChecks::ClaimVerifiers::CensusSubjectsTaught,
-      AutomatedChecks::ClaimVerifiers::Employment,
-      AutomatedChecks::ClaimVerifiers::StudentLoanAmount,
-      AutomatedChecks::ClaimVerifiers::FraudRisk,
-      AutomatedChecks::ClaimVerifiers::MatchingClaims
-    ])
-  end
-
   specify {
     expect(subject).to have_attributes(
       short_name: "Student Loans",

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Claims", type: :request do
 
     context "student loans claim" do
       it "created for the current academic year and redirects to the next question in the sequence" do
+        FeatureFlag.enable!(:student_loans_teacher_auth)
         @journey_configuration = create(:journey_configuration, :student_loans)
 
         check_claims_created


### PR DESCRIPTION
Add stub teacher auth integration to loans.
Replaces loans teacher id integration with a teacher auth mock page.
I've wired up the journey and the admin task to work with teacher auth so once
we have the credentials for the real integration it should just be a case of
hooking that in and writing to the correct form attributes.

I've left the test suite running against the old teacher id integration. We'll
add a separate ticket to remove that and update the test suite as part of that
ticket. I think we should leave that until after the teacher auth integration is
properly wired in so we can stub the real oauth call rather than relying on the
debug form in the test suite.
